### PR TITLE
Create unified heartbeat middleware, and premium routing fix

### DIFF
--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -189,6 +189,49 @@ describe("RoutingService", () => {
 
       expect(newService.getRoutingToken()).toBe("stored-token")
     })
+
+    test("should persist user tier to localStorage", () => {
+      const premiumUser = createPremiumUser()
+      routingService.updateRoutingInfo(premiumUser)
+
+      expect(localStorageMock.getItem("routing_tier")).toBe("premium")
+    })
+
+    test("should load tier from localStorage on initialization", () => {
+      localStorageMock.setItem("routing_tier", "premium")
+
+      const newService = new RoutingService()
+
+      expect(newService.getUserTier()).toBe("premium")
+    })
+
+    test("should include stored tier in headers after page refresh", () => {
+      localStorageMock.setItem("routing_id", "stored-token")
+      localStorageMock.setItem("routing_tier", "premium")
+
+      const newService = new RoutingService()
+      const headers = newService.getRoutingHeaders()
+
+      expect(headers["X-Routing-ID"]).toBe("stored-token")
+      expect(headers["X-User-Tier"]).toBe("premium")
+    })
+
+    test("should ignore invalid tier values from localStorage", () => {
+      localStorageMock.setItem("routing_tier", "invalid-tier")
+
+      const newService = new RoutingService()
+
+      expect(newService.getUserTier()).toBeNull()
+    })
+
+    test("should remove tier from localStorage on clear", () => {
+      routingService.updateRoutingInfo(createPremiumUser())
+      expect(localStorageMock.getItem("routing_tier")).toBe("premium")
+
+      routingService.clearRoutingInfo()
+
+      expect(localStorageMock.getItem("routing_tier")).toBeNull()
+    })
   })
 
   describe("isRoutingInfoStale", () => {

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -41,13 +41,16 @@ export interface PremiumAssignmentResult {
 export class RoutingService {
   private routingInfo: RoutingInfo | null = null
   private routingToken: string | null = null
+  private storedTier: UserTier | null = null
   private lastFetch: number = 0
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
   private readonly STORAGE_KEY = "routing_id"
+  private readonly TIER_STORAGE_KEY = "routing_tier"
 
   constructor() {
-    // Load token from localStorage on initialization
+    // Load token and tier from localStorage on initialization
     this.loadTokenFromStorage()
+    this.loadTierFromStorage()
   }
 
   /**
@@ -63,9 +66,10 @@ export class RoutingService {
       [RoutingHeaders.ROUTING_ID]: this.routingToken,
     }
 
-    // Include user tier header for ALB routing rules
-    if (this.routingInfo?.user_tier) {
-      headers[RoutingHeaders.USER_TIER] = this.routingInfo.user_tier
+    // Use routingInfo.user_tier if available, fall back to stored tier
+    const tier = this.routingInfo?.user_tier ?? this.storedTier
+    if (tier) {
+      headers[RoutingHeaders.USER_TIER] = tier
     }
 
     return headers
@@ -86,13 +90,18 @@ export class RoutingService {
    */
   updateRoutingInfo(user: UserDTO): void {
     const isPremium = this.isPremiumUser(user)
+    const userTier = isPremium ? UserTier.PREMIUM : UserTier.FREE
 
     this.routingInfo = {
       user_id: user.uid || "",
-      user_tier: isPremium ? UserTier.PREMIUM : UserTier.FREE,
+      user_tier: userTier,
       requires_premium_routing: isPremium,
       routing_headers: {}, // No longer client-controlled
     }
+
+    // Persist tier to localStorage
+    this.storedTier = userTier
+    this.saveTierToStorage(userTier)
 
     this.lastFetch = Date.now()
   }
@@ -103,8 +112,10 @@ export class RoutingService {
   clearRoutingInfo(): void {
     this.routingInfo = null
     this.routingToken = null
+    this.storedTier = null
     this.lastFetch = 0
     this.clearTokenFromStorage()
+    this.clearTierFromStorage()
   }
 
   /**
@@ -125,7 +136,7 @@ export class RoutingService {
    * Get current user tier
    */
   getUserTier(): UserTier | null {
-    return this.routingInfo?.user_tier || null
+    return this.routingInfo?.user_tier ?? this.storedTier ?? null
   }
 
   /**
@@ -188,6 +199,49 @@ export class RoutingService {
     } catch (e) {
       console.warn("Failed to clear routing ID from localStorage:", e)
     }
+  }
+
+  /**
+   * Load user tier from localStorage
+   */
+  private loadTierFromStorage(): void {
+    try {
+      const tier = localStorage.getItem(this.TIER_STORAGE_KEY)
+      if (tier && this.isValidUserTier(tier)) {
+        this.storedTier = tier as UserTier
+      }
+    } catch (e) {
+      console.warn("Failed to load user tier from localStorage:", e)
+    }
+  }
+
+  /**
+   * Save user tier to localStorage
+   */
+  private saveTierToStorage(tier: UserTier): void {
+    try {
+      localStorage.setItem(this.TIER_STORAGE_KEY, tier)
+    } catch (e) {
+      console.warn("Failed to save user tier to localStorage:", e)
+    }
+  }
+
+  /**
+   * Clear user tier from localStorage
+   */
+  private clearTierFromStorage(): void {
+    try {
+      localStorage.removeItem(this.TIER_STORAGE_KEY)
+    } catch (e) {
+      console.warn("Failed to clear user tier from localStorage:", e)
+    }
+  }
+
+  /**
+   * Validate that a string is a valid UserTier value
+   */
+  private isValidUserTier(value: string): value is UserTier {
+    return value === UserTier.PREMIUM || value === UserTier.FREE
   }
 }
 

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -17,9 +17,9 @@ from studio.app.common.core.auth.auth_dependencies import (
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.middleware import (
     ClientIdLoggingMiddleware,
-    FreeUserActivityMiddleware,
     SecureRoutingMiddleware,
     SPARoutingMiddleware,
+    UserActivityMiddleware,
 )
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
@@ -217,8 +217,10 @@ app.add_middleware(SPARoutingMiddleware)
 # Add LoggingMiddleware to capture client_id for logging
 app.add_middleware(ClientIdLoggingMiddleware)
 
-# Add FreeUserActivityMiddleware to track free tier user activity
-app.add_middleware(FreeUserActivityMiddleware)
+# Add UserActivityMiddleware to track activity for both free and premium users
+# - Free users: enables intelligent load balancing and migration
+# - Premium users: prevents stale assignment cleanup for active users
+app.add_middleware(UserActivityMiddleware)
 
 # Add SecureRoutingMiddleware to add routing headers based on JWT validation
 app.add_middleware(SecureRoutingMiddleware)

--- a/studio/app/common/core/middleware/__init__.py
+++ b/studio/app/common/core/middleware/__init__.py
@@ -2,9 +2,6 @@
 Middleware modules for the Studio application
 """
 
-from studio.app.common.core.middleware.free_user_activity_middleware import (
-    FreeUserActivityMiddleware,
-)
 from studio.app.common.core.middleware.logging_middleware import (
     ClientIdLoggingMiddleware,
 )
@@ -14,10 +11,17 @@ from studio.app.common.core.middleware.secure_routing_middleware import (
 from studio.app.common.core.middleware.spa_routing_middleware import (
     SPARoutingMiddleware,
 )
+from studio.app.common.core.middleware.user_activity_middleware import (
+    FreeUserActivityMiddleware,  # Backwards compatibility alias
+)
+from studio.app.common.core.middleware.user_activity_middleware import (
+    UserActivityMiddleware,
+)
 
 __all__ = [
     "ClientIdLoggingMiddleware",
-    "FreeUserActivityMiddleware",
+    "FreeUserActivityMiddleware",  # Backwards compatibility alias
     "SecureRoutingMiddleware",
     "SPARoutingMiddleware",
+    "UserActivityMiddleware",
 ]

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -1,12 +1,18 @@
 """
-Free User Activity Tracking Middleware
+User Activity Tracking Middleware
 
-This middleware tracks activity for free tier users to enable intelligent load balancing
-and autoscaling. It updates the last_activity timestamp in the database for every HTTP
-request from a free tier user, which allows the Free Manager Lambda to:
-1. Identify idle users (no activity for 10+ minutes)
-2. Safely migrate idle users to newly launched instances
-3. Count active users to trigger autoscaling
+This middleware tracks activity for both free and premium tier users to enable:
+
+For Free Users:
+1. Intelligent load balancing and autoscaling
+2. Identify idle users (no activity for 10+ minutes)
+3. Safely migrate idle users to newly launched instances
+4. Count active users to trigger autoscaling
+
+For Premium Users:
+1. Prevent stale assignment cleanup for active users
+2. Enable proper scale-down of premium instance pool
+3. Track actual usage for billing/analytics
 
 IMPORTANT: Database updates run in background tasks to avoid blocking requests.
 
@@ -18,9 +24,11 @@ See: https://github.com/encode/starlette/issues/1012
 import asyncio
 import os
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
+from sqlalchemy import text
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
@@ -38,7 +46,9 @@ TIER_FREE = "free"
 TIER_PREMIUM = "premium"
 
 # In-memory cache to reduce database load (tracks last update time per user)
-_last_activity_cache = {}
+# Separate caches for free and premium to avoid key collisions
+_free_activity_cache = {}
+_premium_activity_cache = {}
 _cache_lock = threading.Lock()
 _CACHE_TTL_SECONDS = 60  # Only update DB once per minute per user
 
@@ -46,16 +56,17 @@ _CACHE_TTL_SECONDS = 60  # Only update DB once per minute per user
 _instance_id_cache = None
 _instance_id_lock = threading.Lock()
 
+logger = AppLogger.get_logger()
 
-class FreeUserActivityMiddleware:
+
+class UserActivityMiddleware:
     """
-    ASGI Middleware to track free tier user activity for load balancing purposes.
+    ASGI Middleware to track user activity for both free and premium tiers.
 
     This middleware:
     - Extracts user ID from authentication tokens
-    - Checks if user is on free tier (subscription_status = "Free")
-    - Updates last_activity timestamp in free_user_assignments table
-    - Records current instance ID for tracking
+    - Determines user tier (free or premium)
+    - Updates last_activity timestamp in appropriate table
     - Runs asynchronously without blocking request processing
     """
 
@@ -77,7 +88,6 @@ class FreeUserActivityMiddleware:
         path = scope.get("path", "")
 
         # Skip health check, auth endpoints, and system-internal API endpoints
-        # System-internal endpoints use their own auth (shared secret, not JWT)
         if path in SKIP_AUTH_PATHS or path.startswith("/system-internal/"):
             await self.app(scope, receive, send)
             return
@@ -111,7 +121,6 @@ class FreeUserActivityMiddleware:
             nonlocal has_tracked
 
             # When response starts, schedule activity tracking
-            # This happens before response completes, so it's non-blocking
             if message["type"] == "http.response.start" and not has_tracked:
                 has_tracked = True
 
@@ -119,24 +128,35 @@ class FreeUserActivityMiddleware:
                     # Get user ID and tier from database
                     user_id, tier = _get_user_id_and_tier(uid)
 
-                    if user_id and tier == TIER_FREE:
-                        # Check cache to avoid excessive DB writes
-                        if _should_update_activity(user_id):
-                            # Schedule background update (doesn't block response)
-                            asyncio.create_task(
-                                _update_free_user_activity_async(user_id)
-                            )
+                    if user_id:
+                        if tier == TIER_FREE:
+                            # Check cache to avoid excessive DB writes
+                            if _should_update_activity(user_id, TIER_FREE):
+                                # Schedule background update (doesn't block response)
+                                asyncio.create_task(
+                                    _update_free_user_activity_async(user_id)
+                                )
+                        elif tier == TIER_PREMIUM:
+                            # Check cache to avoid excessive DB writes
+                            if _should_update_activity(user_id, TIER_PREMIUM):
+                                # Schedule background update (doesn't block response)
+                                asyncio.create_task(
+                                    _update_premium_user_activity_async(user_id)
+                                )
 
                 except Exception as e:
                     # Log error but don't fail the request
-                    logger = AppLogger.get_logger()
-                    logger.warning(f"Failed to track free user activity: {e}")
+                    logger.warning(f"Failed to track user activity: {e}")
 
             # Always send the original message
             await send(message)
 
         # Process the request with our wrapped send function
         await self.app(scope, receive, send_wrapper)
+
+
+# Keep FreeUserActivityMiddleware as alias for backwards compatibility
+FreeUserActivityMiddleware = UserActivityMiddleware
 
 
 def _get_user_id_and_tier(uid: str) -> Tuple[Optional[int], Optional[str]]:
@@ -179,23 +199,21 @@ def _get_user_id_and_tier(uid: str) -> Tuple[Optional[int], Optional[str]]:
         finally:
             db.close()
     except Exception as e:
-        logger = AppLogger.get_logger()
         logger.warning(f"Failed to get user tier for {uid}: {e}")
         return None, None
 
 
-def _should_update_activity(user_id: str) -> bool:
+def _should_update_activity(user_id: int, tier: str) -> bool:
     """
     Check if we should update activity for this user (throttling).
     Only update DB once per minute per user to reduce load.
 
-    IMPORTANT: This only CHECKS the cache. The actual cache update happens
-    in _update_cache_after_commit() AFTER successful database commit.
+    Uses separate caches for free and premium users.
     """
-    import time
+    cache = _free_activity_cache if tier == TIER_FREE else _premium_activity_cache
 
     with _cache_lock:
-        last_update = _last_activity_cache.get(user_id, 0)
+        last_update = cache.get(user_id, 0)
         now = time.time()
 
         if now - last_update >= _CACHE_TTL_SECONDS:
@@ -203,27 +221,29 @@ def _should_update_activity(user_id: str) -> bool:
         return False
 
 
-def _update_cache_after_commit(user_id: str):
+def _update_cache_after_commit(user_id: int, tier: str):
     """
     Update cache timestamp after successful database commit.
     This ensures cache consistency with database state.
     """
-    import time
+    cache = _free_activity_cache if tier == TIER_FREE else _premium_activity_cache
 
     with _cache_lock:
-        _last_activity_cache[user_id] = time.time()
+        cache[user_id] = time.time()
 
 
-async def _update_free_user_activity_async(user_id: str):
+# ============================================================================
+# FREE USER ACTIVITY TRACKING
+# ============================================================================
+
+
+async def _update_free_user_activity_async(user_id: int):
     """
     Update last_activity timestamp for free tier user (async wrapper).
     Runs in background to avoid blocking request.
-
-    Cache is updated optimistically before database commit to minimize latency.
-    If database update fails, the cache will be refreshed on next request.
     """
     # Update cache immediately (optimistic) to reduce perceived latency
-    _update_cache_after_commit(user_id)
+    _update_cache_after_commit(user_id, TIER_FREE)
 
     # Run blocking database call in thread pool (fire-and-forget)
     loop = asyncio.get_event_loop()
@@ -231,11 +251,12 @@ async def _update_free_user_activity_async(user_id: str):
         await loop.run_in_executor(None, _update_free_user_activity_sync, user_id)
     except Exception as e:
         # Log error but don't propagate (fire-and-forget pattern)
-        logger = AppLogger.get_logger()
-        logger.warning(f"Background activity update failed for user {user_id}: {e}")
+        logger.warning(
+            f"Background activity update failed for free user {user_id}: {e}"
+        )
 
 
-def _update_free_user_activity_sync(user_id: str) -> bool:
+def _update_free_user_activity_sync(user_id: int) -> bool:
     """
     Update last_activity timestamp for free tier user (sync implementation).
 
@@ -285,9 +306,83 @@ def _update_free_user_activity_sync(user_id: str) -> bool:
             return True
 
     except Exception as e:
-        logger = AppLogger.get_logger()
         logger.error(f"Error updating free user activity for user {user_id}: {e}")
         return False
+
+
+# ============================================================================
+# PREMIUM USER ACTIVITY TRACKING
+# ============================================================================
+
+
+async def _update_premium_user_activity_async(user_id: int):
+    """
+    Update last_activity timestamp for premium tier user (async wrapper).
+    Runs in background to avoid blocking request.
+    """
+    # Update cache immediately (optimistic) to reduce perceived latency
+    _update_cache_after_commit(user_id, TIER_PREMIUM)
+
+    # Run blocking database call in thread pool (fire-and-forget)
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(None, _update_premium_user_activity_sync, user_id)
+    except Exception as e:
+        # Log error but don't propagate (fire-and-forget pattern)
+        logger.warning(
+            f"Background activity update failed for premium user {user_id}: {e}"
+        )
+
+
+def _update_premium_user_activity_sync(user_id: int) -> bool:
+    """
+    Update last_activity timestamp for premium tier user (sync implementation).
+
+    This method updates the last_activity column in the premium_user_assignments
+    table, which is used by the Premium Cleanup Lambda to determine if an
+    assignment is stale.
+
+    Returns:
+        True if update successful, False otherwise
+    """
+    try:
+        with session_scope() as session:
+            now = datetime.now(timezone.utc)
+
+            # Update last_activity for this user's premium assignment
+            # Uses raw SQL for efficiency (no need to load full ORM object)
+            result = session.execute(
+                text(
+                    """
+                UPDATE premium_user_assignments
+                SET last_activity = :now
+                WHERE user_id = :user_id
+                AND status = 'active'
+                AND is_standby = 0
+                """
+                ),
+                {"now": now, "user_id": user_id},
+            )
+
+            session.commit()
+
+            if result.rowcount > 0:
+                logger.debug(
+                    f"Updated premium activity for user {user_id} at {now.isoformat()}"
+                )
+                return True
+            else:
+                # No assignment found (user may not have active premium assignment)
+                return False
+
+    except Exception as e:
+        logger.error(f"Error updating premium user activity for user {user_id}: {e}")
+        return False
+
+
+# ============================================================================
+# UTILITY FUNCTIONS
+# ============================================================================
 
 
 def _get_instance_id() -> Optional[str]:
@@ -358,7 +453,6 @@ def _get_instance_id() -> Optional[str]:
             pass
 
         # Local development or metadata service unavailable
-        logger = AppLogger.get_logger()
         logger.warning(
             "Could not retrieve EC2 instance ID from metadata service. "
             "Using 'local' as instance ID. This is OK for local development "

--- a/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
@@ -1,0 +1,333 @@
+"""
+Unit Tests for UserActivityMiddleware
+
+Tests the combined activity tracking middleware for both free and premium users.
+
+WHAT IT TESTS:
+1. Middleware correctly identifies free vs premium users
+2. Activity updates are cached (60-second TTL)
+3. Free users: updates free_user_assignments table
+4. Premium users: updates premium_user_assignments table
+5. Skips health checks, auth endpoints, system-internal paths
+6. Standalone mode bypass
+7. Error handling (graceful degradation)
+8. Missing/invalid JWT handling
+
+HOW TO RUN:
+  cd studio/
+  pytest tests/app/common/core/middleware/test_user_activity_middleware.py -v
+
+REQUIREMENTS:
+- pytest
+- pytest-asyncio
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Test data
+TEST_UID = "test_user_12345"
+TEST_USER_ID = 42
+TEST_JWT_TOKEN = "mock_firebase_jwt_token"
+TIER_FREE = "free"
+TIER_PREMIUM = "premium"
+
+
+class TestMiddlewarePathSkipping:
+    """Test that middleware skips appropriate paths"""
+
+    @pytest.mark.asyncio
+    async def test_skips_health_endpoint(self):
+        """Middleware should skip /health endpoint"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            UserActivityMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = UserActivityMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/health",
+            "headers": [],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request"}
+
+        async def mock_send(message):
+            pass
+
+        with patch.object(MODE, "IS_STANDALONE", False):
+            await middleware(scope, mock_receive, mock_send)
+
+        # App should be called directly without any user lookup
+        mock_app.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_system_internal_paths(self):
+        """Middleware should skip /system-internal/* paths"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            UserActivityMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = UserActivityMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/system-internal/sync-experiments/1",
+            "headers": [],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request"}
+
+        async def mock_send(message):
+            pass
+
+        with patch.object(MODE, "IS_STANDALONE", False):
+            await middleware(scope, mock_receive, mock_send)
+
+        mock_app.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_standalone_mode(self):
+        """Middleware should skip in standalone mode"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            UserActivityMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = UserActivityMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/api/test",
+            "headers": [(b"authorization", b"Bearer " + TEST_JWT_TOKEN.encode())],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request"}
+
+        async def mock_send(message):
+            pass
+
+        with patch.object(MODE, "IS_STANDALONE", True):
+            await middleware(scope, mock_receive, mock_send)
+
+        mock_app.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_missing_auth_header(self):
+        """Middleware should skip requests without Authorization header"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            UserActivityMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = UserActivityMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/api/test",
+            "headers": [],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request"}
+
+        async def mock_send(message):
+            pass
+
+        with patch.object(MODE, "IS_STANDALONE", False):
+            await middleware(scope, mock_receive, mock_send)
+
+        mock_app.assert_called_once()
+
+
+class TestCacheThrottling:
+    """Test activity update caching/throttling"""
+
+    def test_should_update_activity_first_time(self):
+        """First activity update for a user should return True"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _free_activity_cache,
+            _should_update_activity,
+        )
+
+        # Clear cache
+        _free_activity_cache.clear()
+
+        # First time should return True
+        result = _should_update_activity(TEST_USER_ID, TIER_FREE)
+        assert result is True
+
+    def test_should_not_update_activity_within_ttl(self):
+        """Activity update within TTL should return False"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _free_activity_cache,
+            _should_update_activity,
+            _update_cache_after_commit,
+        )
+
+        # Clear and set cache
+        _free_activity_cache.clear()
+        _update_cache_after_commit(TEST_USER_ID, TIER_FREE)
+
+        # Immediately after should return False
+        result = _should_update_activity(TEST_USER_ID, TIER_FREE)
+        assert result is False
+
+    def test_should_update_activity_after_ttl(self):
+        """Activity update after TTL should return True"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _CACHE_TTL_SECONDS,
+            _cache_lock,
+            _free_activity_cache,
+            _should_update_activity,
+        )
+
+        # Clear cache and set old timestamp
+        _free_activity_cache.clear()
+        with _cache_lock:
+            _free_activity_cache[TEST_USER_ID] = time.time() - _CACHE_TTL_SECONDS - 1
+
+        # After TTL should return True
+        result = _should_update_activity(TEST_USER_ID, TIER_FREE)
+        assert result is True
+
+    def test_free_and_premium_caches_are_separate(self):
+        """Free and premium users should have separate caches"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _free_activity_cache,
+            _premium_activity_cache,
+            _should_update_activity,
+            _update_cache_after_commit,
+        )
+
+        # Clear both caches
+        _free_activity_cache.clear()
+        _premium_activity_cache.clear()
+
+        # Update free cache
+        _update_cache_after_commit(TEST_USER_ID, TIER_FREE)
+
+        # Free should be cached, premium should not
+        assert _should_update_activity(TEST_USER_ID, TIER_FREE) is False
+        assert _should_update_activity(TEST_USER_ID, TIER_PREMIUM) is True
+
+
+class TestUserTierDetection:
+    """Test user tier detection"""
+
+    def test_get_user_id_and_tier_free_user(self):
+        """Test detecting free tier user"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _get_user_id_and_tier,
+        )
+        from studio.app.common.core.subscription.constants import SubscriptionPlanIds
+
+        mock_user = MagicMock()
+        mock_user.id = TEST_USER_ID
+
+        mock_plan = MagicMock()
+        mock_plan.id = SubscriptionPlanIds.FREE
+
+        mock_subscription = MagicMock()
+
+        # Patch at the actual module location (imports are inside the function)
+        with patch("studio.app.common.db.database.get_db") as mock_get_db:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.first.return_value = (
+                mock_user
+            )
+            mock_get_db.return_value = iter([mock_db])
+
+            with patch(
+                "studio.app.common.core.subscription.subscription_service."
+                "SubscriptionService.get_user_subscription"
+            ) as mock_get_sub:
+                mock_get_sub.return_value = (mock_subscription, mock_plan)
+
+                user_id, tier = _get_user_id_and_tier(TEST_UID)
+
+                assert user_id == TEST_USER_ID
+                assert tier == TIER_FREE
+
+    def test_get_user_id_and_tier_premium_user(self):
+        """Test detecting premium tier user"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _get_user_id_and_tier,
+        )
+        from studio.app.common.core.subscription.constants import SubscriptionPlanIds
+
+        mock_user = MagicMock()
+        mock_user.id = TEST_USER_ID
+
+        mock_plan = MagicMock()
+        mock_plan.id = SubscriptionPlanIds.PREMIUM
+
+        mock_subscription = MagicMock()
+
+        with patch("studio.app.common.db.database.get_db") as mock_get_db:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.first.return_value = (
+                mock_user
+            )
+            mock_get_db.return_value = iter([mock_db])
+
+            with patch(
+                "studio.app.common.core.subscription.subscription_service."
+                "SubscriptionService.get_user_subscription"
+            ) as mock_get_sub:
+                mock_get_sub.return_value = (mock_subscription, mock_plan)
+
+                user_id, tier = _get_user_id_and_tier(TEST_UID)
+
+                assert user_id == TEST_USER_ID
+                assert tier == TIER_PREMIUM
+
+    def test_get_user_id_and_tier_user_not_found(self):
+        """Test handling user not found"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _get_user_id_and_tier,
+        )
+
+        with patch("studio.app.common.db.database.get_db") as mock_get_db:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.first.return_value = None
+            mock_get_db.return_value = iter([mock_db])
+
+            user_id, tier = _get_user_id_and_tier(TEST_UID)
+
+            assert user_id is None
+            assert tier is None
+
+
+class TestBackwardsCompatibility:
+    """Test backwards compatibility alias"""
+
+    def test_free_user_activity_middleware_alias(self):
+        """FreeUserActivityMiddleware should be alias for UserActivityMiddleware"""
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            FreeUserActivityMiddleware,
+            UserActivityMiddleware,
+        )
+
+        assert FreeUserActivityMiddleware is UserActivityMiddleware
+
+    def test_import_from_init(self):
+        """Both classes should be importable from __init__"""
+        from studio.app.common.core.middleware import (
+            FreeUserActivityMiddleware,
+            UserActivityMiddleware,
+        )
+
+        assert FreeUserActivityMiddleware is UserActivityMiddleware

--- a/studio/tests/app/common/routers/test_data_sync.py
+++ b/studio/tests/app/common/routers/test_data_sync.py
@@ -513,20 +513,15 @@ class TestLazySync:
 class TestMiddlewareBypass:
     """Tests for middleware skipping /system-internal/ paths."""
 
-    def test_free_user_middleware_skips_internal_paths(self):
-        """FreeUserActivityMiddleware should skip /system-internal/* routes."""
-        # Verify the logic in middleware checks for /system-internal/ prefix
-        test_paths = [
-            "/system-internal/sync-experiments/1",
-            "/system-internal/health",
-            "/system-internal/anything",
-        ]
+    def test_user_activity_middleware_skips_internal_paths(self):
+        """UserActivityMiddleware should skip /system-internal/* routes."""
+        # Verify the middleware has the skip logic
+        import inspect
 
-        for path in test_paths:
-            # The middleware checks: path.startswith("/system-internal/")
-            assert path.startswith(
-                "/system-internal/"
-            ), f"Path {path} should start with /system-internal/"
+        import studio.app.common.core.middleware.user_activity_middleware as uam
+
+        source = inspect.getsource(uam.UserActivityMiddleware)
+        assert 'startswith("/system-internal/")' in source
 
     def test_secure_routing_middleware_skips_internal_paths(self):
         """SecureRoutingMiddleware should skip /system-internal/* routes."""


### PR DESCRIPTION
### Content                                                                                                                     
                                                                                                                              
  This branch fixes a critical bug where premium user assignments were being cleaned up even when users were actively using   
  the system. The last_activity timestamp was only set on initial assignment and never updated during usage.                  
                                                                                                                              
### Problem                                                                                                                     
                                                                                                                              
  Premium users' last_activity was never updated after initial assignment:                                                    
  -- Database showed:                                                                                                         
  | user_id | assigned_at         | last_activity       | hours_idle |                                                        
  |---------|---------------------|---------------------|------------|                                                        
  |      35 | 2026-01-25 23:46:22 | 2026-01-25 23:46:22 |          2 |                                                        
                                                                                                                              
  This caused the Premium Cleanup Lambda (3-hour timeout) to remove active users' assignments.                                
                                                                                                                                                                                                                                          
                                                                                                                              
  The heartbeat API existed but was only called when users clicked "Stay Active" on the inactivity warning—not automatically  
  during normal usage.                                                                                                        
                                                                                                                              
### Solution                                                                                                                    
                                                                                                                              
  Created a combined UserActivityMiddleware that automatically updates last_activity for both free and premium users on every 
  HTTP request.                                                                                                               
                                                                                                                              
### Changes                                                                                                                     
                                                                                                                              
  1. New Combined Activity Middleware                                                                                         
                                                                                                                              
  File: user_activity_middleware.py                                                                                           
                                                                                                                              
  Replaces the separate FreeUserActivityMiddleware with a unified middleware that handles both tiers:                         
                                                
  Both use a 60-second cache to avoid excessive database writes:                                                              
  _CACHE_TTL_SECONDS = 60  # Only update DB once per minute per user                                                          
                                                                                                                              
  2. Middleware Registration Simplified                                                                                       
                                                                                                                              
  File: __main_unit__.py                                                                                                      
                                                                                                                              
  Before (2 middleware):                                                                                                      
  app.add_middleware(FreeUserActivityMiddleware)                                                                              
  app.add_middleware(PremiumUserActivityMiddleware)                                                                           
                                                                                                                              
  After (1 middleware):                                                                                                       
  app.add_middleware(UserActivityMiddleware)                                                                                  
                                                                                                                              
  3. Backwards Compatibility                                                                                                  
                                                                                                                              
  File: __init__.py                                                                                                           
                                                                                                                              
  Maintained alias for any external references:                                                                               
  FreeUserActivityMiddleware = UserActivityMiddleware  # Backwards compatibility                                              
                                                                                                                              
### Testing                                                                                                                     
                                                                                                                              
  Unit Tests: 13 passed                                                                                                       
-   TestMiddlewarePathSkipping::test_skips_health_endpoint PASSED                                                               
-   TestMiddlewarePathSkipping::test_skips_system_internal_paths PASSED                                                         
-   TestMiddlewarePathSkipping::test_skips_standalone_mode PASSED                                                               
-   TestMiddlewarePathSkipping::test_skips_missing_auth_header PASSED                                                           
-   TestCacheThrottling::test_should_update_activity_first_time PASSED                                                          
-   TestCacheThrottling::test_should_not_update_activity_within_ttl PASSED                                                      
-   TestCacheThrottling::test_should_update_activity_after_ttl PASSED                                                           
-   TestCacheThrottling::test_free_and_premium_caches_are_separate PASSED                                                       
-   TestUserTierDetection::test_get_user_id_and_tier_free_user PASSED                                                           
-   TestUserTierDetection::test_get_user_id_and_tier_premium_user PASSED                                                        
-   TestUserTierDetection::test_get_user_id_and_tier_user_not_found PASSED                                                      
-   TestBackwardsCompatibility::test_free_user_activity_middleware_alias PASSED                                                 
-   TestBackwardsCompatibility::test_import_from_init PASSED                                                                    

                                                                                                                              
  Files Changed                                                                                                               
```
  studio/app/common/core/middleware/user_activity_middleware.py                                   
  studio/app/common/core/middleware/__init__.py                                
  studio/app/common/core/middleware/free_user_activity_middleware.py DELETED                                                  
  studio/__main_unit__.py                               
  studio/tests/app/common/core/middleware/test_user_activity_middleware.py                                 
  studio/tests/app/common/routers/test_data_sync.py
```

---

### Frontend: Persist User Tier to localStorage

### Problem

  On page refresh, the `X-User-Tier` header was missing from initial requests because:
  - `routing_token` loads from localStorage (key: `"routing_id"`)
  - `user_tier` only existed in memory (`routingInfo`) - not persisted
  - ALB routing rules require BOTH headers to route premium users correctly

### Solution

  Persist `user_tier` to localStorage alongside `routing_token` using a separate key (`"routing_tier"`).

### Changes

  1. Added `storedTier` property and `TIER_STORAGE_KEY = "routing_tier"` constant
  2. Constructor now loads tier from localStorage on initialization
  3. `getRoutingHeaders()` uses stored tier as fallback when `routingInfo` is not yet populated
  4. `updateRoutingInfo()` persists tier to localStorage
  5. `clearRoutingInfo()` clears stored tier on logout
  6. `getUserTier()` falls back to stored tier
  7. Added `isValidUserTier()` validation to ignore invalid localStorage values

### Testing

  Unit Tests: 21 passed (5 new tests added)
  - `should persist user tier to localStorage`
  - `should load tier from localStorage on initialization`
  - `should include stored tier in headers after page refresh`
  - `should ignore invalid tier values from localStorage`
  - `should remove tier from localStorage on clear`

  Files Changed
```
  frontend/src/utils/routing/RoutingService.ts
  frontend/src/utils/routing/RoutingService.test.ts
```