### PR TITLE
Add Remote Storage Sync for Copying Records.

### DIFF
--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -72,15 +72,19 @@ export const copyExperimentByList = createAsyncThunk<
   ThunkApiConfig
 >(`${EXPERIMENTS_SLICE_NAME}/copyExperimentByList`, async (uid, thunkAPI) => {
   const workspaceId = selectCurrentWorkspaceId(thunkAPI.getState())
-  if (workspaceId) {
-    try {
-      const response = await copyExperimentByListApi(workspaceId, uid)
-      return response
-    } catch (e) {
-      return thunkAPI.rejectWithValue(e)
-    }
-  } else {
+  if (!workspaceId) {
     return thunkAPI.rejectWithValue("workspace id does not exist.")
+  }
+
+  try {
+    const response = await copyExperimentByListApi(workspaceId, uid)
+    if (!response) {
+      return thunkAPI.rejectWithValue("Copy API returned falsy result.")
+    }
+    // Don't return anything if success is only indicated by non-error
+    return true
+  } catch (e) {
+    return thunkAPI.rejectWithValue(e)
   }
 })
 

--- a/studio/app/common/core/experiment/experiment_services.py
+++ b/studio/app/common/core/experiment/experiment_services.py
@@ -80,11 +80,14 @@ class ExperimentService:
         try:
             for unique_id in copyItem.uidList:
                 new_unique_id = WorkflowRunner.create_workflow_unique_id()
-                await ExptDataWriter(
+                success = await ExptDataWriter(
                     remote_bucket_name,
                     workspace_id,
                     unique_id,
                 ).copy_data(new_unique_id)
+
+                if not success:
+                    raise Exception(f"Failed to copy data for unique_id: {unique_id}")
 
                 if WorkspaceDataCapacityService.is_available():
                     cls._copy_experiment_db(

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -255,6 +255,13 @@ class ExptDataWriter:
         logger = AppLogger.get_logger()
 
         try:
+            if RemoteStorageController.is_available():
+                # Check for remote-sync-lock-file
+                # - If lock file exists, an exception is raised (raise_error=True)
+                RemoteSyncLockFileUtil.check_sync_lock_file(
+                    self.workspace_id, self.unique_id, raise_error=True
+                )
+
             # Define file paths
             output_dir = join_filepath(
                 [DIRPATH.OUTPUT_DIR, self.workspace_id, self.unique_id]
@@ -281,12 +288,6 @@ class ExptDataWriter:
 
             # Operate remote storage data.
             if RemoteStorageController.is_available():
-                # Check for remote-sync-lock-file
-                # - If lock file exists, an exception is raised (raise_error=True)
-                RemoteSyncLockFileUtil.check_sync_lock_file(
-                    self.workspace_id, self.unique_id, raise_error=True
-                )
-
                 # Upload a new data with new unique id to remote data
                 async with RemoteStorageWriter(
                     self.remote_bucket_name, self.workspace_id, new_unique_id

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -279,6 +279,22 @@ class ExptDataWriter:
                 logger.error("Failed to update unique_id in files.")
                 return False
 
+            # Operate remote storage data.
+            if RemoteStorageController.is_available():
+                # Check for remote-sync-lock-file
+                # - If lock file exists, an exception is raised (raise_error=True)
+                RemoteSyncLockFileUtil.check_sync_lock_file(
+                    self.workspace_id, self.unique_id, raise_error=True
+                )
+
+                # Upload a new data with new unique id to remote data
+                async with RemoteStorageWriter(
+                    self.remote_bucket_name, self.workspace_id, new_unique_id
+                ) as remote_storage_controller:
+                    await remote_storage_controller.upload_experiment(
+                        self.workspace_id, new_unique_id
+                    )
+
             logger.info(f"Data successfully copied to {new_output_dir}")
             return True
 


### PR DESCRIPTION
## ✨ Implement Remote Storage Sync for Record Replication Function

This pull request adds synchronization logic for the **Record Copy / Replication Function**, ensuring that when records are duplicated, all associated data is also properly synchronized with **remote storage (AWS S3)**.

---

### 🛠 Changes Introduced

- Implemented remote sync within the **Record Replication Function**.
- When a record is copied (manually or programmatically), the following are now ensured:
  - Associated input/output data is duplicated and uploaded to S3.
  - A new unique record ID is generated for the copied record.
  - Remote storage consistency is preserved across copy, rename, and execution operations.
  
---

### 📌 Related Issue

- [Record Replication Function #487](https://github.com/arayabrain/barebone-studio/issues/487)

---

### 🔗 Reference to Sync Implementation

- Synchronization logic is implemented at:  
  [`workflow_result.py#L406`](https://github.com/arayabrain/optinist-for-cloud/blob/develop-main/studio/app/common/core/workflow/workflow_result.py#L406)

---

### Manual Test Cases: Record Copy + Remote Sync

#### ✅ Test 1: Single Record Copy & Remote Sync Verification

- [x] **Run Tutorial 1 Workflow**  
      Ensure it completes successfully. This creates the base record for testing.
- [x] **Copy Tutorial 1 from Records Screen**  
      This should create a new record with a different unique ID.
- [x] **Verify Remote Storage for Copied Record**  
      Check AWS S3 and confirm that a new folder/object exists under the copied record’s ID path. All necessary assets (e.g. output files) must be present.
- [x] **Rename Copied Tutorial 1**  
      Change the record name via UI. The name update should not affect the unique ID or S3 path.
- [x] **Run Workflow on the Copied Record**  
      Confirm the workflow runs successfully using the copied data.
- [x] **Recheck S3 After Workflow Execution**  
      Validate that the output data generated during the copied workflow run is uploaded under the new record's S3 path.

---

#### ✅ Test 2: Multiple Record Copy & Remote Sync Verification

- [x] **Run Tutorial 2 and 3 Workflows**  
      Ensure both complete successfully.
- [x] **Copy Tutorial 1, 2, 3 from Records Screen**  
      Each copied record should have a new unique ID.
- [x] **Verify Remote Storage for Each Copied Record**  
      Check AWS S3 for each copied record to confirm:
      - output folders are duplicated correctly
      - File counts match the originals
- [x] **Reproduce and Run Copied Tutorial 2 and 3 Workflows**  
      Trigger workflows for the copied versions and ensure successful execution.
- [x] **Recheck S3 for Output Sync After Workflow Run**  
      Confirm new output data is generated and correctly stored under each copied record's new S3 path.

---

#### Additional Manual Validation Steps

- [x] **Compare File Count Between Original and Copied Record in S3**  
      Ensure no missing assets during the replication.
- [x] **Check Metadata Consistency**  
      Verify that any associated metadata (e.g., timestamps, parameters) is correctly retained or regenerated.
- [x] **Try Copying a Record Without Internet Access**  
      Confirm that sync fails gracefully and the copied record is not synced
- [x] **Try Copying a Record With Lock File**  
　   It wont copy the record.