### PR TITLE
Run enabled before S3 upload finished

### DIFF
--- a/frontend/src/api/run/Run.ts
+++ b/frontend/src/api/run/Run.ts
@@ -90,10 +90,19 @@ export type RunResultDTO = {
   }
 }
 
+// Sync status values from backend RemoteSyncStatus enum
+export const SYNC_STATUS = {
+  PROCESSING: "processing",
+  SUCCESS: "success",
+  ERROR: "error",
+} as const
+
+export type SyncStatus = (typeof SYNC_STATUS)[keyof typeof SYNC_STATUS] | null
+
 // Response wrapper from poll endpoint - includes sync status for S3 upload tracking
 export type PollRunResultDTO = {
   nodeResults: RunResultDTO
-  syncStatus?: string | null // "processing", "success", "error", or null
+  syncStatus?: SyncStatus
 }
 
 export type OutputPathsDTO = {

--- a/frontend/src/api/run/Run.ts
+++ b/frontend/src/api/run/Run.ts
@@ -90,19 +90,21 @@ export type RunResultDTO = {
   }
 }
 
-// Sync status values from backend RemoteSyncStatus enum
-export const SYNC_STATUS = {
+// Post-run completion status values from backend
+export const COMPLETE_STATUS = {
   PROCESSING: "processing",
   SUCCESS: "success",
   ERROR: "error",
 } as const
 
-export type SyncStatus = (typeof SYNC_STATUS)[keyof typeof SYNC_STATUS] | null
+export type CompleteStatus =
+  | (typeof COMPLETE_STATUS)[keyof typeof COMPLETE_STATUS]
+  | null
 
-// Response wrapper from poll endpoint - includes sync status for S3 upload tracking
+// Response wrapper from poll endpoint - includes post-run completion tracking
 export type PollRunResultDTO = {
   nodeResults: RunResultDTO
-  syncStatus?: SyncStatus
+  completeStatus?: CompleteStatus
 }
 
 export type OutputPathsDTO = {

--- a/frontend/src/api/run/Run.ts
+++ b/frontend/src/api/run/Run.ts
@@ -90,6 +90,12 @@ export type RunResultDTO = {
   }
 }
 
+// Response wrapper from poll endpoint - includes sync status for S3 upload tracking
+export type PollRunResultDTO = {
+  nodeResults: RunResultDTO
+  syncStatus?: string | null // "processing", "success", "error", or null
+}
+
 export type OutputPathsDTO = {
   [outputKey: string]: {
     path: string
@@ -103,7 +109,7 @@ export async function runResult(data: {
   workspaceId: number
   uid: string
   pendingNodeIdList: string[]
-}): Promise<RunResultDTO> {
+}): Promise<PollRunResultDTO> {
   const { workspaceId, uid, pendingNodeIdList } = data
   const response = await axios.post(
     `${BASE_URL}/run/result/${workspaceId}/${uid}`,

--- a/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
@@ -82,13 +82,15 @@ export const experimentsSlice = createSlice({
         if (state.status === "fulfilled") {
           const uid = action.meta.arg.uid
           const target = state.experimentList[uid]
-          Object.entries(action.payload).forEach(([nodeId, value]) => {
-            if (value.status === "success") {
-              target.functions[nodeId].status = "success"
-            } else if (value.status === "error") {
-              target.functions[nodeId].status = "error"
-            }
-          })
+          Object.entries(action.payload.nodeResults).forEach(
+            ([nodeId, value]) => {
+              if (value.status === "success") {
+                target.functions[nodeId].status = "success"
+              } else if (value.status === "error") {
+                target.functions[nodeId].status = "error"
+              }
+            },
+          )
         }
       })
       .addCase(importSampleData.pending, (state) => {

--- a/frontend/src/store/slice/Pipeline/PipelineActions.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineActions.ts
@@ -5,6 +5,7 @@ import {
   runByUidApi,
   runResult,
   RunResultDTO,
+  PollRunResultDTO,
   RunPostData,
   cancelResultApi,
   runFilterApi,
@@ -100,7 +101,7 @@ export const runByCurrentUid = createAsyncThunk<
 )
 
 export const pollRunResult = createAsyncThunk<
-  RunResultDTO,
+  PollRunResultDTO,
   {
     uid: string
   },

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, isAnyOf, PayloadAction } from "@reduxjs/toolkit"
 
-import { SYNC_STATUS } from "api/run/Run"
+import { COMPLETE_STATUS } from "api/run/Run"
 import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
 import { convertFunctionsToRunResultDTO } from "store/slice/Experiments/ExperimentsUtils"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
@@ -60,15 +60,11 @@ export const pipelineSlice = createSlice({
           const runResultPendingList = Object.values(
             state.run.runResult,
           ).filter(isNodeResultPending)
-          // Only mark as finished when all nodes are done AND S3 sync is not in progress
-          // syncStatus will be:
-          // - "success" when upload completed successfully
-          // - "error" when upload failed (still allow button to enable for retry)
-          // - "processing" while uploading (keep button disabled)
-          // - null/undefined if remote storage is not enabled
-          const syncStatus = action.payload.syncStatus
-          const isSyncComplete = syncStatus !== SYNC_STATUS.PROCESSING
-          if (runResultPendingList.length === 0 && isSyncComplete) {
+          // Only mark as finished when all nodes complete AND
+          // post-run processing (e.g. remote upload) is not in progress
+          const { completeStatus } = action.payload
+          const isComplete = completeStatus !== COMPLETE_STATUS.PROCESSING
+          if (runResultPendingList.length === 0 && isComplete) {
             // 終了
             state.run.status = RUN_STATUS.FINISHED
           }

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, isAnyOf, PayloadAction } from "@reduxjs/toolkit"
 
+import { SYNC_STATUS } from "api/run/Run"
 import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
 import { convertFunctionsToRunResultDTO } from "store/slice/Experiments/ExperimentsUtils"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
@@ -66,7 +67,7 @@ export const pipelineSlice = createSlice({
           // - "processing" while uploading (keep button disabled)
           // - null/undefined if remote storage is not enabled
           const syncStatus = action.payload.syncStatus
-          const isSyncComplete = syncStatus !== "processing"
+          const isSyncComplete = syncStatus !== SYNC_STATUS.PROCESSING
           if (runResultPendingList.length === 0 && isSyncComplete) {
             // 終了
             state.run.status = RUN_STATUS.FINISHED

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -59,14 +59,14 @@ export const pipelineSlice = createSlice({
           const runResultPendingList = Object.values(
             state.run.runResult,
           ).filter(isNodeResultPending)
-          // Only mark as finished when all nodes are done AND S3 upload is complete
-          // syncStatus will be "success" when upload is done, "processing" while uploading,
-          // or null/undefined if remote storage is not enabled
+          // Only mark as finished when all nodes are done AND S3 sync is not in progress
+          // syncStatus will be:
+          // - "success" when upload completed successfully
+          // - "error" when upload failed (still allow button to enable for retry)
+          // - "processing" while uploading (keep button disabled)
+          // - null/undefined if remote storage is not enabled
           const syncStatus = action.payload.syncStatus
-          const isSyncComplete =
-            syncStatus === null ||
-            syncStatus === undefined ||
-            syncStatus === "success"
+          const isSyncComplete = syncStatus !== "processing"
           if (runResultPendingList.length === 0 && isSyncComplete) {
             // 終了
             state.run.status = RUN_STATUS.FINISHED

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -54,12 +54,20 @@ export const pipelineSlice = createSlice({
         if (state.run.status === RUN_STATUS.START_SUCCESS) {
           state.run.runResult = {
             ...state.run.runResult, // pendingのNodeResultはそのままでsuccessもしくはerrorのみ上書き
-            ...convertToRunResult(action.payload),
+            ...convertToRunResult(action.payload.nodeResults),
           }
           const runResultPendingList = Object.values(
             state.run.runResult,
           ).filter(isNodeResultPending)
-          if (runResultPendingList.length === 0) {
+          // Only mark as finished when all nodes are done AND S3 upload is complete
+          // syncStatus will be "success" when upload is done, "processing" while uploading,
+          // or null/undefined if remote storage is not enabled
+          const syncStatus = action.payload.syncStatus
+          const isSyncComplete =
+            syncStatus === null ||
+            syncStatus === undefined ||
+            syncStatus === "success"
+          if (runResultPendingList.length === 0 && isSyncComplete) {
             // 終了
             state.run.status = RUN_STATUS.FINISHED
           }

--- a/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
@@ -10,7 +10,7 @@ import {
   AlgorithmNodePostData,
   EdgeDict,
   RunPostData,
-  SYNC_STATUS,
+  COMPLETE_STATUS,
 } from "api/run/Run"
 import { ParamType, ParamMap } from "utils/param/ParamType"
 
@@ -106,7 +106,7 @@ export const pollRunResultPayload = {
     },
     node2: { status: "failed", message: "Node 2 failed", name: "Node 2" },
   },
-  syncStatus: SYNC_STATUS.SUCCESS,
+  completeStatus: COMPLETE_STATUS.SUCCESS,
 }
 
 export const createFulfilledWithRunPostDataAction = (

--- a/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
@@ -94,15 +94,18 @@ export const runPostData: RunPostData = {
 }
 
 export const pollRunResultPayload = {
-  node1: {
-    status: "success",
-    message: "Node 1 completed successfully",
-    name: "Node 1",
-    outputPaths: {
-      output1: { path: "/path/to/output1", type: "images" },
+  nodeResults: {
+    node1: {
+      status: "success",
+      message: "Node 1 completed successfully",
+      name: "Node 1",
+      outputPaths: {
+        output1: { path: "/path/to/output1", type: "images" },
+      },
     },
+    node2: { status: "failed", message: "Node 2 failed", name: "Node 2" },
   },
-  node2: { status: "failed", message: "Node 2 failed", name: "Node 2" },
+  syncStatus: "success",
 }
 
 export const createFulfilledWithRunPostDataAction = (

--- a/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineTestUtils.ts
@@ -10,6 +10,7 @@ import {
   AlgorithmNodePostData,
   EdgeDict,
   RunPostData,
+  SYNC_STATUS,
 } from "api/run/Run"
 import { ParamType, ParamMap } from "utils/param/ParamType"
 
@@ -105,7 +106,7 @@ export const pollRunResultPayload = {
     },
     node2: { status: "failed", message: "Node 2 failed", name: "Node 2" },
   },
-  syncStatus: "success",
+  syncStatus: SYNC_STATUS.SUCCESS,
 }
 
 export const createFulfilledWithRunPostDataAction = (

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -205,7 +205,7 @@ async def run_result(
 
         return PollRunResultResponse(
             nodeResults=node_results,
-            completeStatus=complete_status.value,
+            completeStatus=complete_status.value if complete_status else None,
         )
 
     except RemoteStorageLockError as e:

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -193,19 +193,18 @@ async def run_result(
                 uid,
             )
 
-        # Get sync status for S3 upload tracking
-        # This allows the frontend to know when data upload is complete
-        sync_status = None
+        # Check post-run completion status (e.g. remote storage upload)
+        complete_status = None
         if RemoteStorageController.is_available():
-            sync_status_enum = RemoteSyncStatusFileUtil.check_sync_status_file(
+            status_enum = RemoteSyncStatusFileUtil.check_sync_status_file(
                 workspace_id, uid
             )
-            if sync_status_enum:
-                sync_status = sync_status_enum.value
+            if status_enum:
+                complete_status = status_enum.value
 
         return PollRunResultResponse(
             nodeResults=node_results,
-            syncStatus=sync_status,
+            completeStatus=complete_status,
         )
 
     except RemoteStorageLockError as e:

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -200,13 +200,12 @@ async def run_result(
                 workspace_id, uid
             )
             if sync_status:
+                # Create CompleteStatus (converted from RemoteSyncStatus)
                 complete_status = CompleteStatus(sync_status.value)
 
         return PollRunResultResponse(
             nodeResults=node_results,
-            completeStatus=(
-                PollRunResultResponse.from_complete_status(complete_status)
-            ),
+            completeStatus=complete_status.value,
         )
 
     except RemoteStorageLockError as e:

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 
@@ -15,13 +15,9 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteStorageLockError,
+    RemoteSyncStatusFileUtil,
 )
-from studio.app.common.core.workflow.workflow import (
-    DataFilterParam,
-    Message,
-    NodeItem,
-    RunItem,
-)
+from studio.app.common.core.workflow.workflow import DataFilterParam, NodeItem, RunItem
 from studio.app.common.core.workflow.workflow_filter import WorkflowNodeDataFilter
 from studio.app.common.core.workflow.workflow_result import (
     WorkflowMonitor,
@@ -36,6 +32,7 @@ from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_owner,
 )
 from studio.app.common.schemas.users import User
+from studio.app.common.schemas.workflow import PollRunResultResponse
 
 router = APIRouter(prefix="/run", tags=["run"])
 
@@ -169,7 +166,7 @@ async def run_id(
 
 @router.post(
     "/result/{workspace_id}/{uid}",
-    response_model=Dict[str, Message],
+    response_model=PollRunResultResponse,
     dependencies=[Depends(is_workspace_available)],
 )
 async def run_result(
@@ -186,16 +183,30 @@ async def run_result(
             workspace_id, uid, remote_bucket_name
         )
 
-        res = await WorkflowResult(workspace_id, uid).observe(
+        node_results = await WorkflowResult(workspace_id, uid).observe(
             nodeDict.pendingNodeIdList
         )
-        if res:
+        if node_results:
             background_tasks.add_task(
                 WorkspaceDataCapacityService.update_experiment_data_usage,
                 workspace_id,
                 uid,
             )
-        return res
+
+        # Get sync status for S3 upload tracking
+        # This allows the frontend to know when data upload is complete
+        sync_status = None
+        if RemoteStorageController.is_available():
+            sync_status_enum = RemoteSyncStatusFileUtil.check_sync_status_file(
+                workspace_id, uid
+            )
+            if sync_status_enum:
+                sync_status = sync_status_enum.value
+
+        return PollRunResultResponse(
+            nodeResults=node_results,
+            syncStatus=sync_status,
+        )
 
     except RemoteStorageLockError as e:
         logger.error(e)

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -32,7 +32,7 @@ from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_owner,
 )
 from studio.app.common.schemas.users import User
-from studio.app.common.schemas.workflow import PollRunResultResponse
+from studio.app.common.schemas.workflow import CompleteStatus, PollRunResultResponse
 
 router = APIRouter(prefix="/run", tags=["run"])
 
@@ -196,15 +196,17 @@ async def run_result(
         # Check post-run completion status (e.g. remote storage upload)
         complete_status = None
         if RemoteStorageController.is_available():
-            status_enum = RemoteSyncStatusFileUtil.check_sync_status_file(
+            sync_status = RemoteSyncStatusFileUtil.check_sync_status_file(
                 workspace_id, uid
             )
-            if status_enum:
-                complete_status = status_enum.value
+            if sync_status:
+                complete_status = CompleteStatus(sync_status.value)
 
         return PollRunResultResponse(
             nodeResults=node_results,
-            completeStatus=complete_status,
+            completeStatus=(
+                PollRunResultResponse.from_complete_status(complete_status)
+            ),
         )
 
     except RemoteStorageLockError as e:

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -205,7 +205,7 @@ async def run_result(
 
         return PollRunResultResponse(
             nodeResults=node_results,
-            completeStatus=complete_status.value if complete_status else None,
+            completeStatus=(complete_status.value if complete_status else None),
         )
 
     except RemoteStorageLockError as e:

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Dict, Optional
 
 from psutil import Process
 
+from studio.app.common.core.compat import StrEnum
 from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.workflow.workflow import Edge, Message, Node
 
 
-class CompleteStatus(Enum):
+class CompleteStatus(StrEnum):
     """Post-run completion status (e.g. remote storage upload)."""
 
     PROCESSING = "processing"

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Dict, Optional
 
 from psutil import Process
@@ -8,7 +8,7 @@ from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.workflow.workflow import Edge, Message, Node
 
 
-class CompleteStatus(Enum):
+class CompleteStatus(StrEnum):
     """Post-run completion status (e.g. remote storage upload)."""
 
     PROCESSING = "processing"
@@ -74,9 +74,3 @@ class PollRunResultResponse:
 
     nodeResults: Dict[str, Message]
     completeStatus: Optional[str] = None
-
-    @staticmethod
-    def from_complete_status(
-        status_enum: Optional[CompleteStatus],
-    ) -> Optional[str]:
-        return status_enum.value if status_enum else None

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 from typing import Dict, Optional
 
 from psutil import Process
@@ -8,7 +8,7 @@ from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.workflow.workflow import Edge, Message, Node
 
 
-class CompleteStatus(StrEnum):
+class CompleteStatus(Enum):
     """Post-run completion status (e.g. remote storage upload)."""
 
     PROCESSING = "processing"

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 from psutil import Process
 
 from studio.app.common.core.experiment.experiment import ExptFunction
-from studio.app.common.core.workflow.workflow import Edge, Node
+from studio.app.common.core.workflow.workflow import Edge, Message, Node
 
 
 @dataclass
@@ -57,3 +57,11 @@ class WorkflowProcessInfo:
 class WorkflowErrorInfo:
     has_error: bool
     error_log: str
+
+
+@dataclass
+class PollRunResultResponse:
+    """Response wrapper for poll run result with sync status for S3 upload."""
+
+    nodeResults: Dict[str, Message]
+    syncStatus: Optional[str] = None  # "processing", "success", "error", or None

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -61,7 +61,7 @@ class WorkflowErrorInfo:
 
 @dataclass
 class PollRunResultResponse:
-    """Response wrapper for poll run result with sync status for S3 upload."""
+    """Response wrapper for poll run result with post-run completion status."""
 
     nodeResults: Dict[str, Message]
-    syncStatus: Optional[str] = None  # "processing", "success", "error", or None
+    completeStatus: Optional[str] = None  # "processing", "success", "error", or None

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -1,10 +1,19 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, Optional
 
 from psutil import Process
 
 from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.workflow.workflow import Edge, Message, Node
+
+
+class CompleteStatus(Enum):
+    """Post-run completion status (e.g. remote storage upload)."""
+
+    PROCESSING = "processing"
+    SUCCESS = "success"
+    ERROR = "error"
 
 
 @dataclass
@@ -64,4 +73,10 @@ class PollRunResultResponse:
     """Response wrapper for poll run result with post-run completion status."""
 
     nodeResults: Dict[str, Message]
-    completeStatus: Optional[str] = None  # "processing", "success", "error", or None
+    completeStatus: Optional[str] = None
+
+    @staticmethod
+    def from_complete_status(
+        status_enum: Optional[CompleteStatus],
+    ) -> Optional[str]:
+        return status_enum.value if status_enum else None

--- a/studio/tests/app/common/routers/test_run_api_contract.py
+++ b/studio/tests/app/common/routers/test_run_api_contract.py
@@ -28,7 +28,7 @@ POLL_RUN_RESULT_DTO_REQUIRED_FIELDS = {
 }
 
 POLL_RUN_RESULT_DTO_OPTIONAL_FIELDS = {
-    "syncStatus": (str, type(None)),  # "processing", "success", "error", or None
+    "completeStatus": (str, type(None)),
 }
 
 # RunResultDTO item (value in nodeResults) - dict of node results by nodeId
@@ -116,7 +116,7 @@ def validate_contract(
 
 def test_contract_poll_run_result_dto_structure():
     """
-    Contract test: PollRunResultDTO has nodeResults wrapper and optional syncStatus.
+    Contract test: PollRunResultDTO has nodeResults wrapper and optional completeStatus.
     """
     poll_result = {
         "nodeResults": {
@@ -131,7 +131,7 @@ def test_contract_poll_run_result_dto_structure():
                 "name": "CaImAn",
             },
         },
-        "syncStatus": RemoteSyncStatus.SUCCESS.value,
+        "completeStatus": RemoteSyncStatus.SUCCESS.value,
     }
 
     # Validate wrapper structure
@@ -154,28 +154,28 @@ def test_contract_poll_run_result_dto_structure():
         )
 
 
-def test_contract_poll_run_result_dto_sync_status_values():
+def test_contract_poll_run_result_dto_complete_status_values():
     """
-    Contract test: syncStatus can be processing, success, error, or None.
+    Contract test: completeStatus can be processing, success, error, or None.
     """
-    valid_sync_statuses = [
+    valid_complete_statuses = [
         RemoteSyncStatus.PROCESSING.value,
         RemoteSyncStatus.SUCCESS.value,
         RemoteSyncStatus.ERROR.value,
         None,
     ]
 
-    for status in valid_sync_statuses:
+    for status in valid_complete_statuses:
         poll_result = {
             "nodeResults": {},
-            "syncStatus": status,
+            "completeStatus": status,
         }
         # Should not raise
         validate_contract(
             poll_result,
             POLL_RUN_RESULT_DTO_REQUIRED_FIELDS,
             POLL_RUN_RESULT_DTO_OPTIONAL_FIELDS,
-            context=f"PollRunResultDTO with syncStatus={status}",
+            context=f"PollRunResultDTO completeStatus={status}",
         )
 
 
@@ -487,7 +487,7 @@ def test_contract_poll_run_result_is_dict():
         "nodeResults": {
             "node1": {"status": "success", "message": "", "name": "Test"},
         },
-        "syncStatus": None,
+        "completeStatus": None,
     }
 
     assert isinstance(poll_result, dict)
@@ -500,7 +500,7 @@ def test_contract_poll_run_result_empty_node_results():
     """
     poll_result = {
         "nodeResults": {},
-        "syncStatus": None,
+        "completeStatus": None,
     }
 
     assert isinstance(poll_result, dict)

--- a/studio/tests/app/common/routers/test_run_api_contract.py
+++ b/studio/tests/app/common/routers/test_run_api_contract.py
@@ -15,7 +15,7 @@ Tested endpoints:
   - POST /run/filter/{workspace_id}/{uid}/{node_id} -> str
 """
 
-from studio.app.common.core.storage.remote_storage_controller import RemoteSyncStatus
+from studio.app.common.schemas.workflow import CompleteStatus
 
 # ============================================================================
 # Frontend Contract Definitions
@@ -131,7 +131,7 @@ def test_contract_poll_run_result_dto_structure():
                 "name": "CaImAn",
             },
         },
-        "completeStatus": RemoteSyncStatus.SUCCESS.value,
+        "completeStatus": CompleteStatus.SUCCESS.value,
     }
 
     # Validate wrapper structure
@@ -159,9 +159,9 @@ def test_contract_poll_run_result_dto_complete_status_values():
     Contract test: completeStatus can be processing, success, error, or None.
     """
     valid_complete_statuses = [
-        RemoteSyncStatus.PROCESSING.value,
-        RemoteSyncStatus.SUCCESS.value,
-        RemoteSyncStatus.ERROR.value,
+        CompleteStatus.PROCESSING.value,
+        CompleteStatus.SUCCESS.value,
+        CompleteStatus.ERROR.value,
         None,
     ]
 

--- a/studio/tests/app/common/routers/test_run_api_contract.py
+++ b/studio/tests/app/common/routers/test_run_api_contract.py
@@ -15,6 +15,8 @@ Tested endpoints:
   - POST /run/filter/{workspace_id}/{uid}/{node_id} -> str
 """
 
+from studio.app.common.core.storage.remote_storage_controller import RemoteSyncStatus
+
 # ============================================================================
 # Frontend Contract Definitions
 # ============================================================================
@@ -129,7 +131,7 @@ def test_contract_poll_run_result_dto_structure():
                 "name": "CaImAn",
             },
         },
-        "syncStatus": "success",  # or "processing", "error", or None
+        "syncStatus": RemoteSyncStatus.SUCCESS.value,
     }
 
     # Validate wrapper structure
@@ -156,7 +158,12 @@ def test_contract_poll_run_result_dto_sync_status_values():
     """
     Contract test: syncStatus can be processing, success, error, or None.
     """
-    valid_sync_statuses = ["processing", "success", "error", None]
+    valid_sync_statuses = [
+        RemoteSyncStatus.PROCESSING.value,
+        RemoteSyncStatus.SUCCESS.value,
+        RemoteSyncStatus.ERROR.value,
+        None,
+    ]
 
     for status in valid_sync_statuses:
         poll_result = {

--- a/studio/tests/app/common/routers/test_run_api_contract.py
+++ b/studio/tests/app/common/routers/test_run_api_contract.py
@@ -20,10 +20,16 @@ Tested endpoints:
 # ============================================================================
 # These mirror the TypeScript interfaces in Run.ts
 
-# RunResultDTO interface
-RUN_RESULT_DTO_REQUIRED_FIELDS = {}  # It's a dict with nodeId keys
+# PollRunResultDTO interface (wrapper structure for poll endpoint)
+POLL_RUN_RESULT_DTO_REQUIRED_FIELDS = {
+    "nodeResults": dict,  # Dict of node results by nodeId
+}
 
-# RunResult item (value in RunResultDTO)
+POLL_RUN_RESULT_DTO_OPTIONAL_FIELDS = {
+    "syncStatus": (str, type(None)),  # "processing", "success", "error", or None
+}
+
+# RunResultDTO item (value in nodeResults) - dict of node results by nodeId
 RUN_RESULT_ITEM_REQUIRED_FIELDS = {
     "status": str,
     "message": str,
@@ -106,31 +112,63 @@ def validate_contract(
 # ============================================================================
 
 
-def test_contract_run_result_dto_structure():
+def test_contract_poll_run_result_dto_structure():
     """
-    Contract test: RunResultDTO is a dict with nodeId keys.
+    Contract test: PollRunResultDTO has nodeResults wrapper and optional syncStatus.
     """
-    run_result = {
-        "node1": {
-            "status": "success",
-            "message": "Completed successfully",
-            "name": "Suite2P",
+    poll_result = {
+        "nodeResults": {
+            "node1": {
+                "status": "success",
+                "message": "Completed successfully",
+                "name": "Suite2P",
+            },
+            "node2": {
+                "status": "running",
+                "message": "Processing...",
+                "name": "CaImAn",
+            },
         },
-        "node2": {
-            "status": "running",
-            "message": "Processing...",
-            "name": "CaImAn",
-        },
+        "syncStatus": "success",  # or "processing", "error", or None
     }
 
-    assert isinstance(run_result, dict)
-    for node_id, result_item in run_result.items():
+    # Validate wrapper structure
+    validate_contract(
+        poll_result,
+        POLL_RUN_RESULT_DTO_REQUIRED_FIELDS,
+        POLL_RUN_RESULT_DTO_OPTIONAL_FIELDS,
+        context="PollRunResultDTO",
+    )
+
+    # Validate nodeResults contents
+    assert isinstance(poll_result["nodeResults"], dict)
+    for node_id, result_item in poll_result["nodeResults"].items():
         assert isinstance(node_id, str)
         validate_contract(
             result_item,
             RUN_RESULT_ITEM_REQUIRED_FIELDS,
             RUN_RESULT_ITEM_OPTIONAL_FIELDS,
-            context=f"RunResultDTO[{node_id}]",
+            context=f"nodeResults[{node_id}]",
+        )
+
+
+def test_contract_poll_run_result_dto_sync_status_values():
+    """
+    Contract test: syncStatus can be processing, success, error, or None.
+    """
+    valid_sync_statuses = ["processing", "success", "error", None]
+
+    for status in valid_sync_statuses:
+        poll_result = {
+            "nodeResults": {},
+            "syncStatus": status,
+        }
+        # Should not raise
+        validate_contract(
+            poll_result,
+            POLL_RUN_RESULT_DTO_REQUIRED_FIELDS,
+            POLL_RUN_RESULT_DTO_OPTIONAL_FIELDS,
+            context=f"PollRunResultDTO with syncStatus={status}",
         )
 
 
@@ -434,22 +472,30 @@ def test_contract_run_returns_unique_id_string():
     assert len(unique_id) > 0
 
 
-def test_contract_run_result_is_dict():
+def test_contract_poll_run_result_is_dict():
     """
-    Contract test: RunResult is a dictionary.
+    Contract test: PollRunResultDTO has nodeResults which is a dictionary.
     """
-    run_result = {
-        "node1": {"status": "success", "message": "", "name": "Test"},
+    poll_result = {
+        "nodeResults": {
+            "node1": {"status": "success", "message": "", "name": "Test"},
+        },
+        "syncStatus": None,
     }
 
-    assert isinstance(run_result, dict)
+    assert isinstance(poll_result, dict)
+    assert isinstance(poll_result["nodeResults"], dict)
 
 
-def test_contract_empty_run_result():
+def test_contract_poll_run_result_empty_node_results():
     """
-    Contract test: RunResult can be empty dict.
+    Contract test: nodeResults can be empty dict.
     """
-    run_result = {}
+    poll_result = {
+        "nodeResults": {},
+        "syncStatus": None,
+    }
 
-    assert isinstance(run_result, dict)
-    assert len(run_result) == 0
+    assert isinstance(poll_result, dict)
+    assert isinstance(poll_result["nodeResults"], dict)
+    assert len(poll_result["nodeResults"]) == 0


### PR DESCRIPTION
#### Problem:
- Run button becomes enabled before S3 upload completes, allowing users to start new workflows while data is still being uploaded

#### Bug Fixes:
- **Run button lock timing**: Extended the run button lock to wait for S3 upload completion, not just node completion
- **Error state handling**: Button now enables on upload error (allows retry) instead of staying disabled forever

#### Enhancements:
- Added `syncStatus` field to poll response (`PollRunResultDTO`) to track S3 upload state
- Frontend checks `syncStatus` before marking workflow as `FINISHED`
- Button stays disabled while `syncStatus === SYNC_STATUS.PROCESSING`, enables for all other states
- Added `SYNC_STATUS` constant to avoid magic strings (mirrors backend `RemoteSyncStatus` enum)

#### How It Works:

```
| syncStatus    | Button State | Reason                          |
|---------------|--------------|----------------------------------|
| null          | Enabled      | Remote storage not configured    |
| "processing"  | Disabled     | S3 upload in progress            |
| "success"     | Enabled      | Upload completed successfully    |
| "error"       | Enabled      | Upload failed, allow retry       |
```

#### Files Modified:

Backend:
- studio/app/common/schemas/workflow.py - Added `PollRunResultResponse` dataclass
- studio/app/common/routers/run.py - Return sync status in poll response

Frontend:
- frontend/src/api/run/Run.ts - Added `PollRunResultDTO` type and `SYNC_STATUS` constant
- frontend/src/store/slice/Pipeline/PipelineActions.ts - Updated thunk return type
- frontend/src/store/slice/Pipeline/PipelineSlice.ts - Check syncStatus using constant
- frontend/src/store/slice/Experiments/ExperimentsSlice.ts - Access nodeResults wrapper

#### Tests Updated:
- studio/tests/app/common/routers/test_run_api_contract.py - Use `RemoteSyncStatus` enum
- frontend/src/store/slice/Pipeline/PipelineTestUtils.ts - Use `SYNC_STATUS` constant