### PR TITLE
Show Caution when premium user delete Account

### DIFF
--- a/frontend/src/components/common/DeleteConfirmModal.tsx
+++ b/frontend/src/components/common/DeleteConfirmModal.tsx
@@ -24,6 +24,7 @@ type DeleteConfirmModalProps = {
   onSubmit: () => void
   titleSubmit: string
   description: string
+  warningItems?: string[]
   loading?: boolean
   iconType?: "warning" | "info"
 }
@@ -34,6 +35,7 @@ const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
   loading,
   titleSubmit,
   description,
+  warningItems,
   iconType,
 }) => {
   useEffect(() => {
@@ -59,7 +61,20 @@ const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
   }
 
   const content = (
-    <DialogContentText>
+    <DialogContentText component="div">
+      {warningItems && warningItems.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <ul style={{ margin: 0, paddingLeft: 20 }}>
+            {warningItems.map((item, index) => (
+              <li key={index}>
+                <Typography variant="body2" color="error">
+                  {item}
+                </Typography>
+              </li>
+            ))}
+          </ul>
+        </Box>
+      )}
       <Typography style={{ whiteSpace: "pre-wrap" }}>
         To continue, type <span style={{ fontWeight: 600 }}>DELETE</span> in the
         box below:

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -87,6 +87,30 @@ const Account = () => {
     setIsDeleteConfirmModalOpen(true)
   }
 
+  const isPremiumUser =
+    userSubscription &&
+    !userSubscription.is_expired &&
+    userSubscription.status === SubscriptionUserStatus.SUBSCRIBED
+
+  const getDeleteAccountDescription = () => {
+    if (isPremiumUser) {
+      return `You have an active ${userSubscription.plan_name} subscription.`
+    }
+    return "Delete account will erase all of your data."
+  }
+
+  const getDeleteAccountWarnings = (): string[] | undefined => {
+    if (isPremiumUser) {
+      return [
+        "Your subscription will be immediately canceled",
+        "You will not receive a refund for the remaining period",
+        "All your data (workspaces, experiments, files) will be permanently deleted",
+        "This action cannot be undone",
+      ]
+    }
+    return undefined
+  }
+
   const onConfirmDelete = async () => {
     if (!user) return
     const data = await dispatch(deleteMe())
@@ -291,7 +315,8 @@ const Account = () => {
         onClose={handleCloseDeleteComfirmModal}
         open={isDeleteConfirmModalOpen}
         onSubmit={onConfirmDelete}
-        description="Delete account will erase all of your data. "
+        description={getDeleteAccountDescription()}
+        warningItems={getDeleteAccountWarnings()}
         iconType="warning"
       />
       <ChangePasswordModal


### PR DESCRIPTION
### Content

Show Caution when premium user delete Account.

Before: All users will just need to type "Delete" without any cautions being shown.
After: For Premium users there will be cautions to show when deleting. This will prevent the users from false deleting their premium accounts.

### Testcase

- [x] Check Delete with Free Users. It should be plain and just ask to type "Delete"
- [x] Check Delete with Premium Users. It should show cautions and ask you to type "Delete"

Cautions Values:

- Your subscription will be immediately canceled
- You will not receive a refund for the remaining period
- All your data (workspaces, experiments, files) will be permanently deleted
- This action cannot be undone

Free:
<img width="656" height="381" alt="Screenshot 2026-02-05 at 21 55 25" src="https://github.com/user-attachments/assets/c58d96e3-8a40-46b5-bb1d-fca274acd438" />

Premium:
<img width="605" height="492" alt="Screenshot 2026-02-05 at 21 54 39" src="https://github.com/user-attachments/assets/dff43d3b-c902-435a-993b-a2d70a6c6303" />
