### PR TITLE
Enhance Icons on Optinist and Update Account Profile

### DIFF
--- a/frontend/src/components/Layout/Profile.tsx
+++ b/frontend/src/components/Layout/Profile.tsx
@@ -5,7 +5,13 @@ import { useNavigate } from "react-router-dom"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import Logout from "@mui/icons-material/Logout"
 import PortraitIcon from "@mui/icons-material/Portrait"
-import { Menu, MenuItem } from "@mui/material"
+import {
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 
 import { logout } from "store/slice/User/UserSlice"
@@ -35,19 +41,20 @@ const Profile: FC = () => {
 
   return (
     <>
-      <IconButton
-        color="inherit"
-        aria-label="open profile menu"
-        aria-haspopup="true"
-        onClick={handleMenu}
-      >
-        <AccountCircleIcon />
-      </IconButton>
+      <Tooltip title="Profile">
+        <IconButton
+          aria-label="open profile menu"
+          aria-haspopup="true"
+          onClick={handleMenu}
+        >
+          <AccountCircleIcon />
+        </IconButton>
+      </Tooltip>
       <Menu
         id="profile-menu"
         anchorEl={anchorEl}
         anchorOrigin={{
-          vertical: "top",
+          vertical: "bottom",
           horizontal: "right",
         }}
         keepMounted
@@ -59,11 +66,16 @@ const Profile: FC = () => {
         onClose={handleCloseMenu}
       >
         <MenuItem onClick={onClickAccount}>
-          <PortraitIcon /> Account Profile
+          <ListItemIcon>
+            <PortraitIcon />
+          </ListItemIcon>
+          <ListItemText>Account Profile</ListItemText>
         </MenuItem>
         <MenuItem onClick={onClickLogout}>
-          <Logout />
-          Sign Out
+          <ListItemIcon>
+            <Logout />
+          </ListItemIcon>
+          <ListItemText>Sign Out</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/frontend/src/components/Layout/Tooltips.tsx
+++ b/frontend/src/components/Layout/Tooltips.tsx
@@ -59,7 +59,10 @@ const Tooltips: FC = () => {
   return (
     <>
       <Tooltip title="GitHub repository">
-        <IconButton href="https://github.com/oist/optinist" target="_blank">
+        <IconButton
+          href="https://github.com/arayabrain/optinist-for-cloud"
+          target="_blank"
+        >
           <GitHub />
         </IconButton>
       </Tooltip>

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -314,10 +314,6 @@ const Account = () => {
       />
       <Title>Account Profile</Title>
       <BoxFlex>
-        <TitleData>Organization</TitleData>
-        <BoxData>{user?.organization?.name}</BoxData>
-      </BoxFlex>
-      <BoxFlex>
         <TitleData>Name</TitleData>
         {isEditName ? (
           <Input
@@ -342,10 +338,6 @@ const Account = () => {
       <BoxFlex>
         <TitleData>Email</TitleData>
         <BoxData>{user?.email}</BoxData>
-      </BoxFlex>
-      <BoxFlex>
-        <TitleData>Role</TitleData>
-        <BoxData>{getRole(user?.role_id)}</BoxData>
       </BoxFlex>
       <BoxFlex>
         <TitleData>Data size</TitleData>


### PR DESCRIPTION
### Content

Enhance Icons on Optinist and update account profile to not show organization and role

### Testcase

- [x] Account icon: Hints are not appearing.
- [x] Account icon: Colour is black but all others are grey
- [x] Account Profile -> Do not display Organisation or Role for Operators
- [x] Update the GitHub icon on the right to optinist-for-cloud.

### Others

<img width="178" height="96" alt="Screenshot 2025-11-21 at 21 39 17" src="https://github.com/user-attachments/assets/c4f09d98-51e0-43e9-bc88-7223833ade88" />

<img width="764" height="626" alt="Screenshot 2025-11-21 at 21 39 35" src="https://github.com/user-attachments/assets/1f56ad51-a539-4f3c-aaf2-7f7ed21e7ffe" />
