### PR TITLE
fix validate fails error in s3

### DIFF
--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -117,7 +117,7 @@ async def get_user_remote_bucket_name(
     """
     get user remote_bucket_name from users.attributes
     """
-    return _get_user_remote_bucket_name(current_user)
+    return await _get_user_remote_bucket_name(current_user)
 
 
 async def _get_user_remote_bucket_name(


### PR DESCRIPTION
### Content
Im getting error with s3 buckets validation.
This is the error log.
`  File "/usr/local/lib/python3.9/site-packages/aiobotocore/hooks.py", line 66, in _emit
    response = await resolve_awaitable(handler(**kwargs))
  File "/usr/local/lib/python3.9/site-packages/botocore/handlers.py", line 282, in validate_bucket_name
    if not VALID_BUCKET.search(bucket) and not VALID_S3_ARN.search(bucket):
TypeError: expected string or bytes-like object`

This happens because it doesn't get the bucket name properly.
The reason for it was it was too fast and didn't wait for the function to get the bucket_name
Therfore, I added `await` to the code in getting the user bucket name.

### Testcase

- [x] Mac or Linux
  - [x] Import Sample Records
  - [x] Run Tutorial 1
  - [x] Run Tutorial 2
  - [x] Run Tutorial 3

- [ ] Windows
  - [ ] Import Sample Records
  - [ ] Run Tutorial 1
  - [ ] Run Tutorial 2
  - [ ] Run Tutorial 3
