### PR TITLE
Various minor fixes

### DIFF
--- a/frontend/src/components/common/LimitAlert.tsx
+++ b/frontend/src/components/common/LimitAlert.tsx
@@ -272,7 +272,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
           // Hide close button for OVERDUE alerts - they require acknowledgment
           !showAsModal &&
           !isOverdueAlert && (
-            <IconButton size="small" onClick={handleDismiss}>
+            <IconButton size="small" onClick={() => handleDismiss()}>
               <CloseIcon />
             </IconButton>
           )
@@ -434,7 +434,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
               <Button
                 variant="outlined"
                 color="inherit"
-                onClick={handleDismiss}
+                onClick={() => handleDismiss()}
                 disabled={!acknowledgedOverdue}
                 size="small"
               >
@@ -451,7 +451,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
     return (
       <Dialog
         open={Boolean(alert?.has_alert && !dismissed)}
-        onClose={isOverdueAlert ? undefined : handleDismiss}
+        onClose={isOverdueAlert ? undefined : () => handleDismiss()}
         maxWidth="md"
         fullWidth
         disableEscapeKeyDown={isOverdueAlert}
@@ -500,7 +500,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
           {isOverdueAlert ? (
             <>
               <Button
-                onClick={handleDismiss}
+                onClick={() => handleDismiss()}
                 color="inherit"
                 disabled={!acknowledgedOverdue}
               >
@@ -534,7 +534,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
             </>
           ) : (
             <>
-              <Button onClick={handleDismiss} color="inherit">
+              <Button onClick={() => handleDismiss()} color="inherit">
                 Handle later
               </Button>
               {showManageFilesButton && (

--- a/frontend/src/components/common/LimitAlert.tsx
+++ b/frontend/src/components/common/LimitAlert.tsx
@@ -141,9 +141,8 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
   const isOverdueAlert = alert?.alert_type === LimitAlertType.OVERDUE
   const canDismissOverdue = !isOverdueAlert || acknowledgedOverdue
 
-  const handleDismiss = () => {
-    // OVERDUE alerts require explicit acknowledgment before dismissal
-    if (isOverdueAlert && !acknowledgedOverdue) {
+  const handleDismiss = (forceAcknowledged = false) => {
+    if (isOverdueAlert && !acknowledgedOverdue && !forceAcknowledged) {
       return
     }
 
@@ -173,11 +172,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
   }
 
   const handleUpgrade = () => {
-    // For OVERDUE alerts, set acknowledged before dismissing
-    if (isOverdueAlert) setAcknowledgedOverdue(true)
-    // Dismiss the alert when user clicks upgrade
-    handleDismiss()
-    // Navigate to payment page
+    handleDismiss(true)
     navigate("/payment")
   }
 
@@ -426,8 +421,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
                 variant="contained"
                 color="primary"
                 onClick={() => {
-                  if (isOverdueAlert) setAcknowledgedOverdue(true)
-                  handleDismiss()
+                  handleDismiss(true)
                   navigate("/workspaces")
                 }}
                 size="small"
@@ -517,8 +511,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
                   variant="contained"
                   color="primary"
                   onClick={() => {
-                    setAcknowledgedOverdue(true)
-                    handleDismiss()
+                    handleDismiss(true)
                     navigate("/workspaces")
                   }}
                 >
@@ -530,8 +523,7 @@ const LimitAlert: React.FC<LimitAlertProps> = ({
                   variant="contained"
                   color="error"
                   onClick={() => {
-                    setAcknowledgedOverdue(true)
-                    handleDismiss()
+                    handleDismiss(true)
                     navigate("/subscription")
                   }}
                   startIcon={<UpgradeIcon />}

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -67,10 +67,6 @@ let failedQueue: Array<{
   reject: (reason?: unknown) => void
 }> = []
 
-// Timeout for debounced queue processing (Case 6 fix)
-let queueProcessTimeout: ReturnType<typeof setTimeout> | null = null
-const QUEUE_PROCESS_DELAY_MS = 100 // Batch multiple 401s within 100ms
-
 const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue.forEach((prom) => {
     if (error) {
@@ -80,22 +76,6 @@ const processQueue = (error: unknown, token: string | null = null) => {
     }
   })
   failedQueue = []
-}
-
-/**
- * Debounced queue processing to batch multiple simultaneous 401 errors.
- * This prevents multiple 401s from triggering individual logout flows.
- * (Fix for Case 6: Multiple 401 errors before logout)
- */
-const processQueueDebounced = (error: unknown, token: string | null = null) => {
-  if (queueProcessTimeout) {
-    clearTimeout(queueProcessTimeout)
-  }
-
-  queueProcessTimeout = setTimeout(() => {
-    processQueue(error, token)
-    queueProcessTimeout = null
-  }, QUEUE_PROCESS_DELAY_MS)
 }
 
 // Export function to set logout state - called by logout functions
@@ -195,8 +175,7 @@ const handleUnauthorizedError = async (
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("Token refresh failed:", e)
-    // Use debounced processing to batch multiple simultaneous 401s (Case 6 fix)
-    processQueueDebounced(e, null)
+    processQueue(e, null)
     isRefreshing = false
 
     if (

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import re
+import time
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING, Dict, List
 
@@ -958,7 +959,11 @@ class S3StorageController(BaseRemoteStorageController):
 
                 if user_id:
                     # Use idempotent key to prevent double-counting
-                    idempotency_key = f"exp_upload_{workspace_id}_{unique_id}"
+                    idempotency_key = (
+                        f"exp_upload_{workspace_id}"
+                        f"_{unique_id}"
+                        f"_{int(time.time())}"
+                    )
                     success = increment_storage_idempotent(
                         user_id, total_bytes_uploaded, idempotency_key
                     )

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -20,6 +20,7 @@ from studio.app.common.core.subscription.constants import (
     PaymentStatus,
     StripeWebhookEvent,
     SubscriptionCurrencyType,
+    SubscriptionPlanIds,
     SyncStatus,
 )
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
@@ -820,7 +821,10 @@ class WebhookService:
                     )
                     user_subscription = (
                         db.query(UserSubscription)
-                        .filter(UserSubscription.user_id == user_id)
+                        .filter(
+                            UserSubscription.user_id == user_id,
+                            UserSubscription.plan_id != SubscriptionPlanIds.FREE,
+                        )
                         .order_by(UserSubscription.expiration.desc())
                         .first()
                     )

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -592,12 +592,19 @@ async def delete_user(db: Session, user_id: int, organization_id: int) -> bool:
             deletion_record.step = DeletionStep.FIREBASE_DELETED.value
             db.commit()
 
+        except firebase_auth.UserNotFoundError:
+            logger.info(
+                f"Firebase user {user_db.uid} already deleted, "
+                f"continuing cleanup for user {user_id}"
+            )
+            deletion_record.step = DeletionStep.FIREBASE_DELETED.value
+            db.commit()
+
         except FirebaseError as e:
-            # Firebase failed - abort, nothing else changed yet
             deletion_record.error = str(e)
             deletion_record.status = DeletionStatus.FAILED.value
             db.commit()
-            logger.error(f"Firebase deletion failed for user {user_id}: {e}")
+            logger.error(f"Firebase deletion failed for user " f"{user_id}: {e}")
             raise HTTPException(
                 status_code=400,
                 detail=f"Firebase deletion failed: {e}",

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -183,12 +183,16 @@ class WorkspaceService:
                     detail="Workspace not found or already deleted",
                 )
 
-            # Create background task as "in progress" marker
             task_id = BackgroundTaskService.queue_workspace_deletion(
                 user_id=int(user_id),
                 workspace_id=int(workspace_id),
             )
-            BackgroundTaskService.mark_in_progress(task_id)
+            if task_id:
+                BackgroundTaskService.mark_in_progress(task_id)
+            else:
+                logger.warning(
+                    f"Failed to create background task " f"for workspace {workspace_id}"
+                )
             db.commit()
 
             try:


### PR DESCRIPTION
## Summary

- Catch `UserNotFoundError` before `FirebaseError` in user deletion so already-deleted Firebase users don't abort the entire cleanup (B1)
- Exclude FREE plans from webhook fallback subscription query to prevent renewing the wrong plan (B3)
- Fix OVERDUE alert dismiss by passing `forceAcknowledged` param instead of relying on batched React state (B5)
- Replace `processQueueDebounced` with direct `processQueue` call in token refresh error path to close 100ms race window (B8)
- Add null check on `queue_workspace_deletion` return value before calling `mark_in_progress` (B13)
- Append timestamp to upload idempotency key so re-uploads of the same experiment are tracked correctly (B17)

---

## Changes by File

### `studio/app/common/core/users/crud_users.py`
- Insert `except firebase_auth.UserNotFoundError` before `except FirebaseError` in `delete_user()` to treat already-deleted Firebase users as success and continue Stripe/S3/workspace cleanup

### `studio/app/common/core/subscription/webhook_service.py`
- Exclude `SubscriptionPlanIds.FREE` from the Case 77 fallback query so a paid invoice renewal cannot match a FREE subscription

### `frontend/src/components/common/LimitAlert.tsx`
- Add `forceAcknowledged` parameter to `handleDismiss()` to bypass the overdue acknowledgment guard
- Simplify `handleUpgrade()` and all modal action buttons to use `handleDismiss(true)` instead of setting state then calling dismiss

### `frontend/src/utils/axios.ts`
- Replace `processQueueDebounced(e, null)` with `processQueue(e, null)` in the catch block; `isRefreshing` already gates concurrent refreshes, so the debounce only introduced a race window

### `studio/app/common/core/workspace/workspace_services.py`
- Guard `BackgroundTaskService.mark_in_progress(task_id)` with a null check since `queue_workspace_deletion` can return `None` on failure

### `studio/app/common/core/storage/s3_storage_controller.py`
- Append `_{int(time.time())}` to the upload idempotency key so re-uploads generate distinct keys instead of being silently deduplicated

---

## Behavior Changes

```
| Scenario                        | Before                            | After                                  |
|---------------------------------|-----------------------------------|----------------------------------------|
| Delete user whose Firebase      | 400 error, Stripe/S3/workspace    | Logs info, marks Firebase step done,   |
| account is already gone (B1)    | cleanup skipped entirely          | continues full deletion                |
| Webhook fallback subscription   | Could match any plan (including   | Excludes FREE plans; paid invoice      |
| lookup (B3)                     | FREE) for the user                | renewal can only match paid plans      |
| Click Upgrade/Manage on OVERDUE | Alert stays visible due to React  | Alert dismisses immediately via        |
| alert (B5)                      | state batching race               | forceAcknowledged bypass               |
| Token refresh failure with      | 100ms debounce window allows      | Queue flushed synchronously;           |
| queued 401s (B8)                | duplicate refresh cycles          | no race window                         |
| queue_workspace_deletion        | NullPointerError on               | Logs warning, continues                |
| returns None (B13)              | mark_in_progress(None)            | without marking                        |
| Re-upload same experiment       | Idempotency key collision skips   | Timestamp makes key unique per         |
| to same workspace (B17)         | storage increment                 | upload attempt                         |
```

---

## Risk Assessment

```
| Area                  | Risk | Mitigation                                                    |
|-----------------------|------|---------------------------------------------------------------|
| Firebase deletion (B1)| Low  | Pattern already used in 3 other places in the codebase;       |
|                       |      | only changes error handling, not deletion logic               |
| Webhook filter (B3)   | Low  | Adds a stricter filter; only excludes FREE (id=1) which      |
|                       |      | never has paid invoices                                      |
| LimitAlert (B5)       | Low  | No logic change to dismissal itself; only bypasses the        |
|                       |      | acknowledgment guard when user explicitly clicks action       |
| Token refresh (B8)    | Low  | isRefreshing flag already prevents concurrent refreshes;      |
|                       |      | removing debounce only closes an edge-case race window        |
| Null check (B13)      | Low  | Pure defensive guard; no behavioral change on success path    |
| Idempotency key (B17) | Low  | Only affects new uploads; existing keys are unmodified        |
```
