### PR TITLE
Fix Thanks Page View When Webhook has failed

### DIFF
--- a/frontend/src/api/subscriptions/SubscriptionsApiDTO.ts
+++ b/frontend/src/api/subscriptions/SubscriptionsApiDTO.ts
@@ -9,10 +9,14 @@ export type SubscriptionPlanDTO = {
   created_at: string
 }
 
+export const CheckoutValidationStatus = {
+  SUCCESS: "success",
+  PAYMENT_FAILED: "payment_failed",
+  WEBHOOK_FAILED: "webhook_failed",
+} as const
+
 export type CheckoutValidationStatus =
-  | "success"
-  | "payment_failed"
-  | "webhook_failed"
+  (typeof CheckoutValidationStatus)[keyof typeof CheckoutValidationStatus]
 
 export type CheckoutValidationResponse = {
   status: CheckoutValidationStatus

--- a/frontend/src/api/subscriptions/SubscriptionsApiDTO.ts
+++ b/frontend/src/api/subscriptions/SubscriptionsApiDTO.ts
@@ -8,3 +8,13 @@ export type SubscriptionPlanDTO = {
   status: boolean
   created_at: string
 }
+
+export type CheckoutValidationStatus =
+  | "success"
+  | "payment_failed"
+  | "webhook_failed"
+
+export type CheckoutValidationResponse = {
+  status: CheckoutValidationStatus
+  message?: string
+}

--- a/frontend/src/components/utils/ValidateCheckoutSession.ts
+++ b/frontend/src/components/utils/ValidateCheckoutSession.ts
@@ -21,8 +21,8 @@ export const validateSession = async (
   navigate: NavigateFunction,
   isThanksPage?: boolean,
 ) => {
-  // If no session ID, redirect to checkout
-  if (!sessionId) {
+  // If no session ID or empty string, redirect to subscription page
+  if (!sessionId || sessionId.trim() === "") {
     navigate("/subscription", { replace: true })
     return
   }
@@ -41,20 +41,14 @@ export const validateSession = async (
     if (response && response.status) {
       setIsValidSession(response.status)
     } else {
-      // On thanks page, show failed result instead of navigating away
-      if (isThanksPage) {
-        setIsValidSession("webhook_failed")
-      } else {
-        navigate("/subscription", { replace: true })
-      }
-    }
-  } catch (error) {
-    // On thanks page, show failed result instead of navigating away
-    if (isThanksPage) {
-      setIsValidSession("webhook_failed")
-    } else {
+      // Invalid session_id - log error and redirect
+      console.error("Invalid session_id:", sessionId)
       navigate("/subscription", { replace: true })
     }
+  } catch (error) {
+    // Invalid session_id - log error and redirect
+    console.error("Invalid session_id:", sessionId, error)
+    navigate("/subscription", { replace: true })
   } finally {
     setIsLoading(false)
   }

--- a/frontend/src/components/utils/ValidateCheckoutSession.ts
+++ b/frontend/src/components/utils/ValidateCheckoutSession.ts
@@ -5,11 +5,17 @@ import {
   validateCheckoutSessionApi,
   validateFailedCheckoutSessionApi,
 } from "api/subscriptions/Subscriptions"
+import {
+  CheckoutValidationResponse,
+  CheckoutValidationStatus,
+} from "api/subscriptions/SubscriptionsApiDTO"
 import { AppDispatch } from "store/store"
 
 export const validateSession = async (
   sessionId: string | null,
-  setIsValidSession: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsValidSession: React.Dispatch<
+    React.SetStateAction<CheckoutValidationStatus | null>
+  >,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
   dispatch: AppDispatch,
   navigate: NavigateFunction,
@@ -31,13 +37,24 @@ export const validateSession = async (
     }
 
     // Check if the validation was successful
-    if (result.payload === true || result.meta?.requestStatus === "fulfilled") {
-      setIsValidSession(true)
+    const response = result.payload as CheckoutValidationResponse
+    if (response && response.status) {
+      setIsValidSession(response.status)
+    } else {
+      // On thanks page, show failed result instead of navigating away
+      if (isThanksPage) {
+        setIsValidSession("webhook_failed")
+      } else {
+        navigate("/subscription", { replace: true })
+      }
+    }
+  } catch (error) {
+    // On thanks page, show failed result instead of navigating away
+    if (isThanksPage) {
+      setIsValidSession("webhook_failed")
     } else {
       navigate("/subscription", { replace: true })
     }
-  } catch (error) {
-    navigate("/subscription", { replace: true })
   } finally {
     setIsLoading(false)
   }

--- a/frontend/src/pages/Subscription/failed.tsx
+++ b/frontend/src/pages/Subscription/failed.tsx
@@ -35,7 +35,7 @@ const Failed: React.FC = () => {
 
   // On the failed page, show payment_failed regardless of validation status
   if (validationStatus) {
-    return <PaymentResult type="payment_failed" />
+    return <PaymentResult type={CheckoutValidationStatus.PAYMENT_FAILED} />
   }
 
   return null

--- a/frontend/src/pages/Subscription/failed.tsx
+++ b/frontend/src/pages/Subscription/failed.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react"
 import { useDispatch } from "react-redux"
 import { useNavigate } from "react-router-dom"
 
+import { CheckoutValidationStatus } from "api/subscriptions/SubscriptionsApiDTO"
 import Loading from "components/common/Loading"
 import { validateSession } from "components/utils/ValidateCheckoutSession"
 import PaymentResult from "pages/Subscription/payment_result"
@@ -13,13 +14,14 @@ const Failed: React.FC = () => {
   const searchParams = new URLSearchParams(window.location.search)
   const sessionId = searchParams.get("session_id")
 
-  const [isValidSession, setIsValidSession] = useState(false)
+  const [validationStatus, setValidationStatus] =
+    useState<CheckoutValidationStatus | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     validateSession(
       sessionId,
-      setIsValidSession,
+      setValidationStatus,
       setIsLoading,
       dispatch,
       navigate,
@@ -31,8 +33,9 @@ const Failed: React.FC = () => {
     return <Loading loading={true} />
   }
 
-  if (isValidSession) {
-    return <PaymentResult type="failed" />
+  // On the failed page, show payment_failed regardless of validation status
+  if (validationStatus) {
+    return <PaymentResult type="payment_failed" />
   }
 
   return null

--- a/frontend/src/pages/Subscription/payment_result.tsx
+++ b/frontend/src/pages/Subscription/payment_result.tsx
@@ -7,13 +7,11 @@ import GitHubIcon from "@mui/icons-material/GitHub"
 import { Box, Button, Typography, Card, CardContent } from "@mui/material"
 
 interface PaymentResultProps {
-  type?: "success" | "failed"
+  type?: "success" | "payment_failed" | "webhook_failed"
 }
 
 const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
   const navigate = useNavigate()
-
-  const isSuccess = type === "success"
 
   interface Config {
     icon: React.ReactNode
@@ -27,7 +25,10 @@ const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
     buttonAction: () => void
   }
 
-  const config: Record<"success" | "failed", Config> = {
+  const config: Record<
+    "success" | "payment_failed" | "webhook_failed",
+    Config
+  > = {
     success: {
       icon: <CheckIcon sx={{ fontSize: "3rem", color: "white" }} />,
       circleColor: "#10b981",
@@ -39,20 +40,34 @@ const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
       buttonHoverColor: "#2563eb",
       buttonAction: () => navigate("/dashboard"),
     },
-    failed: {
+    payment_failed: {
       icon: <CloseIcon sx={{ fontSize: "3rem", color: "white" }} />,
       circleColor: "#ef4444",
       title: "Payment Failed",
-      subtitle: "We are not able to process your payment",
-      description: "Please check your payment information and try again.",
+      subtitle: "We were unable to process your payment",
+      description:
+        "Please check your payment information and try again. Common issues include insufficient funds, expired cards, or incorrect billing details.",
       buttonText: "Try Again",
       buttonColor: "#ef4444",
       buttonHoverColor: "#dc2626",
       buttonAction: () => navigate("/subscription"),
     },
+    webhook_failed: {
+      icon: <CloseIcon sx={{ fontSize: "3rem", color: "white" }} />,
+      circleColor: "#f59e0b",
+      title: "Activation Pending",
+      subtitle:
+        "Payment successful, but subscription activation is in progress",
+      description:
+        "Your payment was processed successfully, but there was a delay in activating your subscription. Please wait a few minutes and refresh, or contact support if this persists.",
+      buttonText: "Contact Support",
+      buttonColor: "#f59e0b",
+      buttonHoverColor: "#d97706",
+      buttonAction: () => navigate("/subscription"),
+    },
   }
 
-  const currentConfig = config[isSuccess ? "success" : "failed"]
+  const currentConfig = config[type]
 
   const styles = {
     pageWrapper: {

--- a/frontend/src/pages/Subscription/payment_result.tsx
+++ b/frontend/src/pages/Subscription/payment_result.tsx
@@ -6,11 +6,15 @@ import CloseIcon from "@mui/icons-material/Close"
 import GitHubIcon from "@mui/icons-material/GitHub"
 import { Box, Button, Typography, Card, CardContent } from "@mui/material"
 
+import { CheckoutValidationStatus } from "api/subscriptions/SubscriptionsApiDTO"
+
 interface PaymentResultProps {
-  type?: "success" | "payment_failed" | "webhook_failed"
+  type?: CheckoutValidationStatus
 }
 
-const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
+const PaymentResult: React.FC<PaymentResultProps> = ({
+  type = CheckoutValidationStatus.SUCCESS,
+}) => {
   const navigate = useNavigate()
 
   interface Config {
@@ -25,11 +29,8 @@ const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
     buttonAction: () => void
   }
 
-  const config: Record<
-    "success" | "payment_failed" | "webhook_failed",
-    Config
-  > = {
-    success: {
+  const config: Record<CheckoutValidationStatus, Config> = {
+    [CheckoutValidationStatus.SUCCESS]: {
       icon: <CheckIcon sx={{ fontSize: "3rem", color: "white" }} />,
       circleColor: "#10b981",
       title: "Thank you!",
@@ -40,7 +41,7 @@ const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
       buttonHoverColor: "#2563eb",
       buttonAction: () => navigate("/dashboard"),
     },
-    payment_failed: {
+    [CheckoutValidationStatus.PAYMENT_FAILED]: {
       icon: <CloseIcon sx={{ fontSize: "3rem", color: "white" }} />,
       circleColor: "#ef4444",
       title: "Payment Failed",
@@ -52,7 +53,7 @@ const PaymentResult: React.FC<PaymentResultProps> = ({ type = "success" }) => {
       buttonHoverColor: "#dc2626",
       buttonAction: () => navigate("/subscription"),
     },
-    webhook_failed: {
+    [CheckoutValidationStatus.WEBHOOK_FAILED]: {
       icon: <CloseIcon sx={{ fontSize: "3rem", color: "white" }} />,
       circleColor: "#f59e0b",
       title: "Activation Pending",

--- a/frontend/src/pages/Subscription/thanks.tsx
+++ b/frontend/src/pages/Subscription/thanks.tsx
@@ -35,13 +35,13 @@ const Thanks: React.FC = () => {
 
   switch (validationStatus) {
     case CheckoutValidationStatus.SUCCESS:
-      return <PaymentResult type="success" />
+      return <PaymentResult type={CheckoutValidationStatus.SUCCESS} />
     case CheckoutValidationStatus.PAYMENT_FAILED:
-      return <PaymentResult type="payment_failed" />
+      return <PaymentResult type={CheckoutValidationStatus.PAYMENT_FAILED} />
     case CheckoutValidationStatus.WEBHOOK_FAILED:
     default:
       // Handle unexpected cases
-      return <PaymentResult type="webhook_failed" />
+      return <PaymentResult type={CheckoutValidationStatus.WEBHOOK_FAILED} />
   }
 }
 

--- a/frontend/src/pages/Subscription/thanks.tsx
+++ b/frontend/src/pages/Subscription/thanks.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react"
 import { useDispatch } from "react-redux"
 import { useNavigate } from "react-router-dom"
 
+import { CheckoutValidationStatus } from "api/subscriptions/SubscriptionsApiDTO"
 import Loading from "components/common/Loading"
 import { validateSession } from "components/utils/ValidateCheckoutSession"
 import PaymentResult from "pages/Subscription/payment_result"
@@ -13,13 +14,14 @@ const Thanks: React.FC = () => {
   const searchParams = new URLSearchParams(window.location.search)
   const sessionId = searchParams.get("session_id")
 
-  const [isValidSession, setIsValidSession] = useState(false)
+  const [validationStatus, setValidationStatus] =
+    useState<CheckoutValidationStatus | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     validateSession(
       sessionId,
-      setIsValidSession,
+      setValidationStatus,
       setIsLoading,
       dispatch,
       navigate,
@@ -31,8 +33,16 @@ const Thanks: React.FC = () => {
     return <Loading loading={true} />
   }
 
-  if (isValidSession) {
+  if (validationStatus === "success") {
     return <PaymentResult type="success" />
+  }
+
+  if (validationStatus === "payment_failed") {
+    return <PaymentResult type="payment_failed" />
+  }
+
+  if (validationStatus === "webhook_failed") {
+    return <PaymentResult type="webhook_failed" />
   }
 
   return null

--- a/frontend/src/pages/Subscription/thanks.tsx
+++ b/frontend/src/pages/Subscription/thanks.tsx
@@ -45,7 +45,8 @@ const Thanks: React.FC = () => {
     return <PaymentResult type="webhook_failed" />
   }
 
-  return null
+  // Handle unexpected cases
+  return <PaymentResult type="webhook_failed" />
 }
 
 export default Thanks

--- a/frontend/src/pages/Subscription/thanks.tsx
+++ b/frontend/src/pages/Subscription/thanks.tsx
@@ -33,20 +33,16 @@ const Thanks: React.FC = () => {
     return <Loading loading={true} />
   }
 
-  if (validationStatus === "success") {
-    return <PaymentResult type="success" />
+  switch (validationStatus) {
+    case CheckoutValidationStatus.SUCCESS:
+      return <PaymentResult type="success" />
+    case CheckoutValidationStatus.PAYMENT_FAILED:
+      return <PaymentResult type="payment_failed" />
+    case CheckoutValidationStatus.WEBHOOK_FAILED:
+    default:
+      // Handle unexpected cases
+      return <PaymentResult type="webhook_failed" />
   }
-
-  if (validationStatus === "payment_failed") {
-    return <PaymentResult type="payment_failed" />
-  }
-
-  if (validationStatus === "webhook_failed") {
-    return <PaymentResult type="webhook_failed" />
-  }
-
-  // Handle unexpected cases
-  return <PaymentResult type="webhook_failed" />
 }
 
 export default Thanks

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -23,6 +23,7 @@ from studio.app.common.core.subscription.subscription_service import Subscriptio
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.db.database import get_db
 from studio.app.common.models.subscription import SubscriptionPlans
+from studio.app.common.models.user import User as UserModel
 from studio.app.common.schemas.checkouts import (
     CheckoutSessionRequest,
     CheckoutValidationResponse,
@@ -40,7 +41,6 @@ from studio.app.common.schemas.subscriptions import (
     UpdateSubscriptionResponse,
     UserSubscriptionResponse,
 )
-from studio.app.common.models.user import User as UserModel
 from studio.app.common.schemas.users import User
 
 # Load callback URL at module level (doesn't require secrets for module import)

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -427,18 +427,23 @@ async def create_checkout_session(
     return await CheckoutService.handle_checkout_session(db, request, user)
 
 
-@router.post("/checkout/validate-checkout-session", response_model=CheckoutValidationResponse)
+@router.post(
+    "/checkout/validate-checkout-session", response_model=CheckoutValidationResponse
+)
 async def validate_checkout_session(
     request: CheckoutSessionRequest,
     db: Session = Depends(get_db),
 ):
     """
-    Validate a Stripe checkout session ID and verify database was updated with premium subscription
+    Validate a Stripe checkout session ID and verify database was
+    updated with premium subscription
 
     Returns detailed status:
     - "success": Payment succeeded and webhook updated database
-    - "payment_failed": Payment itself failed (card declined, insufficient funds, etc.)
-    - "webhook_failed": Payment succeeded but webhook didn't update database (internal error)
+    - "payment_failed": Payment itself failed
+      (card declined, insufficient funds, etc.)
+    - "webhook_failed": Payment succeeded but webhook didn't update
+      database (internal error)
     """
     try:
         # Retrieve the session from Stripe
@@ -450,19 +455,26 @@ async def validate_checkout_session(
             session.payment_status == StripeCheckoutPaymentStatus.PAID
             and session.status == StripeCheckoutSessionStatus.COMPLETE
         ):
-            logger.warning(f"Checkout session {request.session_id} is not complete/paid")
+            logger.warning(
+                f"Checkout session {request.session_id} is not complete/paid"
+            )
             return CheckoutValidationResponse(
                 status="payment_failed",
-                message="Payment was not completed. Please check your payment information and try again."
+                message=(
+                    "Payment was not completed. Please check your payment "
+                    "information and try again."
+                ),
             )
 
         # Get customer email from session
-        customer_email = session.customer_details.email if session.customer_details else None
+        customer_email = (
+            session.customer_details.email if session.customer_details else None
+        )
         if not customer_email:
             logger.error(f"No customer email found in session {request.session_id}")
             return CheckoutValidationResponse(
                 status="webhook_failed",
-                message="An internal error occurred. Please contact support."
+                message="An internal error occurred. Please contact support.",
             )
 
         # Find user by email
@@ -474,31 +486,40 @@ async def validate_checkout_session(
             logger.error(f"No user found with email {customer_email}")
             return CheckoutValidationResponse(
                 status="webhook_failed",
-                message="An internal error occurred. Please contact support."
+                message="An internal error occurred. Please contact support.",
             )
 
-        # Verify database was updated by webhook - check if user has active premium subscription
+        # Verify database was updated by webhook - check if user has
+        # active premium subscription
         subscription = SubscriptionService.get_user_subscription(db, user.id)
         if not subscription:
             logger.warning(
-                f"Checkout session {request.session_id} is complete but no subscription "
-                f"found in database for user {user.id}. Webhook may have failed."
+                f"Checkout session {request.session_id} is complete but no "
+                f"subscription found in database for user {user.id}. "
+                f"Webhook may have failed."
             )
             return CheckoutValidationResponse(
                 status="webhook_failed",
-                message="Payment was successful, but subscription activation is pending. Please contact support if this persists."
+                message=(
+                    "Payment was successful, but subscription activation "
+                    "is pending. Please contact support if this persists."
+                ),
             )
 
         # Verify it's a premium subscription (not free)
         sub_data, plan_data = subscription
         if plan_data.id == SubscriptionPlanIds.FREE:
             logger.warning(
-                f"Checkout session {request.session_id} is complete but user {user.id} "
-                f"only has free subscription (plan_id={plan_data.id}). Webhook may have failed."
+                f"Checkout session {request.session_id} is complete but user "
+                f"{user.id} only has free subscription (plan_id={plan_data.id}). "
+                f"Webhook may have failed."
             )
             return CheckoutValidationResponse(
                 status="webhook_failed",
-                message="Payment was successful, but subscription activation is pending. Please contact support if this persists."
+                message=(
+                    "Payment was successful, but subscription activation "
+                    "is pending. Please contact support if this persists."
+                ),
             )
 
         logger.info(
@@ -507,7 +528,7 @@ async def validate_checkout_session(
         )
         return CheckoutValidationResponse(
             status="success",
-            message="Payment successful! Your premium subscription is now active."
+            message="Payment successful! Your premium subscription is now active.",
         )
 
     except stripe.error.StripeError as e:

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -12,6 +12,7 @@ from studio.app.common.core.subscription.constants import (
     INVOICE_LIST_LIMIT,
     StripeCheckoutPaymentStatus,
     StripeCheckoutSessionStatus,
+    SubscriptionPlanIds,
     SubscriptionUserStatus,
 )
 from studio.app.common.core.subscription.stripe_service import (
@@ -39,6 +40,7 @@ from studio.app.common.schemas.subscriptions import (
     UpdateSubscriptionResponse,
     UserSubscriptionResponse,
 )
+from studio.app.common.models.user import User as UserModel
 from studio.app.common.schemas.users import User
 
 # Load callback URL at module level (doesn't require secrets for module import)
@@ -478,10 +480,7 @@ async def validate_checkout_session(
             )
 
         # Find user by email
-        from studio.app.common.core.subscription.constants import SubscriptionPlanIds
-        from studio.app.common.models.user import User
-
-        user = db.query(User).filter(User.email == customer_email).first()
+        user = db.query(UserModel).filter(UserModel.email == customer_email).first()
         if not user:
             logger.error(f"No user found with email {customer_email}")
             return CheckoutValidationResponse(

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -27,6 +27,7 @@ from studio.app.common.models.user import User as UserModel
 from studio.app.common.schemas.checkouts import (
     CheckoutSessionRequest,
     CheckoutValidationResponse,
+    CheckoutValidationStatus,
 )
 from studio.app.common.schemas.subscriptions import (
     CancelSubscriptionResponse,
@@ -461,7 +462,7 @@ async def validate_checkout_session(
                 f"Checkout session {request.session_id} is not complete/paid"
             )
             return CheckoutValidationResponse(
-                status="payment_failed",
+                status=CheckoutValidationStatus.PAYMENT_FAILED,
                 message=(
                     "Payment was not completed. Please check your payment "
                     "information and try again."
@@ -475,7 +476,7 @@ async def validate_checkout_session(
         if not customer_email:
             logger.error(f"No customer email found in session {request.session_id}")
             return CheckoutValidationResponse(
-                status="webhook_failed",
+                status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message="An internal error occurred. Please contact support.",
             )
 
@@ -484,7 +485,7 @@ async def validate_checkout_session(
         if not user:
             logger.error(f"No user found with email {customer_email}")
             return CheckoutValidationResponse(
-                status="webhook_failed",
+                status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message="An internal error occurred. Please contact support.",
             )
 
@@ -498,7 +499,7 @@ async def validate_checkout_session(
                 f"Webhook may have failed."
             )
             return CheckoutValidationResponse(
-                status="webhook_failed",
+                status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message=(
                     "Payment was successful, but subscription activation "
                     "is pending. Please contact support if this persists."
@@ -514,7 +515,7 @@ async def validate_checkout_session(
                 f"Webhook may have failed."
             )
             return CheckoutValidationResponse(
-                status="webhook_failed",
+                status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message=(
                     "Payment was successful, but subscription activation "
                     "is pending. Please contact support if this persists."
@@ -526,7 +527,7 @@ async def validate_checkout_session(
             f"with premium subscription (plan_id={plan_data.id}) for user {user.id}"
         )
         return CheckoutValidationResponse(
-            status="success",
+            status=CheckoutValidationStatus.SUCCESS,
             message="Payment successful! Your premium subscription is now active.",
         )
 

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -22,7 +22,10 @@ from studio.app.common.core.subscription.subscription_service import Subscriptio
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.db.database import get_db
 from studio.app.common.models.subscription import SubscriptionPlans
-from studio.app.common.schemas.checkouts import CheckoutSessionRequest
+from studio.app.common.schemas.checkouts import (
+    CheckoutSessionRequest,
+    CheckoutValidationResponse,
+)
 from studio.app.common.schemas.subscriptions import (
     CancelSubscriptionResponse,
     CreateCheckoutSessionRequest,
@@ -424,12 +427,18 @@ async def create_checkout_session(
     return await CheckoutService.handle_checkout_session(db, request, user)
 
 
-@router.post("/checkout/validate-checkout-session", response_model=bool)
+@router.post("/checkout/validate-checkout-session", response_model=CheckoutValidationResponse)
 async def validate_checkout_session(
     request: CheckoutSessionRequest,
+    db: Session = Depends(get_db),
 ):
     """
-    Validate a Stripe checkout session ID
+    Validate a Stripe checkout session ID and verify database was updated with premium subscription
+
+    Returns detailed status:
+    - "success": Payment succeeded and webhook updated database
+    - "payment_failed": Payment itself failed (card declined, insufficient funds, etc.)
+    - "webhook_failed": Payment succeeded but webhook didn't update database (internal error)
     """
     try:
         # Retrieve the session from Stripe
@@ -437,15 +446,69 @@ async def validate_checkout_session(
         session = stripe.checkout.Session.retrieve(request.session_id)
 
         # Check if the session is complete and paid
-        if (
+        if not (
             session.payment_status == StripeCheckoutPaymentStatus.PAID
             and session.status == StripeCheckoutSessionStatus.COMPLETE
         ):
-            logger.info(f"Checkout session {request.session_id} is valid")
-            return True
-        else:
-            logger.warning(f"Checkout session {request.session_id} is invalid")
-            return False
+            logger.warning(f"Checkout session {request.session_id} is not complete/paid")
+            return CheckoutValidationResponse(
+                status="payment_failed",
+                message="Payment was not completed. Please check your payment information and try again."
+            )
+
+        # Get customer email from session
+        customer_email = session.customer_details.email if session.customer_details else None
+        if not customer_email:
+            logger.error(f"No customer email found in session {request.session_id}")
+            return CheckoutValidationResponse(
+                status="webhook_failed",
+                message="An internal error occurred. Please contact support."
+            )
+
+        # Find user by email
+        from studio.app.common.core.subscription.constants import SubscriptionPlanIds
+        from studio.app.common.models.user import User
+
+        user = db.query(User).filter(User.email == customer_email).first()
+        if not user:
+            logger.error(f"No user found with email {customer_email}")
+            return CheckoutValidationResponse(
+                status="webhook_failed",
+                message="An internal error occurred. Please contact support."
+            )
+
+        # Verify database was updated by webhook - check if user has active premium subscription
+        subscription = SubscriptionService.get_user_subscription(db, user.id)
+        if not subscription:
+            logger.warning(
+                f"Checkout session {request.session_id} is complete but no subscription "
+                f"found in database for user {user.id}. Webhook may have failed."
+            )
+            return CheckoutValidationResponse(
+                status="webhook_failed",
+                message="Payment was successful, but subscription activation is pending. Please contact support if this persists."
+            )
+
+        # Verify it's a premium subscription (not free)
+        sub_data, plan_data = subscription
+        if plan_data.id == SubscriptionPlanIds.FREE:
+            logger.warning(
+                f"Checkout session {request.session_id} is complete but user {user.id} "
+                f"only has free subscription (plan_id={plan_data.id}). Webhook may have failed."
+            )
+            return CheckoutValidationResponse(
+                status="webhook_failed",
+                message="Payment was successful, but subscription activation is pending. Please contact support if this persists."
+            )
+
+        logger.info(
+            f"Checkout session {request.session_id} is valid and database is updated "
+            f"with premium subscription (plan_id={plan_data.id}) for user {user.id}"
+        )
+        return CheckoutValidationResponse(
+            status="success",
+            message="Payment successful! Your premium subscription is now active."
+        )
 
     except stripe.error.StripeError as e:
         logger.error(f"Stripe error validating checkout session: {str(e)}")

--- a/studio/app/common/schemas/checkouts.py
+++ b/studio/app/common/schemas/checkouts.py
@@ -1,8 +1,13 @@
-from typing import Any, Dict, Literal, Optional
+from enum import StrEnum
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
-CheckoutValidationStatus = Literal["success", "payment_failed", "webhook_failed"]
+
+class CheckoutValidationStatus(StrEnum):
+    SUCCESS = "success"
+    PAYMENT_FAILED = "payment_failed"
+    WEBHOOK_FAILED = "webhook_failed"
 
 
 class CheckoutSessionRequest(BaseModel):

--- a/studio/app/common/schemas/checkouts.py
+++ b/studio/app/common/schemas/checkouts.py
@@ -18,8 +18,11 @@ class CheckoutValidationResponse(BaseModel):
 
     status values:
     - "success": Payment succeeded and webhook updated database
-    - "payment_failed": Payment itself failed (card declined, insufficient funds, etc.)
-    - "webhook_failed": Payment succeeded but webhook didn't update database (internal error)
+    - "payment_failed": Payment itself failed
+      (card declined, insufficient funds, etc.)
+    - "webhook_failed": Payment succeeded but webhook didn't update
+      database (internal error)
     """
+
     status: str  # "success", "payment_failed", or "webhook_failed"
     message: Optional[str] = None

--- a/studio/app/common/schemas/checkouts.py
+++ b/studio/app/common/schemas/checkouts.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel
+
+CheckoutValidationStatus = Literal["success", "payment_failed", "webhook_failed"]
 
 
 class CheckoutSessionRequest(BaseModel):
@@ -24,5 +26,5 @@ class CheckoutValidationResponse(BaseModel):
       database (internal error)
     """
 
-    status: str  # "success", "payment_failed", or "webhook_failed"
+    status: CheckoutValidationStatus
     message: Optional[str] = None

--- a/studio/app/common/schemas/checkouts.py
+++ b/studio/app/common/schemas/checkouts.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -10,3 +10,16 @@ class CheckoutSessionRequest(BaseModel):
 class WebhookRequest(BaseModel):
     event_type: str
     data: Dict[str, Any]
+
+
+class CheckoutValidationResponse(BaseModel):
+    """
+    Response for checkout session validation
+
+    status values:
+    - "success": Payment succeeded and webhook updated database
+    - "payment_failed": Payment itself failed (card declined, insufficient funds, etc.)
+    - "webhook_failed": Payment succeeded but webhook didn't update database (internal error)
+    """
+    status: str  # "success", "payment_failed", or "webhook_failed"
+    message: Optional[str] = None


### PR DESCRIPTION
### Content

Previously, the Thanks page always displayed a success message even when the webhook failed and the database was not updated. This could confuse users, as the page indicated a successful payment while their account was not upgraded to premium.

Before:
Only two states were handled: payment success and payment failed.
If the webhook failed, the Thanks page still showed a success message, but the user’s account remained non-premium.

After:
The logic has been updated to handle three distinct states:

- success
- payment_failed
- webhook_failed

After checkout, the Thanks page now verifies the checkout session. The checkout session ID is used to query Stripe for detailed payment information.

If the checkout session is paid and completed with no issues, the success page is shown.

If the checkout session is paid and completed, but the payment status indicates failure, the payment failed page is shown.

If the checkout session is paid and completed, but the user’s data does not reflect a premium account, this indicates that the webhook did not process correctly. In this case, the webhook failed page is shown, prompting the user to contact support.

### References

Review Log -> https://docs.google.com/spreadsheets/d/1c46FLyIbDEqDrD0QcbfR2L0s6oiAggrj6LKhgD1QOHo/edit?gid=1395226523#gid=1395226523

<img width="1420" height="897" alt="Screenshot 2026-01-09 at 9 04 17" src="https://github.com/user-attachments/assets/e34700b5-db2d-4cba-bcd7-3e106d942565" />

### Testcase

 

- [x] 1. Loading State
After checkout session the page will load.
  - Verify <Loading /> is displayed while isLoading is true                                                                                                                                                                                                                                                             
  - Verify loading disappears after validation completes                                                                                                                                                                                                                                                                

- [x] 2. Session ID Handling

  - Test behavior when session_id is missing from URL -> Redirect to subscriptions page.
  - Test behavior when session_id is empty -> Redirect to subscriptions page
  - Test behavior when session_id is invalid -> show console error invalid session_id and redirect to subscriptions page

- [x]  3. Validation Status Rendering                                                                                                                                                                                                                                                                                        

  - Renders <PaymentResult type="success" /> when status is "success"
    - Process checkout with valid credit card. This will access you to success thanks page. Make sure you have your stripe listener open when testing in local.  Find the Stripe 環境構築ガイド (Webhook & Plan 管理).md file on the link below
    https://drive.google.com/drive/u/0/folders/1FBIAqBjIdzkXCvNKKGgKu17J4-O3dX-F                                                                                                                                                                                                  
  - Renders <PaymentResult type="payment_failed" /> when status is "payment_failed"                                                                                                                                                                                                                                     
    - You cant do this without testing the test mode. You have to change the status on the code manually to check the page. The reason it cant be test because during checkout invalid cards cant be registered as payment method.
  - Renders <PaymentResult type="webhook_failed" /> when status is "webhook_failed"                       
    - Do not open your stripe listener so webhook will fail to test webhook_failed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                        
  ---                                                                                                                                                                                                                                                                                                                   
  Unit Tests for PaymentResult Component                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                        
- [x]  4. Success State                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                        
  - Displays green check icon                                                                                                                                                                                                                                                                                           
  - Shows success message
  - Dashboard button redirect you to dashboard                                                                                                                                                                                                                                                                                   

- [x]  5. Payment Failed State
                                                                                                                                                                                                                                                                                                                        
  - Displays red error icon                                                                                                                                                                                                                                                                                             
  - Shows payment failed message
  - Retry button redirect you to subscriptions page 
(Result of payment failed when I did it with payment failed status on code.)
<img width="1270" height="1212" alt="Screenshot 2026-01-20 at 13 44 27" src="https://github.com/user-attachments/assets/60024be2-a6d5-4acf-9865-b294313868f0" />

- [x]  6. Webhook Failed State                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                        
  - Displays orange warning icon                                                                                                                                                                                                                                                                                        
  - Shows webhook failed message
  - Contact support button redirect you too subscriptions page                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                    
  ---                                                                                                                                                                                                                                                                                                                   
  E2E Tests                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                        
- [x]  7. Full Flow                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                        
  - Navigate to /subscription/thanks?session_id={valid_id} → expect success page                                                                                                                                                                                                                                          
  - Navigate to /subscription/thanks?session_id=invalid_id → expect error handling                                                                                                                                                                                                     
  - Verify navigation buttons work (dashboard, retry, contact support)
