### PR TITLE
Add Trial and Update expiration date to get from stripe

### DIFF
--- a/frontend/src/pages/Subscription/index.tsx
+++ b/frontend/src/pages/Subscription/index.tsx
@@ -598,7 +598,7 @@ const SubscriptionPlans = () => {
           {/* Data Storage Warning in Dialog */}
           <Alert severity="warning" sx={{ mb: 2 }}>
             <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-              ⚠️ Data Storage Notice:
+              Data Storage Notice:
             </Typography>
             <Typography variant="body2">
               Your premium data will be stored for <strong>30 days</strong>{" "}

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -24,6 +24,9 @@ from studio.app.common.schemas.subscriptions import (
 logger = AppLogger.get_logger()
 STRIPE_CALLBACK_URL = SubscriptionService.get_base_url()
 
+# Trial subscription configuration
+TRIAL_PERIOD_DAYS = 30  # Number of days for trial subscription period
+
 
 class SUBSCRIPTION_ACTIVE_STATUS(Enum):
     ACTIVE = "1"
@@ -438,33 +441,56 @@ class CheckoutService:
                     ).id
                 )
 
-                checkout_session = stripe.checkout.Session.create(
-                    payment_method_types=["card", "link"],
-                    line_items=[
+                # Check if user has any previous purchase history
+                previous_purchase = SubscriptionService.get_user_subscription_purchase(
+                    db, user.id
+                )
+                is_first_time_user = previous_purchase is None
+
+                # Prepare subscription parameters
+                subscription_params = {
+                    "payment_method_types": ["card", "link"],
+                    "line_items": [
                         {
                             "price": plan.stripe_price_id,
                             "quantity": 1,
                         }
                     ],
-                    mode="subscription",
-                    success_url=(
+                    "mode": "subscription",
+                    "success_url": (
                         f"{STRIPE_CALLBACK_URL}/console/subscription/thanks"
                         "?session_id={CHECKOUT_SESSION_ID}"
                     ),
-                    cancel_url=(f"{STRIPE_CALLBACK_URL}/console/subscription"),
-                    customer=customer_id,
-                    client_reference_id=str(user.id),
-                    metadata={
+                    "cancel_url": f"{STRIPE_CALLBACK_URL}/console/subscription",
+                    "customer": customer_id,
+                    "client_reference_id": str(user.id),
+                    "metadata": {
                         "user_id": str(user.id),
                         "plan_id": request.plan_id,
                         "plan_name": plan.name,
                     },
                     # Enable automatic tax calculation
-                    automatic_tax={"enabled": True},
+                    "automatic_tax": {"enabled": True},
                     # Collect customer address for tax calculation and save it
-                    billing_address_collection="required",
-                    customer_update={"address": "auto"},
-                )
+                    "billing_address_collection": "required",
+                    "customer_update": {"address": "auto"},
+                }
+
+                # Add trial period for first-time users
+                if is_first_time_user:
+                    subscription_params["subscription_data"] = {
+                        "trial_period_days": TRIAL_PERIOD_DAYS,
+                        "metadata": {
+                            "is_trial": "true",
+                            "trial_days": str(TRIAL_PERIOD_DAYS),
+                        },
+                    }
+                    logger.info(
+                        f"Adding {TRIAL_PERIOD_DAYS}-day trial for first-time user "
+                        f"{user.id}"
+                    )
+
+                checkout_session = stripe.checkout.Session.create(**subscription_params)
 
                 return CreateCheckoutSessionResponse(
                     checkout_url=checkout_session.url, session_id=checkout_session.id

--- a/studio/app/common/core/subscription/stripe_service.py
+++ b/studio/app/common/core/subscription/stripe_service.py
@@ -465,7 +465,7 @@ class StripeService:
             if not stripe_subscriptions.data:
                 raise HTTPException(
                     status_code=404,
-                    detail="No active or trialing Stripe subscription found",
+                    detail="No active or Trial Stripe subscription found",
                 )
 
             stripe_subscription = stripe_subscriptions.data[0]

--- a/studio/app/common/core/subscription/stripe_service.py
+++ b/studio/app/common/core/subscription/stripe_service.py
@@ -29,7 +29,7 @@ class StripeSubscriptionStatus(StrEnum):
 
     INCOMPLETE = "incomplete"
     INCOMPLETE_EXPIRED = "incomplete_expired"
-    TRIALING = "trialing"
+    TRIAL = "trialing"
     ACTIVE = "active"
     PAST_DUE = "past_due"
     CANCELED = "canceled"
@@ -446,7 +446,7 @@ class StripeService:
                     status_code=404, detail="No Stripe customer found for user"
                 )
 
-            # Get active or trialing Stripe subscription
+            # Get active or trial Stripe subscription
             # First try to find active subscription
             stripe_subscriptions = stripe.Subscription.list(
                 customer=customer.id,
@@ -454,11 +454,11 @@ class StripeService:
                 limit=1,
             )
 
-            # If no active subscription found, check for trialing subscription
+            # If no active subscription found, check for trial subscription
             if not stripe_subscriptions.data:
                 stripe_subscriptions = stripe.Subscription.list(
                     customer=customer.id,
-                    status=StripeSubscriptionStatus.TRIALING,
+                    status=StripeSubscriptionStatus.TRIAL,
                     limit=1,
                 )
 
@@ -595,22 +595,22 @@ class StripeService:
                 status_code=404, detail="No Stripe customer found for user"
             )
 
-        # Get active or trialing Stripe subscription
+        # Get active or trial Stripe subscription
         # First try to find active subscription
         stripe_subscriptions = stripe.Subscription.list(
             customer=customer.id, status=StripeSubscriptionStatus.ACTIVE, limit=1
         )
 
-        # If no active subscription found, check for trialing subscription
+        # If no active subscription found, check for trial subscription
         if not stripe_subscriptions.data:
             stripe_subscriptions = stripe.Subscription.list(
-                customer=customer.id, status=StripeSubscriptionStatus.TRIALING, limit=1
+                customer=customer.id, status=StripeSubscriptionStatus.TRIAL, limit=1
             )
 
         if not stripe_subscriptions.data:
             raise HTTPException(
                 status_code=404,
-                detail="No active or trialing Stripe subscription found",
+                detail="No active or trial Stripe subscription found",
             )
 
         stripe_subscription = stripe_subscriptions.data[0]

--- a/studio/app/common/core/subscription/stripe_service.py
+++ b/studio/app/common/core/subscription/stripe_service.py
@@ -29,6 +29,7 @@ class StripeSubscriptionStatus(StrEnum):
 
     INCOMPLETE = "incomplete"
     INCOMPLETE_EXPIRED = "incomplete_expired"
+    TRIALING = "trialing"
     ACTIVE = "active"
     PAST_DUE = "past_due"
     CANCELED = "canceled"
@@ -412,9 +413,7 @@ class StripeService:
         """
         try:
             # Get the new plan details
-            new_plan = stripe.SubscriptionService.get_plan_by_id(
-                db, request.new_plan_id
-            )
+            new_plan = SubscriptionService.get_plan_by_id(db, request.new_plan_id)
             if not new_plan:
                 raise HTTPException(
                     status_code=404, detail="New subscription plan not found"
@@ -447,16 +446,26 @@ class StripeService:
                     status_code=404, detail="No Stripe customer found for user"
                 )
 
-            # Get active Stripe subscription
+            # Get active or trialing Stripe subscription
+            # First try to find active subscription
             stripe_subscriptions = stripe.Subscription.list(
                 customer=customer.id,
                 status=StripeSubscriptionStatus.ACTIVE,
                 limit=1,
             )
 
+            # If no active subscription found, check for trialing subscription
+            if not stripe_subscriptions.data:
+                stripe_subscriptions = stripe.Subscription.list(
+                    customer=customer.id,
+                    status=StripeSubscriptionStatus.TRIALING,
+                    limit=1,
+                )
+
             if not stripe_subscriptions.data:
                 raise HTTPException(
-                    status_code=404, detail="No active Stripe subscription found"
+                    status_code=404,
+                    detail="No active or trialing Stripe subscription found",
                 )
 
             stripe_subscription = stripe_subscriptions.data[0]
@@ -586,14 +595,22 @@ class StripeService:
                 status_code=404, detail="No Stripe customer found for user"
             )
 
-        # Get active Stripe subscription
+        # Get active or trialing Stripe subscription
+        # First try to find active subscription
         stripe_subscriptions = stripe.Subscription.list(
             customer=customer.id, status=StripeSubscriptionStatus.ACTIVE, limit=1
         )
 
+        # If no active subscription found, check for trialing subscription
+        if not stripe_subscriptions.data:
+            stripe_subscriptions = stripe.Subscription.list(
+                customer=customer.id, status=StripeSubscriptionStatus.TRIALING, limit=1
+            )
+
         if not stripe_subscriptions.data:
             raise HTTPException(
-                status_code=404, detail="No active Stripe subscription found"
+                status_code=404,
+                detail="No active or trialing Stripe subscription found",
             )
 
         stripe_subscription = stripe_subscriptions.data[0]

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -133,24 +133,26 @@ class WebhookService:
                     .first()
                 )
 
-                logger.info(
-                    f"Webhook: Duplicate processing detected for user {user_id}, "
-                    f"session {session_id}"
-                )
-                return {
-                    "success": True,
-                    "subscription_user_id": (
-                        existing_subscription.id if existing_subscription else None
-                    ),
-                    "purchase_id": existing_purchase.id,
-                    "expiration_date": (
-                        existing_subscription.expiration
-                        if existing_subscription
-                        else None
-                    ),
-                    "message": "Subscription already processed successfully",
-                    "webhook_processed": True,
-                }
+                # Only treat as duplicate if there's an ACTIVE subscription
+                # If subscription is expired/cancelled, allow new purchase to proceed
+                if existing_subscription:
+                    logger.info(
+                        f"Webhook: Duplicate processing detected for user {user_id}, "
+                        f"session {session_id}"
+                    )
+                    return {
+                        "success": True,
+                        "subscription_user_id": existing_subscription.id,
+                        "purchase_id": existing_purchase.id,
+                        "expiration_date": existing_subscription.expiration,
+                        "message": "Subscription already processed successfully",
+                        "webhook_processed": True,
+                    }
+                else:
+                    logger.info(
+                        f"Webhook: Found recent purchase but no active subscription "
+                        f"for user {user_id}. Proceeding with new subscription."
+                    )
 
             # 2. Verify payment status from webhook data
             if payment_status != PaymentStatus.PAID:
@@ -177,10 +179,159 @@ class WebhookService:
             # 6. SET DEFAULT PAYMENT METHOD
             CheckoutService.set_default_payment_method(session_id, customer_id)
 
-            # 7. Calculate expiration date
-            expiration_date = CheckoutService.calculate_expiration_date(
-                plan.billing_cycle
-            )
+            # 7. Get expiration date from Stripe subscription
+            stripe_subscription_id = session_data.get("subscription")
+            if not stripe_subscription_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"No subscription ID found in session: {session_id}",
+                )
+
+            # Retrieve subscription from Stripe to get the current_period_end
+            try:
+                stripe_subscription = stripe.Subscription.retrieve(
+                    stripe_subscription_id
+                )
+
+                # Log the full subscription object for debugging
+                logger.info(
+                    f"Webhook: Retrieved subscription {stripe_subscription_id}, "
+                    f"status: {getattr(stripe_subscription, 'status', 'unknown')}"
+                )
+
+                # Access current_period_end - use getattr to handle both objects
+                # and dicts
+                current_period_end = getattr(
+                    stripe_subscription, "current_period_end", None
+                )
+                if current_period_end is None and isinstance(stripe_subscription, dict):
+                    current_period_end = stripe_subscription.get("current_period_end")
+
+                # Check for trial end as well (in case of trial subscriptions)
+                trial_end = getattr(stripe_subscription, "trial_end", None)
+                if trial_end is None and isinstance(stripe_subscription, dict):
+                    trial_end = stripe_subscription.get("trial_end")
+
+                # Also check current_period_start for fallback calculation
+                current_period_start = getattr(
+                    stripe_subscription, "current_period_start", None
+                )
+                if current_period_start is None and isinstance(
+                    stripe_subscription, dict
+                ):
+                    current_period_start = stripe_subscription.get(
+                        "current_period_start"
+                    )
+
+                # Debug logging to see raw values
+                logger.info(
+                    f"Webhook: Raw subscription data - "
+                    f"current_period_end: {current_period_end}, "
+                    f"trial_end: {trial_end}, "
+                    f"current_period_start: {current_period_start}, "
+                    f"created: {getattr(stripe_subscription, 'created', None)}"
+                )
+
+                logger.info(
+                    f"Webhook: Stripe subscription type: {type(stripe_subscription)}, "
+                    f"current_period_end: {current_period_end}, trial_end: {trial_end}, "
+                    f"current_period_start: {current_period_start}"
+                )
+
+                # For trial subscriptions, use trial_end.
+                # Otherwise use current_period_end
+                expiration_timestamp = None
+                if trial_end:
+                    # Subscription is in trial period
+                    expiration_timestamp = trial_end
+                    logger.info(
+                        f"Webhook: Subscription is in trial period, "
+                        f"using trial_end: {trial_end}"
+                    )
+                elif current_period_end:
+                    # Regular subscription
+                    expiration_timestamp = current_period_end
+                    logger.info(
+                        f"Webhook: Regular subscription, "
+                        f"using current_period_end: {current_period_end}"
+                    )
+                elif current_period_start:
+                    # Fallback: calculate expiration as 1 month from start
+                    # This handles edge case where subscription is just created
+                    start_date = datetime.fromtimestamp(current_period_start)
+                    expiration_date = start_date + relativedelta(months=1)
+                    expiration_timestamp = int(expiration_date.timestamp())
+                    logger.warning(
+                        f"Webhook: current_period_end not available, "
+                        f"calculated from current_period_start: {expiration_date}"
+                    )
+                else:
+                    # Final fallback: Try to get expiration from the latest invoice
+                    logger.warning(
+                        "Webhook: No period data found in subscription, "
+                        "trying to get from latest invoice"
+                    )
+                    try:
+                        latest_invoice_id = getattr(
+                            stripe_subscription, "latest_invoice", None
+                        )
+                        if latest_invoice_id:
+                            invoice = stripe.Invoice.retrieve(latest_invoice_id)
+                            lines = invoice.get("lines", {}).get("data", [])
+                            if lines:
+                                period_end = lines[0].get("period", {}).get("end")
+                                if period_end:
+                                    expiration_timestamp = period_end
+                                    logger.info(
+                                        f"Webhook: Got expiration from invoice: "
+                                        f"{datetime.fromtimestamp(period_end)}"
+                                    )
+                                else:
+                                    raise HTTPException(
+                                        status_code=400,
+                                        detail=(
+                                            f"No period end found in invoice lines for "
+                                            f"subscription: {stripe_subscription_id}"
+                                        ),
+                                    )
+                            else:
+                                raise HTTPException(
+                                    status_code=400,
+                                    detail=(
+                                        f"No invoice lines found for subscription: "
+                                        f"{stripe_subscription_id}"
+                                    ),
+                                )
+                        else:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=(
+                                    f"No expiration date found in subscription: "
+                                    f"{stripe_subscription_id}"
+                                ),
+                            )
+                    except stripe.error.StripeError as e:
+                        logger.error(f"Webhook: Error retrieving invoice: {str(e)}")
+                        raise HTTPException(
+                            status_code=500,
+                            detail=f"Error retrieving invoice: {str(e)}",
+                        )
+
+                # Convert Unix timestamp to datetime
+                expiration_date = datetime.fromtimestamp(expiration_timestamp)
+                logger.info(
+                    f"Webhook: Using expiration date from Stripe: {expiration_date} "
+                    f"(Unix timestamp: {expiration_timestamp})"
+                )
+
+            except stripe.error.StripeError as e:
+                logger.error(
+                    f"Webhook: Stripe API error retrieving subscription: {str(e)}"
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error retrieving subscription from Stripe: {str(e)}",
+                )
 
             # 8. Create or update subscription
             subscription_user_id = CheckoutService.create_or_update_subscription(
@@ -208,9 +359,13 @@ class WebhookService:
                 "session_id": session_id,
             }
 
-        except HTTPException:
+        except HTTPException as e:
+            logger.error(
+                f"Webhook: HTTPException processing checkout for session "
+                f"{session_id}: {e.detail}"
+            )
             db.rollback()
-            raise HTTPException(status_code=400, detail="Invalid webhook data")
+            raise  # Re-raise the original HTTPException with its details
         except Exception as e:
             logger.error(
                 f"Webhook: Error processing checkout success for session "
@@ -309,17 +464,40 @@ class WebhookService:
                 # Remove any scheduled downgrade
                 subscription.scheduled_downgrade = False
 
-                # Record cancellation
-                cancellation = SubscriptionCancellation(
-                    cancelled_by_user_id=user_account.user_id,
-                    purchases_id=subscription.id,
-                    reason=CancellationReason.USER_REQUEST,
-                    notes=(
-                        f"Cancelled via Stripe webhook for subscription "
-                        f"{stripe_subscription_id}"
-                    ),
+                # Find the most recent purchase for this user and plan
+                purchase = (
+                    db.query(SubscriptionUserPurchase)
+                    .filter(
+                        SubscriptionUserPurchase.user_id == user_account.user_id,
+                        SubscriptionUserPurchase.plan_id == subscription.plan_id,
+                    )
+                    .order_by(SubscriptionUserPurchase.created_at.desc())
+                    .first()
                 )
-                db.add(cancellation)
+
+                # Only record cancellation if we have a purchase record
+                if purchase:
+                    # Record cancellation
+                    cancellation = SubscriptionCancellation(
+                        cancelled_by_user_id=user_account.user_id,
+                        purchases_id=purchase.id,
+                        reason=CancellationReason.USER_REQUEST,
+                        notes=(
+                            f"Cancelled via Stripe webhook for subscription "
+                            f"{stripe_subscription_id}"
+                        ),
+                    )
+                    db.add(cancellation)
+                    logger.info(
+                        f"Recorded cancellation for user {user_account.user_id}, "
+                        f"purchase {purchase.id}"
+                    )
+                else:
+                    logger.warning(
+                        f"No purchase record found for user {user_account.user_id}, "
+                        f"plan {subscription.plan_id}. Skipping cancellation record."
+                    )
+
                 db.commit()
 
                 logger.info(f"Cancelled subscription for user {user_account.user_id}")
@@ -471,11 +649,7 @@ class WebhookService:
 
             # Extract data from webhook payload
             customer_id = invoice_data.get("customer")
-            subscription_id = (
-                invoice_data.get("parent", {})
-                .get("subscription_details", {})
-                .get("subscription")
-            )
+            subscription_id = invoice_data.get("subscription")
             payment_status = invoice_data.get("status")
             amount_paid = invoice_data.get("amount_paid", 0)
             billing_reason = invoice_data.get("billing_reason")
@@ -598,34 +772,52 @@ class WebhookService:
                     status_code=500, detail=f"Error getting subscription plan: {str(e)}"
                 )
 
-            # 4. Calculate new expiration date (extend from current expiration)
+            # 4. Get expiration date from invoice line items
             try:
-                logger.info("Webhook: Calculating new expiration date...")
+                logger.info("Webhook: Getting expiration date from invoice...")
 
                 current_expiration = user_subscription.expiration
-                billing_cycle = plan.billing_cycle
 
-                # Calculate extension period
-                if billing_cycle == BILLING_CYCLE.MONTHLY:
-                    new_expiration = current_expiration + relativedelta(months=1)
-                elif billing_cycle == BILLING_CYCLE.YEARLY:
-                    new_expiration = current_expiration + relativedelta(years=1)
-                else:
-                    # Default to monthly if unknown
-                    new_expiration = current_expiration + relativedelta(months=1)
-                    logger.warning(
-                        f"Unknown billing cycle: {billing_cycle}, defaulting to monthly"
+                # Get the period end from invoice line items
+                lines = invoice_data.get("lines", {}).get("data", [])
+                if not lines:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"No line items found in invoice: {invoice_id}",
                     )
 
+                # Get the period end from the first line item
+                period_end_timestamp = lines[0].get("period", {}).get("end")
+                if not period_end_timestamp:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"No period end found in invoice line items: "
+                            f"{invoice_id}"
+                        ),
+                    )
+
+                # Convert Unix timestamp to datetime
+                new_expiration = datetime.fromtimestamp(period_end_timestamp)
+
+                logger.info(
+                    f"Webhook: Using expiration date from invoice: {new_expiration} "
+                    f"(Unix timestamp: {period_end_timestamp})"
+                )
                 logger.info(
                     f"Webhook: Extending expiration from {current_expiration} "
                     f"to {new_expiration}"
                 )
 
+            except HTTPException:
+                raise
             except Exception as e:
-                logger.error(f"Webhook: Error calculating expiration: {str(e)}")
+                logger.error(
+                    f"Webhook: Error getting expiration from invoice: {str(e)}"
+                )
                 raise HTTPException(
-                    status_code=500, detail=f"Error calculating expiration: {str(e)}"
+                    status_code=500,
+                    detail=f"Error getting expiration from invoice: {str(e)}",
                 )
 
             # 5. Update subscription expiration

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -234,7 +234,7 @@ class WebhookService:
 
                 logger.info(
                     f"Webhook: Stripe subscription type: {type(stripe_subscription)}, "
-                    f"current_period_end: {current_period_end}, trial_end: {trial_end}, "
+                    f"current_period_end: {current_period_end}, trial_end: {trial_end},"
                     f"current_period_start: {current_period_start}"
                 )
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -650,6 +650,14 @@ class WebhookService:
             # Extract data from webhook payload
             customer_id = invoice_data.get("customer")
             subscription_id = invoice_data.get("subscription")
+
+            # If subscription_id is None, check in parent.subscription_details
+            if not subscription_id:
+                parent = invoice_data.get("parent", {})
+                if parent.get("type") == "subscription_details":
+                    subscription_details = parent.get("subscription_details", {})
+                    subscription_id = subscription_details.get("subscription")
+
             payment_status = invoice_data.get("status")
             amount_paid = invoice_data.get("amount_paid", 0)
             billing_reason = invoice_data.get("billing_reason")
@@ -694,6 +702,7 @@ class WebhookService:
             # 1. Find user by Stripe customer ID
             try:
                 logger.info(f"Webhook: Finding user by customer_id: {customer_id}")
+                logger.info(f"Webhook: Invoice ID: {invoice_id}")
 
                 user_account = (
                     db.query(SubscriptionUserAccount)
@@ -701,9 +710,16 @@ class WebhookService:
                     .first()
                 )
 
-                logger.info(f"Webhook: Query result: {user_account}")
+                logger.info(f"Webhook: User account query result: {user_account}")
 
                 if not user_account:
+                    logger.error(
+                        f"Webhook: No user account found for customer_id: {customer_id}"
+                    )
+                    logger.error(
+                        "Webhook: This likely means the user hasn't completed initial "
+                        "checkout or the customer_id wasn't stored correctly"
+                    )
                     raise HTTPException(
                         status_code=404,
                         detail=f"User not found for customer_id: {customer_id}",
@@ -721,30 +737,60 @@ class WebhookService:
                     status_code=500, detail=f"Error finding user: {str(e)}"
                 )
 
-            # 2. Find active subscription by Stripe subscription ID
+            # 2. Find active or recently expired subscription
+            # (for trial to paid conversion, the trial might have just expired)
             try:
-                logger.info(
-                    f"Webhook: Finding active subscription for user_id: {user_id}"
-                )
+                logger.info(f"Webhook: Finding subscription for user_id: {user_id}")
+                current_time = SubscriptionService.get_current_datetime()
+                logger.info(f"Webhook: Current datetime: {current_time}")
+
+                # First try to find active subscription
                 user_subscription = (
                     db.query(UserSubscription)
                     .filter(
                         UserSubscription.user_id == user_id,
-                        UserSubscription.expiration
-                        > SubscriptionService.get_current_datetime(),
+                        UserSubscription.expiration > current_time,
                     )
                     .order_by(UserSubscription.expiration.desc())
                     .first()
                 )
 
+                # If no active subscription, check for recently expired ones
+                # (within last 7 days) - this handles trial-to-paid conversion
                 if not user_subscription:
+                    logger.info(
+                        "Webhook: No active subscription found, "
+                        "checking for recently expired subscription"
+                    )
+                    user_subscription = (
+                        db.query(UserSubscription)
+                        .filter(
+                            UserSubscription.user_id == user_id,
+                            UserSubscription.expiration
+                            > current_time - timedelta(days=7),
+                        )
+                        .order_by(UserSubscription.expiration.desc())
+                        .first()
+                    )
+
+                logger.info(f"Webhook: Subscription query result: {user_subscription}")
+
+                if not user_subscription:
+                    logger.error(f"Webhook: No subscription found for user: {user_id}")
+                    logger.error(
+                        "Webhook: No active or recently expired subscription found. "
+                        "This means the subscription wasn't created during checkout."
+                    )
                     raise HTTPException(
                         status_code=404,
-                        detail=f"Active subscription not found for user: {user_id}",
+                        detail=f"Subscription not found for user: {user_id}",
                     )
 
                 plan_id = user_subscription.plan_id
                 logger.info(f"Webhook: Found subscription plan_id: {plan_id}")
+                logger.info(
+                    f"Webhook: Current expiration: {user_subscription.expiration}"
+                )
 
             except HTTPException:
                 raise HTTPException(status_code=400, detail="Invalid webhook data")

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -268,14 +268,22 @@ async def reactivate_user_subscription(
                 status_code=404, detail="No Stripe customer found for user"
             )
 
-        # Get active Stripe subscription
+        # Get active or trialing Stripe subscription
+        # First try to find active subscription
         stripe_subscriptions = stripe.Subscription.list(
             customer=customer.id, status="active", limit=1
         )
 
+        # If no active subscription found, check for trialing subscription
+        if not stripe_subscriptions.data:
+            stripe_subscriptions = stripe.Subscription.list(
+                customer=customer.id, status="trialing", limit=1
+            )
+
         if not stripe_subscriptions.data:
             raise HTTPException(
-                status_code=404, detail="No active Stripe subscription found"
+                status_code=404,
+                detail="No active or trialing Stripe subscription found",
             )
 
         stripe_subscription = stripe_subscriptions.data[0]

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -61,12 +61,22 @@ class TestInvoicePaymentSucceeded:
         return {
             "id": "in_test123",
             "customer": "cus_test123",
+            "subscription": "sub_stripe123",  # Added subscription at top level
             "parent": {"subscription_details": {"subscription": "sub_stripe123"}},
             "status": "paid",
             "amount_paid": 2999,  # $29.99 in cents
             "billing_reason": "subscription_cycle",
             "period_start": 1699999999,
             "period_end": 1702678399,
+            "lines": {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "il_test123",
+                        "period": {"end": 1702678399, "start": 1699999999},
+                    }
+                ],
+            },
         }
 
     @pytest.fixture
@@ -75,6 +85,7 @@ class TestInvoicePaymentSucceeded:
         return {
             "id": "in_test456",
             "customer": "cus_test123",
+            "subscription": "sub_stripe123",  # Added subscription at top level
             "parent": {"subscription_details": {"subscription": "sub_stripe123"}},
             "status": "paid",
             "amount_paid": 2999,
@@ -171,6 +182,7 @@ class TestInvoicePaymentSucceeded:
         """Test error handling for missing customer_id"""
         invoice_data = {
             "id": "in_test789",
+            "subscription": "sub_stripe123",  # Added subscription at top level
             "parent": {"subscription_details": {"subscription": "sub_stripe123"}},
             "status": "paid",
             "amount_paid": 2999,
@@ -189,6 +201,7 @@ class TestInvoicePaymentSucceeded:
         invoice_data = {
             "id": "in_test789",
             "customer": "cus_test123",
+            "subscription": "sub_stripe123",  # Added subscription at top level
             "parent": {"subscription_details": {"subscription": "sub_stripe123"}},
             "status": "open",  # Not paid
             "amount_paid": 2999,


### PR DESCRIPTION
### Content

Add Trial and Update expiration date to get from stripe.
Added Trial for 30days and Expiration date will be base on the stripe request data. 
In case there is no request data it will do a monthly calculation base on starting date from stripe.

### Testcase

- [x] Test Checkout on Trial
- [x] Test Automatic Payment on Trial to convert into non-trial 
- [x] Test Downgrade
- [x] Test Continue Plan after downgrade
- [x] Test Downgrade plan to free
- [x] Test Downgraded user to free to re subscribe into premium

Account used to test.

2025/11/19 Created
<img width="2210" height="2004" alt="image" src="https://github.com/user-attachments/assets/f6d18271-126c-409f-b798-bb148946a3c6" />

Will convert to subscription on 2025/11/20 will be updated on 1pm
<img width="1757" height="860" alt="Screenshot 2025-11-20 at 14 41 20" src="https://github.com/user-attachments/assets/093399e2-da59-488c-838c-c51fd5a7ba94" />

<img width="1247" height="700" alt="Screenshot 2025-11-20 at 14 53 54" src="https://github.com/user-attachments/assets/559049f2-542f-47f5-88fd-d9fc03f7c93a" />


