### PR TITLE
Fix handle checkout error for new users.

### DIFF
--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -556,10 +556,6 @@ class CheckoutService:
                     }
                     # Require payment method during trial so it can be charged later
                     subscription_params["payment_method_collection"] = "always"
-                    # Save payment method for future invoices
-                    subscription_params["payment_method_options"] = {
-                        "card": {"setup_future_usage": "off_session"}
-                    }
                     logger.info(
                         f"Adding {SubscriptionPeriods.TRIAL_PERIOD_DAYS}-day trial "
                         f"for first-time user {user.id}"


### PR DESCRIPTION
### Content

1. In Stripe's subscription mode, payment methods are automatically saved for future billing cycles

2. The payment_method_collection = "always" on line 558 is sufficient to ensure users provide a payment method during the trial period

3. Stripe will automatically use that payment method when the trial ends, without needing the explicit payment_method_options parameter

### References

Before:
<img width="1065" height="882" alt="Screenshot 2025-12-24 at 1 21 00" src="https://github.com/user-attachments/assets/cb511b9c-9607-4e91-846a-7697dc9be8f1" />

After:
<img width="1091" height="885" alt="Screenshot 2025-12-24 at 1 21 25" src="https://github.com/user-attachments/assets/1df4ab1a-e4a2-4426-9650-01cb39448034" />

### Testcase

- [x] Upgrade with new user
- [x] Upgrade with old premium user