### PR TITLE
[Dataview] Added authentication specific to outputs requests

### DIFF
--- a/frontend/src/utils/DataviewUtils.ts
+++ b/frontend/src/utils/DataviewUtils.ts
@@ -1,0 +1,16 @@
+/**
+ * Checks whether the request is for public outputs from the Dataview screen.
+ */
+export const isDataviewPublicOutputsRequest = (url: string): boolean => {
+  // Check if we're on the public dataview screen from path
+  const path = window.location.pathname
+  const isPublicDataviewPage =
+    path === "/" || (path === "/dataview" && !path.includes("/console"))
+
+  // Checks whether the request is to the outputs API
+  const isOutputsApi = !!url && url.includes("/outputs/")
+
+  return isPublicDataviewPage && isOutputsApi
+}
+
+export const DATAVIEW_PUBLIC_REQUEST_KEY = "DATAVIEW_PUBLIC_REQUEST"

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -3,6 +3,10 @@ import axiosLibrary from "axios"
 import { refreshTokenApi } from "api/auth/Auth"
 import { BASE_URL } from "const/API"
 import { getExToken, getToken, logout, saveToken } from "utils/auth/AuthUtils"
+import {
+  isDataviewPublicOutputsRequest,
+  DATAVIEW_PUBLIC_REQUEST_KEY,
+} from "utils/DataviewUtils"
 
 const axios = axiosLibrary.create({
   baseURL: BASE_URL,
@@ -13,6 +17,12 @@ axios.interceptors.request.use(
   async (config) => {
     config.headers!.Authorization = `Bearer ${getToken()}`
     config.headers!.ExToken = getExToken()
+
+    // Check whether the access is to public output data (HTTP header setting)
+    if (config.url && isDataviewPublicOutputsRequest(config.url)) {
+      config.headers![DATAVIEW_PUBLIC_REQUEST_KEY] = "true"
+    }
+
     return config
   },
   (error) => Promise.reject(error),

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -122,9 +122,9 @@ def skip_dependencies():
 
 if MODE.IS_STANDALONE:
     app.dependency_overrides[get_current_user] = skip_dependencies
-    app.dependency_overrides[get_current_user_with_dataview_outputs_check] = (
-        skip_dependencies
-    )
+    app.dependency_overrides[
+        get_current_user_with_dataview_outputs_check
+    ] = skip_dependencies
     app.dependency_overrides[get_admin_user] = skip_dependencies
     app.dependency_overrides[is_workspace_owner] = skip_dependencies
     app.dependency_overrides[is_workspace_available] = skip_dependencies

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -12,6 +12,7 @@ from starlette.middleware.cors import CORSMiddleware
 from studio.app.common.core.auth.auth_dependencies import (
     get_admin_user,
     get_current_user,
+    get_current_user_with_dataview_outputs_check,
 )
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
@@ -96,8 +97,8 @@ app.include_router(experiment.router, dependencies=[Depends(get_current_user)])
 app.include_router(files.router, dependencies=[Depends(get_current_user)])
 app.include_router(logs.router, dependencies=[Depends(get_current_user)])
 app.include_router(
-    outputs.router
-)  # NOTE: Deauthentication for for-cloud Dataview functionality.
+    outputs.router, dependencies=[Depends(get_current_user_with_dataview_outputs_check)]
+)  # NOTE: The outputs router uses the unique get_current_user.
 app.include_router(params.router, dependencies=[Depends(get_current_user)])
 app.include_router(run.router, dependencies=[Depends(get_current_user)])
 app.include_router(users_admin.router, dependencies=[Depends(get_admin_user)])
@@ -121,6 +122,9 @@ def skip_dependencies():
 
 if MODE.IS_STANDALONE:
     app.dependency_overrides[get_current_user] = skip_dependencies
+    app.dependency_overrides[get_current_user_with_dataview_outputs_check] = (
+        skip_dependencies
+    )
     app.dependency_overrides[get_admin_user] = skip_dependencies
     app.dependency_overrides[is_workspace_owner] = skip_dependencies
     app.dependency_overrides[is_workspace_available] = skip_dependencies

--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Optional
 
-from fastapi import Depends, HTTPException, Response, status
+from fastapi import Depends, HTTPException, Request, Response, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from firebase_admin import auth as firebase_auth
 from pydantic import ValidationError
@@ -12,6 +12,7 @@ from sqlmodel import Session, select
 
 from studio.app.common.core.auth.auth_config import AUTH_CONFIG
 from studio.app.common.core.auth.security import validate_access_token
+from studio.app.common.core.dataview.dataview_services import DataviewService
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.db.database import get_db
@@ -20,6 +21,36 @@ from studio.app.common.models import UserRole as UserRoleModel
 from studio.app.common.models.experiment import ExperimentRecord
 from studio.app.common.models.workspace import Workspace
 from studio.app.common.schemas.users import User
+
+
+async def get_current_user_with_dataview_outputs_check(
+    req: Request,
+    res: Response,
+    ex_token: Optional[str] = Depends(APIKeyHeader(name="ExToken", auto_error=False)),
+    credential: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+    db: Session = Depends(get_db),
+) -> User:
+    """
+    Authentication process specialized for outputs requests from the dataview screen
+    """
+
+    # Checks whether public outputs are accessed from a dataview
+    if DataviewService.is_dataview_public_outputs_request(req):
+        is_allowed_access = DataviewService.validate_dataview_public_outputs_request(
+            req, db
+        )
+
+        if is_allowed_access:
+            # To access public resources, skip authentication (return)
+            return
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This resource is not publicly available.",
+            )
+
+    # Fallback to get_current_user()
+    return await get_current_user(res, ex_token, credential, db)
 
 
 async def get_current_user(

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -1,10 +1,12 @@
 import os
+import re
 from pathlib import Path
 from typing import List
 
+from fastapi import Request
 from sqlmodel import Session, delete
 
-from studio.app.common.core.experiment.experiment import ExptConfig
+from studio.app.common.core.experiment.experiment import ExptConfig, ExptOutputPathIds
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_record_services import (
     ExperimentRecordService,
@@ -29,10 +31,17 @@ logger = AppLogger.get_logger()
 
 
 class DataviewService:
+    DATAVIEW_PUBLIC_REQUEST_KEY = "DATAVIEW_PUBLIC_REQUEST"
+    OUTPUTS_URL_PREFIX = r"^/outputs/[^/]+/"
+    OUTPUTS_IMAGE_URL_PREFIX = r"^/outputs/image/"
+
     @classmethod
     def find_published_dataview_record(
         cls, db: Session, workspace_id: int, unique_id: str
     ) -> ExperimentRecord:
+        """
+        Search for a published experiment_record that matches the specified id
+        """
         record: ExperimentRecord = (
             db.query(ExperimentRecord)
             .join(
@@ -51,9 +60,42 @@ class DataviewService:
         return record
 
     @classmethod
+    def find_published_dataview_record_input(
+        cls, db: Session, workspace_id: int, input_path: str
+    ) -> ExperimentRecord:
+        """
+        Search for an experiment_record that contains the specified input data
+        """
+
+        record: ExperimentRecord = (
+            db.query(ExperimentRecord)
+            .join(
+                Workspace,
+                Workspace.id == ExperimentRecord.workspace_id,
+            )
+            .filter(
+                Workspace.deleted.is_(False),
+                ExperimentRecord.workspace_id == int(workspace_id),
+                ExperimentRecord.publish_status == PublishStatus.on.value,
+                ExperimentRecord.thumbnails["image_url"].as_string() == input_path,
+                # > Note: input data does not depend on unique_id (shared within
+                # >   a workspace), so it is determined by workspace_id only.
+                # models.ExperimentRecord.uid == unique_id,
+            )
+            .first()
+        )
+
+        return record
+
+    @classmethod
     def find_user_owned_dataview_record(
         cls, db: Session, record_id: int, user_id: int
     ) -> ExperimentRecord:
+        """
+        Search for the experiment_record
+          that belongs to the specified record_id and user_id
+        """
+
         record: ExperimentRecord = (
             db.query(ExperimentRecord)
             .join(
@@ -73,6 +115,81 @@ class DataviewService:
         )
 
         return record
+
+    @classmethod
+    def is_dataview_public_outputs_request(cls, req: Request) -> bool:
+        """
+        Check whether the access is to public output data (HTTP header check)
+        """
+
+        has_public_request_header = (
+            cls.DATAVIEW_PUBLIC_REQUEST_KEY.lower() in req.headers
+        )
+        is_outputs_request = re.match(cls.OUTPUTS_URL_PREFIX, req.url.path)
+
+        return has_public_request_header and is_outputs_request
+
+    @classmethod
+    def validate_dataview_public_outputs_request(
+        cls, req: Request, db: Session
+    ) -> bool:
+        """
+        Validate requests for public outputs data
+        *Deny access to private outputs data
+        """
+
+        if not cls.is_dataview_public_outputs_request(req):
+            return False
+
+        request_url_path = req.url.path
+        data_file_path = re.sub(cls.OUTPUTS_URL_PREFIX, "", request_url_path)
+        is_allowed_access = False
+
+        # Request case for output data
+        if data_file_path.startswith(DIRPATH.OUTPUT_DIR):
+            # Note: Processing specific paths of some data
+            data_file_path = re.sub(
+                r"/tiff/mc_images.*$", "", data_file_path
+            )  # output of caiman_mc
+
+            ids = ExptOutputPathIds(os.path.dirname(data_file_path))
+
+            # Check whether the data is in a public record
+            record = DataviewService.find_published_dataview_record(
+                db, int(ids.workspace_id), ids.unique_id
+            )
+            is_allowed_access = record is not None
+
+        # Request case for input data
+        else:
+            ids = None
+            query_params = dict(req.query_params)
+            workspace_id = query_params.get("workspace_id")
+
+            # For image data
+            if re.match(cls.OUTPUTS_IMAGE_URL_PREFIX, request_url_path):
+                # Check whether the data is in a public record
+                record = cls.find_published_dataview_record_input(
+                    db, workspace_id, data_file_path
+                )
+                is_allowed_access = record is not None
+
+            # For other data
+            else:
+                """
+                Currently (2025-9), this feature does not support validation
+                  of data other than images.
+                - This is because information about input data other than images is not
+                  stored in experiment_records (a specification change is required).
+                - While validation will need to be strengthened in the future,
+                  the initial version will only validate images
+                  (since most preview requests are images).
+                """
+
+                # Force Allow Access
+                is_allowed_access = True
+
+        return is_allowed_access
 
     @classmethod
     def multiple_publish_dataview_records(

--- a/studio/tests/app/conftest.py
+++ b/studio/tests/app/conftest.py
@@ -21,9 +21,9 @@ from studio.app.dir_path import DIRPATH
 def session_fixture():
     app.dependency_overrides[get_admin_user] = skip_dependencies
     app.dependency_overrides[get_current_user] = skip_dependencies
-    app.dependency_overrides[get_current_user_with_dataview_outputs_check] = (
-        skip_dependencies
-    )
+    app.dependency_overrides[
+        get_current_user_with_dataview_outputs_check
+    ] = skip_dependencies
     app.dependency_overrides[is_workspace_available] = skip_dependencies
     app.dependency_overrides[is_workspace_owner] = skip_dependencies
 

--- a/studio/tests/app/conftest.py
+++ b/studio/tests/app/conftest.py
@@ -8,6 +8,7 @@ from studio.__main_unit__ import app, skip_dependencies
 from studio.app.common.core.auth.auth_dependencies import (
     get_admin_user,
     get_current_user,
+    get_current_user_with_dataview_outputs_check,
 )
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
@@ -20,6 +21,9 @@ from studio.app.dir_path import DIRPATH
 def session_fixture():
     app.dependency_overrides[get_admin_user] = skip_dependencies
     app.dependency_overrides[get_current_user] = skip_dependencies
+    app.dependency_overrides[get_current_user_with_dataview_outputs_check] = (
+        skip_dependencies
+    )
     app.dependency_overrides[is_workspace_available] = skip_dependencies
     app.dependency_overrides[is_workspace_owner] = skip_dependencies
 


### PR DESCRIPTION
### Content

Added authentication process specific to outputs requests from the dataview screen

- Requests to the outputs API needed to be referenced from the public dataview screen, and in the initial development version of dataview, authentication for the outputs API was temporarily disabled.
- This PR fix adds authentication processing specific to the outputs API, maintaining normal authentication while also supporting requests from the public dataview screen (no authentication required).

### Testcase

#### multiuser mode

  - Public Dataview (non-sign in)
    - [ ] List, Publish operation
    - [ ] Popup ... InputsDialog, OutputsDialog, DetailsDialog
  - Console Dataview
    - [ ] List, Publish operation
    - [ ] Popup ... InputsDialog, OutputsDialog, DetailsDialog
  - Run Workflow (Creating an experiments_records record)
    - [ ] Workflow Run is successful
    - [ ] The record is displayed on the Dataview Screen.
  - Visualize
    - [ ] Each output can be plotted successfully

#### standalone mode

  - Visualize
    - [ ] Each output can be plotted successfully

#### Check for invalid requests

*This cannot be confirmed from the UI, so skip it in this test case.
You can also check this by temporarily editing the source code below.

  1. Edit frontend/src/utils/axios.ts
      - Comment out the following:
         `config.headers![DATAVIEW_PUBLIC_REQUEST_KEY] = "true"`
  2. Access the public dataview screen. If all input and output requests are rejected, authentication is enabled.