### PR TITLE
Fix subscription plans layout during checkouts

### DIFF
--- a/frontend/src/pages/Invoice/CardBrandIcon.tsx
+++ b/frontend/src/pages/Invoice/CardBrandIcon.tsx
@@ -25,7 +25,7 @@ const CardBrandIcon: React.FC<CardBrandIconProps> = ({ brand, size = 32 }) => {
       case "diners club":
         return "/images/card-brands/diners.png"
       case "unionpay":
-        return "/images/card-brands/unionpay.png"
+        return "/images/card-brands/union.png"
       default:
         return "/images/card-brands/default.png"
     }

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -158,6 +158,14 @@ app.mount(
     name="static",
 )
 
+# Mount images directory for card brand icons and other images
+os.makedirs(f"{DIRPATH.FRONTEND_DIRS.BUILD}/images", exist_ok=True)
+app.mount(
+    "/images",
+    StaticFiles(directory=f"{DIRPATH.FRONTEND_DIRS.BUILD}/images"),
+    name="images",
+)
+
 public_templates = Jinja2Templates(directory=DIRPATH.FRONTEND_DIRS.PUBLIC)
 build_templates = Jinja2Templates(directory=DIRPATH.FRONTEND_DIRS.BUILD)
 

--- a/studio/alembic/versions/af8c4144cd54_add_stripe_integration_tables.py
+++ b/studio/alembic/versions/af8c4144cd54_add_stripe_integration_tables.py
@@ -34,6 +34,8 @@ def upgrade() -> None:
         sa.Column("features", sa.JSON(), nullable=False),
         sa.Column("currency", mysql.TINYINT(unsigned=True), nullable=False),
         sa.Column("status", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("stripe_product_id", sa.String(length=255), nullable=True),
+        sa.Column("stripe_price_id", sa.String(length=255), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(),
@@ -109,7 +111,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column(
-            "name", sa.String(length=50), nullable=False
+            "name", sa.String(length=100), nullable=False
         ),  # e.g "stripe", "paypal"
         sa.Column(
             "created_at",
@@ -265,7 +267,8 @@ def upgrade() -> None:
     op.execute(
         """
 INSERT INTO subscription_plans
-(id, name, price, billing_cycle, features, currency, status, created_at)
+(id, name, price, billing_cycle, features, currency, status, stripe_product_id,
+ stripe_price_id, created_at)
 VALUES
 (1, 'Free', 0, 1, JSON_OBJECT(
     'Free', JSON_ARRAY(
@@ -276,7 +279,7 @@ VALUES
         JSON_OBJECT('text', 'Basic data storage of 5GB', 'isPremium', false),
         JSON_OBJECT('text', 'Standard processing speed', 'isPremium', false)
     )
-), 1, 1, NOW()),
+), 1, 1, 'prod_TPVTq7ZyjIAyn6', 'price_1SSgSLF4TJpWTMN0uqc6IPZr', NOW()),
 (2, 'Premium', 2000, 1, JSON_OBJECT(
     'Premium', JSON_ARRAY(
         JSON_OBJECT('text', 'Basic compute access with fair-use limitations',
@@ -291,7 +294,7 @@ VALUES
         JSON_OBJECT('text', 'Advanced features like extended job history',
                    'isPremium', true)
     )
-), 1, 1, NOW())
+), 1, 1, 'prod_TPXFOLnvKR5kRr', 'price_1SSiBSF4TJpWTMN0ivAKTfbq', NOW())
 """
     )
 

--- a/studio/alembic/versions/af8c4144cd54_add_stripe_integration_tables.py
+++ b/studio/alembic/versions/af8c4144cd54_add_stripe_integration_tables.py
@@ -262,41 +262,7 @@ def upgrade() -> None:
         sa.Index("idx_subscription_cancellations_cancelled_at", "cancelled_at"),
     )
 
-    # Insert initial data
-    # Insert subscription plans
-    op.execute(
-        """
-INSERT INTO subscription_plans
-(id, name, price, billing_cycle, features, currency, status, stripe_product_id,
- stripe_price_id, created_at)
-VALUES
-(1, 'Free', 0, 1, JSON_OBJECT(
-    'Free', JSON_ARRAY(
-        JSON_OBJECT('text', 'Basic compute access with fair-use limitations',
-                   'isPremium', false),
-        JSON_OBJECT('text', 'Standard support through documentation and community',
-                   'isPremium', false),
-        JSON_OBJECT('text', 'Basic data storage of 5GB', 'isPremium', false),
-        JSON_OBJECT('text', 'Standard processing speed', 'isPremium', false)
-    )
-), 1, 1, 'prod_TPVTq7ZyjIAyn6', 'price_1SSgSLF4TJpWTMN0uqc6IPZr', NOW()),
-(2, 'Premium', 2000, 1, JSON_OBJECT(
-    'Premium', JSON_ARRAY(
-        JSON_OBJECT('text', 'Basic compute access with fair-use limitations',
-                   'isPremium', false),
-        JSON_OBJECT('text', 'Standard support through documentation and community',
-                   'isPremium', false),
-        JSON_OBJECT('text', 'Priority compute access with guaranteed allocation',
-                   'isPremium', true),
-        JSON_OBJECT('text', 'Upgraded data storage of 200GB', 'isPremium', true),
-        JSON_OBJECT('text', 'Enhanced support including direct assistance',
-                   'isPremium', true),
-        JSON_OBJECT('text', 'Advanced features like extended job history',
-                   'isPremium', true)
-    )
-), 1, 1, 'prod_TPXFOLnvKR5kRr', 'price_1SSiBSF4TJpWTMN0ivAKTfbq', NOW())
-"""
-    )
+    # Initial data should be inserted manually following SUBSCRIPTION_PLANS_SETUP.md
 
 
 def downgrade() -> None:

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -7,9 +7,7 @@ from fastapi import HTTPException
 from sqlmodel import Enum, Session
 
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.subscription.subscription_service import (
-    SubscriptionService,
-)
+from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.models.subscription import (
     SubscriptionPlans,
     SubscriptionProvider,

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -423,7 +423,7 @@ class CheckoutService:
                 )
 
                 checkout_session = stripe.checkout.Session.create(
-                    payment_method_types=["card"],
+                    payment_method_types=["card", "link"],
                     line_items=[
                         {
                             "price": plan.stripe_price_id,
@@ -442,15 +442,6 @@ class CheckoutService:
                         "user_id": str(user.id),
                         "plan_id": request.plan_id,
                         "plan_name": plan.name,
-                    },
-                    # Enable automatic tax calculation
-                    automatic_tax={"enabled": True},
-                    # Collect customer's billing address for tax calculation
-                    billing_address_collection="required",
-                    # Save the address to the customer for future use
-                    customer_update={
-                        "address": "auto",
-                        "shipping": "auto",
                     },
                 )
 

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from http.client import HTTPException
 from typing import Any, Dict, Optional
 
 import stripe
 from dateutil.relativedelta import relativedelta
+from fastapi import HTTPException
 from sqlmodel import Enum, Session
 
 from studio.app.common.core.logger import AppLogger
@@ -393,16 +393,23 @@ class CheckoutService:
                     status_code=404, detail="Subscription plan not found"
                 )
 
-            # Use the price and currency from the request
-            price = plan.price
-            currency = SubscriptionCurrencyType(plan.currency).get_currency_string()
+            # Validate that the plan has Stripe product and price IDs
+            if not plan.stripe_price_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Subscription plan '{plan.name}' is not configured "
+                        f"with a Stripe price ID"
+                    ),
+                )
 
-            logger.info(f"Request details - price: {price}, currency: {currency}")
+            logger.info(
+                f"Request details - plan: {plan.name}, "
+                f"stripe_product_id: {plan.stripe_product_id}, "
+                f"stripe_price_id: {plan.stripe_price_id}"
+            )
 
-            # Determine billing cycle for Stripe (default to monthly if not specified)
-            price_interval = "month"  # You can modify this based on your needs
-
-            # Create Stripe checkout session directly with price_data
+            # Create Stripe checkout session using the price ID from the database
             try:
                 logger.info("Initializing Stripe")
                 subscription_account = CheckoutService.get_subscription_account(
@@ -422,15 +429,7 @@ class CheckoutService:
                     payment_method_types=["card"],
                     line_items=[
                         {
-                            "price_data": {
-                                "currency": currency,
-                                "product_data": {
-                                    "name": plan.name,
-                                    "description": "Subscription Plan Purchase",
-                                },
-                                "unit_amount": price,
-                                "recurring": {"interval": price_interval},
-                            },
+                            "price": plan.stripe_price_id,
                             "quantity": 1,
                         }
                     ],
@@ -446,6 +445,15 @@ class CheckoutService:
                         "user_id": str(user.id),
                         "plan_id": request.plan_id,
                         "plan_name": plan.name,
+                    },
+                    # Enable automatic tax calculation
+                    automatic_tax={"enabled": True},
+                    # Collect customer's billing address for tax calculation
+                    billing_address_collection="required",
+                    # Save the address to the customer for future use
+                    customer_update={
+                        "address": "auto",
+                        "shipping": "auto",
                     },
                 )
 

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -8,7 +8,6 @@ from sqlmodel import Enum, Session
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.subscription.subscription_service import (
-    SubscriptionCurrencyType,
     SubscriptionService,
 )
 from studio.app.common.models.subscription import (

--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -53,6 +53,16 @@ class SubscriptionPlans(SQLModel, table=True):
         sa_column=Column(BIGINT, nullable=False, default=1),  # Fixed: Use BIGINT
         description="Currency code in enum format (e.g., 1 for USD, 2 for JPY)",
     )
+    stripe_product_id: Optional[str] = Field(
+        sa_column=Column(String(255), nullable=True),
+        default=None,
+        description="Stripe product ID for this subscription plan",
+    )
+    stripe_price_id: Optional[str] = Field(
+        sa_column=Column(String(255), nullable=True),
+        default=None,
+        description="Stripe price ID for this subscription plan",
+    )
     created_at: Optional[datetime] = Field(
         sa_column_kwargs={"server_default": current_timestamp()},
     )


### PR DESCRIPTION
### Content

Before -> The products on stripe is created when the product on database is 1st time or the name is changed.
After its registered on stripe it will refer to the stripe product using its name.
It wont occur a duplication but its not best practice.

After -> The Products are created first on stripe then the id for the products are used during checkout.
This way it wont do any duplications.

### References

<img width="1294" height="457" alt="Screenshot 2025-11-13 at 11 35 28" src="https://github.com/user-attachments/assets/03759e31-12c0-465f-8b54-0437adf75178" />

### Testcase

- [x] Check if the product is created on stripe dashboard
- [x] During checkout you can check the product name, description, price is the same with product on dashboard.
- [x] Test on 2 users to upgrade if the product is not being duplicated.

- [x] Set the billing address to japan it should show the Tax of 10%
- [x] Invoice and Receipt should have the tax written with it.