### PR TITLE
Fixed Post Process run error

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -230,6 +230,13 @@ class Runner:
         return output_info
 
     @classmethod
+    def read_input_info(cls, input_files: list) -> dict:
+        """
+        A wrapper for external access to __read_input_info
+        """
+        return cls.__read_input_info(input_files)
+
+    @classmethod
     def __read_input_info(cls, input_files: list) -> dict:
         """
         Read input files (.pkl) and construct data for further processing

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -57,6 +57,13 @@ class RemoteStorageLockError(Exception):
         message = "Remote data is temporary locked. " f"[{workspace_id}/{unique_id}]"
         super().__init__(message)
 
+    def __reduce__(self):
+        """
+        Code required to unpack pickled data on multiprocessing
+        (specifying the unpacking process)
+        """
+        return (self.__class__, (self.workspace_id, self.unique_id))
+
 
 class RemoteSyncStatusFileUtil:
     REMOTE_SYNC_STATUS_FILE = "remote_sync_stat.json"


### PR DESCRIPTION
### Content

The latest version was ported from the barebone-studio repo, but this caused an execution error in the post process.

#### Solution

- Restore renamed method names in fork repositories using aliases
- Also fixed a minor bug in a related area.
  - Resolved pickle unpack error for exception classes when running multiprocessing

### Testcase

- [x] The workflow execution is successful. At the same time, the post process is also successful.
    And the data is uploaded to the remote storage.
