### PR TITLE
Added a bucket name display field

### DIFF
--- a/frontend/src/api/users/UsersApiDTO.ts
+++ b/frontend/src/api/users/UsersApiDTO.ts
@@ -9,6 +9,9 @@ export type UserDTO = {
     name: string
   }
   role_id?: number
+  attributes?: {
+    remote_bucket_name?: string
+  }
   created_at?: string
   updated_at?: string
 }

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -217,6 +217,10 @@ const Account = () => {
         <TitleData>Data size</TitleData>
         <BoxData>{convertBytes(user?.data_usage || 0)}</BoxData>
       </BoxFlex>
+      <BoxFlex>
+        <TitleData>Bucket name</TitleData>
+        <BoxData>{user?.attributes?.remote_bucket_name || "-"}</BoxData>
+      </BoxFlex>
       <BoxFlex sx={{ justifyContent: "space-between", mt: 10, maxWidth: 600 }}>
         <Button variant="contained" color="primary" onClick={onChangePwClick}>
           Change Password

--- a/frontend/src/pages/AccountManager/index.tsx
+++ b/frontend/src/pages/AccountManager/index.tsx
@@ -611,7 +611,7 @@ const AccountManager = () => {
       headerName: "ID",
       field: "id",
       filterable: false,
-      minWidth: 100,
+      minWidth: 80,
       flex: 1,
     },
     {
@@ -694,6 +694,16 @@ const AccountManager = () => {
       field: "data_usage",
       renderCell: (params: GridRenderCellParams<GridValidRowModel>) => {
         return convertBytes(params.value)
+      },
+    },
+    {
+      headerName: "Bucket name",
+      field: "remote_bucket_name",
+      minWidth: 200,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: GridRenderCellParams<GridValidRowModel>) => {
+        return params.row?.attributes?.remote_bucket_name || "-"
       },
     },
     {


### PR DESCRIPTION
### Content

Added a bucket name display field to each account info display area.

- Target screen
  - Account Profile
    - <img width="650" height="511" alt="2025-07-15 12 42 20" src="https://github.com/user-attachments/assets/e0365f8d-4615-4d28-a05a-37aba805832b" />
  - Account Manager
    - <img width="1354" height="545" alt="2025-07-15 12 41 38" src="https://github.com/user-attachments/assets/96f3529d-4fb2-43f5-91b8-11403d72deb2" />

### Testcase

- [x] 1. Your bucket name is displayed on the Account Profile Screen (check the value stored in the database).
- [x] 2. The Account Manager Screen displays the bucket name for each user (check the value stored in the database).