### PR TITLE
Insert Subscription User when creating user from account manager

### DIFF
--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -142,12 +142,12 @@ class CheckoutService:
         )
 
     @staticmethod
-    def calculate_expiration_date(billing_cycle: int) -> datetime:
+    def calculate_expiration_date(billing_cycle: int = 1) -> datetime:
         """
         Calculate subscription expiration date based on billing cycle
 
         Args:
-            billing_cycle: Billing cycle in months
+            billing_cycle: Billing cycle in months (default: 1)
 
         Returns:
             Expiration datetime

--- a/studio/app/common/core/subscription/subscription_service.py
+++ b/studio/app/common/core/subscription/subscription_service.py
@@ -135,12 +135,20 @@ class SubscriptionService:
             return False
 
         # Find the most recent purchase that matches or came before this subscription
-        latest_purchase = (
-            db.query(SubscriptionUserPurchase)
+        latest_purchase, user = (
+            db.query(SubscriptionUserPurchase, User)
+            .join(
+                User,
+                SubscriptionUserPurchase.user_id == User.id,
+            )
             .filter(
-                SubscriptionUserPurchase.user_id == user_id,
-                SubscriptionUserPurchase.plan_id == active_subscription.plan_id,
-                SubscriptionUserPurchase.created_at <= active_subscription.created_at,
+                and_(
+                    SubscriptionUserPurchase.user_id == user_id,
+                    SubscriptionUserPurchase.plan_id == active_subscription.plan_id,
+                    SubscriptionUserPurchase.created_at
+                    <= active_subscription.created_at,
+                    User.active.is_(True),
+                )
             )
             .order_by(SubscriptionUserPurchase.created_at.desc())
             .first()
@@ -213,40 +221,45 @@ class SubscriptionService:
     @staticmethod
     def get_user_subscription_purchase(
         db: Session, user_id: int
-    ) -> Optional[SubscriptionUserPurchase]:
+    ) -> Optional[Tuple[SubscriptionUserPurchase, User]]:
         return (
-            db.query(SubscriptionUserPurchase)
-            .filter(SubscriptionUserPurchase.user_id == user_id)
+            db.query(SubscriptionUserPurchase, User)
+            .join(
+                User,
+                SubscriptionUserPurchase.user_id == User.id,
+            )
+            .filter(
+                and_(
+                    SubscriptionUserPurchase.user_id == user_id,
+                    User.active.is_(True),
+                )
+            )
             .order_by(SubscriptionUserPurchase.created_at.desc())
             .first()
         )
 
     @staticmethod
-    def get_user_expired_subscription(
-        db: Session, user_id: int
-    ) -> common_model.UserSubscription:
+    def get_user_expired_subscription(db: Session, user_id: int) -> UserSubscription:
         return (
             db.query(
-                common_model.UserSubscription,
-                common_model.SubscriptionPlans,
-                common_model.User,
+                UserSubscription,
+                SubscriptionPlans,
+                User,
             )
             .join(
-                common_model.SubscriptionPlans,
-                common_model.UserSubscription.plan_id
-                == common_model.SubscriptionPlans.id,
+                SubscriptionPlans,
+                UserSubscription.plan_id == SubscriptionPlans.id,
             )
             .join(
-                common_model.User,
-                common_model.UserSubscription.user_id == common_model.User.id,
+                User,
+                UserSubscription.user_id == User.id,
             )
             .filter(
-                common_model.UserSubscription.user_id == user_id,
-                common_model.UserSubscription.expiration
-                <= __class__.get_current_datetime(),
-                common_model.User.active.is_(True),
+                UserSubscription.user_id == user_id,
+                UserSubscription.expiration <= __class__.get_current_datetime(),
+                User.active.is_(True),
             )
-            .order_by(common_model.UserSubscription.expiration.desc())
+            .order_by(UserSubscription.expiration.desc())
             .first()
         )
 
@@ -272,13 +285,19 @@ class SubscriptionService:
         try:
             subscription = (
                 db.query(UserSubscription)
-                .filter(UserSubscription.user_id == user_id)
+                .join(User, UserSubscription.user_id == User.id)
+                .filter(
+                    and_(
+                        UserSubscription.user_id == user_id,
+                        User.active.is_(True),
+                    )
+                )
                 .first()
             )
 
             if subscription:
                 subscription.scheduled_downgrade = scheduled
-                db.commit()
+            db.commit()
         except Exception as e:
             db.rollback()
             logger.error(
@@ -299,9 +318,13 @@ class SubscriptionService:
             # Get existing subscription
             subscription = (
                 db.query(UserSubscription)
+                .join(User, UserSubscription.user_id == User.id)
                 .filter(
-                    UserSubscription.user_id == user_id,
-                    UserSubscription.expiration > __class__.get_current_datetime(),
+                    and_(
+                        UserSubscription.user_id == user_id,
+                        UserSubscription.expiration > __class__.get_current_datetime(),
+                        User.active.is_(True),
+                    )
                 )
                 .first()
             )

--- a/studio/app/common/core/subscription/subscription_service.py
+++ b/studio/app/common/core/subscription/subscription_service.py
@@ -177,6 +177,17 @@ class SubscriptionService:
         )
 
     @staticmethod
+    def get_user_subscription_purchase(
+        db: Session, user_id: int
+    ) -> Optional[SubscriptionUserPurchase]:
+        return (
+            db.query(SubscriptionUserPurchase)
+            .filter(SubscriptionUserPurchase.user_id == user_id)
+            .order_by(SubscriptionUserPurchase.created_at.desc())
+            .first()
+        )
+
+    @staticmethod
     def get_user_expired_subscription(
         db: Session, user_id: int
     ) -> common_model.UserSubscription:

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -168,7 +168,7 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
             active=True,
         )
         db.add(user_db)
-        db.flush()  # Get user_db.id
+        db.flush()
 
         await set_role(db, user_id=user_db.id, role_id=data.role_id, auto_commit=False)
 

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -158,7 +158,7 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
 
     try:
         # Create Firebase user
-        firebase_user = firebase_auth.create_user(
+        firebase_user: UserRecord = firebase_auth.create_user(
             email=data.email, password=data.password
         )
 

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from enum import IntEnum
 
+from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from fastapi_pagination.ext.sqlmodel import paginate
 from firebase_admin import auth as firebase_auth
@@ -193,7 +194,10 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
         subscription = UserSubscription(
             plan_id=SubscriptionType.FREE,
             user_id=user_db.id,
-            expiration=datetime.now(timezone.utc) + timedelta(days=30),  # Fixed!
+            expiration=datetime.now(timezone.utc)
+            + relativedelta(
+                months=1
+            ),  # 1 month is fixed since it just a new created user
         )
         db.add(subscription)
 

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import IntEnum
+
 from fastapi import HTTPException
 from fastapi_pagination.ext.sqlmodel import paginate
 from firebase_admin import auth as firebase_auth
@@ -153,28 +154,28 @@ async def list_user(
 
 
 async def create_user(db: Session, data: UserCreate, organization_id: int):
+    firebase_user = None
+
     try:
-        # create firebase user
-        user: UserRecord = firebase_auth.create_user(
+        # Create Firebase user
+        firebase_user = firebase_auth.create_user(
             email=data.email, password=data.password
         )
 
-        # create application db user
+        # Create application DB user
         user_db = UserModel(
-            uid=user.uid,
-            email=user.email,
+            uid=firebase_user.uid,
+            email=firebase_user.email,
             name=data.name,
             organization_id=organization_id,
             active=True,
         )
-        # it may be possible to specify the organization_id externally in the future
         db.add(user_db)
-        db.flush()
-        await set_role(db, user_id=user_db.id, role_id=data.role_id, auto_commit=False)
-        db.commit()
-        user_db.__dict__["role_id"] = data.role_id
+        db.flush()  # Get user_db.id
 
-        # create remote_storage bucket
+        await set_role(db, user_id=user_db.id, role_id=data.role_id, auto_commit=False)
+
+        # Create remote storage bucket
         if RemoteStorageController.is_available():
             new_bucket_name = RemoteStorageController.create_user_bucket_name(
                 id=user_db.id
@@ -185,24 +186,42 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
             ) as remote_storage_controller:
                 await remote_storage_controller.create_bucket()
 
-            # store bucket info in user record
             user_db.attributes = {"remote_bucket_name": new_bucket_name}
-            db.flush()
-            db.commit()
-        # create subscription user record
+
+        # Create subscription user record
         subscription = UserSubscription(
-            plan_id=SubscriptionType.FREE,  # Default to free plan
+            plan_id=SubscriptionType.FREE,
             user_id=user_db.id,
-            expiration=datetime.now() - timedelta(days=1),
+            expiration=datetime.now(timezone.utc) + timedelta(days=30),  # Fixed!
         )
         db.add(subscription)
-        db.flush()
+
+        # Commit all changes
         db.commit()
 
+        # Add role_id for response (if needed)
+        user_db.__dict__["role_id"] = data.role_id
+
         return User.from_orm(user_db)
+
     except Exception as e:
-        logger.error(e, exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.error(f"Failed to create user: {e}", exc_info=True)
+
+        # Rollback database
+        db.rollback()
+
+        # Cleanup Firebase user if created
+        if firebase_user:
+            try:
+                firebase_auth.delete_user(firebase_user.uid)
+                logger.info(f"Cleaned up Firebase user: {firebase_user.uid}")
+            except Exception as cleanup_error:
+                logger.error(f"Failed to cleanup Firebase user: {cleanup_error}")
+
+        # Return appropriate error
+        if isinstance(e, ValueError):
+            raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=500, detail="Failed to create user")
 
 
 async def update_user(

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -1,7 +1,3 @@
-from datetime import datetime, timezone
-from enum import IntEnum
-
-from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from fastapi_pagination.ext.sqlmodel import paginate
 from firebase_admin import auth as firebase_auth
@@ -16,7 +12,11 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteStorageSimpleWriter,
 )
+from studio.app.common.core.subscription.checkout_service import CheckoutService
 from studio.app.common.core.subscription.stripe_service import StripeService
+from studio.app.common.core.subscription.subscription_service import (
+    SubscriptionUserStatus,
+)
 from studio.app.common.core.workspace.workspace_services import WorkspaceService
 from studio.app.common.models import Role as RoleModel
 from studio.app.common.models import User as UserModel
@@ -35,11 +35,6 @@ from studio.app.common.schemas.users import (
 )
 
 logger = AppLogger.get_logger()
-
-
-class SubscriptionType(IntEnum):
-    FREE = 1
-    BASIC = 2
 
 
 async def set_role(db: Session, user_id: int, role_id: int, auto_commit=True):
@@ -192,11 +187,10 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
 
         # Create subscription user record
         subscription = UserSubscription(
-            plan_id=SubscriptionType.FREE,
+            plan_id=SubscriptionUserStatus.FREE,
             user_id=user_db.id,
-            expiration=datetime.now(timezone.utc)
-            + relativedelta(
-                months=1
+            expiration=CheckoutService.calculate_expiration_date(
+                1
             ),  # 1 month is fixed since it just a new created user
         )
         db.add(subscription)

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+from enum import IntEnum
 from fastapi import HTTPException
 from fastapi_pagination.ext.sqlmodel import paginate
 from firebase_admin import auth as firebase_auth
@@ -17,6 +19,7 @@ from studio.app.common.models import Role as RoleModel
 from studio.app.common.models import User as UserModel
 from studio.app.common.models import UserRole as UserRoleModel
 from studio.app.common.models.experiment import ExperimentRecord
+from studio.app.common.models.subscription import UserSubscription
 from studio.app.common.models.workspace import Workspace
 from studio.app.common.schemas.auth import UserAuth
 from studio.app.common.schemas.base import SortOptions
@@ -29,6 +32,11 @@ from studio.app.common.schemas.users import (
 )
 
 logger = AppLogger.get_logger()
+
+
+class SubscriptionType(IntEnum):
+    FREE = 1
+    BASIC = 2
 
 
 async def set_role(db: Session, user_id: int, role_id: int, auto_commit=True):
@@ -181,6 +189,15 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
             user_db.attributes = {"remote_bucket_name": new_bucket_name}
             db.flush()
             db.commit()
+        # create subscription user record
+        subscription = UserSubscription(
+            plan_id=SubscriptionType.FREE,  # Default to free plan
+            user_id=user_db.id,
+            expiration=datetime.now() - timedelta(days=1),
+        )
+        db.add(subscription)
+        db.flush()
+        db.commit()
 
         return User.from_orm(user_db)
     except Exception as e:

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -189,9 +189,7 @@ async def create_user(db: Session, data: UserCreate, organization_id: int):
         subscription = UserSubscription(
             plan_id=SubscriptionUserStatus.FREE,
             user_id=user_db.id,
-            expiration=CheckoutService.calculate_expiration_date(
-                1
-            ),  # 1 month is fixed since it just a new created user
+            expiration=CheckoutService.calculate_expiration_date(),
         )
         db.add(subscription)
 

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -96,6 +96,9 @@ async def get_user_subscription(
     try:
         # Get the most recent active subscription
         subscription = SubscriptionService.get_user_subscription(db, current_user.id)
+        user_purchase = SubscriptionService.get_user_subscription_purchase(
+            db, current_user.id
+        )
         logger.info(f"Fetched subscription for user {current_user.id}: {subscription}")
 
         if subscription is None:
@@ -104,7 +107,7 @@ async def get_user_subscription(
                 db, current_user.id
             )
 
-            if expired_subscription:
+            if expired_subscription and user_purchase:
                 try:
                     sub_data, plan_data, _ = expired_subscription
                     subscription_dict = {

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -96,7 +96,7 @@ async def get_user_subscription(
     try:
         # Get the most recent active subscription
         subscription = SubscriptionService.get_user_subscription(db, current_user.id)
-        user_purchase = SubscriptionService.get_user_subscription_purchase(
+        user_purchase, _ = SubscriptionService.get_user_subscription_purchase(
             db, current_user.id
         )
         logger.info(f"Fetched subscription for user {current_user.id}: {subscription}")


### PR DESCRIPTION
### Content
When the user is created from account manager.
It will create a record on subscription_user table also.

This prevents the data to be incorrect. If there is a user data there will always be a subscription status data for the user.

### Testcase

Action (Working test) :
- Login with an admin account.
- Create a user test

Action (Failed Test):
- Login with an admin account.
- Change the code after creating user to raise an error. (studio/app/common/core/users/crud_users.py)
- Create a user

To Check:

- [x] check the users table if the new created user exists
- [x] check subscription_users table if the new created user is created with plan_id = 1 (Free) and expiration date of current date.
- [x] subscription_users table user_id is correct the users table
- [x] if subscription users fails would creating users record rollback?
