### PR TITLE
Fix Delete Webhook

### DIFF
--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -309,17 +309,40 @@ class WebhookService:
                 # Remove any scheduled downgrade
                 subscription.scheduled_downgrade = False
 
-                # Record cancellation
-                cancellation = SubscriptionCancellation(
-                    cancelled_by_user_id=user_account.user_id,
-                    purchases_id=subscription.id,
-                    reason=CancellationReason.USER_REQUEST,
-                    notes=(
-                        f"Cancelled via Stripe webhook for subscription "
-                        f"{stripe_subscription_id}"
-                    ),
+                # Find the most recent purchase for this user and plan
+                purchase = (
+                    db.query(SubscriptionUserPurchase)
+                    .filter(
+                        SubscriptionUserPurchase.user_id == user_account.user_id,
+                        SubscriptionUserPurchase.plan_id == subscription.plan_id,
+                    )
+                    .order_by(SubscriptionUserPurchase.created_at.desc())
+                    .first()
                 )
-                db.add(cancellation)
+
+                # Only record cancellation if we have a purchase record
+                if purchase:
+                    # Record cancellation
+                    cancellation = SubscriptionCancellation(
+                        cancelled_by_user_id=user_account.user_id,
+                        purchases_id=purchase.id,
+                        reason=CancellationReason.USER_REQUEST,
+                        notes=(
+                            f"Cancelled via Stripe webhook for subscription "
+                            f"{stripe_subscription_id}"
+                        ),
+                    )
+                    db.add(cancellation)
+                    logger.info(
+                        f"Recorded cancellation for user {user_account.user_id}, "
+                        f"purchase {purchase.id}"
+                    )
+                else:
+                    logger.warning(
+                        f"No purchase record found for user {user_account.user_id}, "
+                        f"plan {subscription.plan_id}. Skipping cancellation record."
+                    )
+
                 db.commit()
 
                 logger.info(f"Cancelled subscription for user {user_account.user_id}")


### PR DESCRIPTION
### Content

Wrong ID to insert into Cancel table.
Therefore I was getting the error below.

2025-11-19 23:27:18,202 ERROR:    [optinist] (pid:43) (client:default) dispatch_webhook_event():791 - Error dispatching webhook event customer.subscription.deleted: (pymysql.err.IntegrityError) (1452, 'Cannot add or update a child row: a foreign key constraint fails (`studio`.`subscription_cancellations`, CONSTRAINT `fk_subscription_cancellations_purchase` FOREIGN KEY (`purchases_id`) REFERENCES `subscription_user_purchases` (`id`))')
[SQL: INSERT INTO subscription_cancellations (cancelled_by_user_id, purchases_id, cancelled_at, reason, notes) VALUES (%(cancelled_by_user_id)s, %(purchases_id)s, %(cancelled_at)s, %(reason)s, %(notes)s)]
[parameters: {'cancelled_by_user_id': 32, 'purchases_id': 12, 'cancelled_at': datetime.datetime(2025, 11, 19, 14, 27, 18, 195168), 'reason': 'user_request', 'notes': 'Cancelled via Stripe webhook for subscription sub_1SVC0vF4TJpWTMN0S4i8xmt1'}]

This wasn't checked on local since there are many value already on database that I can insert the data without a problem.

I fixed it by putting the correct value for the purchase_id.

### Testcase

- [x] Create a Premium User. Cancel the premium on stripe to trigger cancel webhook.
※ Make sure to listen to stripe webhook for this to work on local.
