### PR TITLE
Storage operation fixes

### DIFF
--- a/studio/app/common/core/cloud/storage_operations.py
+++ b/studio/app/common/core/cloud/storage_operations.py
@@ -289,6 +289,9 @@ def process_failed_storage_operations(
                         )
                         usage_record.storage_usage_bytes = new_usage
                         usage_record.last_updated = datetime.now(timezone.utc)
+                    elif op.operation_type == StorageOperationType.INCREMENT.value:
+                        usage_record.storage_usage_bytes += op.bytes_delta
+                        usage_record.last_updated = datetime.now(timezone.utc)
 
                     op.status = StorageOperationStatus.COMPLETED.value
                     op.completed_at = datetime.now(timezone.utc)
@@ -358,34 +361,16 @@ def process_stale_pending_operations(
                     )
                     continue
 
-                try:
-                    op.retry_count = current_retries + 1
-
-                    if op.operation_type == StorageOperationType.INCREMENT.value:
-                        success = increment_user_storage(op.user_id, op.bytes_delta)
-                    else:
-                        success = decrement_user_storage(op.user_id, op.bytes_delta)
-
-                    if success:
-                        op.status = StorageOperationStatus.COMPLETED.value
-                        op.completed_at = datetime.now(timezone.utc)
-                        result["succeeded"] += 1
-                        logger.info(
-                            "Recovered stale operation " f"{op.idempotency_key}"
-                        )
-                    else:
-                        op.status = StorageOperationStatus.FAILED.value
-                        op.error_message = "Recovery retry returned false"
-                        result["failed"] += 1
-                        logger.warning(
-                            "Failed to recover stale operation " f"{op.idempotency_key}"
-                        )
-                except Exception as e:
-                    op.error_message = str(e)[:200]
-                    result["failed"] += 1
-                    logger.error(
-                        "Error recovering operation " f"{op.idempotency_key}: {e}"
-                    )
+                # Mark as FAILED instead of retrying to avoid
+                # double-counting if original op already succeeded
+                op.status = StorageOperationStatus.FAILED.value
+                op.error_message = "Stale pending: deferred to reconciliation"
+                result["failed"] += 1
+                logger.warning(
+                    f"Marked stale operation "
+                    f"{op.idempotency_key} as FAILED "
+                    f"for reconciliation"
+                )
 
             db.commit()
 

--- a/studio/app/common/core/cloud/storage_tracking.py
+++ b/studio/app/common/core/cloud/storage_tracking.py
@@ -671,82 +671,61 @@ async def _perform_full_scan_and_reset_delta(
     Perform full S3 scan and reset delta counter with
     distributed lock protection.
 
-    Uses MySQL GET_LOCK to prevent concurrent scans of the
-    same user. If another process is already scanning this
-    user, this function returns early.
+    Uses MySQL GET_LOCK within a single session so the lock
+    persists across the scan and DB update. If another
+    process is already scanning this user, returns early.
 
     Args:
         user_id: User ID to scan
     """
-    lock_acquired = False
-    lock_name = None
+    from sqlalchemy import text, update
+
+    lock_name = (
+        f"storage_scan_"
+        f"{StorageReconciliation.ADVISORY_LOCK_NAMESPACE}"
+        f"_{user_id}"
+    )
 
     try:
-        from sqlalchemy import text, update
-
-        lock_name = (
-            f"storage_scan_"
-            f"{StorageReconciliation.ADVISORY_LOCK_NAMESPACE}"
-            f"_{user_id}"
-        )
-        lock_timeout = 0
-
         with session_scope() as db:
             lock_result = db.execute(
                 text("SELECT GET_LOCK(:lock_name, :timeout)" " as lock_result"),
-                {
-                    "lock_name": lock_name,
-                    "timeout": lock_timeout,
-                },
+                {"lock_name": lock_name, "timeout": 0},
             )
-            result = lock_result.scalar()
-            lock_acquired = result == 1
-
-        if not lock_acquired:
-            logger.info(
-                f"Skipping scan for user {user_id}: "
-                f"another process is already scanning"
-            )
-            return
-
-        logger.debug(f"Acquired distributed lock for user " f"{user_id} scan")
-
-        actual_storage = await _calculate_live_storage_usage(user_id)
-
-        with session_scope() as db:
-            stmt = (
-                update(UserStorageUsage)
-                .where(UserStorageUsage.user_id == user_id)
-                .values(
-                    storage_usage_bytes=actual_storage,
-                    delta_since_last_scan=0,
-                    last_full_scan=(SubscriptionService.get_current_datetime()),
-                    last_updated=(SubscriptionService.get_current_datetime()),
+            if lock_result.scalar() != 1:
+                logger.info(
+                    f"Skipping scan for user {user_id}: " f"another process is scanning"
                 )
-            )
-            db.execute(stmt)
+                return
 
-        logger.info(
-            f"Full S3 scan completed for user {user_id}: "
-            f"{actual_storage:,} bytes (delta reset)"
-        )
+            try:
+                actual_storage = await _calculate_live_storage_usage(user_id)
+                now = SubscriptionService.get_current_datetime()
+                stmt = (
+                    update(UserStorageUsage)
+                    .where(UserStorageUsage.user_id == user_id)
+                    .values(
+                        storage_usage_bytes=actual_storage,
+                        delta_since_last_scan=0,
+                        last_full_scan=now,
+                        last_updated=now,
+                    )
+                )
+                db.execute(stmt)
+
+                logger.info(
+                    f"Full S3 scan completed for user "
+                    f"{user_id}: "
+                    f"{actual_storage:,} bytes (delta reset)"
+                )
+            finally:
+                db.execute(
+                    text("SELECT RELEASE_LOCK(:lock_name)"),
+                    {"lock_name": lock_name},
+                )
 
     except Exception as e:
         logger.error(f"Failed to perform full scan for " f"user {user_id}: {e}")
-    finally:
-        if lock_acquired and lock_name:
-            try:
-                with session_scope() as db:
-                    db.execute(
-                        text("SELECT RELEASE_LOCK(:lock_name)"),
-                        {"lock_name": lock_name},
-                    )
-                logger.debug(f"Released distributed lock for " f"user {user_id}")
-            except Exception as unlock_error:
-                logger.warning(
-                    f"Failed to release distributed lock "
-                    f"for user {user_id}: {unlock_error}"
-                )
 
 
 async def update_user_storage_after_workflow(

--- a/studio/tests/app/common/core/cloud/test_storage_idempotent.py
+++ b/studio/tests/app/common/core/cloud/test_storage_idempotent.py
@@ -251,10 +251,10 @@ class TestGetPendingStorageOperations:
 class TestProcessStalePendingOperations:
     """Tests for process_stale_pending_operations function (Case 69)."""
 
-    @patch("studio.app.common.core.cloud.storage_operations.increment_user_storage")
     @patch("studio.app.common.core.cloud.storage_operations.session_scope")
-    def test_retries_stale_increment_operations(self, mock_session, mock_increment):
-        """Should retry stale pending increment operations."""
+    def test_marks_stale_increment_as_failed(self, mock_session):
+        """Stale pending ops are marked FAILED for reconciliation
+        instead of retried, to avoid double-counting."""
         from datetime import datetime, timedelta, timezone
 
         from studio.app.common.core.cloud.storage_operations import (
@@ -262,7 +262,6 @@ class TestProcessStalePendingOperations:
             process_stale_pending_operations,
         )
 
-        # Create mock stale operation
         mock_op = MagicMock()
         mock_op.idempotency_key = "test_key"
         mock_op.operation_type = "increment"
@@ -276,20 +275,18 @@ class TestProcessStalePendingOperations:
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_db.execute.return_value.all.return_value = [(mock_op,)]
-        mock_increment.return_value = True
 
         result = process_stale_pending_operations()
 
         assert result["processed"] == 1
-        assert result["succeeded"] == 1
-        assert result["failed"] == 0
-        mock_increment.assert_called_once_with(1, 1000)
-        assert mock_op.status == "completed"
+        assert result["failed"] == 1
+        assert result["succeeded"] == 0
+        assert mock_op.status == "failed"
 
-    @patch("studio.app.common.core.cloud.storage_operations.decrement_user_storage")
     @patch("studio.app.common.core.cloud.storage_operations.session_scope")
-    def test_retries_stale_decrement_operations(self, mock_session, mock_decrement):
-        """Should retry stale pending decrement operations."""
+    def test_marks_stale_decrement_as_failed(self, mock_session):
+        """Stale pending decrements are also marked FAILED
+        for reconciliation."""
         from datetime import datetime, timedelta, timezone
 
         from studio.app.common.core.cloud.storage_operations import (
@@ -310,13 +307,12 @@ class TestProcessStalePendingOperations:
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_db.execute.return_value.all.return_value = [(mock_op,)]
-        mock_decrement.return_value = True
 
         result = process_stale_pending_operations()
 
         assert result["processed"] == 1
-        assert result["succeeded"] == 1
-        mock_decrement.assert_called_once_with(1, 500)
+        assert result["failed"] == 1
+        assert mock_op.status == "failed"
 
     @patch("studio.app.common.core.cloud.storage_operations.increment_user_storage")
     @patch("studio.app.common.core.cloud.storage_operations.session_scope")
@@ -364,10 +360,9 @@ class TestProcessStalePendingOperations:
 
         assert result == {"processed": 0, "succeeded": 0, "failed": 0}
 
-    @patch("studio.app.common.core.cloud.storage_operations.increment_user_storage")
     @patch("studio.app.common.core.cloud.storage_operations.session_scope")
-    def test_handles_operation_failure_gracefully(self, mock_session, mock_increment):
-        """Should handle individual operation failures gracefully."""
+    def test_sets_deferred_error_message(self, mock_session):
+        """Stale ops should have reconciliation deferral message."""
         from datetime import datetime, timedelta, timezone
 
         from studio.app.common.core.cloud.storage_operations import (
@@ -388,10 +383,9 @@ class TestProcessStalePendingOperations:
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_db.execute.return_value.all.return_value = [(mock_op,)]
-        mock_increment.side_effect = Exception("Operation failed")
 
         result = process_stale_pending_operations()
 
         assert result["processed"] == 1
         assert result["failed"] == 1
-        assert "Operation failed" in mock_op.error_message
+        assert "reconciliation" in mock_op.error_message

--- a/studio/tests/app/common/core/subscription/test_storage_reconciliation.py
+++ b/studio/tests/app/common/core/subscription/test_storage_reconciliation.py
@@ -57,11 +57,10 @@ async def test_reconciliation_job_batch_processing():
                 )
 
                 def execute_side_effect(*args, **kwargs):
-                    query = args[0] if args else ""
-                    if "COUNT(*)" in str(query):
+                    query = str(args[0]).lower() if args else ""
+                    if "count(" in query:
                         return mock_count_result
-                    elif "SELECT user_id" in str(query):
-                        # Return batches in sequence
+                    elif "user_id" in query and "limit" in query:
                         if not hasattr(execute_side_effect, "batch_count"):
                             execute_side_effect.batch_count = 0
                         execute_side_effect.batch_count += 1
@@ -133,10 +132,10 @@ async def test_reconciliation_detects_drift():
                     def execute_side_effect(*args, **kwargs):
                         nonlocal call_count
                         call_count += 1
-                        query = str(args[0]) if args else ""
-                        if "COUNT(*)" in query:
+                        query = str(args[0]).lower()
+                        if "count(" in query:
                             return mock_count_result
-                        elif "SELECT user_id" in query:
+                        elif "user_id" in query and "limit" in query:
                             if call_count <= 2:
                                 return mock_batch_result
                             return mock_empty_result


### PR DESCRIPTION
## Summary

- Handle failed INCREMENT operations in retry queue instead of silently marking them COMPLETED without adjusting storage (B10)
- Mark stale PENDING operations as FAILED for reconciliation instead of blindly retrying, which could double-count if the original operation already succeeded (B11)
- Fix broken distributed lock in `_perform_full_scan_and_reset_delta` by keeping GET_LOCK and RELEASE_LOCK in a single DB session so the lock persists across the S3 scan and DB update (B2)

---

## Changes by File

`studio/app/common/core/cloud/storage_operations.py`
- **B10:** Add `elif INCREMENT` branch in `process_failed_storage_operations` so failed increment operations actually add bytes to `storage_usage_bytes` before being marked COMPLETED
- **B11:** Replace retry logic in `process_stale_pending_operations` with immediate FAILED marking and a "deferred to reconciliation" message; removes calls to `increment_user_storage`/`decrement_user_storage` that could double-count

`studio/app/common/core/cloud/storage_tracking.py`
- **B2:** Collapse three separate `session_scope()` blocks (lock, update, release) into a single session with a `try/finally` for lock release, so `GET_LOCK` is held across the entire S3 scan and DB update

`studio/tests/app/common/core/cloud/test_storage_idempotent.py`
- Update `TestProcessStalePendingOperations` tests to match new B11 behavior: stale ops are marked FAILED (not retried), and error message contains "reconciliation"

---

## Behavior Changes

```
| Scenario                        | Before                            | After                                  |
|---------------------------------|-----------------------------------|----------------------------------------|
| Failed INCREMENT retry (B10)    | Marked COMPLETED without adding   | Adds bytes_delta to storage_usage      |
|                                 | bytes to storage_usage_bytes      | before marking COMPLETED               |
| Stale PENDING operation (B11)   | Retried via increment/decrement   | Marked FAILED immediately; deferred    |
|                                 | calls, risking double-counting    | to periodic reconciliation scan        |
| Concurrent storage scans (B2)   | GET_LOCK released when first      | Single session holds lock across       |
|                                 | session_scope exits; S3 scan and  | lock, scan, update, and release        |
|                                 | DB update run without protection  |                                        |
```

---

## Risk Assessment

```
| Area                    | Risk | Mitigation                                                  |
|-------------------------|------|-------------------------------------------------------------|
| Failed INCREMENT (B10)  | Low  | Mirrors existing DECREMENT path; only adds the missing      |
|                         |      | branch for INCREMENT operations                             |
| Stale PENDING (B11)     | Low  | Safer than retrying: reconciliation scan corrects drift     |
|                         |      | accurately using actual S3 data instead of replaying ops    |
| Distributed lock (B2)   | Low  | Single-session pattern is the correct MySQL GET_LOCK usage; |
|                         |      | lock release is in a finally block for crash safety         |
```
