### PR TITLE
Fixed an issue with logging client_id in post_process

### DIFF
--- a/studio/app/common/core/rules/post_process.py
+++ b/studio/app/common/core/rules/post_process.py
@@ -17,6 +17,9 @@ sys.path.append(ROOT_DIRPATH)
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    init_client_id_from_snakemake_config,
+)
 from studio.app.common.core.rules.runner import Runner
 from studio.app.common.core.snakemake.smk import Rule
 from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
@@ -97,6 +100,9 @@ class PostProcessRunner:
 
 
 if __name__ == "__main__":
+    # Initialize client_id from snakemake config
+    init_client_id_from_snakemake_config(snakemake.config)
+
     logger.debug(
         "post process startup debug logging\n"
         f"[snakemake.input: {snakemake.input}]\n"


### PR DESCRIPTION
### Content

Fixed the issue where `client_id` was not recorded when logging in post_process

- Before modification (client:default)
  ```
  [optinist] (pid:30515) (client:default) run():45 - start post_process runner
  [optinist] (pid:30515) (client:default) upload_experiment():624 - upload data to S3 [optinist-testdir-202408] (1/22) output/1/f035fa49/whole.nwb (209,888 bytes)
  ```
- After modification
  ```
  [optinist] (pid:36871) (client:4e782f44eac52685) run():48 - start post_process runner
  [optinist] (pid:36871) (client:4e782f44eac52685) upload_experiment():624 - upload data to S3 [optinist-testdir-202408] (1/22) output/1/1c9ca4bf/whole.nwb (209,888 bytes)
  ```

### Reference

- arayabrain/barebone-studio#949