### PR TITLE
Enhance Design for public header, login and registration

### DIFF
--- a/frontend/src/components/Dataview/DataviewRecords.tsx
+++ b/frontend/src/components/Dataview/DataviewRecords.tsx
@@ -1196,7 +1196,7 @@ const DataviewRecords = ({
 
 const DataviewRecordsWrapper = styled(Box)(() => ({
   width: "100%",
-  height: "calc(100vh - 220px)",
+  height: "calc(100vh - 280px)",
   display: "flex",
   flexDirection: "column",
 }))

--- a/frontend/src/components/PublicLayout/PublicHeader.tsx
+++ b/frontend/src/components/PublicLayout/PublicHeader.tsx
@@ -1,54 +1,105 @@
 import { FC } from "react"
-import { useNavigate } from "react-router-dom"
+import { useSelector } from "react-redux"
+import { Link } from "react-router-dom"
 
-import {
-  AppBar,
-  Button,
-  Container,
-  styled,
-  Toolbar,
-  Typography,
-} from "@mui/material"
-import { SxProps, Theme } from "@mui/material/styles"
+import { Box, styled, Typography } from "@mui/material"
+
+import { selectCurrentUser } from "store/slice/User/UserSelector"
 
 const PublicHeader: FC = () => {
+  const user = useSelector(selectCurrentUser)
+
   return (
-    <PublicAppBar>
-      <Container maxWidth={false}>
-        <Toolbar>
-          <PublicNavMenu
-            displayName="Studio Dataview"
-            navLink="/"
-            sx={{ fontWeight: 600, fontSize: 22, mr: 2 }}
-          />
-          <PublicNavMenu displayName="Console" navLink="/console" />
-        </Toolbar>
-      </Container>
-    </PublicAppBar>
+    <HeaderContainer>
+      <HeaderLogoLink to="/dataview">
+        <HeaderContent>
+          <HeaderLogo src="/static/optinist_logo.png" alt="OptiNiSt" />
+          <HeaderTitle>OptiNiSt</HeaderTitle>
+        </HeaderContent>
+      </HeaderLogoLink>
+      <NavSection>
+        {user ? (
+          <NavLink to="/console">Console</NavLink>
+        ) : (
+          <LoginButton to="/login">Login</LoginButton>
+        )}
+      </NavSection>
+    </HeaderContainer>
   )
 }
 
-const PublicAppBar = styled(AppBar)({
+const HeaderContainer = styled(Box)({
+  width: "98%",
+  height: 64,
+  backgroundColor: "#ffffff",
+  borderBottom: "1px solid #e5e7eb",
+  display: "flex",
+  alignItems: "center",
+  padding: "0 24px",
   position: "fixed",
+  top: 0,
+  left: 0,
+  zIndex: 1000,
 })
 
-const PublicNavMenu: FC<{
-  displayName: string
-  navLink: string
-  sx?: SxProps<Theme>
-}> = ({ displayName, navLink, sx }) => {
-  const navigate = useNavigate()
-  const handleMenuClick = () => {
-    navigate(navLink)
-  }
+const HeaderLogoLink = styled(Link)({
+  textDecoration: "none",
+  display: "flex",
+  alignItems: "center",
+  transition: "opacity 0.2s",
+  ":hover": {
+    opacity: 0.8,
+  },
+})
 
-  return (
-    <Button key={displayName} onClick={handleMenuClick}>
-      <Typography color="white" sx={sx}>
-        {displayName}
-      </Typography>
-    </Button>
-  )
-}
+const HeaderContent = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+})
+
+const HeaderLogo = styled("img")({
+  height: 40,
+  width: "auto",
+})
+
+const HeaderTitle = styled(Typography)({
+  fontSize: 20,
+  fontWeight: 600,
+  color: "#000000",
+})
+
+const NavSection = styled(Box)({
+  marginLeft: "auto",
+  display: "flex",
+  alignItems: "center",
+  gap: 16,
+})
+
+const NavLink = styled(Link)({
+  fontSize: 14,
+  fontWeight: 500,
+  color: "#374151",
+  textDecoration: "none",
+  transition: "color 0.2s",
+  ":hover": {
+    color: "#000000",
+  },
+})
+
+const LoginButton = styled(Link)({
+  display: "inline-block",
+  padding: "8px 16px",
+  fontSize: 14,
+  fontWeight: 500,
+  color: "#ffffff",
+  backgroundColor: "#000000",
+  borderRadius: 6,
+  textDecoration: "none",
+  transition: "background-color 0.2s",
+  ":hover": {
+    backgroundColor: "#1f2937",
+  },
+})
 
 export default PublicHeader

--- a/frontend/src/pages/Dataview/index.tsx
+++ b/frontend/src/pages/Dataview/index.tsx
@@ -24,6 +24,12 @@ const Dataview = () => {
   )
 }
 
-const Title = styled("h1")(() => ({}))
+const Title = styled("h1")(() => ({
+  fontSize: 24,
+  fontWeight: 600,
+  color: "#000000",
+  marginBottom: 24,
+  marginTop: 0,
+}))
 
 export default Dataview

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -277,7 +277,7 @@ const LoginContent = styled(Box)({
 const LinkWrappper = styled(Link)({
   fontSize: 14,
   marginLeft: 6,
-  color: "#1892d1",
+  color: "#000000",
 })
 
 const CardHeader = styled(Box)({

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -216,24 +216,6 @@ const Login = () => {
               Sign In
             </ButtonLogin>
 
-            {/* Social login - Not implemented yet */}
-            {/* <SeparatorWrapper>
-            <Separator />
-            <SeparatorText>Or continue with</SeparatorText>
-            <Separator />
-          </SeparatorWrapper>
-
-          <SocialButtonsWrapper>
-            <SocialButton type="button">
-              <GoogleIcon />
-              Google
-            </SocialButton>
-            <SocialButton type="button">
-              <GitHubIcon />
-              GitHub
-            </SocialButton>
-          </SocialButtonsWrapper> */}
-
             <SignUpWrapper>
               Don&apos;t have an account?{" "}
               <SignUpLink to="/register">Sign up</SignUpLink>
@@ -379,84 +361,6 @@ const ButtonLogin = styled("button")({
   },
   marginBottom: 16,
 })
-
-// Social login components - Commented out (not implemented yet)
-// const SeparatorWrapper = styled(Box)({
-//   display: "flex",
-//   alignItems: "center",
-//   marginTop: 24,
-//   marginBottom: 16,
-// })
-
-// const Separator = styled(Box)({
-//   flex: 1,
-//   height: 1,
-//   backgroundColor: "#e5e7eb",
-// })
-
-// const SeparatorText = styled("span")({
-//   padding: "0 8px",
-//   fontSize: 14,
-//   color: "#6b7280",
-//   backgroundColor: "#ffffff",
-// })
-
-// const SocialButtonsWrapper = styled(Box)({
-//   display: "grid",
-//   gridTemplateColumns: "1fr 1fr",
-//   gap: 12,
-//   marginBottom: 24,
-// })
-
-// const SocialButton = styled("button")({
-//   display: "flex",
-//   alignItems: "center",
-//   justifyContent: "center",
-//   height: 40,
-//   backgroundColor: "#ffffff",
-//   border: "1px solid #d1d5db",
-//   borderRadius: 6,
-//   color: "#374151",
-//   fontSize: 14,
-//   fontWeight: 500,
-//   cursor: "pointer",
-//   transition: "all 0.2s",
-//   ":hover": {
-//     backgroundColor: "#f9fafb",
-//     color: "#000000",
-//   },
-// })
-
-// const GoogleIcon = () => (
-//   <svg style={{ width: 20, height: 20, marginRight: 8 }} viewBox="0 0 24 24">
-//     <path
-//       fill="#4285F4"
-//       d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-//     />
-//     <path
-//       fill="#34A853"
-//       d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-//     />
-//     <path
-//       fill="#FBBC05"
-//       d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-//     />
-//     <path
-//       fill="#EA4335"
-//       d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-//     />
-//   </svg>
-// )
-
-// const GitHubIcon = () => (
-//   <svg
-//     style={{ width: 20, height: 20, marginRight: 8 }}
-//     fill="currentColor"
-//     viewBox="0 0 24 24"
-//   >
-//     <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-//   </svg>
-// )
 
 const SignUpWrapper = styled(Typography)({
   textAlign: "center",

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -4,21 +4,23 @@ import { Link, useNavigate } from "react-router-dom"
 
 import { AxiosError } from "axios"
 
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined"
+import MailOutlineIcon from "@mui/icons-material/MailOutline"
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Snackbar,
+  styled,
+  Typography,
+} from "@mui/material"
+
 interface ErrorResponse {
   detail?: string
 }
 
-import {
-  Box,
-  Stack,
-  styled,
-  Typography,
-  CircularProgress,
-  Alert,
-  Snackbar,
-} from "@mui/material"
-
 import Loading from "components/common/Loading"
+import PublicHeader from "components/PublicLayout/PublicHeader"
 import { resendVerificationEmail } from "store/slice/Registration/RegistrationActions"
 import { getMe, login } from "store/slice/User/UserActions"
 import { AppDispatch } from "store/store"
@@ -127,141 +129,208 @@ const Login = () => {
   }
 
   return (
-    <LoginWrapper>
-      <LoginContent>
-        <Title data-testid="title">Sign in to your account</Title>
-        <FormSignUp autoComplete="off" onSubmit={onSubmit}>
-          <Box sx={{ position: "relative", mb: 2 }}>
-            <LabelField>
-              Email<LableRequired>*</LableRequired>
-            </LabelField>
-            <Input
-              data-testid="email"
-              autoComplete="off"
-              error={!!errors.email}
-              name="email"
-              onChange={onChangeValue}
-              value={values.email}
-              placeholder="Enter your email"
-            />
-            <TextError data-testid="error-email">{errors.email}</TextError>
-          </Box>
-          <Box sx={{ position: "relative", mb: 2 }}>
-            <LabelField>
-              Password<LableRequired>*</LableRequired>
-            </LabelField>
-            <Input
-              data-testid="password"
-              autoComplete="off"
-              error={!!errors.password}
-              onChange={onChangeValue}
-              name="password"
-              type="password"
-              value={values.password}
-              placeholder="Enter your password"
-            />
-            <TextError data-testid="error-password">
-              {errors.password}
-            </TextError>
-          </Box>
+    <>
+      <PublicHeader />
+      <LoginWrapper>
+        <LoginContent>
+          <CardHeader>
+            <LogoWrapper>
+              <Logo src="/static/optinist_logo.png" alt="OptiNiSt Logo" />
+            </LogoWrapper>
+            <Title data-testid="title">Login to OptiNiSt</Title>
+            <Subtitle>Enter your credentials to access your account</Subtitle>
+          </CardHeader>
 
-          {/* Verification Alert */}
-          {needsVerification && (
-            <Alert
-              severity="warning"
-              sx={{ mb: 2, fontSize: 12 }}
-              action={
-                <ResendButton
-                  onClick={handleResendEmail}
-                  disabled={resendingEmail}
-                >
-                  {resendingEmail ? (
-                    <>
-                      <CircularProgress size={12} sx={{ mr: 0.5 }} />
-                      Sending...
-                    </>
-                  ) : (
-                    "Resend Email"
-                  )}
-                </ResendButton>
-              }
-            >
-              Please verify your email address to continue.
-            </Alert>
-          )}
+          <FormSignUp autoComplete="off" onSubmit={onSubmit}>
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Email</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <MailOutlineIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  data-testid="email"
+                  autoComplete="off"
+                  error={!!errors.email}
+                  name="email"
+                  onChange={onChangeValue}
+                  value={values.email}
+                  placeholder="name@example.com"
+                />
+              </InputWrapper>
+              {errors.email && (
+                <TextError data-testid="error-email">{errors.email}</TextError>
+              )}
+            </Box>
 
-          <Description>
-            Forgot your password?
-            <LinkWrappper to="/reset-password">Reset password</LinkWrappper>
-          </Description>
-          <Stack
-            flexDirection="row"
-            gap={2}
-            mt={3}
-            alignItems="center"
-            justifyContent="flex-end"
-          >
-            <LinkWrappper to="/register">
-              Don&apos;t have an account? Sign up
-            </LinkWrappper>
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Password</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <LockOutlinedIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  data-testid="password"
+                  autoComplete="off"
+                  error={!!errors.password}
+                  onChange={onChangeValue}
+                  name="password"
+                  type="password"
+                  value={values.password}
+                  placeholder="••••••••"
+                />
+              </InputWrapper>
+              {errors.password && (
+                <TextError data-testid="error-password">
+                  {errors.password}
+                </TextError>
+              )}
+            </Box>
+
+            {/* Verification Alert */}
+            {needsVerification && (
+              <Alert
+                severity="warning"
+                sx={{ mb: 2, fontSize: 12 }}
+                action={
+                  <ResendButton
+                    onClick={handleResendEmail}
+                    disabled={resendingEmail}
+                  >
+                    {resendingEmail ? (
+                      <>
+                        <CircularProgress size={12} sx={{ mr: 0.5 }} />
+                        Sending...
+                      </>
+                    ) : (
+                      "Resend Email"
+                    )}
+                  </ResendButton>
+                }
+              >
+                Please verify your email address to continue.
+              </Alert>
+            )}
+
             <ButtonLogin data-testid="button-submit" type="submit">
-              SIGN IN
+              Sign In
             </ButtonLogin>
-          </Stack>
-        </FormSignUp>
-      </LoginContent>
-      <Loading loading={loading} />
 
-      {/* Resend success snackbar */}
-      <Snackbar
-        open={showResendSnackbar}
-        autoHideDuration={6000}
-        onClose={() => setShowResendSnackbar(false)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-      >
-        <Alert
+            {/* Social login - Not implemented yet */}
+            {/* <SeparatorWrapper>
+            <Separator />
+            <SeparatorText>Or continue with</SeparatorText>
+            <Separator />
+          </SeparatorWrapper>
+
+          <SocialButtonsWrapper>
+            <SocialButton type="button">
+              <GoogleIcon />
+              Google
+            </SocialButton>
+            <SocialButton type="button">
+              <GitHubIcon />
+              GitHub
+            </SocialButton>
+          </SocialButtonsWrapper> */}
+
+            <SignUpWrapper>
+              Don&apos;t have an account?{" "}
+              <SignUpLink to="/register">Sign up</SignUpLink>
+            </SignUpWrapper>
+          </FormSignUp>
+        </LoginContent>
+        <Loading loading={loading} />
+
+        {/* Resend success snackbar */}
+        <Snackbar
+          open={showResendSnackbar}
+          autoHideDuration={6000}
           onClose={() => setShowResendSnackbar(false)}
-          severity="success"
-          sx={{ width: "100%" }}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         >
-          Verification email resent successfully
-        </Alert>
-      </Snackbar>
-    </LoginWrapper>
+          <Alert
+            onClose={() => setShowResendSnackbar(false)}
+            severity="success"
+            sx={{ width: "100%" }}
+          >
+            Verification email resent successfully
+          </Alert>
+        </Snackbar>
+      </LoginWrapper>
+    </>
   )
 }
 
 const LoginWrapper = styled(Box)({
   width: "100%",
-  height: "100%",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+  paddingTop: 64,
 })
 
 const LoginContent = styled(Box)({
-  width: 400,
-  padding: 30,
-  boxShadow: "2px 1px 3px 1px rgba(0,0,0,0.1)",
-  borderRadius: 4,
+  width: "100%",
+  maxWidth: 448,
+  padding: "32px",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  boxShadow:
+    "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+})
+
+const CardHeader = styled(Box)({
+  marginBottom: 32,
+  textAlign: "center",
+})
+
+const LogoWrapper = styled(Box)({
+  display: "flex",
+  justifyContent: "center",
+  marginBottom: 24,
+})
+
+const Logo = styled("img")({
+  height: 60,
+  width: "auto",
 })
 
 const Title = styled(Typography)({
-  fontSize: 15,
+  fontSize: 24,
   fontWeight: 600,
-  marginBottom: 24,
+  color: "#000000",
+  marginBottom: 8,
+})
+
+const Subtitle = styled(Typography)({
+  fontSize: 14,
+  color: "#6b7280",
 })
 
 const FormSignUp = styled("form")({})
 
-const LabelField = styled(Typography)({
+const LabelField = styled("label")({
+  display: "block",
   fontSize: 14,
+  fontWeight: 500,
+  color: "#374151",
+  marginBottom: 8,
 })
 
-const LableRequired = styled("span")({
-  color: "red",
-  fontSize: 14,
-  marginLeft: 2,
+const InputWrapper = styled(Box)({
+  position: "relative",
+  display: "flex",
+  alignItems: "center",
+})
+
+const IconWrapper = styled(Box)({
+  position: "absolute",
+  left: 12,
+  display: "flex",
+  alignItems: "center",
+  pointerEvents: "none",
 })
 
 const Input = styled("input", {
@@ -269,39 +338,139 @@ const Input = styled("input", {
 })<{ error: boolean }>(({ error }) => {
   return {
     width: "100%",
-    height: 35,
-    borderRadius: 4,
+    height: 40,
+    borderRadius: 6,
     border: "1px solid",
-    borderColor: error ? "red" : "#d9d9d9",
-    padding: "5px 12px",
-    transition: "all 0.3s",
+    borderColor: error ? "#ef4444" : "#d1d5db",
+    paddingLeft: 40,
+    paddingRight: 12,
+    backgroundColor: "#ffffff",
+    color: "#000000",
+    fontSize: 14,
+    transition: "all 0.2s",
     outline: "none",
     boxSizing: "border-box",
-    ":focus, :hover": {
-      borderColor: "#1677ff",
+    "::placeholder": {
+      color: "#9ca3af",
+    },
+    ":focus": {
+      borderColor: error ? "#ef4444" : "#000000",
+      boxShadow: error
+        ? "0 0 0 3px rgba(239, 68, 68, 0.1)"
+        : "0 0 0 3px rgba(0, 0, 0, 0.1)",
     },
   }
 })
 
-const Description = styled(Typography)(({ theme }) => ({
-  fontSize: 12,
-  color: "rgba(0, 0, 0, 0.65)",
-  marginTop: theme.spacing(1),
-}))
-
-const LinkWrappper = styled(Link)({
-  marginLeft: 6,
-  color: "#1892d1",
-})
-
 const ButtonLogin = styled("button")({
-  backgroundColor: "#283237",
+  width: "100%",
+  height: 40,
+  backgroundColor: "#000000",
   color: "#ffffff",
-  borderRadius: 4,
+  borderRadius: 6,
   border: "none",
   outline: "none",
-  padding: "10px 20px",
+  fontSize: 14,
+  fontWeight: 500,
   cursor: "pointer",
+  transition: "background-color 0.2s",
+  ":hover": {
+    backgroundColor: "#1f2937",
+  },
+  marginBottom: 16,
+})
+
+// Social login components - Commented out (not implemented yet)
+// const SeparatorWrapper = styled(Box)({
+//   display: "flex",
+//   alignItems: "center",
+//   marginTop: 24,
+//   marginBottom: 16,
+// })
+
+// const Separator = styled(Box)({
+//   flex: 1,
+//   height: 1,
+//   backgroundColor: "#e5e7eb",
+// })
+
+// const SeparatorText = styled("span")({
+//   padding: "0 8px",
+//   fontSize: 14,
+//   color: "#6b7280",
+//   backgroundColor: "#ffffff",
+// })
+
+// const SocialButtonsWrapper = styled(Box)({
+//   display: "grid",
+//   gridTemplateColumns: "1fr 1fr",
+//   gap: 12,
+//   marginBottom: 24,
+// })
+
+// const SocialButton = styled("button")({
+//   display: "flex",
+//   alignItems: "center",
+//   justifyContent: "center",
+//   height: 40,
+//   backgroundColor: "#ffffff",
+//   border: "1px solid #d1d5db",
+//   borderRadius: 6,
+//   color: "#374151",
+//   fontSize: 14,
+//   fontWeight: 500,
+//   cursor: "pointer",
+//   transition: "all 0.2s",
+//   ":hover": {
+//     backgroundColor: "#f9fafb",
+//     color: "#000000",
+//   },
+// })
+
+// const GoogleIcon = () => (
+//   <svg style={{ width: 20, height: 20, marginRight: 8 }} viewBox="0 0 24 24">
+//     <path
+//       fill="#4285F4"
+//       d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+//     />
+//     <path
+//       fill="#34A853"
+//       d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+//     />
+//     <path
+//       fill="#FBBC05"
+//       d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+//     />
+//     <path
+//       fill="#EA4335"
+//       d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+//     />
+//   </svg>
+// )
+
+// const GitHubIcon = () => (
+//   <svg
+//     style={{ width: 20, height: 20, marginRight: 8 }}
+//     fill="currentColor"
+//     viewBox="0 0 24 24"
+//   >
+//     <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+//   </svg>
+// )
+
+const SignUpWrapper = styled(Typography)({
+  textAlign: "center",
+  fontSize: 14,
+  color: "#6b7280",
+})
+
+const SignUpLink = styled(Link)({
+  color: "#000000",
+  textDecoration: "none",
+  fontWeight: 500,
+  ":hover": {
+    textDecoration: "underline",
+  },
 })
 
 const ResendButton = styled("button")({
@@ -327,8 +496,8 @@ const ResendButton = styled("button")({
 
 const TextError = styled(Typography)({
   fontSize: 12,
-  color: "red",
-  bottom: 4,
+  color: "#ef4444",
+  marginTop: 4,
   wordWrap: "break-word",
   wordBreak: "break-word",
   whiteSpace: "normal",

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -11,6 +11,7 @@ import {
   Box,
   CircularProgress,
   Snackbar,
+  Stack,
   styled,
   Typography,
 } from "@mui/material"
@@ -211,6 +212,16 @@ const Login = () => {
                 Please verify your email address to continue.
               </Alert>
             )}
+            <LinkWrappper to="/reset-password">
+              Forgot your password?
+            </LinkWrappper>
+            <Stack
+              flexDirection="row"
+              gap={2}
+              mt={3}
+              alignItems="center"
+              justifyContent="flex-end"
+            ></Stack>
 
             <ButtonLogin data-testid="button-submit" type="submit">
               Sign In
@@ -261,6 +272,12 @@ const LoginContent = styled(Box)({
   borderRadius: 8,
   boxShadow:
     "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+})
+
+const LinkWrappper = styled(Link)({
+  fontSize: 14,
+  marginLeft: 6,
+  color: "#1892d1",
 })
 
 const CardHeader = styled(Box)({

--- a/frontend/src/pages/PublicDataview/index.tsx
+++ b/frontend/src/pages/PublicDataview/index.tsx
@@ -1,12 +1,33 @@
+import { Box, styled } from "@mui/material"
+
 import DataviewRecords from "components/Dataview/DataviewRecords"
 import PublicDataviewWrapper from "components/Dataview/PublicDataviewWrapper"
+import PublicHeader from "components/PublicLayout/PublicHeader"
 
 const PublicDataview = () => {
   return (
-    <PublicDataviewWrapper>
-      <DataviewRecords />
-    </PublicDataviewWrapper>
+    <>
+      <PublicHeader />
+      <PageWrapper>
+        <Title>Public Dataview</Title>
+        <PublicDataviewWrapper>
+          <DataviewRecords />
+        </PublicDataviewWrapper>
+      </PageWrapper>
+    </>
   )
 }
+
+const PageWrapper = styled(Box)({
+  paddingTop: 32,
+})
+
+const Title = styled("h1")(() => ({
+  fontSize: 24,
+  fontWeight: 600,
+  color: "#000000",
+  marginBottom: 24,
+  marginTop: 0,
+}))
 
 export default PublicDataview

--- a/frontend/src/pages/PublicDataview/index.tsx
+++ b/frontend/src/pages/PublicDataview/index.tsx
@@ -9,7 +9,7 @@ const PublicDataview = () => {
     <>
       <PublicHeader />
       <PageWrapper>
-        <Title>Public Dataview</Title>
+        <Title>OptiNiSt Public Repository</Title>
         <PublicDataviewWrapper>
           <DataviewRecords />
         </PublicDataviewWrapper>

--- a/frontend/src/pages/Register/MainRegistration.tsx
+++ b/frontend/src/pages/Register/MainRegistration.tsx
@@ -1,43 +1,39 @@
-import { useState, FormEvent, ChangeEvent, useEffect } from "react"
+import { ChangeEvent, FormEvent, useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 
 import CheckCircleIcon from "@mui/icons-material/CheckCircle"
-import EmailIcon from "@mui/icons-material/Email"
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
-import LockIcon from "@mui/icons-material/Lock"
-import PersonIcon from "@mui/icons-material/Person"
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined"
+import MailOutlineIcon from "@mui/icons-material/MailOutline"
+import PersonOutlineIcon from "@mui/icons-material/PersonOutline"
 import {
-  Box,
-  Button,
-  TextField,
-  Typography,
   Alert,
-  styled,
+  Box,
   CircularProgress,
-  Paper,
-  Checkbox,
-  FormControlLabel,
   Snackbar,
+  styled,
+  Typography,
 } from "@mui/material"
 
-import { regexPassword, regexIgnoreS } from "const/Auth"
+import PublicHeader from "components/PublicLayout/PublicHeader"
+import { regexIgnoreS, regexPassword } from "const/Auth"
 import {
   registerUser,
   resendVerificationEmail,
 } from "store/slice/Registration/RegistrationActions"
 import {
+  selectRegistrationError,
   selectRegistrationLoading,
   selectRegistrationSuccess,
-  selectRegistrationError,
   selectRegistrationUser,
   selectResendEmailLoading,
   selectResendEmailSuccess,
 } from "store/slice/Registration/RegistrationSelector"
 import {
+  clearAllRegistrationState,
   clearRegistrationErrors,
   clearResendSuccess,
-  clearAllRegistrationState,
 } from "store/slice/Registration/RegistrationSlice"
 import { AppDispatch } from "store/store"
 
@@ -180,240 +176,193 @@ const RegistrationForm = () => {
   // Success view
   if (success) {
     return (
-      <PageWrapper>
-        <FormCard elevation={3}>
-          <SuccessContent>
-            <CheckCircleIcon sx={{ fontSize: 80, color: "#10b981", mb: 2 }} />
+      <>
+        <PublicHeader />
+        <PageWrapper>
+          <FormCard>
+            <SuccessContent>
+              <CheckCircleIcon sx={{ fontSize: 80, color: "#10b981", mb: 2 }} />
 
-            <Typography variant="h4" fontWeight="bold" gutterBottom>
-              Registration Almost Complete!
-            </Typography>
+              <Title>Registration Almost Complete!</Title>
 
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-              A verification email has been sent to{" "}
-              <strong>{user?.email || formData.email}</strong>
-            </Typography>
+              <Subtitle>
+                A verification email has been sent to{" "}
+                <strong>{user?.email || formData.email}</strong>
+              </Subtitle>
 
-            <Alert severity="info" icon={<InfoOutlinedIcon />} sx={{ mb: 3 }}>
-              <Typography variant="body2">
-                To complete your registration, please check your email and click
-                the verification link. You&apos;ll be able to log in once your
-                email is verified.
-              </Typography>
-            </Alert>
+              <Alert severity="info" icon={<InfoOutlinedIcon />} sx={{ mb: 3 }}>
+                <Typography variant="body2">
+                  To complete your registration, please check your email and
+                  click the verification link. You&apos;ll be able to log in
+                  once your email is verified.
+                </Typography>
+              </Alert>
 
-            <Button
-              variant="outlined"
-              onClick={handleResendEmail}
-              disabled={resendingEmail}
-              sx={{
-                mb: 2,
-                borderColor: "#667eea",
-                color: "#667eea",
-                "&:hover": {
-                  borderColor: "#5568d3",
-                  backgroundColor: "rgba(102, 126, 234, 0.04)",
-                },
-              }}
-            >
-              {resendingEmail ? (
-                <>
-                  <CircularProgress size={16} sx={{ mr: 1 }} />
-                  Sending...
-                </>
-              ) : (
-                "Resend Verification Email"
-              )}
-            </Button>
+              <ResendButton
+                onClick={handleResendEmail}
+                disabled={resendingEmail}
+              >
+                {resendingEmail ? (
+                  <>
+                    <CircularProgress size={16} sx={{ mr: 1 }} />
+                    Sending...
+                  </>
+                ) : (
+                  "Resend Verification Email"
+                )}
+              </ResendButton>
 
-            <Button
-              variant="contained"
-              onClick={() => navigate("/login")}
-              fullWidth
-              sx={{
-                backgroundColor: "#667eea",
-                "&:hover": {
-                  backgroundColor: "#5568d3",
-                },
-              }}
-            >
-              Go to Login Page
-            </Button>
-          </SuccessContent>
-        </FormCard>
+              <SubmitButton onClick={() => navigate("/login")}>
+                Go to Login Page
+              </SubmitButton>
+            </SuccessContent>
+          </FormCard>
 
-        {/* Resend success snackbar */}
-        <Snackbar
-          open={showResendSnackbar}
-          autoHideDuration={6000}
-          onClose={() => setShowResendSnackbar(false)}
-          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        >
-          <Alert
+          {/* Resend success snackbar */}
+          <Snackbar
+            open={showResendSnackbar}
+            autoHideDuration={6000}
             onClose={() => setShowResendSnackbar(false)}
-            severity="success"
-            sx={{ width: "100%" }}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
           >
-            Verification email resent successfully
-          </Alert>
-        </Snackbar>
-      </PageWrapper>
+            <Alert
+              onClose={() => setShowResendSnackbar(false)}
+              severity="success"
+              sx={{ width: "100%" }}
+            >
+              Verification email resent successfully
+            </Alert>
+          </Snackbar>
+        </PageWrapper>
+      </>
     )
   }
 
   // Registration form
   return (
-    <PageWrapper>
-      <FormCard elevation={3}>
-        <Typography variant="h4" fontWeight="bold" textAlign="center" mb={1}>
-          Sign Up
-        </Typography>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          textAlign="center"
-          mb={3}
-        >
-          Please fill in all information
-        </Typography>
+    <>
+      <PublicHeader />
+      <PageWrapper>
+        <FormCard>
+          <CardHeader>
+            <LogoWrapper>
+              <Logo src="/static/optinist_logo.png" alt="OptiNiSt Logo" />
+            </LogoWrapper>
+            <Title>Create your account</Title>
+            <Subtitle>Sign up to get started with OptiNiSt</Subtitle>
+          </CardHeader>
 
-        <form onSubmit={handleSubmit}>
-          {/* Validation or server error */}
-          {(validationError || error) && (
-            <Alert severity="error" sx={{ mb: 3 }}>
-              {validationError || error}
-            </Alert>
-          )}
+          <form onSubmit={handleSubmit}>
+            {/* Validation or server error */}
+            {(validationError || error) && (
+              <Alert severity="error" sx={{ mb: 3, fontSize: 12 }}>
+                {validationError || error}
+              </Alert>
+            )}
 
-          {/* Name input */}
-          <TextField
-            fullWidth
-            label="Name"
-            name="name"
-            value={formData.name}
-            onChange={handleChange}
-            disabled={loading}
-            autoFocus
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <PersonIcon sx={{ mr: 1, color: "action.disabled" }} />
-              ),
-            }}
-          />
+            {/* Name input */}
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Name</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <PersonOutlineIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  autoComplete="off"
+                  name="name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  placeholder="John Doe"
+                  disabled={loading}
+                  autoFocus
+                />
+              </InputWrapper>
+            </Box>
 
-          {/* Email input */}
-          <TextField
-            fullWidth
-            type="email"
-            label="Email Address"
-            name="email"
-            value={formData.email}
-            onChange={handleChange}
-            disabled={loading}
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <EmailIcon sx={{ mr: 1, color: "action.disabled" }} />
-              ),
-            }}
-          />
+            {/* Email input */}
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Email</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <MailOutlineIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  autoComplete="off"
+                  type="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  placeholder="name@example.com"
+                  disabled={loading}
+                />
+              </InputWrapper>
+            </Box>
 
-          {/* Password input */}
-          <TextField
-            fullWidth
-            type={showPassword ? "text" : "password"}
-            label="Password"
-            name="password"
-            value={formData.password}
-            onChange={handleChange}
-            disabled={loading}
-            helperText="At least 6 characters including letters, numbers, and special characters (!#$%&()*+,-./@_|)"
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <LockIcon sx={{ mr: 1, color: "action.disabled" }} />
-              ),
-            }}
-          />
+            {/* Password input */}
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Password</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <LockOutlinedIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  autoComplete="off"
+                  type={showPassword ? "text" : "password"}
+                  name="password"
+                  value={formData.password}
+                  onChange={handleChange}
+                  placeholder="••••••••"
+                  disabled={loading}
+                />
+              </InputWrapper>
+              <HelperText>
+                At least 6 characters including letters, numbers, and special
+                characters
+              </HelperText>
+            </Box>
 
-          {/* Confirm password input */}
-          <TextField
-            fullWidth
-            type={showPassword ? "text" : "password"}
-            label="Confirm Password"
-            name="confirmPassword"
-            value={formData.confirmPassword}
-            onChange={handleChange}
-            disabled={loading}
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <LockIcon sx={{ mr: 1, color: "action.disabled" }} />
-              ),
-            }}
-          />
+            {/* Confirm password input */}
+            <Box sx={{ mb: 3 }}>
+              <LabelField>Confirm Password</LabelField>
+              <InputWrapper>
+                <IconWrapper>
+                  <LockOutlinedIcon sx={{ fontSize: 18, color: "#9ca3af" }} />
+                </IconWrapper>
+                <Input
+                  autoComplete="off"
+                  type={showPassword ? "text" : "password"}
+                  name="confirmPassword"
+                  value={formData.confirmPassword}
+                  onChange={handleChange}
+                  placeholder="••••••••"
+                  disabled={loading}
+                />
+              </InputWrapper>
+            </Box>
 
-          {/* Show password checkbox */}
-          <FormControlLabel
-            control={
+            {/* Show password checkbox */}
+            <CheckboxWrapper>
               <Checkbox
+                type="checkbox"
                 checked={showPassword}
                 onChange={(e) => setShowPassword(e.target.checked)}
-                sx={{
-                  color: "#667eea",
-                  "&.Mui-checked": {
-                    color: "#667eea",
-                  },
-                }}
               />
-            }
-            label="Show Password"
-            sx={{ mb: 2 }}
-          />
+              <CheckboxLabel>Show Password</CheckboxLabel>
+            </CheckboxWrapper>
 
-          {/* Submit button */}
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-            disabled={loading}
-            startIcon={
-              loading ? <CircularProgress size={20} color="inherit" /> : null
-            }
-            sx={{
-              py: 1.5,
-              fontSize: "1rem",
-              fontWeight: 600,
-              textTransform: "none",
-              backgroundColor: "#667eea",
-              "&:hover": {
-                backgroundColor: "#5568d3",
-                transform: "translateY(-2px)",
-                boxShadow: "0 6px 20px rgba(102, 126, 234, 0.4)",
-              },
-              "&:disabled": {
-                backgroundColor: "#9ca3af",
-              },
-              transition: "all 0.2s ease-in-out",
-            }}
-          >
-            {loading ? "Registering..." : "Register"}
-          </Button>
-        </form>
+            {/* Submit button */}
+            <SubmitButton type="submit" disabled={loading}>
+              {loading ? "Registering..." : "Sign Up"}
+            </SubmitButton>
 
-        {/* Login link */}
-        <Typography variant="body2" textAlign="center" mt={2}>
-          Already have an account?{" "}
-          <span
-            onClick={() => navigate("/login")}
-            style={{ color: "#667eea", cursor: "pointer", fontWeight: 600 }}
-          >
-            Login
-          </span>
-        </Typography>
-      </FormCard>
-    </PageWrapper>
+            {/* Login link */}
+            <LoginWrapper>
+              Already have an account? <LoginLink to="/login">Login</LoginLink>
+            </LoginWrapper>
+          </form>
+        </FormCard>
+      </PageWrapper>
+    </>
   )
 }
 
@@ -422,18 +371,183 @@ const RegistrationForm = () => {
 // ========================================
 
 const PageWrapper = styled(Box)({
-  minHeight: "70vh",
+  width: "100%",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  padding: "2rem",
+  paddingTop: 64,
 })
 
-const FormCard = styled(Paper)({
-  padding: "3rem",
-  maxWidth: "500px",
+const FormCard = styled(Box)({
   width: "100%",
-  borderRadius: "1rem",
+  maxWidth: 448,
+  padding: "32px",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  boxShadow:
+    "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+})
+
+const CardHeader = styled(Box)({
+  marginBottom: 32,
+  textAlign: "center",
+})
+
+const LogoWrapper = styled(Box)({
+  display: "flex",
+  justifyContent: "center",
+  marginBottom: 24,
+})
+
+const Logo = styled("img")({
+  height: 60,
+  width: "auto",
+})
+
+const Title = styled(Typography)({
+  fontSize: 24,
+  fontWeight: 600,
+  color: "#000000",
+  marginBottom: 8,
+})
+
+const Subtitle = styled(Typography)({
+  fontSize: 14,
+  color: "#6b7280",
+  marginBottom: 16,
+})
+
+const LabelField = styled("label")({
+  display: "block",
+  fontSize: 14,
+  fontWeight: 500,
+  color: "#374151",
+  marginBottom: 8,
+})
+
+const InputWrapper = styled(Box)({
+  position: "relative",
+  display: "flex",
+  alignItems: "center",
+})
+
+const IconWrapper = styled(Box)({
+  position: "absolute",
+  left: 12,
+  display: "flex",
+  alignItems: "center",
+  pointerEvents: "none",
+})
+
+const Input = styled("input")({
+  width: "100%",
+  height: 40,
+  borderRadius: 6,
+  border: "1px solid #d1d5db",
+  paddingLeft: 40,
+  paddingRight: 12,
+  backgroundColor: "#ffffff",
+  color: "#000000",
+  fontSize: 14,
+  transition: "all 0.2s",
+  outline: "none",
+  boxSizing: "border-box",
+  "::placeholder": {
+    color: "#9ca3af",
+  },
+  ":focus": {
+    borderColor: "#000000",
+    boxShadow: "0 0 0 3px rgba(0, 0, 0, 0.1)",
+  },
+  ":disabled": {
+    backgroundColor: "#f3f4f6",
+    cursor: "not-allowed",
+  },
+})
+
+const HelperText = styled(Typography)({
+  fontSize: 12,
+  color: "#6b7280",
+  marginTop: 4,
+})
+
+const CheckboxWrapper = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  marginBottom: 16,
+})
+
+const Checkbox = styled("input")({
+  width: 16,
+  height: 16,
+  marginRight: 8,
+  cursor: "pointer",
+})
+
+const CheckboxLabel = styled("label")({
+  fontSize: 14,
+  color: "#374151",
+  cursor: "pointer",
+})
+
+const SubmitButton = styled("button")({
+  width: "100%",
+  height: 40,
+  backgroundColor: "#000000",
+  color: "#ffffff",
+  borderRadius: 6,
+  border: "none",
+  outline: "none",
+  fontSize: 14,
+  fontWeight: 500,
+  cursor: "pointer",
+  transition: "background-color 0.2s",
+  ":hover": {
+    backgroundColor: "#1f2937",
+  },
+  ":disabled": {
+    backgroundColor: "#9ca3af",
+    cursor: "not-allowed",
+  },
+  marginBottom: 16,
+})
+
+const ResendButton = styled("button")({
+  width: "100%",
+  height: 40,
+  backgroundColor: "#ffffff",
+  color: "#000000",
+  borderRadius: 6,
+  border: "1px solid #d1d5db",
+  outline: "none",
+  fontSize: 14,
+  fontWeight: 500,
+  cursor: "pointer",
+  transition: "all 0.2s",
+  marginBottom: 16,
+  ":hover": {
+    backgroundColor: "#f9fafb",
+  },
+  ":disabled": {
+    opacity: 0.6,
+    cursor: "not-allowed",
+  },
+})
+
+const LoginWrapper = styled(Typography)({
+  textAlign: "center",
+  fontSize: 14,
+  color: "#6b7280",
+})
+
+const LoginLink = styled(Link)({
+  color: "#000000",
+  textDecoration: "none",
+  fontWeight: 500,
+  ":hover": {
+    textDecoration: "underline",
+  },
 })
 
 const SuccessContent = styled(Box)({


### PR DESCRIPTION
### Content

Enhance Design for public header, login and registration

### Reference

I refer to github login page with the design/placement of texts.
https://github.com/login

### Testcase

<img width="1455" height="1022" alt="Screenshot 2025-11-21 at 19 27 11" src="https://github.com/user-attachments/assets/b89fc350-ce79-4709-b1b5-4ba1067b0660" />
<img width="1465" height="1164" alt="Screenshot 2025-11-21 at 19 26 59" src="https://github.com/user-attachments/assets/3bbcf5eb-10c1-415a-8c77-19a7d3e008dd" />
<img width="1260" height="805" alt="Screenshot 2025-11-28 at 15 01 24" src="https://github.com/user-attachments/assets/b51df433-4322-4547-8b1b-41a57a85b1b7" />
