### PR TITLE
Dataview sync fixes

### DIFF
--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -95,6 +95,23 @@ async def lifespan(app: FastAPI):
     # (e.g., when using cron)
     disable_scheduler = os.environ.get("DISABLE_BACKGROUND_SCHEDULER", "0") == "1"
 
+    # Startup sync runs on ALL containers (including API workers
+    # with disabled scheduler) to ensure published experiments are
+    # available locally
+    if not MODE.IS_STANDALONE:
+        import asyncio
+
+        async def _startup_sync():
+            try:
+                await asyncio.sleep(5)
+                await PublishedExperimentSyncJob.run_startup_sync()
+            except Exception as e:
+                logger.error(f"Startup sync error: {e}", exc_info=True)
+
+        # Store on app.state to prevent GC mid-execution
+        app.state.startup_sync_task = asyncio.create_task(_startup_sync())
+        logger.info("Startup sync task scheduled (runs in background)")
+
     if not MODE.IS_STANDALONE and not disable_scheduler:
         logger.info("Initializing background job scheduler")
         BackgroundScheduler.initialize()

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -500,8 +500,20 @@ class DataCleanupJob:
                         response = ec2.describe_instances(
                             InstanceIds=[assignment.instance_id]
                         )
-                        instances = response["Reservations"][0]["Instances"]
-                        instance_state = instances[0]["State"]["Name"]
+                        reservations = response.get("Reservations", [])
+                        if not reservations or not reservations[0].get("Instances"):
+                            logger.warning(
+                                f"Instance "
+                                f"{assignment.instance_id} has "
+                                f"no reservation data, "
+                                f"treating as terminated"
+                            )
+                            cls._cleanup_orphaned_assignment(db, assignment)
+                            continue
+
+                        instance_state = reservations[0]["Instances"][0]["State"][
+                            "Name"
+                        ]
 
                         # If instance is terminated, clean up user data
                         if instance_state in ["terminated", "terminating"]:

--- a/studio/app/common/core/background/storage_reconciliation_job.py
+++ b/studio/app/common/core/background/storage_reconciliation_job.py
@@ -10,6 +10,9 @@ Runs every 60 minutes to balance accuracy vs. cost/performance.
 
 import asyncio
 
+from sqlalchemy import func, or_
+from sqlmodel import select
+
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.subscription.constants import StorageReconciliation
@@ -55,6 +58,7 @@ class StorageReconciliationJob:
         try:
             # Get all users with storage records in batches
             from studio.app.common.db.database import session_scope
+            from studio.app.common.models import UserStorageUsage
 
             reconciled_count = 0
             drift_detected_count = 0
@@ -65,11 +69,14 @@ class StorageReconciliationJob:
             # First, get total count for logging
             with session_scope() as db:
                 count_result = db.execute(
-                    """
-                    SELECT COUNT(*)
-                    FROM user_storage_usage
-                    WHERE delta_since_last_scan > 0 OR last_full_scan IS NULL
-                    """
+                    select(func.count())
+                    .select_from(UserStorageUsage)
+                    .where(
+                        or_(
+                            UserStorageUsage.delta_since_last_scan > 0,
+                            UserStorageUsage.last_full_scan.is_(None),
+                        )
+                    )
                 )
                 total_users = count_result.scalar() or 0
 
@@ -84,15 +91,21 @@ class StorageReconciliationJob:
                 # Fetch next batch of users
                 with session_scope() as db:
                     batch_records = db.execute(
-                        """
-                        SELECT user_id, storage_usage_bytes,
-                        delta_since_last_scan, last_full_scan
-                        FROM user_storage_usage
-                        WHERE delta_since_last_scan > 0 OR last_full_scan IS NULL
-                        ORDER BY user_id
-                        LIMIT %s OFFSET %s
-                        """,
-                        (StorageReconciliation.BATCH_SIZE, offset),
+                        select(
+                            UserStorageUsage.user_id,
+                            UserStorageUsage.storage_usage_bytes,
+                            UserStorageUsage.delta_since_last_scan,
+                            UserStorageUsage.last_full_scan,
+                        )
+                        .where(
+                            or_(
+                                UserStorageUsage.delta_since_last_scan > 0,
+                                UserStorageUsage.last_full_scan.is_(None),
+                            )
+                        )
+                        .order_by(UserStorageUsage.user_id)
+                        .limit(StorageReconciliation.BATCH_SIZE)
+                        .offset(offset)
                     ).fetchall()
 
                 # Exit if no more users to process
@@ -129,9 +142,9 @@ class StorageReconciliationJob:
                         # Get updated storage to log drift
                         with session_scope() as update_db:
                             query_result = update_db.execute(
-                                "SELECT storage_usage_bytes FROM user_storage_usage "
-                                "WHERE user_id = %s",
-                                (user_id,),
+                                select(UserStorageUsage.storage_usage_bytes).where(
+                                    UserStorageUsage.user_id == user_id
+                                )
                             )
                             result_row = query_result.first()
                             actual_storage = result_row[0] if result_row else db_storage

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -42,6 +42,9 @@ class PublishedExperimentSyncJob:
     THUMBNAIL_SYNC_LIMIT = 50
     # Standard limit for metadata sync
     METADATA_SYNC_LIMIT = SyncStatusConstants.MAX_SYNC_PER_RUN
+    # Concurrency limits for parallel downloads
+    THUMBNAIL_CONCURRENCY = 10
+    METADATA_CONCURRENCY = 3
 
     @classmethod
     async def run(cls):
@@ -81,6 +84,99 @@ class PublishedExperimentSyncJob:
             logger.error(f"Fatal error in sync job: {e}", exc_info=True)
 
     @classmethod
+    async def run_startup_sync(cls):
+        """
+        One-time sync at container startup.
+
+        Unlike the periodic sync job, this:
+        - Queries ALL published experiments (ignores local_sync_status)
+        - Checks local file existence instead of DB status
+        - Downloads only experiments missing locally
+        - Does NOT modify DB sync status
+        - Does NOT use file locking
+        """
+        logger.info("Starting one-time startup sync")
+
+        try:
+            all_experiments = cls._get_all_published_experiments()
+            if not all_experiments:
+                logger.info("No published experiments to sync")
+                return
+
+            from studio.app.common.core.utils.filepath_creater import join_filepath
+
+            missing = []
+            for ws_id, uid, exp_id, bucket in all_experiments:
+                local_path = join_filepath([DIRPATH.OUTPUT_DIR, ws_id, uid])
+                exp_yaml = os.path.join(local_path, DIRPATH.EXPERIMENT_YML)
+                wf_yaml = os.path.join(local_path, DIRPATH.WORKFLOW_YML)
+                if not os.path.exists(exp_yaml) or not os.path.exists(wf_yaml):
+                    missing.append((ws_id, uid, exp_id, bucket))
+
+            if not missing:
+                logger.info("All published experiments already present locally")
+                return
+
+            logger.info(
+                f"Startup sync: {len(missing)}/{len(all_experiments)}"
+                f" experiments missing locally"
+            )
+
+            s3_controllers: dict[str, S3StorageController] = {}
+
+            def get_s3(bucket_name: str) -> S3StorageController:
+                if bucket_name not in s3_controllers:
+                    s3_controllers[bucket_name] = S3StorageController(bucket_name)
+                return s3_controllers[bucket_name]
+
+            # Phase 1: thumbnails (high concurrency)
+            thumb_sem = asyncio.Semaphore(cls.THUMBNAIL_CONCURRENCY)
+
+            async def dl_thumb(ws_id, uid, bucket):
+                async with thumb_sem:
+                    try:
+                        s3 = get_s3(bucket)
+                        await s3.download_experiment(
+                            ws_id,
+                            uid,
+                            sync_mode="thumbnails_only",
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Startup thumb sync failed " f"{ws_id}/{uid}: {e}"
+                        )
+
+            await asyncio.gather(
+                *[dl_thumb(w, u, b) for w, u, _, b in missing],
+            )
+
+            # Phase 2: essential metadata (lower concurrency)
+            meta_sem = asyncio.Semaphore(cls.METADATA_CONCURRENCY)
+
+            async def dl_meta(ws_id, uid, bucket):
+                async with meta_sem:
+                    try:
+                        s3 = get_s3(bucket)
+                        await s3.download_experiment(
+                            ws_id,
+                            uid,
+                            sync_mode="essential_only",
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Startup meta sync failed " f"{ws_id}/{uid}: {e}"
+                        )
+
+            await asyncio.gather(
+                *[dl_meta(w, u, b) for w, u, _, b in missing],
+            )
+
+            logger.info(f"Startup sync completed for {len(missing)} experiments")
+
+        except Exception as e:
+            logger.error(f"Startup sync error: {e}", exc_info=True)
+
+    @classmethod
     async def _sync_thumbnails(cls):
         """
         Phase 1: Download thumbnail PNGs for pending experiments.
@@ -108,8 +204,7 @@ class PublishedExperimentSyncJob:
             return s3_controllers[bucket_name]
 
         # Sync thumbnails with higher concurrency (they're small files)
-        max_concurrent = 10
-        semaphore = asyncio.Semaphore(max_concurrent)
+        semaphore = asyncio.Semaphore(cls.THUMBNAIL_CONCURRENCY)
 
         async def sync_thumbnails_for_experiment(
             workspace_id, unique_id, exp_id, bucket_name
@@ -161,9 +256,7 @@ class PublishedExperimentSyncJob:
                 return s3_controllers[bucket_name]
 
             # Sync experiments in parallel with limited concurrency
-            # Limit to 3 concurrent downloads to avoid overloading S3/network
-            max_concurrent = 3
-            semaphore = asyncio.Semaphore(max_concurrent)
+            semaphore = asyncio.Semaphore(cls.METADATA_CONCURRENCY)
 
             async def sync_with_semaphore(workspace_id, unique_id, exp_id, bucket_name):
                 """Wrapper to limit concurrent downloads"""
@@ -210,7 +303,7 @@ class PublishedExperimentSyncJob:
 
             logger.info(
                 f"Sync job completed: {synced_count} synced, {error_count} errors "
-                f"(parallel downloads with max {max_concurrent} concurrent)"
+                f"(parallel downloads with max {cls.METADATA_CONCURRENCY} concurrent)"
             )
 
             # Publish CloudWatch metrics
@@ -275,6 +368,58 @@ class PublishedExperimentSyncJob:
                 exp_id = row[2]
                 user_attributes = row[3]
                 # Get bucket name from user attributes, fall back to default
+                bucket_name = (
+                    user_attributes.get("remote_bucket_name")
+                    if user_attributes
+                    else None
+                ) or default_bucket
+                experiments.append((workspace_id, unique_id, exp_id, bucket_name))
+
+            return experiments
+
+    @classmethod
+    def _get_all_published_experiments(
+        cls,
+    ) -> List[Tuple[str, str, int, str]]:
+        """
+        Query ALL published experiments regardless of sync status.
+
+        Used by startup sync to check local file presence instead of
+        relying on DB sync status (which reflects background service,
+        not this container).
+
+        Returns:
+            List of (workspace_id, unique_id, exp_id, bucket_name)
+        """
+        default_bucket = os.environ.get("S3_DEFAULT_BUCKET_NAME")
+
+        with session_scope() as db:
+            statement = (
+                select(
+                    ExperimentRecord.workspace_id,
+                    ExperimentRecord.uid,
+                    ExperimentRecord.id,
+                    User.attributes,
+                )
+                .join(
+                    Workspace,
+                    Workspace.id == ExperimentRecord.workspace_id,
+                )
+                .join(User, User.id == Workspace.user_id)
+                .where(ExperimentRecord.publish_status == PublishStatus.on.value)
+                .where(Workspace.deleted == 0)
+                .where(ExperimentRecord.success == 1)
+                .order_by(ExperimentRecord.analyzed_at.desc())
+            )
+
+            result = db.execute(statement)
+
+            experiments = []
+            for row in result:
+                workspace_id = str(row[0])
+                unique_id = row[1]
+                exp_id = row[2]
+                user_attributes = row[3]
                 bucket_name = (
                     user_attributes.get("remote_bucket_name")
                     if user_attributes

--- a/studio/tests/app/common/core/background/test_cleanup_job.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job.py
@@ -194,6 +194,38 @@ class TestHandleOrphanedData:
 
                 mock_session.delete.assert_not_called()
 
+    def test_handle_orphaned_data_empty_reservations(self):
+        """Test cleanup when EC2 returns empty Reservations"""
+        mock_assignment = MagicMock()
+        mock_assignment.user_id = "123"
+        mock_assignment.instance_id = "i-12345"
+        mock_assignment.active_workflow_count = 0
+
+        with patch("boto3.client") as mock_boto:
+            mock_ec2 = MagicMock()
+            mock_boto.return_value = mock_ec2
+            mock_ec2.describe_instances.return_value = {"Reservations": []}
+
+            with patch(
+                "studio.app.common.core.background" ".cleanup_job.session_scope"
+            ) as mock:
+                mock_session = MagicMock()
+                mock.return_value.__enter__.return_value = mock_session
+                mock_session.execute.return_value.all.return_value = [
+                    (mock_assignment,)
+                ]
+                mock_session.get.return_value = MagicMock(id=123)
+
+                with patch.dict("os.environ", {"INSTANCE_ID": "i-current"}):
+                    with patch.object(
+                        DataCleanupJob,
+                        "_cleanup_user_data",
+                        return_value=True,
+                    ):
+                        DataCleanupJob._handle_orphaned_data()
+
+                mock_session.delete.assert_called_once_with(mock_assignment)
+
     def test_handle_orphaned_data_active_workflows(self):
         """Test no cleanup when workflows are active"""
         mock_assignment = MagicMock()

--- a/studio/tests/app/common/core/background/test_sync_job.py
+++ b/studio/tests/app/common/core/background/test_sync_job.py
@@ -174,3 +174,69 @@ class TestSyncExperiment:
         assert result is True
         # Should NOT call download because local files exist
         assert mock_s3_controller.download_experiment.call_count == 0
+
+
+class TestStartupSync:
+    """Test one-time startup sync for API containers"""
+
+    @pytest.mark.asyncio
+    async def test_downloads_missing_experiments(self):
+        """Test startup sync downloads experiments missing locally"""
+        published = [
+            ("ws1", "uid1", 1, "bucket1"),
+            ("ws2", "uid2", 2, "bucket1"),
+        ]
+
+        mock_s3 = MagicMock()
+        mock_s3.download_experiment = AsyncMock(return_value=True)
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_all_published_experiments",
+            return_value=published,
+        ):
+            with patch("os.path.exists", return_value=False):
+                with patch(
+                    "studio.app.common.core.background" ".sync_job.S3StorageController",
+                    return_value=mock_s3,
+                ):
+                    await PublishedExperimentSyncJob.run_startup_sync()
+
+        # 2 experiments x 2 phases = 4 download calls
+        assert mock_s3.download_experiment.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_skips_locally_present_experiments(self):
+        """Test startup sync skips experiments already on disk"""
+        published = [
+            ("ws1", "uid1", 1, "bucket1"),
+        ]
+
+        mock_s3 = MagicMock()
+        mock_s3.download_experiment = AsyncMock(return_value=True)
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_all_published_experiments",
+            return_value=published,
+        ):
+            # Both yaml files exist locally
+            with patch("os.path.exists", return_value=True):
+                with patch(
+                    "studio.app.common.core.background" ".sync_job.S3StorageController",
+                    return_value=mock_s3,
+                ):
+                    await PublishedExperimentSyncJob.run_startup_sync()
+
+        assert mock_s3.download_experiment.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_published_list(self):
+        """Test startup sync handles no published experiments"""
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_all_published_experiments",
+            return_value=[],
+        ):
+            # Should not raise
+            await PublishedExperimentSyncJob.run_startup_sync()


### PR DESCRIPTION
## Summary

- Add one-time startup sync so API worker containers download published experiments on boot (not just from the periodic scheduler)
- Handle empty EC2 Reservations in orphaned data cleanup to prevent KeyError crashes
- Migrate raw SQL to SQLAlchemy ORM in the storage reconciliation job
- Force-rebuild Terraform Lambda package on every apply (temporary debug trigger)

---

## Changes by File

### `studio/__main_unit__.py`
- Schedule a background `asyncio.create_task` at startup that waits 5s then calls `PublishedExperimentSyncJob.run_startup_sync()`
- Runs on ALL non-standalone containers, even those with the scheduler disabled, ensuring published experiments are available locally

### `studio/app/common/core/background/sync_job.py`
- **`run_startup_sync()`**: New classmethod that queries all published experiments, checks local file presence, and downloads missing ones in two phases (thumbnails at high concurrency, then metadata at lower concurrency)
- **`_get_all_published_experiments()`**: New classmethod that queries all published+successful experiments regardless of `local_sync_status`, used by the startup sync

### `studio/app/common/core/background/cleanup_job.py`
- Use `.get()` for EC2 `describe_instances` response instead of direct dict indexing
- Handle empty `Reservations` list (or missing `Instances` key) by treating the instance as terminated and cleaning up the orphaned assignment

### `studio/app/common/core/background/storage_reconciliation_job.py`
- Replace all raw SQL strings with SQLAlchemy ORM queries using `select()`, `func.count()`, and `or_()`
- Import `UserStorageUsage` model and use typed column access instead of string-based SQL

### `infrastructure/terraform/common_user_manager.tf`
- Change Lambda package rebuild trigger from `filesha256()` (content-based) to `timestamp()` (always-run) -- forces dependency reinstall on every `terraform apply`

### Tests
- **`test_cleanup_job.py`**: Add `test_handle_orphaned_data_empty_reservations` covering the empty EC2 Reservations edge case
- **`test_sync_job.py`**: Add `TestStartupSync` class with 3 tests: downloads missing experiments, skips locally present experiments, handles empty published list

---

## Behavior Changes

```
| Scenario                        | Before                             | After                                    |
|---------------------------------|------------------------------------|------------------------------------------|
| API worker container startup    | No sync until scheduler runs       | Startup sync downloads missing published |
|                                 |                                    | experiments after 5s delay               |
| EC2 returns empty Reservations  | KeyError crash in cleanup job      | Treated as terminated, cleanup proceeds  |
| Storage reconciliation queries  | Raw SQL strings                    | SQLAlchemy ORM select() statements       |
| Terraform Lambda rebuild        | Only when code hash changes        | Every terraform apply (temporary)        |
```

---

## Risk Assessment

```
| Area                  | Risk   | Mitigation                                              |
|-----------------------|--------|---------------------------------------------------------|
| Startup sync          | Medium | 5s delay avoids boot contention; exceptions are caught  |
|                       |        | and logged; does not modify DB sync status              |
| EC2 empty Reservations| Low    | Defensive .get() with fallback; matches existing        |
|                       |        | InvalidInstanceID.NotFound handling pattern             |
| ORM migration         | Low    | Functionally equivalent queries; no schema changes      |
| Terraform trigger     | Low    | Only affects build speed; should be reverted before     |
|                       |        | production                                              |
```

