### PR TITLE
Fix/alb rule duplicates

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -74,6 +74,33 @@ class RoutingHeaders:
     USER_TIER = "X-User-Tier"
 
 
+class PremiumAssignment:
+    """
+    Premium user assignment constants.
+
+    These values are used in the premium_user_assignments table
+    to track assignment states and special markers.
+
+    Status values:
+        ACTIVE, MIGRATING, TERMINATING - lifecycle states
+
+    Marker values:
+        STANDBY, RESERVING - placeholder values for special entries
+    """
+
+    # Status: Active assignment - user is assigned and can access the instance
+    ACTIVE = "active"
+    # Status: Assignment is being migrated to a new instance
+    MIGRATING = "migrating"
+    # Status: Assignment is being terminated
+    TERMINATING = "terminating"
+
+    # Marker: Standby pool entries (no real ALB rule/target group yet)
+    STANDBY = "standby"
+    # Marker: Instances being reserved for a user
+    RESERVING = "reserving"
+
+
 class DatabaseConfig:
     """
     Database connection configuration constants.

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -156,8 +156,9 @@ def handler(event, context):
     Operations:
     1. cleanup_stale_assignments() - Remove >2hr inactive assignments
     2. cleanup_orphaned_alb_resources() - Delete ALB rules with no DB entry
-    3. reconcile_instance_states() - Update DB to match AWS reality
-    4. ensure_standby_pool_capacity() - Monitor standby health (read-only)
+    3. cleanup_duplicate_alb_rules() - Remove redundant rules with same routing_id
+    4. reconcile_instance_states() - Update DB to match AWS reality
+    5. ensure_standby_pool_capacity() - Monitor standby health (read-only)
 
     Does NOT stop/start instances - that's premium_manager's job.
     """
@@ -165,6 +166,7 @@ def handler(event, context):
 
     results["cleanup_stats"] = cleanup_stale_assignments()
     results["orphaned_cleanup_stats"] = cleanup_orphaned_alb_resources()
+    results["duplicate_cleanup_stats"] = cleanup_duplicate_alb_rules()
     results["reconciliation_stats"] = reconcile_instance_states()
     results["capacity_check"] = ensure_standby_pool_capacity()
 
@@ -185,6 +187,7 @@ Premium Cleanup Lambda - Data & Resource Hygiene
 Responsibilities:
 - Remove stale assignments from database (>2 hours inactive)
 - Clean up orphaned ALB resources (rules/target groups with no DB entry)
+- Remove duplicate ALB rules (multiple rules with same routing_id)
 - Reconcile instance states (ensure DB matches AWS reality)
 - Monitor standby pool health (read-only)
 
@@ -254,14 +257,21 @@ Coordinates with premium_manager which handles all compute/capacity decisions.
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 3. reconcile_instance_states()                          │
+│ 3. cleanup_duplicate_alb_rules()                        │
+│    → Group ALB rules by routing_id                      │
+│    → Keep rule matching database entry                  │
+│    → Delete all duplicate rules                         │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ 4. reconcile_instance_states()                          │
 │    → Query AWS for actual instance states               │
 │    → Update DB to match reality                         │
 │    → Fix discrepancies (e.g., terminated instances)     │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 4. ensure_standby_pool_capacity() [Read-Only]          │
+│ 5. ensure_standby_pool_capacity() [Read-Only]          │
 │    → Check if standby pool has minimum capacity         │
 │    → Log warnings if capacity is low                    │
 │    → Does NOT create or terminate instances             │
@@ -421,6 +431,7 @@ PREMIUM_INSTANCE_IDS        # Comma-separated EC2 instance IDs
 **In Premium Cleanup:**
 - `cleanup_stale_assignments()` - Remove >2hr inactive assignments
 - `cleanup_orphaned_alb_resources()` - Delete ALB rules with no DB entry
+- `cleanup_duplicate_alb_rules()` - Remove redundant rules with same routing_id
 - `reconcile_instance_states()` - Sync DB with AWS reality
 - `ensure_standby_pool_capacity()` - Monitor standby health (read-only)
 

--- a/infrastructure/scripts/cleanup_premium_instances.py
+++ b/infrastructure/scripts/cleanup_premium_instances.py
@@ -312,12 +312,12 @@ def main():
 
     # Print results
     logger.info("Cleanup Results:")
-    logger.info(f"  Total premium instances: {results['total_premium_instances']}")
-    logger.info(f"  Active premium instances: {results['active_premium_instances']}")
-    logger.info(f"  Orphaned instances: {results['orphaned_instances']}")
-    logger.info(f"  Terminated instances: {results['terminated_instances']}")
-    logger.info(f"  Cleaned target groups: {results['cleaned_target_groups']}")
-    logger.info(f"  Cleaned DB entries: {results['cleaned_db_entries']}")
+    logger.info(f"Total premium instances: {results['total_premium_instances']}")
+    logger.info(f"Active premium instances: {results['active_premium_instances']}")
+    logger.info(f"Orphaned instances: {results['orphaned_instances']}")
+    logger.info(f"Terminated instances: {results['terminated_instances']}")
+    logger.info(f"Cleaned target groups: {results['cleaned_target_groups']}")
+    logger.info(f"Cleaned DB entries: {results['cleaned_db_entries']}")
 
     if dry_run and results["orphaned_instances"] > 0:
         logger.info("\nTo actually perform cleanup, run with --execute flag")

--- a/infrastructure/scripts/cleanup_premium_instances.py
+++ b/infrastructure/scripts/cleanup_premium_instances.py
@@ -240,8 +240,9 @@ def cleanup_orphaned_instances(dry_run: bool = True) -> Dict:
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
                 # Get all assignments
+                # (include id for proper deletion of NULL user_id rows)
                 cursor.execute(
-                    "SELECT user_id, instance_id FROM premium_user_assignments "
+                    "SELECT id, user_id, instance_id FROM premium_user_assignments "
                     "WHERE status = 'active'"
                 )
                 db_assignments = cursor.fetchall()
@@ -252,21 +253,22 @@ def cleanup_orphaned_instances(dry_run: bool = True) -> Dict:
                 }
 
                 for assignment in db_assignments:
+                    assignment_id = assignment["id"]
                     user_id = assignment["user_id"]
                     instance_id = assignment["instance_id"]
 
                     # If instance doesn't exist in AWS, clean up database
                     if instance_id not in all_instance_ids:
                         logger.info(
-                            f"Cleaning up database entry for terminated instance "
-                            f"{instance_id} (user {user_id})"
+                            f"Cleaning up database entry id={assignment_id} for "
+                            f"terminated instance {instance_id} (user {user_id})"
                         )
 
                         if not dry_run:
+                            # Use id for deletion (handles NULL user_id for standby)
                             cursor.execute(
-                                "DELETE FROM premium_user_assignments "
-                                "WHERE user_id = %s",
-                                (user_id,),
+                                "DELETE FROM premium_user_assignments " "WHERE id = %s",
+                                (assignment_id,),
                             )
                             cleanup_results["cleaned_db_entries"] += 1
             # Connection automatically closed when exiting 'with' block

--- a/infrastructure/scripts/test_premium_lambda.py
+++ b/infrastructure/scripts/test_premium_lambda.py
@@ -740,6 +740,336 @@ class TestLambdaIntegration:
                 print(f"Cleanup lambda execution failed: {e}")
                 return False
 
+    def test_early_check_returns_existing_assignment(self):
+        """
+        TC-1: Test that assign_premium_user returns existing assignment
+        without creating new ALB rules (prevents duplicate rule accumulation)
+
+        Tests assign_premium_user() directly with mocked get_existing_user_assignment
+        """
+        print("\n Testing Early Check Returns Existing Assignment")
+        print("=" * 50)
+
+        test_user_id = 12345  # Numeric user ID (already converted from UID)
+
+        # Existing assignment data to return
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": self.test_instance_id,
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", self.mock_env_vars), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_existing:
+            # Directly mock get_existing_user_assignment to return existing assignment
+            mock_get_existing.return_value = existing_assignment
+
+            # Mock AWS services - should NOT be called for rule creation
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            try:
+                from premium_manager import assign_premium_user
+
+                # Call assign_premium_user directly (bypasses UID->ID conversion)
+                result = assign_premium_user(test_user_id, {"tier": "premium"})
+
+                status_code = result["statusCode"]
+                response_body = json.loads(result["body"])
+
+                print(f"Status Code: {status_code}")
+                print(f"Response: {json.dumps(response_body, indent=2)}")
+
+                # Should return 200 with existing assignment
+                assert status_code == 200, "Should return 200 for existing assignment"
+                assert (
+                    "already assigned" in response_body.get("message", "").lower()
+                    or response_body.get("assignment_source") == "existing"
+                ), "Should indicate existing assignment"
+
+                # CRITICAL: create_rule should NOT be called
+                assert (
+                    not mock_elbv2.create_rule.called
+                ), "create_rule should NOT be called for existing assignment"
+
+                # Verify get_existing_user_assignment was called with correct user_id
+                mock_get_existing.assert_called_once_with(test_user_id)
+
+                print("Early check correctly returned existing assignment")
+                return True
+
+            except Exception as e:
+                print(f"Test failed: {e}")
+                import traceback
+
+                traceback.print_exc()
+                return False
+
+    def test_exception_handler_cleans_up_alb_rule(self):
+        """
+        TC-2: Test that exception handler cleans up ALB rule if created
+        (prevents orphaned rules on failure)
+        """
+        print("\n Testing Exception Handler ALB Rule Cleanup")
+        print("=" * 50)
+
+        with patch.dict("os.environ", self.mock_env_vars), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            # Setup database - no existing assignment, but store will fail
+            mock_connection = self.setup_db_mock(
+                fetchone_values=[
+                    None,  # No existing assignment
+                    None,  # No reservation
+                    MockRow({"count": 0}),  # Standby count
+                ],
+                fetchall_values=[
+                    [],  # No standby instances
+                    [
+                        MockRow(
+                            {"instance_id": self.test_instance_id, "state": "running"}
+                        )
+                    ],
+                    [],  # No existing rules
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            # Mock AWS services
+            mock_elbv2 = MagicMock()
+            mock_ec2 = MagicMock()
+
+            # Simulate successful rule creation
+            created_rule_arn = "arn:aws:rule/test-created-rule"
+            mock_elbv2.create_rule.return_value = {
+                "Rules": [{"RuleArn": created_rule_arn}]
+            }
+            mock_elbv2.describe_rules.return_value = {"Rules": []}
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                elif service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": self.test_instance_id,
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {"Key": "Name", "Value": "premium-instance"},
+                                    {"Key": "Tier", "Value": "premium"},
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            try:
+                from premium_manager import cleanup_duplicate_rules_for_routing_id
+
+                # Test the cleanup function directly
+                test_routing_id = "test123abc"
+                test_listener_arn = self.mock_env_vars["ALB_LISTENER_ARN"]
+
+                # Setup mock to return rules with matching routing_id
+                mock_elbv2.describe_rules.return_value = {
+                    "Rules": [
+                        {
+                            "RuleArn": "arn:aws:rule/duplicate1",
+                            "Priority": "100",
+                            "Conditions": [
+                                {
+                                    "Field": "http-header",
+                                    "HttpHeaderConfig": {
+                                        "HttpHeaderName": "X-Routing-ID",
+                                        "Values": [test_routing_id],
+                                    },
+                                }
+                            ],
+                            "Actions": [
+                                {
+                                    "Type": "forward",
+                                    "TargetGroupArn": "arn:aws:tg/orphaned",
+                                }
+                            ],
+                        },
+                        {
+                            "RuleArn": "arn:aws:rule/duplicate2",
+                            "Priority": "101",
+                            "Conditions": [
+                                {
+                                    "Field": "http-header",
+                                    "HttpHeaderConfig": {
+                                        "HttpHeaderName": "X-Routing-ID",
+                                        "Values": [test_routing_id],
+                                    },
+                                }
+                            ],
+                            "Actions": [
+                                {
+                                    "Type": "forward",
+                                    "TargetGroupArn": "arn:aws:tg/orphaned2",
+                                }
+                            ],
+                        },
+                    ]
+                }
+
+                deleted_count = cleanup_duplicate_rules_for_routing_id(
+                    test_listener_arn, test_routing_id
+                )
+
+                print(f"Deleted {deleted_count} duplicate rules")
+
+                # Should have called delete_rule for both duplicates
+                call_count = mock_elbv2.delete_rule.call_count
+                assert (
+                    call_count == 2
+                ), f"Expected 2 delete_rule calls, got {call_count}"
+
+                print("Cleanup function correctly deleted duplicate rules")
+                return True
+
+            except Exception as e:
+                print(f"Test failed: {e}")
+                import traceback
+
+                traceback.print_exc()
+                return False
+
+    def test_cleanup_duplicate_alb_rules_scheduled(self):
+        """
+        TC-4: Test scheduled duplicate cleanup in premium_cleanup Lambda
+        Tests cleanup_duplicate_alb_rules() function directly with mocks
+        """
+        print("\n Testing Scheduled Duplicate ALB Rules Cleanup")
+        print("=" * 50)
+
+        valid_rule_arn = "arn:aws:rule/valid-in-db"
+        duplicate_rule_arn = "arn:aws:rule/duplicate-not-in-db"
+        routing_id = "test-routing-id-123"
+
+        with patch.dict("os.environ", self.mock_env_vars), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_cleanup.get_db_connection") as mock_get_db:
+            # Mock database context manager to return valid rule ARN
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = [{"alb_rule_arn": valid_rule_arn}]
+
+            mock_connection = MagicMock()
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_connection.__enter__.return_value = mock_connection
+            mock_connection.__exit__.return_value = None
+
+            mock_get_db.return_value.__enter__.return_value = mock_connection
+            mock_get_db.return_value.__exit__.return_value = None
+
+            # Mock AWS services
+            mock_elbv2 = MagicMock()
+
+            # Return rules including duplicates (same routing_id)
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {"RuleArn": "default", "Priority": "default"},
+                    {
+                        "RuleArn": valid_rule_arn,
+                        "Priority": "100",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": "X-Routing-ID",
+                                    "Values": [routing_id],
+                                },
+                            },
+                        ],
+                        "Actions": [{"Type": "forward", "TargetGroupArn": "arn:tg/1"}],
+                    },
+                    {
+                        "RuleArn": duplicate_rule_arn,
+                        "Priority": "101",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": "X-Routing-ID",
+                                    "Values": [routing_id],
+                                },
+                            },
+                        ],
+                        "Actions": [{"Type": "forward", "TargetGroupArn": "arn:tg/2"}],
+                    },
+                ]
+            }
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            try:
+                from premium_cleanup import cleanup_duplicate_alb_rules
+
+                result = cleanup_duplicate_alb_rules()
+
+                print(f"Cleanup result: {result}")
+
+                # Should identify duplicate and delete it
+                assert (
+                    "duplicates_deleted" in result
+                ), "Result should include duplicates_deleted"
+
+                # Check which rules were deleted
+                delete_calls = mock_elbv2.delete_rule.call_args_list
+                deleted_arns = [call[1]["RuleArn"] for call in delete_calls]
+
+                print(f"Deleted rule ARNs: {deleted_arns}")
+
+                # Valid rule (in DB) should NOT be deleted
+                assert (
+                    valid_rule_arn not in deleted_arns
+                ), f"Valid rule {valid_rule_arn} should not be deleted"
+
+                # Duplicate rule (not in DB) SHOULD be deleted
+                assert (
+                    duplicate_rule_arn in deleted_arns
+                ), f"Duplicate rule {duplicate_rule_arn} should be deleted"
+
+                print("Scheduled cleanup correctly identified and deleted duplicates")
+                return True
+
+            except ImportError:
+                print("premium_cleanup.py not found, skipping test")
+                return True
+            except Exception as e:
+                print(f"Test failed: {e}")
+                import traceback
+
+                traceback.print_exc()
+                return False
+
 
 def run_lambda_integration_tests():
     """Run all Lambda integration tests"""
@@ -781,6 +1111,19 @@ def run_lambda_integration_tests():
         (
             "Premium Cleanup - Scheduled Event",
             test_suite.test_premium_cleanup_lambda_scheduled_event,
+        ),
+        # ALB Duplicate Rules Fix Tests (TC-1 through TC-4)
+        (
+            "TC-1: Early Check Returns Existing Assignment",
+            test_suite.test_early_check_returns_existing_assignment,
+        ),
+        (
+            "TC-2: Exception Handler Cleans Up ALB Rule",
+            test_suite.test_exception_handler_cleans_up_alb_rule,
+        ),
+        (
+            "TC-4: Scheduled Duplicate ALB Rules Cleanup",
+            test_suite.test_cleanup_duplicate_alb_rules_scheduled,
         ),
     ]
 

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -12,6 +12,7 @@ premium_manager and free_manager lambdas.
 
 import json
 import os
+import traceback
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict
@@ -20,7 +21,7 @@ import boto3
 import pymysql
 
 # Shared constants from Lambda Layer (mounted at /opt/python by AWS Lambda)
-from aws_constants import DatabaseConfig, SubscriptionType
+from aws_constants import DatabaseConfig, PremiumAssignment, SubscriptionType
 
 if TYPE_CHECKING:
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
@@ -308,8 +309,8 @@ def check_free_user_inactivity() -> Dict[str, int]:
                 user_ids = [u["user_id"] for u in inactive_users]
                 placeholders = ",".join(["%s"] * len(user_ids))
                 cursor.execute(
-                    f"DELETE FROM free_user_assignments "
-                    f"WHERE user_id IN ({placeholders})",
+                    "DELETE FROM free_user_assignments "
+                    "WHERE user_id IN (" + placeholders + ")",
                     user_ids,
                 )
                 conn.commit()
@@ -321,6 +322,7 @@ def check_free_user_inactivity() -> Dict[str, int]:
 
     except Exception as e:
         print(f"Failed to check free user inactivity: {e}")
+        traceback.print_exc()
         return {"logged_out": 0, "error": str(e)}
 
 
@@ -359,11 +361,22 @@ def check_premium_user_inactivity() -> Dict[str, int]:
                 for user in inactive_users:
                     user_id = user["user_id"]
                     try:
-                        # Clean up ALB resources first (before DB deletion)
-                        if user["alb_rule_arn"] and user["alb_rule_arn"] not in [
-                            "STANDBY",
-                            "standby",
-                            "reserving",
+                        # Delete from database FIRST
+                        # This ensures user appears "not assigned" immediately
+                        # If ALB cleanup fails later, orphaned resources are cleaned
+                        # by hourly cleanup job
+                        cursor.execute(
+                            "DELETE FROM premium_user_assignments WHERE user_id = %s",
+                            (user_id,),
+                        )
+
+                        # Clean up ALB resources (after DB deletion)
+                        # Skip marker values (standby/reserving placeholders)
+                        if user["alb_rule_arn"] and user[
+                            "alb_rule_arn"
+                        ].lower() not in [
+                            PremiumAssignment.STANDBY,
+                            PremiumAssignment.RESERVING,
                         ]:
                             try:
                                 elbv2.delete_rule(RuleArn=user["alb_rule_arn"])
@@ -375,8 +388,11 @@ def check_premium_user_inactivity() -> Dict[str, int]:
                         )
                         if (
                             user["target_group_arn"]
-                            and user["target_group_arn"]
-                            not in ["STANDBY", "standby", "reserving"]
+                            and user["target_group_arn"].lower()
+                            not in [
+                                PremiumAssignment.STANDBY,
+                                PremiumAssignment.RESERVING,
+                            ]
                             and user["target_group_arn"] != autoscaling_tg
                         ):
                             try:
@@ -388,11 +404,6 @@ def check_premium_user_inactivity() -> Dict[str, int]:
                                     f"Target group already deleted for user {user_id}"
                                 )
 
-                        # Delete assignment from database
-                        cursor.execute(
-                            "DELETE FROM premium_user_assignments WHERE user_id = %s",
-                            (user_id,),
-                        )
                         logged_out += 1
 
                     except Exception as e:
@@ -415,6 +426,7 @@ def check_premium_user_inactivity() -> Dict[str, int]:
 
     except Exception as e:
         print(f"Failed to check premium user inactivity: {e}")
+        traceback.print_exc()
         return {"logged_out": 0, "error": str(e)}
 
 
@@ -475,8 +487,6 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     except Exception as e:
         print(f"Error in common user manager: {str(e)}")
-        import traceback
-
         traceback.print_exc()
         return {
             "statusCode": 500,

--- a/infrastructure/terraform/free_cleanup_package/free_cleanup.py
+++ b/infrastructure/terraform/free_cleanup_package/free_cleanup.py
@@ -176,8 +176,8 @@ def cleanup_test_user_sessions(connection, user_emails: List[str]) -> Dict[str, 
             # Delete free_user_assignments for these users
             user_id_placeholders = ", ".join(["%s"] * len(user_ids))
             cursor.execute(
-                f"""DELETE FROM free_user_assignments
-                    WHERE user_id IN ({user_id_placeholders})""",
+                "DELETE FROM free_user_assignments "
+                "WHERE user_id IN (" + user_id_placeholders + ")",
                 user_ids,
             )
             deleted_count = cursor.rowcount
@@ -290,8 +290,8 @@ def cleanup_all_test_users(connection) -> Dict[str, Any]:
             placeholders = ", ".join(["%s"] * len(user_ids))
 
             cursor.execute(
-                f"""DELETE FROM free_user_assignments
-                    WHERE user_id IN ({placeholders})""",
+                "DELETE FROM free_user_assignments "
+                "WHERE user_id IN (" + placeholders + ")",
                 user_ids,
             )
             deleted_count = cursor.rowcount

--- a/infrastructure/terraform/premium_cleanup_package/README.md
+++ b/infrastructure/terraform/premium_cleanup_package/README.md
@@ -6,6 +6,7 @@ Maintains data hygiene and resource reconciliation for premium tier. Runs hourly
 ## Primary Responsibilities
 - **Stale Assignment Cleanup**: Remove inactive user assignments (>2 hours idle)
 - **Orphaned Resource Cleanup**: Delete ALB rules/target groups with no database entry
+- **Duplicate Rule Cleanup**: Remove redundant ALB rules with same routing_id
 - **State Reconciliation**: Sync database instance states with AWS reality
 - **Standby Pool Monitoring**: Health checks on standby instances (read-only)
 
@@ -48,13 +49,18 @@ Maintains data hygiene and resource reconciliation for premium tier. Runs hourly
     │     - Delete rules without DB entry            │
     │     - Delete orphaned target groups            │
     │                                                 │
-    │  3. STATE RECONCILIATION                       │
+    │  3. DUPLICATE RULE CLEANUP                     │
+    │     - Group rules by routing_id                │
+    │     - Keep rule matching database entry        │
+    │     - Delete all duplicates                    │
+    │                                                 │
+    │  4. STATE RECONCILIATION                       │
     │     - Get AWS instance states                  │
     │     - Compare with database                    │
     │     - Update DB to match AWS                   │
     │     - Remove terminated instances              │
     │                                                 │
-    │  4. STANDBY POOL CHECK                         │
+    │  5. STANDBY POOL CHECK                         │
     │     - Count standby instances                  │
     │     - Check health status                      │
     │     - Report issues (read-only)                │

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -755,7 +755,7 @@ def _reconcile_instance_states_transaction(
 
     with connection.cursor() as cursor:
         cursor.execute(
-            """SELECT user_id, instance_id, instance_state, status,
+            """SELECT id, user_id, instance_id, instance_state, status,
                       target_group_arn, alb_rule_arn
                FROM premium_user_assignments WHERE status = %s""",
             (PremiumAssignment.ACTIVE,),
@@ -763,6 +763,7 @@ def _reconcile_instance_states_transaction(
         db_assignments = cursor.fetchall()
 
         for assignment in db_assignments:
+            assignment_id = assignment["id"]
             user_id = assignment["user_id"]
             instance_id = assignment["instance_id"]
             db_state = assignment["instance_state"]
@@ -770,9 +771,10 @@ def _reconcile_instance_states_transaction(
 
             if not aws_instance:
                 # Instance no longer exists in AWS - cleanup
+                # Use assignment id for deletion (handles NULL user_id for standby)
                 print(
-                    f"Cleaning up assignment for terminated instance "
-                    f"{instance_id} (user {user_id})"
+                    f"Cleaning up assignment id={assignment_id} for "
+                    f"terminated instance {instance_id} (user {user_id})"
                 )
 
                 # Clean up ALB resources before DB deletion
@@ -805,22 +807,23 @@ def _reconcile_instance_states_transaction(
                         )
 
                 cursor.execute(
-                    "DELETE FROM premium_user_assignments WHERE user_id = %s",
-                    (user_id,),
+                    "DELETE FROM premium_user_assignments WHERE id = %s",
+                    (assignment_id,),
                 )
                 cleanup_count += 1
             elif aws_instance["state"] != db_state:
                 # Update database state to match AWS
+                # Use assignment id for update (handles NULL user_id for standby)
                 aws_state = aws_instance["state"]
                 print(
-                    f"Updating instance state for user "
-                    f"{user_id}: {db_state} → {aws_state}"
+                    f"Updating instance state for assignment id={assignment_id} "
+                    f"(user {user_id}): {db_state} → {aws_state}"
                 )
                 cursor.execute(
                     """UPDATE premium_user_assignments
                        SET instance_state = %s, last_state_check = NOW()
-                       WHERE user_id = %s""",
-                    (aws_state, user_id),
+                       WHERE id = %s""",
+                    (aws_state, assignment_id),
                 )
                 update_count += 1
 

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -28,9 +28,15 @@ import pymysql
 from aws_constants import (
     DatabaseConfig,
     ECSTaskStatus,
+    PremiumAssignment,
     PremiumInstanceConfig,
     RoutingHeaders,
 )
+
+# Constants
+# Default hours before stale premium assignments are cleaned up
+# Can be overridden by PREMIUM_IDLE_TIMEOUT_HOURS environment variable
+DEFAULT_STALE_ASSIGNMENT_TIMEOUT_HOURS = 2
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2 import EC2Client
@@ -120,8 +126,8 @@ def get_assigned_users_for_instance(instance_id: str) -> List[str]:
             with connection.cursor() as cursor:
                 cursor.execute(
                     """SELECT user_id FROM premium_user_assignments
-                       WHERE instance_id = %s AND status = 'active'""",
-                    (instance_id,),
+                       WHERE instance_id = %s AND status = %s""",
+                    (instance_id, PremiumAssignment.ACTIVE),
                 )
                 users = cursor.fetchall()
                 return [user["user_id"] for user in users]
@@ -174,7 +180,10 @@ def cleanup_stale_assignments(connection) -> Dict[str, Any]:
     """
     try:
         stale_threshold_hours = int(
-            get_required_env_var("PREMIUM_IDLE_TIMEOUT_HOURS", "2")
+            get_required_env_var(
+                "PREMIUM_IDLE_TIMEOUT_HOURS",
+                str(DEFAULT_STALE_ASSIGNMENT_TIMEOUT_HOURS),
+            )
         )
 
         print(f"Starting cleanup of assignments idle for >{stale_threshold_hours}h")
@@ -186,12 +195,12 @@ def cleanup_stale_assignments(connection) -> Dict[str, Any]:
                 SELECT user_id, instance_id, target_group_arn,
                 alb_rule_arn, last_activity
                 FROM premium_user_assignments
-                WHERE status = 'active'
+                WHERE status = %s
                 AND is_standby = 0
                 AND last_activity < DATE_SUB(NOW(), INTERVAL %s HOUR)
                 FOR UPDATE
             """,
-                (stale_threshold_hours,),
+                (PremiumAssignment.ACTIVE, stale_threshold_hours),
             )
 
             stale_assignments = cursor.fetchall()
@@ -217,15 +226,21 @@ def cleanup_stale_assignments(connection) -> Dict[str, Any]:
                 try:
                     print(f"Cleaning stale assignment for user {user_id}")
 
-                    # Delete ALB rule and target group
-                    if alb_rule_arn and alb_rule_arn != "STANDBY":
+                    # Delete ALB rule and target group (skip marker values)
+                    if (
+                        alb_rule_arn
+                        and alb_rule_arn.lower() != PremiumAssignment.STANDBY
+                    ):
                         try:
                             elbv2.delete_rule(RuleArn=alb_rule_arn)
                             print(f"Deleted ALB rule: {alb_rule_arn}")
                         except Exception as e:
                             print(f"Warning: Failed to delete ALB rule: {e}")
 
-                    if target_group_arn and target_group_arn != "STANDBY":
+                    if (
+                        target_group_arn
+                        and target_group_arn.lower() != PremiumAssignment.STANDBY
+                    ):
                         try:
                             elbv2.delete_target_group(TargetGroupArn=target_group_arn)
                             print(f"Deleted target group: {target_group_arn}")
@@ -311,12 +326,16 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
                 cursor.execute(
                     """SELECT alb_rule_arn, target_group_arn, user_id
                        FROM premium_user_assignments
-                       WHERE status = 'active' AND is_standby = 0"""
+                       WHERE status = %s AND is_standby = 0""",
+                    (PremiumAssignment.ACTIVE,),
                 )
                 db_assignments = cursor.fetchall()
 
         db_rule_arns = {
-            a["alb_rule_arn"] for a in db_assignments if a["alb_rule_arn"] != "STANDBY"
+            a["alb_rule_arn"]
+            for a in db_assignments
+            if a["alb_rule_arn"]
+            and a["alb_rule_arn"].lower() != PremiumAssignment.STANDBY
         }
         print(f"Found {len(db_rule_arns)} active assignments in database")
 
@@ -389,6 +408,136 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
         return {
             "orphaned_rules_deleted": 0,
             "orphaned_target_groups_deleted": 0,
+            "error": str(e),
+        }
+
+
+def cleanup_duplicate_alb_rules() -> Dict[str, Any]:
+    """
+    Clean up duplicate ALB rules that have the same routing_id.
+
+    This handles cases where multiple rules were created for the same user
+    due to race conditions or failed cleanup. Only keeps the rule that matches
+    the database entry; deletes all others.
+    """
+    try:
+        print("Scanning for duplicate ALB rules by routing_id...")
+
+        elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+        alb_listener_arn = get_required_env_var("ALB_LISTENER_ARN")
+
+        # Get all ALB listener rules
+        rules_response = elbv2.describe_rules(ListenerArn=alb_listener_arn)
+        alb_rules = rules_response.get("Rules", [])
+
+        # Group rules by routing_id
+        rules_by_routing_id: Dict[str, list] = {}
+        for rule in alb_rules:
+            if rule.get("Priority") == "default":
+                continue
+
+            # Extract routing_id from conditions
+            conditions = rule.get("Conditions", [])
+            routing_id = None
+            for cond in conditions:
+                if (
+                    cond.get("Field") == "http-header"
+                    and cond.get("HttpHeaderConfig", {}).get("HttpHeaderName")
+                    == RoutingHeaders.ROUTING_ID
+                ):
+                    values = cond.get("HttpHeaderConfig", {}).get("Values", [])
+                    if values:
+                        routing_id = values[0]
+                        break
+
+            if routing_id:
+                if routing_id not in rules_by_routing_id:
+                    rules_by_routing_id[routing_id] = []
+                rules_by_routing_id[routing_id].append(rule)
+
+        # Get all active assignments from database to know which rules to keep
+        with get_db_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """SELECT alb_rule_arn FROM premium_user_assignments
+                       WHERE status IN (%s, %s, %s)
+                       AND is_standby = 0
+                       AND alb_rule_arn NOT IN (%s, %s)""",
+                    (
+                        PremiumAssignment.ACTIVE,
+                        PremiumAssignment.MIGRATING,
+                        PremiumAssignment.TERMINATING,
+                        PremiumAssignment.STANDBY,
+                        "STANDBY",  # Handle legacy uppercase values
+                    ),
+                )
+                db_assignments = cursor.fetchall()
+
+        db_rule_arns = {a["alb_rule_arn"] for a in db_assignments}
+
+        # Find and delete duplicates
+        duplicates_deleted = 0
+        target_groups_deleted = 0
+
+        for routing_id, rules in rules_by_routing_id.items():
+            if len(rules) <= 1:
+                continue  # No duplicates
+
+            print(f"Found {len(rules)} rules for routing_id {routing_id[:8]}...")
+
+            # Keep the rule that's in the database, delete others
+            for rule in rules:
+                rule_arn = rule["RuleArn"]
+                if rule_arn in db_rule_arns:
+                    print(f"Keeping rule {rule_arn} (in database)")
+                    continue
+
+                # Delete this duplicate rule
+                try:
+                    print(f"Deleting duplicate rule {rule_arn}")
+                    elbv2.delete_rule(RuleArn=rule_arn)
+                    duplicates_deleted += 1
+
+                    # Try to delete associated target group
+                    # Note: AWS returns ResourceInUse error if TG is still
+                    # referenced by another rule. This is expected behavior
+                    # and the exception is logged but not fatal.
+                    for action in rule.get("Actions", []):
+                        if action.get("Type") == "forward":
+                            tg_arn = action.get("TargetGroupArn")
+                            if tg_arn:
+                                try:
+                                    elbv2.delete_target_group(TargetGroupArn=tg_arn)
+                                    target_groups_deleted += 1
+                                    print(f"Deleted target group {tg_arn}")
+                                except Exception as tg_error:
+                                    # Target group might be in use by another rule
+                                    print(
+                                        f"Could not delete target group : "
+                                        f"{tg_arn}: {tg_error}"
+                                    )
+
+                except Exception as e:
+                    print(f"Failed to delete rule {rule_arn}: {e}")
+
+        print(
+            f"Duplicate cleanup complete: {duplicates_deleted} rules, "
+            f"{target_groups_deleted} target groups deleted"
+        )
+
+        return {
+            "duplicates_deleted": duplicates_deleted,
+            "target_groups_deleted": target_groups_deleted,
+            "routing_ids_with_duplicates": sum(
+                1 for rules in rules_by_routing_id.values() if len(rules) > 1
+            ),
+        }
+
+    except Exception as e:
+        print(f"Error during duplicate rule cleanup: {str(e)}")
+        return {
+            "duplicates_deleted": 0,
+            "target_groups_deleted": 0,
             "error": str(e),
         }
 
@@ -582,62 +731,106 @@ def reconcile_instance_states() -> Dict[str, Any]:
                 "state": instance["state"],
             }
 
-        # Get all assignments from database
-        cleanup_count = 0
-        update_count = 0
-
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    """SELECT user_id, instance_id, instance_state, status
-                       FROM premium_user_assignments WHERE status = 'active'"""
-                )
-                db_assignments = cursor.fetchall()
-
-                for assignment in db_assignments:
-                    user_id = assignment["user_id"]
-                    instance_id = assignment["instance_id"]
-                    db_state = assignment["instance_state"]
-                    aws_instance = aws_instance_map.get(instance_id)
-
-                    if not aws_instance:
-                        # Instance no longer exists in AWS - cleanup
-                        print(
-                            f"Cleaning up assignment for terminated instance "
-                            f"{instance_id} (user {user_id})"
-                        )
-                        cursor.execute(
-                            "DELETE FROM premium_user_assignments WHERE user_id = %s",
-                            (user_id,),
-                        )
-                        cleanup_count += 1
-                        connection.commit()
-                    elif aws_instance["state"] != db_state:
-                        # Update database state to match AWS
-                        aws_state = aws_instance["state"]
-                        print(
-                            f"Updating instance state for user "
-                            f"{user_id}: {db_state} → {aws_state}"
-                        )
-                        cursor.execute(
-                            """UPDATE premium_user_assignments
-                               SET instance_state = %s, last_state_check = NOW()
-                               WHERE user_id = %s""",
-                            (aws_state, user_id),
-                        )
-                        update_count += 1
-                        connection.commit()
-
-        return {
-            "cleanup_count": cleanup_count,
-            "update_count": update_count,
-            "total_aws_instances": len(aws_instance_map),
-            "total_db_assignments": len(db_assignments),
-        }
+        # Delegate to transaction-safe internal function
+        return _reconcile_instance_states_transaction(aws_instance_map)
 
     except Exception as e:
         print(f"Error reconciling instance states: {str(e)}")
         return {"error": str(e)}
+
+
+@with_transaction
+def _reconcile_instance_states_transaction(
+    connection, aws_instance_map: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Internal function: Reconcile instance states with transaction safety.
+    All changes are committed together or rolled back on error.
+    """
+    cleanup_count = 0
+    update_count = 0
+
+    # Client for ALB cleanup when instances are gone
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT user_id, instance_id, instance_state, status,
+                      target_group_arn, alb_rule_arn
+               FROM premium_user_assignments WHERE status = %s""",
+            (PremiumAssignment.ACTIVE,),
+        )
+        db_assignments = cursor.fetchall()
+
+        for assignment in db_assignments:
+            user_id = assignment["user_id"]
+            instance_id = assignment["instance_id"]
+            db_state = assignment["instance_state"]
+            aws_instance = aws_instance_map.get(instance_id)
+
+            if not aws_instance:
+                # Instance no longer exists in AWS - cleanup
+                print(
+                    f"Cleaning up assignment for terminated instance "
+                    f"{instance_id} (user {user_id})"
+                )
+
+                # Clean up ALB resources before DB deletion
+                target_group_arn = assignment.get("target_group_arn")
+                alb_rule_arn = assignment.get("alb_rule_arn")
+
+                # Delete ALB rule (skip standby markers)
+                if alb_rule_arn and alb_rule_arn.lower() != PremiumAssignment.STANDBY:
+                    try:
+                        elbv2.delete_rule(RuleArn=alb_rule_arn)
+                        print(f"Deleted ALB rule for user {user_id}: {alb_rule_arn}")
+                    except Exception as e:
+                        print(f"Warning: Failed to delete ALB rule {alb_rule_arn}: {e}")
+
+                # Delete target group (skip standby markers)
+                if (
+                    target_group_arn
+                    and target_group_arn.lower() != PremiumAssignment.STANDBY
+                ):
+                    try:
+                        elbv2.delete_target_group(TargetGroupArn=target_group_arn)
+                        print(
+                            f"Deleted target group for user "
+                            f"{user_id}: {target_group_arn}"
+                        )
+                    except Exception as e:
+                        print(
+                            f"Warning: Failed to delete target group "
+                            f"{target_group_arn}: {e}"
+                        )
+
+                cursor.execute(
+                    "DELETE FROM premium_user_assignments WHERE user_id = %s",
+                    (user_id,),
+                )
+                cleanup_count += 1
+            elif aws_instance["state"] != db_state:
+                # Update database state to match AWS
+                aws_state = aws_instance["state"]
+                print(
+                    f"Updating instance state for user "
+                    f"{user_id}: {db_state} → {aws_state}"
+                )
+                cursor.execute(
+                    """UPDATE premium_user_assignments
+                       SET instance_state = %s, last_state_check = NOW()
+                       WHERE user_id = %s""",
+                    (aws_state, user_id),
+                )
+                update_count += 1
+
+    # Transaction decorator handles commit on success, rollback on error
+    return {
+        "cleanup_count": cleanup_count,
+        "update_count": update_count,
+        "total_aws_instances": len(aws_instance_map),
+        "total_db_assignments": len(db_assignments),
+    }
 
 
 @with_transaction
@@ -741,15 +934,21 @@ def cleanup_test_user_assignments(connection, user_emails: List[str]) -> Dict[st
                 alb_rule_arn = assignment["alb_rule_arn"]
 
                 try:
-                    # Delete ALB rule and target group (skip STANDBY markers)
-                    if alb_rule_arn and alb_rule_arn != "STANDBY":
+                    # Delete ALB rule and target group (skip standby markers)
+                    if (
+                        alb_rule_arn
+                        and alb_rule_arn.lower() != PremiumAssignment.STANDBY
+                    ):
                         try:
                             elbv2.delete_rule(RuleArn=alb_rule_arn)
                             print(f"Deleted ALB rule for user {user_id}")
                         except Exception as e:
                             print(f"Warning: Failed to delete ALB rule: {e}")
 
-                    if target_group_arn and target_group_arn != "STANDBY":
+                    if (
+                        target_group_arn
+                        and target_group_arn.lower() != PremiumAssignment.STANDBY
+                    ):
                         try:
                             elbv2.delete_target_group(TargetGroupArn=target_group_arn)
                             print(f"Deleted target group for user {user_id}")
@@ -825,6 +1024,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         results: Dict[str, Any] = {
             "cleanup_stats": {},
             "orphaned_cleanup_stats": {},
+            "duplicate_cleanup_stats": {},
             "reconciliation_stats": {},
             "capacity_check": {},
             "timestamp": time.time(),
@@ -838,18 +1038,23 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         print("Step 2: Cleaning up orphaned ALB resources...")
         results["orphaned_cleanup_stats"] = cleanup_orphaned_alb_resources()
 
-        # 3. Reconcile instance states (update DB to match AWS reality)
-        print("Step 3: Reconciling instance states...")
+        # 3. Cleanup duplicate ALB rules (multiple rules with same routing_id)
+        print("Step 3: Cleaning up duplicate ALB rules...")
+        results["duplicate_cleanup_stats"] = cleanup_duplicate_alb_rules()
+
+        # 4. Reconcile instance states (update DB to match AWS reality)
+        print("Step 4: Reconciling instance states...")
         results["reconciliation_stats"] = reconcile_instance_states()
 
-        # 4. Monitor standby pool capacity (read-only check)
-        print("Step 4: Checking standby pool capacity...")
+        # 5. Monitor standby pool capacity (read-only check)
+        print("Step 5: Checking standby pool capacity...")
         results["capacity_check"] = ensure_standby_pool_capacity()
 
         # Summary
         total_operations = (
             results["cleanup_stats"].get("cleaned_assignments", 0)
             + results["orphaned_cleanup_stats"].get("orphaned_rules_deleted", 0)
+            + results["duplicate_cleanup_stats"].get("duplicates_deleted", 0)
             + results["reconciliation_stats"].get("cleanup_count", 0)
             + results["reconciliation_stats"].get("update_count", 0)
         )

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -432,8 +432,11 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
       },
       # CloudWatch metrics (requires wildcard)
       {
-        Effect   = "Allow"
-        Action   = "cloudwatch:PutMetricData"
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData",
+          "cloudwatch:GetMetricData"
+        ]
         Resource = "*"
       },
       # ASG Describe (read-only)

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3277,7 +3277,8 @@ def trigger_experiment_sync(user_id: int) -> bool:
     Returns:
         True if sync was initiated successfully, False otherwise
     """
-    import requests
+    import ssl
+    import urllib.request
 
     alb_dns = os.environ.get("ALB_DNS_NAME")
     internal_secret = os.environ.get("INTERNAL_API_SECRET")
@@ -3296,16 +3297,18 @@ def trigger_experiment_sync(user_id: int) -> bool:
     }
 
     try:
-        response = requests.post(url, headers=headers, timeout=10.0, verify=True)
-        if response.status_code == 200:
-            print(f"Experiment sync initiated for user {user_id}")
-            return True
-        else:
-            print(
-                f"Experiment sync request failed for user {user_id}: "
-                f"status {response.status_code}"
-            )
-            return False
+        req = urllib.request.Request(url, method="POST", headers=headers, data=b"")
+        context = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=10.0, context=context) as response:
+            if response.status == 200:
+                print(f"Experiment sync initiated for user {user_id}")
+                return True
+            else:
+                print(
+                    f"Experiment sync request failed for user {user_id}: "
+                    f"status {response.status}"
+                )
+                return False
     except Exception as e:
         # Don't fail migration if sync fails - user can still work
         print(f"Failed to trigger experiment sync for user {user_id}: {e}")

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -49,6 +49,7 @@ import pymysql
 from aws_constants import (
     DatabaseConfig,
     ECSTaskStatus,
+    PremiumAssignment,
     PremiumInstanceConfig,
     RoutingHeaders,
 )
@@ -65,6 +66,10 @@ if TYPE_CHECKING:
 # Default fallback value for premium user count in development/testing scenarios
 # Used when database queries fail or no premium users exist
 DEFAULT_DEVELOPMENT_CAPACITY = 3
+
+# Default hours before idle premium instances are converted to standby pool
+# Can be overridden by PREMIUM_IDLE_TIMEOUT_HOURS environment variable
+DEFAULT_IDLE_TIMEOUT_HOURS = 3
 
 
 def generate_routing_id(uid: str, secret_key: str) -> str:
@@ -272,36 +277,52 @@ def _store_user_assignment_transaction(
         is_standby: Whether this is a standby pool assignment (user_id should be None)
     """
     with connection.cursor() as cursor:
-        # Check if user already has assignment with lock to prevent race conditions
-        # For standby instances (user_id=None), WHERE user_id = NULL returns no results
-        # This allows multiple standby instances with user_id=NULL
-        cursor.execute(
-            """SELECT user_id, assignment_attempts FROM premium_user_assignments
-               WHERE user_id = %s FOR UPDATE""",
-            (user_id,),
-        )
-        existing = cursor.fetchone()
-
-        if existing:
-            # User already has assignment - increment attempts counter
-            current_attempts = existing[1] if existing[1] is not None else 1
-            new_attempts = current_attempts + 1
-
+        # For standby instances (user_id=None), check by instance_id instead
+        # because WHERE user_id = NULL doesn't match any rows in SQL
+        if is_standby or user_id is None:
             cursor.execute(
-                """UPDATE premium_user_assignments
-                   SET assignment_attempts = %s, last_state_check = NOW()
-                   WHERE user_id = %s""",
-                (new_attempts, user_id),
+                """SELECT instance_id FROM premium_user_assignments
+                   WHERE instance_id = %s FOR UPDATE""",
+                (instance_id,),
             )
+            existing_instance = cursor.fetchone()
+            if existing_instance:
+                print(
+                    f"Instance {instance_id} already has an assignment entry, "
+                    f"skipping duplicate standby creation"
+                )
+                raise Exception(
+                    f"Instance {instance_id} already exists in assignments table"
+                )
+        else:
+            # For regular user assignments, check by user_id
+            cursor.execute(
+                """SELECT user_id, assignment_attempts FROM premium_user_assignments
+                   WHERE user_id = %s FOR UPDATE""",
+                (user_id,),
+            )
+            existing = cursor.fetchone()
 
-            print(
-                f"User {user_id} already has assignment, "
-                f"incremented attempts to {new_attempts}"
-            )
-            raise Exception(
-                f"User {user_id} already has a premium "
-                f"assignment (attempt #{new_attempts})"
-            )
+            if existing:
+                # User already has assignment - increment attempts counter
+                current_attempts = existing[1] if existing[1] is not None else 1
+                new_attempts = current_attempts + 1
+
+                cursor.execute(
+                    """UPDATE premium_user_assignments
+                       SET assignment_attempts = %s, last_state_check = NOW()
+                       WHERE user_id = %s""",
+                    (new_attempts, user_id),
+                )
+
+                print(
+                    f"User {user_id} already has assignment, "
+                    f"incremented attempts to {new_attempts}"
+                )
+                raise Exception(
+                    f"User {user_id} already has a premium "
+                    f"assignment (attempt #{new_attempts})"
+                )
 
         # Insert new assignment with enhanced tracking including is_standby
         # Use CASE to set standby_created_at to NOW() only if is_standby is true
@@ -386,6 +407,34 @@ def _remove_user_assignment_transaction(connection, user_id: int):
 def remove_user_assignment(user_id: int):
     """Remove user assignment from RDS with proper transaction isolation"""
     return _remove_user_assignment_transaction(user_id)
+
+
+@with_transaction
+def _get_existing_user_assignment_transaction(
+    connection, user_id: int
+) -> Optional[Dict[str, Any]]:
+    """Check if user already has an active premium assignment.
+
+    Returns the assignment details if found, None otherwise.
+    This is used for early-exit optimization to avoid creating resources
+    for users who are already assigned.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT user_id, instance_id, target_group_arn, alb_rule_arn,
+                      status, instance_state, is_shared
+               FROM premium_user_assignments
+               WHERE user_id = %s AND status = %s
+               AND is_standby = 0""",
+            (user_id, PremiumAssignment.ACTIVE),
+        )
+        result = cursor.fetchone()
+        return result
+
+
+def get_existing_user_assignment(user_id: int) -> Optional[Dict[str, Any]]:
+    """Check if user already has an active premium assignment."""
+    return _get_existing_user_assignment_transaction(user_id)
 
 
 @with_transaction
@@ -953,8 +1002,8 @@ def register_orphaned_stopped_instances():
                 store_user_assignment(
                     user_id=None,
                     instance_id=instance_id,
-                    target_group_arn="standby",
-                    rule_arn="standby",
+                    target_group_arn=PremiumAssignment.STANDBY,
+                    rule_arn=PremiumAssignment.STANDBY,
                     instance_state="launching",  # Use valid enum value
                     is_shared=False,
                     is_standby=True,
@@ -1079,10 +1128,16 @@ def try_reserve_instance_transaction(
                (user_id, instance_id, target_group_arn, alb_rule_arn,
                 status, instance_state, is_shared, assignment_attempts,
                 last_state_check)
-               VALUES (%s, %s, 'reserving', 'reserving', 'active',
-                       'reserving', 0, 1, NOW())
+               VALUES (%s, %s, %s, %s, %s, %s, 0, 1, NOW())
             """,
-            (user_id, instance_id),
+            (
+                user_id,
+                instance_id,
+                PremiumAssignment.RESERVING,
+                PremiumAssignment.RESERVING,
+                PremiumAssignment.ACTIVE,
+                PremiumAssignment.RESERVING,
+            ),
         )
         print(f"Reserved instance {instance_id} for user {user_id}")
         return True
@@ -1106,8 +1161,8 @@ def release_instance_reservation(instance_id: str, user_id: int):
                     """DELETE FROM premium_user_assignments
                        WHERE instance_id = %s
                        AND user_id = %s
-                       AND target_group_arn = 'reserving'""",
-                    (instance_id, user_id),
+                       AND target_group_arn = %s""",
+                    (instance_id, user_id, PremiumAssignment.RESERVING),
                 )
                 connection.commit()
                 print(f"Released reservation for instance {instance_id}")
@@ -1176,13 +1231,9 @@ def create_and_stop_standby_instance():
     creation_id = None
 
     try:
-        # Register pending creation BEFORE acquiring lock to signal intent
-        creation_id = register_pending_standby_creation()
-        if not creation_id:
-            print("Failed to register pending standby creation")
-            return None
-
         # DISTRIBUTED LOCK: Use MySQL GET_LOCK to prevent race conditions
+        # Must acquire lock BEFORE registering pending creation to prevent
+        # multiple Lambdas from registering and then each creating an instance
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
                 # Try to acquire lock (returns 1 if successful,
@@ -1198,12 +1249,17 @@ def create_and_stop_standby_instance():
                         "Another Lambda is already creating a standby instance, "
                         "skipping"
                     )
-                    # Clean up our pending registration
-                    if creation_id:
-                        unregister_pending_standby_creation(creation_id)
                     return None
 
                 print("Acquired distributed lock for standby creation")
+
+                # Register pending creation AFTER acquiring lock
+                # This ensures only one Lambda registers at a time
+                creation_id = register_pending_standby_creation()
+                if not creation_id:
+                    print("Failed to register pending standby creation")
+                    cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
+                    return None
 
                 # STANDBY COUNT CHECK: Re-check after acquiring lock
                 standby_count = get_standby_count()
@@ -1313,8 +1369,8 @@ def create_and_stop_standby_instance():
         store_user_assignment(
             user_id=None,
             instance_id=instance_id,
-            target_group_arn="standby",
-            rule_arn="standby",
+            target_group_arn=PremiumAssignment.STANDBY,
+            rule_arn=PremiumAssignment.STANDBY,
             instance_state="stopped",
             is_shared=False,
             is_standby=True,
@@ -1866,6 +1922,90 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return {"statusCode": 500, "body": json.dumps({"error": str(e)})}
 
 
+def cleanup_duplicate_rules_for_routing_id(listener_arn: str, routing_id: str) -> int:
+    """
+    Find and delete any existing ALB rules with the same routing_id.
+
+    This prevents duplicate rules from accumulating when a user is reassigned.
+    The routing_id is deterministic (HMAC of user_id), so all rules for the
+    same user will have the same routing_id.
+
+    Args:
+        listener_arn: ALB listener ARN to check
+        routing_id: The routing ID to search for
+
+    Returns:
+        Number of rules deleted
+    """
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+
+    try:
+        # Get all existing rules for this listener
+        response = elbv2.describe_rules(ListenerArn=listener_arn)
+        rules = response.get("Rules", [])
+
+        rules_deleted = 0
+        for rule in rules:
+            if rule.get("Priority") == "default":
+                continue
+
+            # Check if this rule has the matching routing_id
+            conditions = rule.get("Conditions", [])
+            for condition in conditions:
+                http_header_config = condition.get("HttpHeaderConfig", {})
+                if (
+                    http_header_config.get("HttpHeaderName")
+                    == RoutingHeaders.ROUTING_ID
+                ):
+                    values = http_header_config.get("Values", [])
+                    if routing_id in values:
+                        # Found a rule with this routing_id - delete it
+                        rule_arn = rule["RuleArn"]
+                        try:
+                            print(
+                                f"Deleting existing rule for routing_id "
+                                f"{routing_id[:8]}...: {rule_arn}"
+                            )
+                            elbv2.delete_rule(RuleArn=rule_arn)
+                            rules_deleted += 1
+
+                            # Also try to delete the associated target group
+                            for action in rule.get("Actions", []):
+                                if action.get("Type") == "forward":
+                                    tg_arn = action.get("TargetGroupArn")
+                                    if tg_arn:
+                                        try:
+                                            elbv2.delete_target_group(
+                                                TargetGroupArn=tg_arn
+                                            )
+                                            print(
+                                                f"Deleted associated "
+                                                f"target group: {tg_arn}"
+                                            )
+                                        except Exception as tg_error:
+                                            # Target group might be
+                                            # in use or already deleted
+                                            print(
+                                                f"Could not delete target group "
+                                                f"{tg_arn}: {tg_error}"
+                                            )
+                        except Exception as delete_error:
+                            print(f"Failed to delete rule {rule_arn}: {delete_error}")
+                        break  # Move to next rule
+
+        if rules_deleted > 0:
+            print(
+                f"Cleaned up {rules_deleted} duplicate rule(s) "
+                f"for routing_id {routing_id[:8]}..."
+            )
+
+        return rules_deleted
+
+    except Exception as e:
+        print(f"Error cleaning up duplicate rules: {str(e)}")
+        return 0
+
+
 def get_next_available_priority(listener_arn: str, start_priority: int = 100) -> int:
     """
     Find next available ALB rule priority by querying existing rules.
@@ -1940,9 +2080,48 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
             ),
         }
 
+    # EARLY CHECK: Return existing assignment if user is already assigned
+    # This prevents unnecessary resource creation and potential duplicates
+    try:
+        existing_assignment = get_existing_user_assignment(user_id)
+        if existing_assignment:
+            print(
+                f"User {user_id} already has active assignment to "
+                f"instance {existing_assignment['instance_id']}"
+            )
+            return {
+                "statusCode": 200,
+                "body": json.dumps(
+                    {
+                        "message": f"User {user_id} already assigned to "
+                        f"instance {existing_assignment['instance_id']}",
+                        "instance_id": existing_assignment["instance_id"],
+                        "target_group_arn": existing_assignment["target_group_arn"],
+                        "rule_arn": existing_assignment["alb_rule_arn"],
+                        "is_shared": bool(existing_assignment.get("is_shared", False)),
+                        "assignment_source": "existing",
+                    }
+                ),
+            }
+    except Exception as check_error:
+        # CRITICAL: If we can't verify assignment status, fail fast to prevent
+        # cleanup_duplicate_rules_for_routing_id() from deleting valid rules
+        print(f"Error: Failed to check existing assignment: {check_error}")
+        return {
+            "statusCode": 503,
+            "body": json.dumps(
+                {
+                    "error": "Service temporarily unavailable",
+                    "message": "Unable to verify assignment status. Please retry.",
+                    "assigned": False,
+                }
+            ),
+        }
+
     # Initialize variables for exception handling scope
     target_group_arn = None
     rule_arn = None
+    assignment_stored = False  # Track if DB write happened for cleanup
 
     try:
         # 0. Register any orphaned stopped instances as standby first
@@ -2405,6 +2584,10 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
             f"(truncated for security)"
         )
 
+        # Clean up any existing duplicate rules for this routing_id
+        # This prevents rule accumulation from failed/retried assignments
+        cleanup_duplicate_rules_for_routing_id(alb_listener_arn, routing_id)
+
         # Get next available priority dynamically to avoid conflicts
         priority = get_next_available_priority(alb_listener_arn, start_priority=100)
 
@@ -2450,7 +2633,7 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
                         f"for instance {instance_id}"
                     )
 
-        # Clean up reservation and store actual assignment
+        # Clean up reservation placeholder
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
                 # Remove the reservation placeholder
@@ -2458,12 +2641,23 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
                     """DELETE FROM premium_user_assignments
                        WHERE instance_id = %s
                        AND user_id = %s
-                       AND target_group_arn = 'reserving'""",
-                    (instance_id, user_id),
+                       AND target_group_arn = %s""",
+                    (instance_id, user_id, PremiumAssignment.RESERVING),
                 )
                 connection.commit()
 
+        # If this was a shared assignment, trigger scaling BEFORE storing in DB
+        # This way, if scaling fails, we haven't written the DB entry yet
+        # and the user can retry immediately without being blocked by stale entry
+        if needs_scaling:
+            print("Triggering scaling for shared assignment...")
+            scale_premium_instances_if_needed()
+
         # 10. Store assignment in RDS with state tracking
+        # This is intentionally the LAST major operation so that:
+        # - If anything above fails, no DB entry exists to block retries
+        # - Orphaned AWS resources are cleaned up by hourly cleanup job
+        # - User can retry immediately without waiting for stale entry cleanup
         store_user_assignment(
             user_id,
             instance_id,
@@ -2472,11 +2666,7 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
             instance_state or "launching",
             is_shared,
         )
-
-        # If this was a shared assignment, trigger scaling now that the user is stored
-        if needs_scaling:
-            print("Triggering scaling for shared assignment...")
-            scale_premium_instances_if_needed()
+        assignment_stored = True
 
         # Initialize activity tracking for the new assignment
         try:
@@ -2507,8 +2697,16 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
 
         # Cleanup on failure
         try:
-            # Clean up target group if created
-            if target_group_arn and target_group_arn != "reserving":
+            # Clean up ALB rule if created (MUST be done before target group)
+            if rule_arn:
+                elbv2.delete_rule(RuleArn=rule_arn)
+                print(f"Cleaned up ALB rule after error: {rule_arn}")
+        except Exception as rule_cleanup_error:
+            print(f"Failed to cleanup ALB rule: {str(rule_cleanup_error)}")
+
+        try:
+            # Clean up target group if created (skip placeholder markers)
+            if target_group_arn and target_group_arn != PremiumAssignment.RESERVING:
                 elbv2.delete_target_group(TargetGroupArn=target_group_arn)
                 print(f"Cleaned up target group after error: {target_group_arn}")
         except Exception as cleanup_error:
@@ -2523,6 +2721,23 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
                     print(f"Released reservation for instance {instance_id}")
         except Exception as reservation_error:
             print(f"Failed to release reservation: {str(reservation_error)}")
+
+        # Safety net: Clean up DB entry if it was written
+        # This shouldn't normally happen since DB write is now last,
+        # but provides defense-in-depth if code is refactored later
+        try:
+            if assignment_stored:
+                print(f"Cleaning up DB assignment for user {user_id} after error")
+                with get_db_connection() as connection:
+                    with connection.cursor() as cursor:
+                        cursor.execute(
+                            "DELETE FROM premium_user_assignments WHERE user_id = %s",
+                            (user_id,),
+                        )
+                        connection.commit()
+                print(f"Cleaned up DB assignment for user {user_id}")
+        except Exception as db_cleanup_error:
+            print(f"Failed to cleanup DB assignment: {str(db_cleanup_error)}")
 
         raise e
 
@@ -3278,7 +3493,7 @@ def release_premium_user(user_id: int) -> Dict[str, Any]:
         autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
         if (
             target_group_arn
-            and target_group_arn != "standby"
+            and target_group_arn != PremiumAssignment.STANDBY
             and target_group_arn != autoscaling_tg_arn
         ):
             try:
@@ -3534,8 +3749,8 @@ def convert_running_instance_to_standby(instance_id: str):
         store_user_assignment(
             user_id=None,
             instance_id=instance_id,
-            target_group_arn="standby",
-            rule_arn="standby",
+            target_group_arn=PremiumAssignment.STANDBY,
+            rule_arn=PremiumAssignment.STANDBY,
             instance_state="stopped",
             is_shared=False,
             is_standby=True,  # Set standby flag in initial INSERT


### PR DESCRIPTION
# Root Cause Analysis: Duplicate ALB Rules for Premium User Routing

## Executive Summary

Premium user 2 has **98 ALB rules** created for the same routing ID (`f94b07de1345409d`), consuming nearly all of the 100-rule limit on the ALB listener. This document explains exactly how these duplicates were created and what code changes are needed to prevent recurrence.

### Test Cases for Verification

| Test Case | Description | Expected Result |
|-----------|-------------|-----------------|
| TC-1: Early check returns existing | Call `assign_premium_user()` for user with active assignment | Returns 200 with existing assignment, no new ALB rule created |
| TC-2: Exception handler cleanup | Force exception after ALB rule creation (mock `store_user_assignment` to throw) | ALB rule is deleted in exception handler |
| TC-3: Duplicate cleanup before create | Create ALB rule manually, then call `assign_premium_user()` for same user | Old rule deleted before new rule created |
| TC-4: Scheduled duplicate cleanup | Create duplicate rules for same routing_id, invoke cleanup Lambda | Only rule matching DB entry remains |
| TC-5: DB check failure returns 503 | Mock `get_existing_user_assignment()` to throw exception | Returns 503, no cleanup_duplicate_rules called |
| TC-6: Concurrent assignment attempts | Simulate rapid repeated calls for same user | At most 1 rule exists after all calls complete |

### Testing Approach

**Unit tests (mocked AWS):** Test cases TC-1, TC-2, and TC-4 are implemented in:
```
infrastructure/scripts/test_premium_lambda.py
```

Run tests:
```bash
cd infrastructure/scripts
python test_premium_lambda.py
```

**Integration tests (real AWS):** TC-6 requires real AWS resources and should be run manually or as part of staging deployment verification.

**Post-deployment verification:**
```bash
# Count rules per routing_id (should all be 1)
aws elbv2 describe-rules --listener-arn $ALB_LISTENER_ARN \
  | jq '[.Rules[].Conditions[] | select(.Field=="http-header")
        | .HttpHeaderConfig | select(.HttpHeaderName=="X-Routing-ID")
        | .Values[0]] | group_by(.) | map({routing_id: .[0], count: length})
        | .[] | select(.count > 1)'
```

---

## The Bug: Detailed Explanation

### Code Flow in `assign_premium_user()` (premium_manager.py)

```
Step 1: Function starts (line 2005)
        ↓
Step 2: Find available instance (lines 2028-2280)
        ↓
Step 3: Create target group if needed (lines 2356-2478)
        ↓
Step 4: Create ALB rule with routing_id (lines 2480-2516)  ← RULE CREATED HERE
        ↓
Step 5: Get rule_arn from response (line 2518)
        ↓
Step 6: Database cleanup operations (lines 2520-2549)      ← CAN FAIL
        ↓
Step 7: store_user_assignment() (line 2552)                ← CAN FAIL
        ↓
        If any step fails after Step 4:
        → Exception handler runs (lines 2591-2613)
        → target_group_arn is cleaned up
        → rule_arn is NOT cleaned up  ← BUG #1
```

### Bug #1: Missing Rule Cleanup in Exception Handler

**Location**: `premium_manager.py`, lines 2591-2613 (before fix)

**The Problem**: When any exception occurs after the ALB rule is created (Step 4), the exception handler only cleans up the `target_group_arn`, NOT the `rule_arn`:

```python
# BEFORE FIX - Only cleans up target group
except Exception as e:
    print(f"Error assigning premium user: {str(e)}")

    try:
        # Clean up target group if created
        if target_group_arn and target_group_arn != "reserving":
            elbv2.delete_target_group(TargetGroupArn=target_group_arn)
    except Exception as cleanup_error:
        print(f"Failed to cleanup target group: {str(cleanup_error)}")

    # NOTE: rule_arn is NEVER cleaned up!
    raise e
```

**Result**: Every failed assignment attempt leaves an orphaned ALB rule.

---

### Bug #2: No Early Check for Existing Assignment

**Location**: `assign_premium_user()` function start (line 2005)

**The Problem**: The function does NOT check if the user already has an assignment at the start. It proceeds to create resources (target group, ALB rule) and only checks for existing assignments inside `store_user_assignment()` (line 2552).

```python
def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
    # NO CHECK HERE for existing assignment!

    # ... 500+ lines of code creating resources ...

    # Only here, AFTER creating ALB rule, does it check:
    store_user_assignment(...)  # This raises exception if user already assigned
```

**Inside `_store_user_assignment_transaction()` (lines 275-304)**:
```python
# Check if user already has assignment
cursor.execute(
    """SELECT user_id, assignment_attempts FROM premium_user_assignments
       WHERE user_id = %s FOR UPDATE""",
    (user_id,),
)
existing = cursor.fetchone()

if existing:
    # User already has assignment - raises exception
    raise Exception(
        f"User {user_id} already has a premium assignment (attempt #{new_attempts})"
    )
```

**Result**: If a user with an existing assignment calls the API again:
1. New ALB rule is created
2. `store_user_assignment()` detects existing assignment
3. Exception is raised
4. ALB rule is NOT cleaned up (Bug #1)
5. Orphaned rule remains

---

### Bug #3: No Deduplication by Routing ID Before Rule Creation

**Location**: Lines 2480-2516 (rule creation)

**The Problem**: Before creating a new ALB rule, the code never checks if rules with the same `routing_id` already exist. Since `routing_id` is deterministic (HMAC of user_id), multiple calls for the same user create multiple rules with identical routing conditions.

```python
# Generate routing ID (deterministic - same user = same routing_id)
routing_id = generate_routing_id(str(user_id), routing_secret_key)

# NO CHECK: Does a rule with this routing_id already exist?

# Just create a new rule every time
rule_response = elbv2.create_rule(
    ListenerArn=alb_listener_arn,
    Priority=priority,
    Conditions=[
        {"Field": "http-header", "HttpHeaderConfig": {
            "HttpHeaderName": "X-Routing-ID",
            "Values": [routing_id],  # Same routing_id for same user!
        }},
    ],
    ...
)
```

---

## How 97 Duplicate Rules Were Created

### Scenario: Repeated Assignment Attempts

1. **Initial State**: User 2 has no assignment

2. **First Attempt** (Successful):
   - Creates ALB rule #1 with routing_id `f94b07de1345409d`
   - Stores assignment in database with rule #1's ARN
   - User 2 is now assigned

3. **Subsequent Attempts** (Failed - 97 times):
   Each time user 2's session refreshes or they log in again:
   - Frontend calls `/users/me/premium/assign` API
   - `assign_premium_user()` creates ALB rule #N
   - `store_user_assignment()` finds existing assignment → raises exception
   - Exception handler runs but does NOT clean up rule #N
   - Rule #N is now orphaned with same routing_id

### Why So Many Attempts?

Looking at the logs, user 2 was repeatedly retrying:
```
10:51:03,579 ERROR: Failed to assign premium user 2: 1
10:51:03,729 WARNING: User 2 rate limited
10:51:03,875 INFO: Assigning premium user 2 to dedicated instance
10:51:04,053 ERROR: Failed to assign premium user 2: 1
```

The pattern shows:
- Rapid retry attempts (multiple per second)
- Rate limiting triggers but doesn't prevent rule creation
- Each failed attempt leaves an orphaned rule

---

## Timeline of Events (From CloudWatch Logs)

### ALB Rule Allocations Per Hour (Last 24h)

| Time (UTC) | Rules Allocated | Notes |
|------------|-----------------|-------|
| 2026-01-27 06:00 | 5 | Normal |
| 2026-01-27 07:00 | 9 | Normal |
| 2026-01-27 08:00 | 203 | Spike begins |
| 2026-01-27 09:00 | 118 | |
| 2026-01-27 10:00 | 22 | |
| 2026-01-28 01:00 | 190 | |
| **2026-01-28 02:00** | **1,182** | **Massive spike!** |
| **2026-01-28 03:00** | **833** | **Still elevated** |

**Over 2,000 rule allocation attempts in just 2 hours!**

### Cleanup Lambda Runs vs Rule Creation

| Time (UTC) | Event | Details |
|------------|-------|---------|
| 2026-01-27 00:30 | Cleanup | Deleted 83 orphaned rules |
| 2026-01-27 01:30 | Cleanup | Deleted 98 orphaned rules |
| 2026-01-27 02:30 | Cleanup | Deleted 98 orphaned rules |
| 2026-01-27 03:30 | Cleanup | Deleted 98 orphaned rules |
| 2026-01-27 04:29 | Cleanup | Deleted 1 orphaned rule |
| ... | ... | Cleanup ran hourly |
| 2026-01-27 08:30 | Cleanup | Deleted 97 orphaned rules |
| 2026-01-27 09:30 | Cleanup | Deleted 98 orphaned rules |
| 2026-01-27 10:30 | Cleanup | Deleted 81 orphaned rules |
| 2026-01-27 11:29 | Cleanup | Deleted 1 orphaned rule |
| ... | ... | Normal operations |
| **2026-01-28 02:30** | Cleanup | Deleted 97 orphaned rules |
| **2026-01-28 03:31** | Cleanup | Deleted 97 orphaned rules |

### Key Insight

**The cleanup IS working.** It successfully deleted 97 rules at 02:30 and 03:31 today.

**But rules are being created faster than cleanup can remove them:**
- Cleanup runs every hour
- Deletes ~97 orphaned rules per run
- But ~1,000+ rules are allocated per hour during peak periods

**The net result:**
- Rules accumulate until ALB hits 100-rule limit
- `TooManyRules` errors start occurring
- Premium user assignments fail

---

## Why Wasn't This Caught by Existing Cleanup?

### `cleanup_orphaned_alb_resources()` in premium_cleanup.py

This function SHOULD clean up orphaned rules, but:

1. **It runs hourly** - too slow for burst scenarios
2. **Rule creation rate >> cleanup rate** during retries
3. **ALB max = 100 rules** - fills up quickly

The cleanup is effective but **reactive, not preventive**. Once the ALB hits 100 rules, new assignments fail with:
```
ERROR: Failed to assign premium user 2: An error occurred (TooManyRules)
when calling the CreateRule operation: The maximum number of rules on
load balancer has been reached
```

---

## The Fixes Applied

### Fix 1: Clean Up Rule in Exception Handler
**File**: `premium_manager.py`, lines 2591-2598

```python
except Exception as e:
    print(f"Error assigning premium user: {str(e)}")

    # NEW: Clean up ALB rule if created
    try:
        if rule_arn:
            elbv2.delete_rule(RuleArn=rule_arn)
            print(f"Cleaned up ALB rule after error: {rule_arn}")
    except Exception as rule_cleanup_error:
        print(f"Failed to cleanup ALB rule: {str(rule_cleanup_error)}")

    # ... rest of cleanup ...
```

**What it prevents**: New orphaned rules from failed assignments.

### Fix 2: Delete Existing Rules for Same Routing ID
**File**: `premium_manager.py`, new function + call at line 2489

```python
# Before creating new rule, delete any existing rules with same routing_id
cleanup_duplicate_rules_for_routing_id(alb_listener_arn, routing_id)

# Then create the new rule
priority = get_next_available_priority(alb_listener_arn, start_priority=100)
rule_response = elbv2.create_rule(...)
```

**What it prevents**: Accumulation of duplicate rules for the same user.

### Fix 3: Scheduled Duplicate Cleanup
**File**: `premium_cleanup.py`, new function `cleanup_duplicate_alb_rules()`

Added as Step 3 in the cleanup handler:
- Groups rules by routing_id
- Keeps only the rule matching the database entry
- Deletes all duplicates

**What it prevents**: Long-term accumulation if real-time cleanup fails.

---

### Fix 4: Early Check for Existing Assignment
**File**: `premium_manager.py`, added after line 2049

```python
# EARLY CHECK: Return existing assignment if user is already assigned
try:
    existing_assignment = get_existing_user_assignment(user_id)
    if existing_assignment:
        print(f"User {user_id} already has active assignment")
        return {
            "statusCode": 200,
            "body": json.dumps({
                "message": f"User already assigned to instance {existing_assignment['instance_id']}",
                "instance_id": existing_assignment["instance_id"],
                ...
            }),
        }
except Exception as check_error:
    print(f"Warning: Failed to check existing assignment: {check_error}")
```

**What it prevents**: Unnecessary resource creation for already-assigned users.

---

## Summary

| Bug | Root Cause | Fixed? |
|-----|------------|--------|
| Missing rule cleanup in exception handler | `rule_arn` not deleted on failure | ✅ Yes |
| No check before creating resources | Assignment check happens too late | ✅ Yes (early check added) |
| No routing_id deduplication | Multiple rules created for same user | ✅ Yes |
| Cleanup runs hourly, not real-time | Orphans accumulate between cleanups | ✅ Yes (real-time cleanup added) |

---

## Immediate Action Required

To clean up the existing 97 duplicate rules:

```bash
# Option 1: Invoke cleanup Lambda
aws lambda invoke --function-name subscr-premium-cleanup \
  --payload '{}' /dev/stdout

# Option 2: Deploy updated code first, then it will clean up automatically
```
