### PR TITLE
Fix and improve backend test code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ testpaths = "/app/studio/tests"
 env = [
   "OPTINIST_DIR=/app/studio/test_data",
   "IS_TEST=True",
+  "REMOTE_STORAGE_TYPE=1",  # See .env
+  "MOCK_STORAGE_DIR=/tmp/studio/mock_storage",  # See .env
+
 ]
 filterwarnings = [
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -15,6 +15,7 @@ from studio.app.common.core.auth.auth_dependencies import (
 )
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
+from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
     is_workspace_owner,
@@ -51,6 +52,7 @@ async def lifespan(app: FastAPI):
 
     sys_version = sys.version.replace("\n", " ")
     mode = "standalone" if MODE.IS_STANDALONE else "multiuser"
+    remote_storage_type = RemoteStorageType.get_activated_type()
 
     logger = AppLogger.get_logger()
     logger.info(
@@ -60,6 +62,7 @@ async def lifespan(app: FastAPI):
         f"    # App Version: {Version.APP_VERSION}\n"
         f"    # Env:DATA_DIR: {DIRPATH.DATA_DIR}\n"
         f"    # Mode: {mode}\n"
+        f"    # REMOTE_STORAGE_TYPE: {remote_storage_type}\n"
     )
 
     yield

--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -137,7 +137,9 @@ def _get_user_remote_bucket_name(
         remote_storage_type = RemoteStorageType.get_activated_type()
 
         if MODE.IS_TEST:
-            remote_bucket_name = "TEST_DUMMY_BUCKET_NAME"
+            remote_bucket_name = os.environ.get(
+                "S3_DEFAULT_BUCKET_NAME", "TEST_DUMMY_BUCKET_NAME"
+            )
         elif remote_storage_type == RemoteStorageType.S3:
             remote_bucket_name = os.environ.get("S3_DEFAULT_BUCKET_NAME")
         else:

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py
@@ -3,6 +3,7 @@ import shutil
 
 import pytest
 
+from studio.app.common.core.auth.auth_dependencies import _get_user_remote_bucket_name
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.snakemake.smk import ForceRun, SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
@@ -10,10 +11,16 @@ from studio.app.common.core.snakemake.snakemake_executor import (
     delete_dependencies,
     snakemake_execute,
 )
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteStorageController,
+    RemoteSyncAction,
+    RemoteSyncStatusFileUtil,
+)
 from studio.app.common.core.utils.pickle_handler import PickleReader
 from studio.app.common.core.workflow.workflow import Edge, Node, NodeData
 from studio.app.dir_path import DIRPATH
 
+remote_bucket_name = _get_user_remote_bucket_name()
 workspace_id = "default"
 unique_id = "smk_exec_lccd"
 
@@ -101,6 +108,15 @@ def test_snakemake_execute(client):
 
     # Force running in standalone-mode
     MODE.reset_mode(is_standalone=True)
+
+    # Write remote storage related files
+    if RemoteStorageController.is_available():
+        RemoteSyncStatusFileUtil.create_sync_status_file_for_processing(
+            remote_bucket_name,
+            workspace_id,
+            unique_id,
+            RemoteSyncAction.UPLOAD,
+        )
 
     # Run snakemake executor
     snakemake_execute(workspace_id, unique_id, smk_param)

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_suite2p.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_suite2p.py
@@ -3,6 +3,7 @@ import shutil
 
 import pytest
 
+from studio.app.common.core.auth.auth_dependencies import _get_user_remote_bucket_name
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.snakemake.smk import ForceRun, SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
@@ -10,10 +11,16 @@ from studio.app.common.core.snakemake.snakemake_executor import (
     delete_dependencies,
     snakemake_execute,
 )
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteStorageController,
+    RemoteSyncAction,
+    RemoteSyncStatusFileUtil,
+)
 from studio.app.common.core.utils.pickle_handler import PickleReader
 from studio.app.common.core.workflow.workflow import Edge, Node, NodeData
 from studio.app.dir_path import DIRPATH
 
+remote_bucket_name = _get_user_remote_bucket_name()
 workspace_id = "default"
 unique_id = "smk_exec_suite2p"
 
@@ -101,6 +108,15 @@ def test_snakemake_execute(client):
 
     # Force running in standalone-mode
     MODE.reset_mode(is_standalone=True)
+
+    # Write remote storage related files
+    if RemoteStorageController.is_available():
+        RemoteSyncStatusFileUtil.create_sync_status_file_for_processing(
+            remote_bucket_name,
+            workspace_id,
+            unique_id,
+            RemoteSyncAction.UPLOAD,
+        )
 
     # Run snakemake executor
     snakemake_execute(workspace_id, unique_id, smk_param)


### PR DESCRIPTION
### Content

Fix and improve backend test code

- Fixes
  - Support for automated testing when remote storage is enabled (REMOTE_STORAGE_TYPE=1|2)

- Improvements
  - Fix REMOTE_STORAGE_TYPE to 1 (mock type) during automated testing (also used on github action)
  - Added information to application startup logs

### Testcase

- [x] 1. REMOTE_STORAGE_TYPE=1 (mock type)
  1. Run `make test_backend` and it will be successful.

- [x] 2. REMOTE_STORAGE_TYPE=2 (s3 type)
  1. Edit pyproject.toml > [tool.pytest.ini_options] > env
      ```yaml
      env = [
        "OPTINIST_DIR=/app/studio/test_data",
        "IS_TEST=True",
        "REMOTE_STORAGE_TYPE=2",
        "S3_DEFAULT_BUCKET_NAME={your-testing-bucket}",
        "MOCK_STORAGE_DIR=/tmp/studio/mock_storage",
      
      ]
      ```
  2. Run `make test_backend` and it will be successful.
