### PR TITLE
Fix/unauth beacon

### DIFF
--- a/frontend/src/api/premium/PremiumAssignmentApi.ts
+++ b/frontend/src/api/premium/PremiumAssignmentApi.ts
@@ -100,3 +100,6 @@ export const sendPremiumHeartbeat =
     const response = await axios.post("/users/me/premium/heartbeat")
     return response.data
   }
+
+export const getBeaconTokenApi = () =>
+  axios.get<{ token: string }>("/users/me/premium/beacon-token")

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -441,6 +441,7 @@ export const PremiumAssignmentProvider: React.FC<{
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn("Auto-assignment failed:", error)
+      routingService.clearRoutingInfo()
     }
   }, [isPremiumUser, hasAttemptedAutoAssignment])
 
@@ -667,6 +668,7 @@ export const PremiumAssignmentProvider: React.FC<{
 
     const handleBeforeUnload = () => {
       if (state.assignmentResult?.instance_id && beaconTokenRef.current) {
+        routingService.clearRoutingInfo()
         const beaconData = JSON.stringify({
           token: beaconTokenRef.current,
         })

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -327,6 +327,8 @@ export const PremiumAssignmentProvider: React.FC<{
 
     try {
       const result = await releasePremiumInstance()
+      // Clear beacon token so beforeunload doesn't fire a duplicate release
+      beaconTokenRef.current = null
       setState((prev) => ({
         ...prev,
         isReleasing: false,

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -17,6 +17,7 @@ import { useSelector } from "react-redux"
 
 import {
   assignPremiumInstance,
+  getBeaconTokenApi,
   getPremiumStatus,
   getRoutingInfo,
   releasePremiumInstance,
@@ -116,6 +117,7 @@ export const PremiumAssignmentProvider: React.FC<{
   // Cross-tab leader election for coordinating polling
   const [isTabLeader, setIsTabLeader] = useState(false)
   const leaderElectionRef = useRef<CrossTabLeaderElection | null>(null)
+  const beaconTokenRef = useRef<string | null>(null)
 
   // Refs for values that inactivity check needs but shouldn't trigger re-renders
   const lastActivityTimeRef = useRef(state.lastActivityTime)
@@ -282,6 +284,15 @@ export const PremiumAssignmentProvider: React.FC<{
           error: result.assigned ? null : result.message,
         }))
 
+        if (result.assigned) {
+          try {
+            const tokenRes = await getBeaconTokenApi()
+            beaconTokenRef.current = tokenRes.data.token
+          } catch {
+            // Non-critical; beacon will fail gracefully
+          }
+        }
+
         return result
       } catch (error: unknown) {
         const errorMessage =
@@ -400,6 +411,12 @@ export const PremiumAssignmentProvider: React.FC<{
           assignmentResult,
           error: null,
         }))
+        try {
+          const tokenRes = await getBeaconTokenApi()
+          beaconTokenRef.current = tokenRes.data.token
+        } catch {
+          // Non-critical; beacon will fail gracefully
+        }
         return
       }
 
@@ -412,6 +429,12 @@ export const PremiumAssignmentProvider: React.FC<{
           assignmentResult: assignmentResponse,
           error: null,
         }))
+        try {
+          const tokenRes = await getBeaconTokenApi()
+          beaconTokenRef.current = tokenRes.data.token
+        } catch {
+          // Non-critical; beacon will fail gracefully
+        }
       }
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -641,10 +664,10 @@ export const PremiumAssignmentProvider: React.FC<{
     if (!isPremiumUser || !currentUser) return
 
     const handleBeforeUnload = () => {
-      // Use sendBeacon for reliable delivery during page unload
-      // Unlike fetch/XHR, sendBeacon is guaranteed to be sent even when page closes
-      if (state.assignmentResult?.instance_id) {
-        const beaconData = JSON.stringify({ user_uid: currentUser.uid })
+      if (state.assignmentResult?.instance_id && beaconTokenRef.current) {
+        const beaconData = JSON.stringify({
+          token: beaconTokenRef.current,
+        })
         navigator.sendBeacon("/api/users/me/premium/release-beacon", beaconData)
       }
     }

--- a/studio/app/common/core/auth/security.py
+++ b/studio/app/common/core/auth/security.py
@@ -90,3 +90,22 @@ def validate_access_token(token: str) -> Tuple[Dict[str, Any], Optional[str]]:
 
 def validate_refresh_token(token: str) -> Tuple[Dict[str, Any], Optional[str]]:
     return _validate_token(token, "refresh_token")
+
+
+BEACON_TOKEN_TTL = timedelta(hours=24)
+
+
+def create_beacon_token(user_uid: str) -> str:
+    return _create_token(
+        subject=user_uid,
+        token_type="beacon_token",
+        expires_delta=BEACON_TOKEN_TTL,
+    )
+
+
+def validate_beacon_token(token: str) -> Optional[str]:
+    """Returns user_uid if valid, None otherwise."""
+    payload, err = _validate_token(token, "beacon_token")
+    if err or not payload:
+        return None
+    return payload.get("sub")

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -173,38 +173,51 @@ async def release_premium_instance(current_user: User = Depends(get_current_user
         return {"message": "Release completed with warnings", "released": True}
 
 
+@router.get("/premium/beacon-token", response_model=Dict)
+async def get_beacon_token(
+    current_user: User = Depends(get_current_user),
+):
+    from studio.app.common.core.auth.security import create_beacon_token
+
+    token = create_beacon_token(current_user.uid)
+    return {"token": token}
+
+
 @router.post("/premium/release-beacon", response_model=Dict)
 async def release_premium_beacon(request: Request, db: Session = Depends(get_db)):
     """
-    Beacon endpoint for reliable cleanup on browser close/refresh.
-
-    Uses navigator.sendBeacon for reliable delivery during page
-    unload. Does not require authentication since the user may be
-    closing the browser.
+    Beacon endpoint for reliable cleanup on browser close.
+    Authenticated via HMAC-signed token (sendBeacon cannot
+    carry Authorization headers).
     """
+    from studio.app.common.core.auth.security import validate_beacon_token
     from studio.app.common.models.user import User as UserModel
 
     try:
         body = await request.json()
-        user_uid = body.get("user_uid")
+        token = body.get("token")
+        if not token:
+            return {"success": False, "message": "Missing token"}
 
+        user_uid = validate_beacon_token(token)
         if not user_uid:
-            logger.warning("Beacon release called without user_uid")
-            return {"success": False, "message": "Missing user_uid"}
+            return {"success": False, "message": "Invalid token"}
 
         user = db.query(UserModel).filter(UserModel.uid == user_uid).first()
-        if user:
-            invalidate_activity_cache(user.id)
-            mark_user_logged_out(user.id)
+        if not user:
+            return {
+                "success": False,
+                "message": "User not found",
+            }
 
-        user_id = user.id if user else 0
+        invalidate_activity_cache(user.id)
+        mark_user_logged_out(user.id)
+
         result = await premium_assignment_service.release_premium_user(
-            user_id=user_id, user_uid=user_uid
+            user_id=user.id, user_uid=user_uid
         )
 
-        logger.info(
-            f"Beacon release for user_uid {user_uid}: " f"{result.get('message')}"
-        )
+        logger.info(f"Beacon release for user {user.id}: " f"{result.get('message')}")
         return {
             "success": True,
             "message": result.get("message", "Release processed"),

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -622,32 +622,47 @@ async def test_contract_beacon_release_success():
     """
     from unittest.mock import AsyncMock, MagicMock
 
+    mock_user = MagicMock()
+    mock_user.id = 1
+    mock_user.uid = "test-user-123"
+
     mock_request = MagicMock()
-    mock_request.json = AsyncMock(return_value={"user_uid": "test-user-123"})
+    mock_request.json = AsyncMock(return_value={"token": "signed-token"})
     mock_db = MagicMock()
-    mock_db.query.return_value.filter.return_value.first.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_user
 
     with patch(
         "studio.app.common.routers.users_me.premium_assignment_service"
     ) as mock_service:
         with patch("studio.app.common.routers.users_me.invalidate_activity_cache"):
             with patch("studio.app.common.routers.users_me.mark_user_logged_out"):
-                mock_service.release_premium_user = AsyncMock(
-                    return_value={"success": True, "message": "Released"}
-                )
+                with patch(
+                    "studio.app.common.routers.users_me" ".validate_beacon_token",
+                    return_value="test-user-123",
+                ):
+                    mock_service.release_premium_user = AsyncMock(
+                        return_value={
+                            "success": True,
+                            "message": "Released",
+                        }
+                    )
 
-                from studio.app.common.routers.users_me import release_premium_beacon
+                    from studio.app.common.routers.users_me import (
+                        release_premium_beacon,
+                    )
 
-                result = await release_premium_beacon(request=mock_request, db=mock_db)
+                    result = await release_premium_beacon(
+                        request=mock_request, db=mock_db
+                    )
 
-                validate_contract(
-                    result,
-                    BEACON_RESULT_REQUIRED_FIELDS,
-                    BEACON_RESULT_OPTIONAL_FIELDS,
-                    context="BeaconResult (success)",
-                )
+                    validate_contract(
+                        result,
+                        BEACON_RESULT_REQUIRED_FIELDS,
+                        BEACON_RESULT_OPTIONAL_FIELDS,
+                        context="BeaconResult (success)",
+                    )
 
-                assert result["success"] is True
+                    assert result["success"] is True
 
 
 @pytest.mark.asyncio

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -637,7 +637,7 @@ async def test_contract_beacon_release_success():
         with patch("studio.app.common.routers.users_me.invalidate_activity_cache"):
             with patch("studio.app.common.routers.users_me.mark_user_logged_out"):
                 with patch(
-                    "studio.app.common.routers.users_me" ".validate_beacon_token",
+                    "studio.app.common.core.auth.security" ".validate_beacon_token",
                     return_value="test-user-123",
                 ):
                     mock_service.release_premium_user = AsyncMock(

--- a/studio/tests/app/common/routers/test_premium_beacon_endpoint.py
+++ b/studio/tests/app/common/routers/test_premium_beacon_endpoint.py
@@ -1,9 +1,4 @@
-"""
-Tests for Premium Release Beacon Endpoint
-
-Tests the /premium/release-beacon endpoint used for reliable cleanup
-when browser closes or page refreshes.
-"""
+"""Tests for Premium Release Beacon Endpoint"""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,109 +9,90 @@ from studio.app.common.routers.users_me import release_premium_beacon
 
 
 class TestReleasePremiumBeacon:
-    """Test beacon endpoint for browser close cleanup"""
+    """Test beacon endpoint with token authentication"""
 
     @pytest.mark.asyncio
-    async def test_beacon_release_success(self):
-        """Test successful beacon release with valid user_uid"""
-        mock_request = MagicMock()
-        mock_request.json = AsyncMock(return_value={"user_uid": "test-user-123"})
-        mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.first.return_value = None
-
-        with patch(
-            "studio.app.common.routers.users_me.premium_assignment_service"
-        ) as mock_service:
-            with patch("studio.app.common.routers.users_me.invalidate_activity_cache"):
-                with patch("studio.app.common.routers.users_me.mark_user_logged_out"):
-                    mock_service.release_premium_user = AsyncMock(
-                        return_value={
-                            "success": True,
-                            "message": "Released from instance i-123456",
-                        }
-                    )
-
-                    result = await release_premium_beacon(
-                        request=mock_request, db=mock_db
-                    )
-
-                    assert result["success"] is True
-                    mock_service.release_premium_user.assert_called_once_with(
-                        user_id=0, user_uid="test-user-123"
-                    )
-
-    @pytest.mark.asyncio
-    async def test_beacon_release_missing_user_uid(self):
-        """Test beacon release with missing user_uid returns failure"""
+    async def test_beacon_missing_token(self):
         mock_request = MagicMock()
         mock_request.json = AsyncMock(return_value={})
         mock_db = MagicMock()
 
         result = await release_premium_beacon(request=mock_request, db=mock_db)
-
         assert result["success"] is False
-        assert "Missing user_uid" in result["message"]
+        assert "Missing token" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_beacon_release_null_user_uid(self):
-        """Test beacon release with null user_uid returns failure"""
+    async def test_beacon_invalid_token(self):
         mock_request = MagicMock()
-        mock_request.json = AsyncMock(return_value={"user_uid": None})
+        mock_request.json = AsyncMock(return_value={"token": "forged:123:abc"})
         mock_db = MagicMock()
 
-        result = await release_premium_beacon(request=mock_request, db=mock_db)
-
+        with patch(
+            "studio.app.common.core.auth.security" ".validate_beacon_token",
+            return_value=None,
+        ):
+            result = await release_premium_beacon(request=mock_request, db=mock_db)
         assert result["success"] is False
-        assert "Missing user_uid" in result["message"]
+        assert "Invalid token" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_beacon_release_service_error(self):
-        """Test beacon release handles service errors gracefully"""
+    async def test_beacon_valid_token_user_not_found(self):
         mock_request = MagicMock()
-        mock_request.json = AsyncMock(return_value={"user_uid": "test-user-123"})
+        mock_request.json = AsyncMock(return_value={"token": "valid"})
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
         with patch(
-            "studio.app.common.routers.users_me.premium_assignment_service"
-        ) as mock_service:
-            with patch("studio.app.common.routers.users_me.invalidate_activity_cache"):
-                with patch("studio.app.common.routers.users_me.mark_user_logged_out"):
-                    mock_service.release_premium_user = AsyncMock(
-                        side_effect=Exception("Lambda timeout")
-                    )
-
-                    result = await release_premium_beacon(
-                        request=mock_request, db=mock_db
-                    )
-
-                    # Should not raise, just return failure
-                    assert result["success"] is False
-                    assert "Lambda timeout" in result["message"]
+            "studio.app.common.core.auth.security" ".validate_beacon_token",
+            return_value="uid-123",
+        ):
+            result = await release_premium_beacon(request=mock_request, db=mock_db)
+        assert result["success"] is False
+        assert "User not found" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_beacon_release_invalid_json(self):
-        """Test beacon release handles invalid JSON gracefully"""
+    async def test_beacon_valid_token_success(self):
         mock_request = MagicMock()
-        mock_request.json = AsyncMock(
-            side_effect=json.JSONDecodeError("Invalid", "", 0)
+        mock_request.json = AsyncMock(return_value={"token": "valid"})
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.uid = "uid-123"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch(
+            "studio.app.common.core.auth.security" ".validate_beacon_token",
+            return_value="uid-123",
+        ):
+            with patch(
+                "studio.app.common.routers.users_me" ".premium_assignment_service"
+            ) as mock_svc:
+                with patch(
+                    "studio.app.common.routers.users_me" ".invalidate_activity_cache"
+                ):
+                    with patch(
+                        "studio.app.common.routers.users_me" ".mark_user_logged_out"
+                    ):
+                        mock_svc.release_premium_user = AsyncMock(
+                            return_value={
+                                "success": True,
+                                "message": "Released",
+                            }
+                        )
+                        result = await release_premium_beacon(
+                            request=mock_request,
+                            db=mock_db,
+                        )
+        assert result["success"] is True
+        mock_svc.release_premium_user.assert_called_once_with(
+            user_id=42, user_uid="uid-123"
         )
+
+    @pytest.mark.asyncio
+    async def test_beacon_invalid_json(self):
+        mock_request = MagicMock()
+        mock_request.json = AsyncMock(side_effect=json.JSONDecodeError("Bad", "", 0))
         mock_db = MagicMock()
 
         result = await release_premium_beacon(request=mock_request, db=mock_db)
-
-        # Should not raise, just return failure
         assert result["success"] is False
-
-    @pytest.mark.asyncio
-    async def test_beacon_does_not_require_auth(self):
-        """Test beacon endpoint does not require authentication"""
-        # The endpoint signature should not have Depends(get_current_user)
-        import inspect
-
-        sig = inspect.signature(release_premium_beacon)
-        params = list(sig.parameters.keys())
-
-        # Should only have 'request' parameter, not 'current_user'
-        assert "request" in params
-        assert "current_user" not in params


### PR DESCRIPTION
## Summary

- Add HMAC-signed JWT token auth to `release-beacon` endpoint, closing a vulnerability where anyone could release another user's premium instance
- Return early with "User not found" when uid is missing from DB instead of passing `user_id=0` (B12)

---

## Changes by File

### `studio/app/common/core/auth/security.py`
- Add `create_beacon_token()` and `validate_beacon_token()` reusing existing `_create_token`/`_validate_token` JWT infrastructure with `token_type="beacon_token"` and 24h TTL

### `studio/app/common/routers/users_me.py`
- Add authenticated `GET /premium/beacon-token` endpoint that returns a signed JWT for the current user
- Replace unauthenticated `release_premium_beacon` with token-validated version: validates JWT, returns early with "User not found" when uid is missing from DB

### `frontend/src/api/premium/PremiumAssignmentApi.ts`
- Add `getBeaconTokenApi()` to fetch a signed beacon token from the new endpoint

### `frontend/src/contexts/PremiumAssignmentContext.tsx`
- Add `beaconTokenRef` to hold the signed beacon token
- Fetch beacon token after successful premium assignment (both auto-assign and direct assign paths)
- `handleBeforeUnload` now sends the signed token instead of raw `user_uid`

### `studio/tests/app/common/routers/test_premium_beacon_endpoint.py`
- Replace with 5 tests covering token auth: missing token, invalid token, user not found, valid token success, invalid JSON

---

## Behavior Changes

```
| Scenario                     | Before                          | After                                 |
|------------------------------|---------------------------------|---------------------------------------|
| Beacon release endpoint      | Unauthenticated; anyone can     | Requires signed JWT token;            |
|                              | release any user's instance     | validates user exists before release  |
| Beacon with unknown user_uid | Passes user_id=0 to release     | Returns early with "User not found"   |
```

---

## Risk Assessment

```
| Area              | Risk | Mitigation                                                   |
|-------------------|------|--------------------------------------------------------------|
| Beacon token auth | Low  | Reuses existing JWT create/validate infrastructure;          |
|                   |      | token fetch is non-critical (beacon fails gracefully)        |
```
