### PR TITLE
Improved error handling in workflow post_process

### DIFF
--- a/studio/app/common/core/rules/post_process.py
+++ b/studio/app/common/core/rules/post_process.py
@@ -40,21 +40,21 @@ class PostProcessRunner:
         try:
             logger.info("start post_process runner")
 
+            # Get workspace_id, unique_id from output file path
+            ids = ExptOutputPathIds(dirname(__rule.output))
+            workspace_id = ids.workspace_id
+            unique_id = ids.unique_id
+
             # Get input data for a rule.
             # Note:
             #   - Check if all node data can be successfully retrieved.
             #     If there is an error in any node, an AssertionError is generated here.
             #   - read_input_info() is used to determine if there is an error,
             #     and the return value is not used here.
-            Runner.read_input_info(__rule.input)
+            _ = Runner.read_input_info(__rule.input)
 
             # Operate remote storage.
             if RemoteStorageController.is_available():
-                # Get workspace_id, unique_id from output file path
-                ids = ExptOutputPathIds(dirname(__rule.output))
-                workspace_id = ids.workspace_id
-                unique_id = ids.unique_id
-
                 # Delete lock file created at the start of workflow.
                 RemoteSyncLockFileUtil.delete_sync_lock_file(workspace_id, unique_id)
 
@@ -88,6 +88,12 @@ class PostProcessRunner:
 
             # save msg for GUI
             PickleWriter.write(__rule.output, err_msg)
+
+        finally:
+            # Operate remote storage.
+            if RemoteStorageController.is_available():
+                # Just to be safe, make sure to delete the sync_lock_file.
+                RemoteSyncLockFileUtil.delete_sync_lock_file(workspace_id, unique_id)
 
 
 if __name__ == "__main__":

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -60,7 +60,7 @@ def _snakemake_execute_process(
         ]
     )
 
-    result = snakemake(
+    snakemake_result = snakemake(
         DIRPATH.SNAKEMAKE_FILEPATH,
         forceall=params.forceall,
         cores=params.cores,
@@ -71,7 +71,7 @@ def _snakemake_execute_process(
         log_handler=[smk_logger.log_handler],
     )
 
-    if result:
+    if snakemake_result:
         logger.info("snakemake_execute succeeded.")
     else:
         logger.error("snakemake_execute failed..")
@@ -82,20 +82,31 @@ def _snakemake_execute_process(
     # Snakemake execution post process
     # ------------------------------------------------------------
 
-    # Update workflow processing results
-    asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+    try:
+        # Update workflow processing results
+        try:
+            asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+        except Exception as e:
+            logger.error(
+                f"snakemake_execute post process (WorkflowResult) failed: {e}",
+                exc_info=True,
+            )
 
-    # Update experiment database record
-    if ExperimentRecordService.is_available():
-        ExperimentRecordService.regist_record_on_workflow_completed(
+        # Update experiment database record
+        if ExperimentRecordService.is_available():
+            ExperimentRecordService.regist_record_on_workflow_completed(
+                workspace_id, unique_id
+            )
+
+        # Data usage calculation
+        WorkspaceDataCapacityService.update_experiment_data_usage(
             workspace_id, unique_id
         )
-
-    # Data usage calculation
-    WorkspaceDataCapacityService.update_experiment_data_usage(workspace_id, unique_id)
+    except Exception as e:
+        logger.error(f"snakemake_execute post process failed: {e}", exc_info=True)
 
     # result error handling
-    if not result:
+    if not snakemake_result:
         # Operate remote storage.
         if RemoteStorageController.is_available():
             # force delete sync lock file
@@ -113,7 +124,7 @@ def _snakemake_execute_process(
                 RemoteSyncAction.UPLOAD,
             )
 
-    return result
+    return snakemake_result
 
 
 def delete_dependencies(


### PR DESCRIPTION
### Content

Improved error handling in workflow post_process
- Adjusted the post_process node to ensure that the remote sync lock file is deleted.
- Improved the try-except in the snakemake_executor post process.

### Testcase

- [x] Verify that the workflow that caused the error has been released from sync lock.
  - Procedure
    - 1\. End Tutorial 1 with an error. 
        *An error will occur if the input data or params are invalid.
    - 2\. Verify that the following operations are possible for the workflow that caused the error.
        *If a sync lock remains, each operation is locked.
        - [x] 1. The workflow can be re-run.
        - [x] 2. The record can be deleted.