### PR TITLE
Countermeasures for unexpected aborted workflow

### DIFF
--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -38,7 +38,7 @@ import {
 } from "store/slice/Workspace/WorkspaceSlice"
 import { AppDispatch } from "store/store"
 
-const POLLING_INTERVAL = 5000
+const POLLING_INTERVAL = 10000
 
 export type UseRunPipelineReturnType = ReturnType<typeof useRunPipeline>
 

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -206,6 +206,7 @@ def main(develop_mode: bool = False):
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--workers", type=int, default=1)
     parser.add_argument("--reload", action="store_true")
+    timeout_keep_alive = 60
     args = parser.parse_args()
 
     logging_config = AppLogger.get_logging_config()
@@ -226,6 +227,7 @@ def main(develop_mode: bool = False):
             port=args.port,
             log_config=logging_config,
             workers=args.workers,
+            timeout_keep_alive=timeout_keep_alive,
             reload=reload,
             **reload_options,
         )
@@ -236,5 +238,6 @@ def main(develop_mode: bool = False):
             port=args.port,
             log_config=logging_config,
             workers=args.workers,
+            timeout_keep_alive=timeout_keep_alive,
             reload=False,
         )


### PR DESCRIPTION
### Content

There is a known issue where a workflow is aborted unexpectedly.
- arayabrain/barebone-studio#597

Because this issue seems to occur relatively frequently in AWS environments, it will be verified in this repository (optinist-for-cloud) before barebone-studio.

#### Countermeasure

*While it is unclear at the time of issuing the initial PR whether this countermeasure will be effective,
it is anticipated that it may be effective, so deployment and operational testing will be conducted.

1. Set uvicorn's timeout_keep_alive (to allow for some leeway) (fc3d28e)
2. Adjusted the polling interval of the /run/result API (increased the time to reduce load) (2550570)

### Testcase

- Verification in a Local Environment
   - [x] Run multiple (4-6) tutorial workflows simultaneously in parallel and verify that none are aborted and all workflows complete successfully.
   - [x] Repeat the above test case three times (a total of 12-18 workflow runs) and verify that all are successful.

- Verification in an AWS Cloud Environment
  - [x] The same procedure as the local environment verification above.

### Others

- This fix (adding LoggingConfigHelper) will also be ported to barebone-studio.