### PR TITLE
Fix CardBrandIcon

### DIFF
--- a/frontend/src/pages/Invoice/CardBrandIcon.tsx
+++ b/frontend/src/pages/Invoice/CardBrandIcon.tsx
@@ -89,8 +89,24 @@ const CardBrandIcon: React.FC<CardBrandIconProps> = ({ brand, size = 32 }) => {
         onError={(e) => {
           // Fallback to default image if specific brand image fails to load
           const target = e.target as HTMLImageElement
-          if (target.src !== "/images/card-brands/default.png") {
+
+          // Check if we've already handled the error to prevent infinite loops
+          if (target.dataset.errorHandled) {
+            return
+          }
+
+          // First attempt: try default image
+          if (!target.dataset.fallbackAttempted) {
+            target.dataset.fallbackAttempted = "true"
             target.src = "/images/card-brands/default.png"
+          } else {
+            // Second attempt failed, show placeholder and mark as handled
+            target.dataset.errorHandled = "true"
+            target.style.display = "none"
+            const parent = target.parentElement
+            if (parent) {
+              parent.innerHTML = `<div style="width: ${size}px; height: ${size * 0.65}px; background-color: #6b7280; border-radius: 4px; display: flex; align-items: center; justify-content: center;"><span style="color: white; font-size: 12px; font-weight: bold;">?</span></div>`
+            }
           }
         }}
       />


### PR DESCRIPTION
### Content

If the default card icon doesnt exist it cause an infinite loop.
Therefore, I have to add measurements to prevent the infinite loop

### References

Logs:
2025-11-13 13:41:35,871 INFO:     [uvicorn.access] (pid:42) (client:default) send():478 - 10.1.27.140:29074 - "GET /images/card-brands/default.png HTTP/1.1" 200
2025-11-13 13:41:35,899 INFO:     [uvicorn.access] (pid:42) (client:default) send():478 - 10.1.27.140:29074 - "GET /images/card-brands/default.png HTTP/1.1" 200