### PR TITLE
Improved remote bucket name getter

### DIFF
--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, select
 from studio.app.common.core.auth.auth_config import AUTH_CONFIG
 from studio.app.common.core.auth.security import validate_access_token
 from studio.app.common.core.mode import MODE
+from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.db.database import get_db
 from studio.app.common.models import User as UserModel
 from studio.app.common.models import UserRole as UserRoleModel
@@ -130,10 +131,17 @@ def _get_user_remote_bucket_name(
     if current_user:
         remote_bucket_name = current_user.remote_bucket_name
     else:
+        remote_bucket_name = None
+
+    if not remote_bucket_name:
+        remote_storage_type = RemoteStorageType.get_activated_type()
+
         if MODE.IS_TEST:
             remote_bucket_name = "TEST_DUMMY_BUCKET_NAME"
-        else:
+        elif remote_storage_type == RemoteStorageType.S3:
             remote_bucket_name = os.environ.get("S3_DEFAULT_BUCKET_NAME")
+        else:
+            remote_bucket_name = "MOCK_DUMMY_BUCKET_NAME"
 
     assert remote_bucket_name, f"Invalid remote_bucket_name: {remote_bucket_name}"
 

--- a/studio/app/common/schemas/users.py
+++ b/studio/app/common/schemas/users.py
@@ -42,7 +42,7 @@ class User(BaseModel):
 
     @property
     def remote_bucket_name(self) -> str:
-        return self.attributes.get("remote_bucket_name")
+        return self.attributes.get("remote_bucket_name") if self.attributes else None
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
### Content

- Relaxed assertion against remote bucket name in non-S3 mode

### Testcase

1. REMOTE_STORAGE_TYPE=0 or Undefined
    - set `database users.attributes = {}` and `Undefined .env S3_DEFAULT_BUCKET_NAME`
        - [x] Run workflow successful
2. REMOTE_STORAGE_TYPE=1 (Mock)
    - set `database users.attributes = {}` and `Undefined .env S3_DEFAULT_BUCKET_NAME`
        - [x] Run workflow successful
3. REMOTE_STORAGE_TYPE=2 (S3)
    1. set `database users.attributes = {"remote_bucket_name": "{your-bucket-name}"}`
        - [x] Run workflow successful
    2. set `database users.attributes = {}` and `.env S3_DEFAULT_BUCKET_NAME = {your-bucket-name}`
        - [x] Run workflow successful
    3. set `database users.attributes = {}` and `Undefined .env S3_DEFAULT_BUCKET_NAME`
        - [x] Workflow display failure
