### PR TITLE
Move all constants to lamda_layers import

### DIFF
--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -19,15 +19,11 @@ resource "null_resource" "install_common_user_manager_dependencies" {
     command = <<-EOT
       mkdir -p ${path.module}/common_user_manager_package
       /usr/bin/python3 -m pip install pymysql sqlalchemy -t ${path.module}/common_user_manager_package/ --no-cache-dir
-      cp ${path.module}/../aws_constants.py ${path.module}/common_user_manager_package/aws_constants.py
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/common_user_manager_package/common_user_manager.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
   }
 }
 
@@ -51,6 +47,7 @@ resource "aws_lambda_function" "common_user_manager" {
   handler       = "common_user_manager.handler"
   runtime       = "python3.9"
   timeout       = 900 # 15 minutes
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.common_user_manager_zip.output_base64sha256
 

--- a/infrastructure/terraform/free_cleanup_package/free_cleanup.py
+++ b/infrastructure/terraform/free_cleanup_package/free_cleanup.py
@@ -66,7 +66,9 @@ def get_db_connection(auto_commit=False):
             rds_host = get_required_env_var("RDS_HOST")
             conn = pymysql.connect(
                 host=rds_host.split(":")[0],
-                port=int(rds_host.split(":")[1]) if ":" in rds_host else DatabaseConfig.DEFAULT_PORT,
+                port=int(rds_host.split(":")[1])
+                if ":" in rds_host
+                else DatabaseConfig.DEFAULT_PORT,
                 user=get_required_env_var("RDS_USER"),
                 password=get_required_env_var("RDS_PASSWORD"),
                 database=get_required_env_var("RDS_DATABASE"),

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -18,15 +18,13 @@ resource "null_resource" "install_free_manager_dependencies" {
     command = <<-EOT
       mkdir -p ${path.module}/free_manager_package
       /usr/bin/python3 -m pip install pymysql boto3 -t ${path.module}/free_manager_package/ --no-cache-dir
-      cp ${path.module}/../aws_constants.py ${path.module}/free_manager_package/aws_constants.py
     EOT
   }
 
   triggers = {
     code_changes = md5(join("", [
       filesha256("${path.module}/free_manager_package/free_manager.py"),
-      filesha256("${path.module}/free_manager_package/free_user_utils.py"),
-      filesha256("${path.module}/../aws_constants.py")
+      filesha256("${path.module}/free_manager_package/free_user_utils.py")
     ]))
   }
 }
@@ -51,6 +49,7 @@ resource "aws_lambda_function" "free_manager" {
   handler       = "free_manager.handler"
   runtime       = "python3.9"
   timeout       = 900 # 15 minutes # Max timeout
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.free_manager_zip.output_base64sha256
 
@@ -341,6 +340,7 @@ resource "aws_lambda_function" "free_cleanup" {
   handler       = "free_cleanup.handler"
   runtime       = "python3.9"
   timeout       = 300 # 5 minutes
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.free_cleanup_zip.output_base64sha256
 

--- a/infrastructure/terraform/lambda_layers.tf
+++ b/infrastructure/terraform/lambda_layers.tf
@@ -1,0 +1,64 @@
+# ===============================================
+# Lambda Layers
+# ===============================================
+# Shared code and dependencies packaged as Lambda Layers
+# for reuse across multiple Lambda functions.
+
+# ===========================
+# AWS Constants Layer
+# ===========================
+# This layer contains shared AWS constants (ECSTaskStatus, BatchJobStatus,
+# PremiumInstanceConfig, RoutingHeaders, DatabaseConfig) used by multiple
+# Lambda functions. Using a layer avoids code duplication and ensures
+# all Lambdas use the same constant values.
+
+# Create the layer directory structure
+# Lambda layers for Python must have files under python/ directory
+resource "null_resource" "prepare_aws_constants_layer" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      mkdir -p ${path.module}/aws_constants_layer/python
+      cp ${path.module}/../aws_constants.py ${path.module}/aws_constants_layer/python/aws_constants.py
+    EOT
+  }
+
+  triggers = {
+    # Rebuild layer when aws_constants.py changes
+    code_hash = filesha256("${path.module}/../aws_constants.py")
+  }
+}
+
+# Create ZIP for the layer
+data "archive_file" "aws_constants_layer_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/aws_constants_layer"
+  output_path = "${path.module}/aws_constants_layer.zip"
+
+  depends_on = [null_resource.prepare_aws_constants_layer]
+}
+
+# Create the Lambda Layer
+resource "aws_lambda_layer_version" "aws_constants" {
+  filename            = "${path.module}/aws_constants_layer.zip"
+  layer_name          = "subscr-aws-constants"
+  description         = "Shared AWS constants for subscription Lambda functions"
+  compatible_runtimes = ["python3.9", "python3.10", "python3.11", "python3.12"]
+
+  source_code_hash = data.archive_file.aws_constants_layer_zip.output_base64sha256
+
+  depends_on = [data.archive_file.aws_constants_layer_zip]
+}
+
+# ===========================
+# Outputs
+# ===========================
+
+output "aws_constants_layer_arn" {
+  description = "ARN of the aws_constants Lambda layer"
+  value       = aws_lambda_layer_version.aws_constants.arn
+}
+
+output "aws_constants_layer_version" {
+  description = "Version of the aws_constants Lambda layer"
+  value       = aws_lambda_layer_version.aws_constants.version
+}

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -65,7 +65,9 @@ def get_db_connection(auto_commit=False):
             rds_host = get_required_env_var("RDS_HOST")
             conn = pymysql.connect(
                 host=rds_host.split(":")[0],
-                port=int(rds_host.split(":")[1]) if ":" in rds_host else DatabaseConfig.DEFAULT_PORT,
+                port=int(rds_host.split(":")[1])
+                if ":" in rds_host
+                else DatabaseConfig.DEFAULT_PORT,
                 user=get_required_env_var("RDS_USER"),
                 password=get_required_env_var("RDS_PASSWORD"),
                 database=get_required_env_var("RDS_DATABASE"),
@@ -145,7 +147,9 @@ def check_instance_readiness(instance_id: str) -> bool:
 
         for task in task_details["tasks"]:
             task_def_arn = task.get("taskDefinitionArn", "")
-            is_premium_task = task_def_arn.find(PremiumInstanceConfig.INSTANCE_IDENTIFIER) != -1
+            is_premium_task = (
+                task_def_arn.find(PremiumInstanceConfig.INSTANCE_IDENTIFIER) != -1
+            )
             if is_premium_task and task.get("lastStatus") == ECSTaskStatus.RUNNING:
                 print(f"Premium task running and ready on instance {instance_id}")
                 return True
@@ -407,9 +411,18 @@ def get_all_premium_instances_with_states():
             instance_id = instance["InstanceId"]
 
             # Check multiple criteria for premium instances
-            name_match = PremiumInstanceConfig.INSTANCE_IDENTIFIER in tags.get("Name", "").lower()
-            tier_match = tags.get("Tier", "").lower() == PremiumInstanceConfig.INSTANCE_IDENTIFIER
-            type_match = PremiumInstanceConfig.INSTANCE_IDENTIFIER in tags.get("Type", "").lower()
+            name_match = (
+                PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                in tags.get("Name", "").lower()
+            )
+            tier_match = (
+                tags.get("Tier", "").lower()
+                == PremiumInstanceConfig.INSTANCE_IDENTIFIER
+            )
+            type_match = (
+                PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                in tags.get("Type", "").lower()
+            )
 
             # Debug logging for tag matching
             print(f"Instance {instance_id} tag analysis:")

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "premium_manager" {
   handler       = "premium_manager.handler"
   runtime       = "python3.9"
   timeout       = 600
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.premium_manager_zip.output_base64sha256
 
@@ -189,6 +190,7 @@ resource "aws_lambda_function" "premium_cleanup" {
   handler       = "premium_cleanup.handler"
   runtime       = "python3.9"
   timeout       = 300
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.premium_cleanup_zip.output_base64sha256
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -44,7 +44,6 @@ from typing import Any, Dict, Optional
 
 import boto3
 import pymysql
-from botocore.exceptions import ClientError
 
 # Shared constants from Lambda Layer (mounted at /opt/python by AWS Lambda)
 from aws_constants import (
@@ -53,6 +52,7 @@ from aws_constants import (
     PremiumInstanceConfig,
     RoutingHeaders,
 )
+from botocore.exceptions import ClientError
 
 # Constants
 # Default fallback value for premium user count in development/testing scenarios
@@ -450,9 +450,18 @@ def get_all_premium_instances_with_states():
             instance_id = instance["InstanceId"]
 
             # Check multiple criteria for premium instances
-            name_match = PremiumInstanceConfig.INSTANCE_IDENTIFIER in tags.get("Name", "").lower()
-            tier_match = tags.get("Tier", "").lower() == PremiumInstanceConfig.INSTANCE_IDENTIFIER
-            type_match = PremiumInstanceConfig.INSTANCE_IDENTIFIER in tags.get("Type", "").lower()
+            name_match = (
+                PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                in tags.get("Name", "").lower()
+            )
+            tier_match = (
+                tags.get("Tier", "").lower()
+                == PremiumInstanceConfig.INSTANCE_IDENTIFIER
+            )
+            type_match = (
+                PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                in tags.get("Type", "").lower()
+            )
 
             # Debug logging for tag matching
             print(f"Instance {instance_id} tag analysis:")

--- a/infrastructure/terraform/storage_reconciliation.tf
+++ b/infrastructure/terraform/storage_reconciliation.tf
@@ -46,6 +46,7 @@ resource "aws_lambda_function" "storage_reconciliation" {
   handler       = "storage_reconciliation.handler"
   runtime       = "python3.9"
   timeout       = 900 # 15 minutes - enough time for large batches
+  layers        = [aws_lambda_layer_version.aws_constants.arn]
 
   source_code_hash = data.archive_file.storage_reconciliation_zip.output_base64sha256
 

--- a/infrastructure/terraform/storage_reconciliation_package/storage_reconciliation.py
+++ b/infrastructure/terraform/storage_reconciliation_package/storage_reconciliation.py
@@ -64,7 +64,9 @@ def get_db_connection(auto_commit=False):
         rds_host = get_required_env_var("RDS_HOST")
         conn = pymysql.connect(
             host=rds_host.split(":")[0],
-            port=int(rds_host.split(":")[1]) if ":" in rds_host else DatabaseConfig.DEFAULT_PORT,
+            port=int(rds_host.split(":")[1])
+            if ":" in rds_host
+            else DatabaseConfig.DEFAULT_PORT,
             user=get_required_env_var("RDS_USER"),
             password=get_required_env_var("RDS_PASSWORD"),
             database=get_required_env_var("RDS_DATABASE"),

--- a/studio/app/common/core/background/scheduler.py
+++ b/studio/app/common/core/background/scheduler.py
@@ -27,9 +27,7 @@ from studio.app.common.core.storage.remote_storage_controller import RemoteStora
 logger = AppLogger.get_logger()
 
 # Lock file path for multi-worker coordination
-_SCHEDULER_LOCK_FILE = os.path.join(
-    tempfile.gettempdir(), "optinist_scheduler.lock"
-)
+_SCHEDULER_LOCK_FILE = os.path.join(tempfile.gettempdir(), "optinist_scheduler.lock")
 
 
 class BackgroundScheduler:
@@ -130,9 +128,7 @@ class BackgroundScheduler:
         try:
             # Atomic file creation - fails if file exists
             fd = os.open(
-                _SCHEDULER_LOCK_FILE,
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o644
+                _SCHEDULER_LOCK_FILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
             )
             # Write our PID to the lock file for staleness detection
             os.write(fd, f"{os.getpid()}\n".encode())

--- a/studio/app/common/core/middleware/free_user_activity_middleware.py
+++ b/studio/app/common/core/middleware/free_user_activity_middleware.py
@@ -26,8 +26,8 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
-from studio.app.common.db.database import session_scope
 from studio.app.common.core.subscription.constants import SubscriptionPlanIds
+from studio.app.common.db.database import session_scope
 from studio.app.common.models import FreeUserAssignment
 
 # Constants

--- a/studio/app/common/core/middleware/secure_routing_middleware.py
+++ b/studio/app/common/core/middleware/secure_routing_middleware.py
@@ -127,9 +127,7 @@ def get_user_tier_cached(uid: str) -> str:
             subscription_data = SubscriptionService.get_user_subscription(db, user.id)
             if subscription_data:
                 _, plan = subscription_data
-                tier = (
-                    "premium" if plan.id == SubscriptionPlanIds.PREMIUM else "free"
-                )
+                tier = "premium" if plan.id == SubscriptionPlanIds.PREMIUM else "free"
             else:
                 tier = "free"
 


### PR DESCRIPTION
### Content

Add shared Lambda Layer for aws_constants 
Creates a Lambda Layer (subscr-aws-constants) to share aws_constants.py across multiple Lambda functions instead of copying it into each package.                                                     

  - Eliminates code duplication in free_manager, common_user_manager, premium_manager, and storage_reconciliation packages
  - Layer automatically rebuilds when aws_constants.py changes 