### PR TITLE
Fixing error during account delete

### DIFF
--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -300,7 +300,7 @@ def __get_current_user_record(db: Session, uid: str) -> sqlalchemy.engine.row.Ro
         .outerjoin(UserSubscription, UserSubscription.user_id == UserModel.id)
         .outerjoin(SubscriptionPlans, SubscriptionPlans.id == UserSubscription.plan_id)
         .outerjoin(UserStorageUsage, UserStorageUsage.user_id == UserModel.id)
-        .filter(UserModel.uid == uid)
+        .filter(UserModel.uid == uid, UserModel.active.is_(True))
         .group_by(UserModel.id)
         .first()
     )

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -957,28 +957,43 @@ class S3StorageController(BaseRemoteStorageController):
         total_bytes_deleted = 0
 
         # do delete data from remote storage
-        async with self.__get_s3_resource() as __s3_resource:
-            bucket = await __s3_resource.Bucket(self.bucket_name)
+        try:
+            async with self.__get_s3_resource() as __s3_resource:
+                bucket = await __s3_resource.Bucket(self.bucket_name)
 
-            objects_to_delete = bucket.objects.filter(Prefix=experiment_remote_path)
-
-            # Collect keys and sizes before deletion
-            keys_to_delete = []
-            async for obj in objects_to_delete:
-                keys_to_delete.append({"Key": obj.key})
-                # Track size for storage update
-                total_bytes_deleted += await obj.size
-
-            if keys_to_delete:
-                logger.info(
-                    f"Deleting {len(keys_to_delete)} objects "
-                    f"({total_bytes_deleted:,} bytes) from {experiment_remote_path}"
+                objects_to_delete = bucket.objects.filter(
+                    Prefix=experiment_remote_path
                 )
-                # S3 delete_objects has a limit of 1000 objects per request
-                batch_size = 1000
-                for i in range(0, len(keys_to_delete), batch_size):
-                    batch = keys_to_delete[i : i + batch_size]
-                    await bucket.delete_objects(Delete={"Objects": batch})
+
+                # Collect keys and sizes before deletion
+                keys_to_delete = []
+                async for obj in objects_to_delete:
+                    keys_to_delete.append({"Key": obj.key})
+                    # Track size for storage update
+                    total_bytes_deleted += await obj.size
+
+                if keys_to_delete:
+                    logger.info(
+                        f"Deleting {len(keys_to_delete)} objects "
+                        f"({total_bytes_deleted:,} bytes) "
+                        f"from {experiment_remote_path}"
+                    )
+                    # S3 delete_objects has a limit of 1000 objects per request
+                    batch_size = 1000
+                    for i in range(0, len(keys_to_delete), batch_size):
+                        batch = keys_to_delete[i : i + batch_size]
+                        await bucket.delete_objects(Delete={"Objects": batch})
+        except Exception as e:
+            if (
+                hasattr(e, "response")
+                and e.response.get("Error", {}).get("Code") == "NoSuchBucket"
+            ):
+                logger.warning(
+                    f"[S3] Bucket '{self.bucket_name}' does not exist, "
+                    f"skipping experiment deletion for '{unique_id}'"
+                )
+                return True
+            raise
 
         # Update user storage with the total bytes deleted (incremental approach)
         if total_bytes_deleted > 0:
@@ -1135,5 +1150,14 @@ class S3StorageController(BaseRemoteStorageController):
             return True
 
         except Exception as e:
+            if (
+                hasattr(e, "response")
+                and e.response.get("Error", {}).get("Code") == "NoSuchBucket"
+            ):
+                logger.warning(
+                    f"[S3] Bucket '{self.bucket_name}' does not exist, "
+                    f"skipping workspace deletion for '{workspace_id}'"
+                )
+                return True
             logger.error(f"[S3] Failed to delete workspace: {e}", exc_info=True)
             return False

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -961,9 +961,7 @@ class S3StorageController(BaseRemoteStorageController):
             async with self.__get_s3_resource() as __s3_resource:
                 bucket = await __s3_resource.Bucket(self.bucket_name)
 
-                objects_to_delete = bucket.objects.filter(
-                    Prefix=experiment_remote_path
-                )
+                objects_to_delete = bucket.objects.filter(Prefix=experiment_remote_path)
 
                 # Collect keys and sizes before deletion
                 keys_to_delete = []

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -121,9 +121,9 @@ def _transform_user_row(item) -> UserModel:
                 user.__dict__["subscription_status"] = SubscriptionStatus.PREMIUM.value
                 user.__dict__["subscription_days_remaining"] = days_remaining
             elif days_remaining >= -SubscriptionPeriods.GRACE_PERIOD_DAYS:
-                user.__dict__["subscription_status"] = (
-                    SubscriptionStatus.LIMIT_GRACE.value
-                )
+                user.__dict__[
+                    "subscription_status"
+                ] = SubscriptionStatus.LIMIT_GRACE.value
                 user.__dict__["subscription_days_remaining"] = (
                     SubscriptionPeriods.GRACE_PERIOD_DAYS + days_remaining
                 )  # Days left in grace period

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -570,9 +570,7 @@ async def delete_user(db: Session, user_id: int, organization_id: int) -> bool:
             await StripeService.handle_cancel_user_subscription(db, user_db)
         except HTTPException as e:
             if e.status_code == 404:
-                logger.info(
-                    f"No subscription to cancel for user {user_id}, skipping"
-                )
+                logger.info(f"No subscription to cancel for user {user_id}, skipping")
             else:
                 raise
 

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -121,9 +121,9 @@ def _transform_user_row(item) -> UserModel:
                 user.__dict__["subscription_status"] = SubscriptionStatus.PREMIUM.value
                 user.__dict__["subscription_days_remaining"] = days_remaining
             elif days_remaining >= -SubscriptionPeriods.GRACE_PERIOD_DAYS:
-                user.__dict__[
-                    "subscription_status"
-                ] = SubscriptionStatus.LIMIT_GRACE.value
+                user.__dict__["subscription_status"] = (
+                    SubscriptionStatus.LIMIT_GRACE.value
+                )
                 user.__dict__["subscription_days_remaining"] = (
                     SubscriptionPeriods.GRACE_PERIOD_DAYS + days_remaining
                 )  # Days left in grace period
@@ -569,10 +569,11 @@ async def delete_user(db: Session, user_id: int, organization_id: int) -> bool:
         try:
             await StripeService.handle_cancel_user_subscription(db, user_db)
         except HTTPException as e:
+            # If no subscription found (Newly Created Free User, etc.), log and continue
             if e.status_code == 404:
                 logger.info(f"No subscription to cancel for user {user_id}, skipping")
             else:
-                raise
+                raise e
 
         # ----------------------------------------
         # Delete a User database record

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -563,41 +563,53 @@ async def delete_user(db: Session, user_id: int, organization_id: int) -> bool:
             )
 
         # ----------------------------------------
-        # Delete a User remote storage data
+        # Cancel a User subscription (must succeed before deletion)
         # ----------------------------------------
 
-        # delete remote_storage bucket
-        if RemoteStorageController.is_available():
-            async with RemoteStorageSimpleWriter(
-                user_db.remote_bucket_name
-            ) as remote_storage_controller:
-                await remote_storage_controller.delete_bucket(force_delete=True)
-
-        # ----------------------------------------
-        # Cancel a User subscription
-        # ----------------------------------------
-
-        await StripeService.handle_cancel_user_subscription(db, user_db)
+        try:
+            await StripeService.handle_cancel_user_subscription(db, user_db)
+        except HTTPException as e:
+            if e.status_code == 404:
+                logger.info(
+                    f"No subscription to cancel for user {user_id}, skipping"
+                )
+            else:
+                raise
 
         # ----------------------------------------
         # Delete a User database record
         # ----------------------------------------
 
         user_db.active = False
-
-        # ----------------------------------------
-        # Delete a User firebase account
-        # ----------------------------------------
-
-        firebase_auth.delete_user(user_db.uid)
-
-        # The transaction is committed at this point
-        # ATTENTION:
-        #   - If an exception occurs when deleting a Firebase account,
-        #     this commit may not be executed and the account may become undeletable.
-        #   - One possible solution to this issue is to add a status
-        #     when an error occurs (such as "Account suspended").
         db.commit()
+
+        # ----------------------------------------
+        # Best-effort cleanup: Firebase account
+        # ----------------------------------------
+
+        try:
+            firebase_auth.delete_user(user_db.uid)
+        except Exception as e:
+            logger.warning(
+                f"Firebase account deletion failed for user {user_id}, "
+                f"needs manual cleanup: {e}"
+            )
+
+        # ----------------------------------------
+        # Best-effort cleanup: Remote storage data
+        # ----------------------------------------
+
+        try:
+            if RemoteStorageController.is_available():
+                async with RemoteStorageSimpleWriter(
+                    user_db.remote_bucket_name
+                ) as remote_storage_controller:
+                    await remote_storage_controller.delete_bucket(force_delete=True)
+        except Exception as e:
+            logger.warning(
+                f"S3 bucket deletion failed for user {user_id}, "
+                f"needs manual cleanup: {e}"
+            )
 
         return True
 


### PR DESCRIPTION
### Content

#### Problem

- When a new user is created, the bucket name is saved to the database, but the bucket itself isn't actually created until sample data is run or imported. This causes an issue when attempting to delete the account, since the system tries to delete a bucket that doesn't exist.
- When a new user is created, no subscription data exists in Stripe yet. However, the account deletion process attempts to delete the user's Stripe subscription, which fails because there's nothing to delete. Depending on the order of operations, the S3 bucket may have already been deleted before the Stripe error occurs. This leaves the user in a broken state — their bucket is gone, but the account deletion didn't fully complete, resulting in the delete account bug.

#### Fix

  - Fix session invalidation for deleted users — Added active check to the authentication dependency so that deleted (soft-deleted) users are    
  immediately rejected with 401 on all API requests, regardless of which browser/session they use
  - Make delete account resilient to missing S3 buckets — Wrapped S3 experiment and workspace deletion in NoSuchBucket error handling so account
  deletion doesn't fail when the bucket doesn't exist
  - Reorder delete account steps for reliability — Moved db.commit() (marking active=False) before Firebase/S3 cleanup, making those steps
  best-effort. Previously, if Firebase deletion failed, the DB commit never ran and the account became undeletable
  
### Changes.

  auth_dependencies.py

  - Added UserModel.active.is_(True) filter to __get_current_user_record() — this is the core fix that prevents deleted users from passing
  authentication on existing sessions

  crud_users.py

  - Reordered deletion steps: subscription cancellation → DB soft-delete (active=False) → Firebase cleanup → S3 cleanup
  - DB commit now happens before Firebase and S3 cleanup, so the user is immediately locked out
  - Firebase and S3 deletions are now best-effort with try/except and warning logs for manual cleanup
  - Subscription cancellation gracefully handles 404 (no subscription to cancel)

  s3_storage_controller.py

  - Added NoSuchBucket handling in delete_experiment_data_from_remote() — returns True instead of raising
  - Added NoSuchBucket handling in workspace deletion — returns True instead of raising

### Testcase

- [x] Delete Free User
  - [x] S3 Deleted
  - [x] Firebase Deleted
  - [x] Account Soft Deleted
- [x] Delete Premium User
  - [x] S3 Deleted
  - [x] Firebase Deleted
  - [x] Account Soft Deleted
  - [x] Premium is canceled on Stripe

- [x] Edge Cases
  - [x] Delete user that has no S3
  - [x] Delete user that have stripe cancelled already
  - [x] Delete user with workflow running
  - [x] Delete user after being deleted from different browser.
      Expected -> 1st Browser delete the account. 2nd browser shows failed. But it should logout the user when accessing the page
