### PR TITLE
IAM permission, SSL cert, instance matching bug

### DIFF
--- a/infrastructure/terraform/free_manager_package/free_user_utils.py
+++ b/infrastructure/terraform/free_manager_package/free_user_utils.py
@@ -243,7 +243,9 @@ def trigger_experiment_sync(user_id: int) -> bool:
     }
 
     try:
-        response = requests.post(url, headers=headers, timeout=10.0, verify=True)
+        # Skip SSL verification for internal VPC traffic;
+        # ALB cert doesn't match AWS-generated hostname
+        response = requests.post(url, headers=headers, timeout=10.0, verify=False)
         if response.status_code == 200:
             print(f"Experiment sync initiated for user {user_id}")
             return True

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -137,15 +137,44 @@ def get_assigned_users_for_instance(instance_id: str) -> List[str]:
         return []
 
 
+def _get_ecs_container_instance_arn(
+    ec2_instance_id: str, cluster_name: str
+) -> str | None:
+    """Map EC2 instance ID to ECS container instance ARN."""
+    ecs: "ECSClient" = boto3.client("ecs")
+    try:
+        response = ecs.list_container_instances(cluster=cluster_name)
+        arns = response.get("containerInstanceArns", [])
+        if not arns:
+            return None
+
+        desc = ecs.describe_container_instances(
+            cluster=cluster_name, containerInstances=arns
+        )
+        for ci in desc.get("containerInstances", []):
+            if ci.get("ec2InstanceId") == ec2_instance_id:
+                return ci.get("containerInstanceArn")
+        return None
+    except Exception as e:
+        print(f"Error mapping EC2 to ECS container instance: " f"{str(e)}")
+        return None
+
+
 def check_instance_readiness(instance_id: str) -> bool:
     """Check if an instance has a running ECS task and is ready for user assignment"""
     ecs: "ECSClient" = boto3.client("ecs")
     cluster_name = get_required_env_var("CLUSTER_NAME")
 
     try:
-        # Get ECS tasks running on this instance
+        # Map EC2 instance ID to ECS container instance ARN
+        container_arn = _get_ecs_container_instance_arn(instance_id, cluster_name)
+        if not container_arn:
+            print(f"No ECS container instance found for " f"EC2 instance {instance_id}")
+            return False
+
         tasks_response = ecs.list_tasks(
-            cluster=cluster_name, containerInstance=instance_id
+            cluster=cluster_name,
+            containerInstance=container_arn,
         )
 
         if not tasks_response["taskArns"]:

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -368,7 +368,8 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Effect = "Allow"
         Action = [
           "ecs:ListTasks",
-          "ecs:ListContainerInstances"
+          "ecs:ListContainerInstances",
+          "ecs:DeregisterContainerInstance"
         ]
         Resource = "*"
       },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3417,7 +3417,11 @@ def trigger_experiment_sync(user_id: int) -> bool:
 
     try:
         req = urllib.request.Request(url, method="POST", headers=headers, data=b"")
+        # Skip SSL verification for internal VPC traffic;
+        # ALB cert doesn't match AWS-generated hostname
         context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
         with urllib.request.urlopen(req, timeout=10.0, context=context) as response:
             if response.status == 200:
                 print(f"Experiment sync initiated for user {user_id}")
@@ -4222,7 +4226,6 @@ def process_shared_instance_optimization() -> Dict[str, Any]:
     """
     Optimize shared instances by migrating users to available dedicated instances.
     Called during assignment operations to improve resource allocation.
-
     IMPORTANT: Only migrates users with no active workflows (active_workflow_count = 0)
     to prevent workflow interruption. Users with running workflows are automatically
     skipped and will be migrated on subsequent attempts after their workflows complete.


### PR DESCRIPTION
## Summary

- Add missing `ecs:DeregisterContainerInstance` IAM permission to the premium-manager Lambda
- Fix SSL certificate mismatch when triggering experiment sync via internal ALB
- Fix EC2-to-ECS instance ID mapping bug in premium-cleanup Lambda

---

## Changes by File

`infrastructure/terraform/premium_manager.tf`
- Add `ecs:DeregisterContainerInstance` to the ECS cluster-level IAM actions block

`infrastructure/terraform/premium_manager_package/premium_manager.py`
- Disable SSL hostname/cert verification for internal VPC experiment sync call (ALB cert doesn't match AWS-generated hostname)

`infrastructure/terraform/free_manager_package/free_user_utils.py`
- Set `verify=False` on requests call for internal VPC experiment sync (same SSL mismatch fix)

`infrastructure/terraform/premium_cleanup_package/premium_cleanup.py`
- Add `_get_ecs_container_instance_arn()` helper to map EC2 instance ID to ECS container instance ARN
- Fix `check_instance_readiness()` to resolve EC2 ID before passing to `ecs.list_tasks()`

---

## Root Causes

**1. Ghost container deregistration (AccessDeniedException)**
The premium-manager Lambda calls `ecs.deregister_container_instance()` in `cleanup_ghost_ecs_registrations()` and `deregister_container_instance_from_ecs()`, but the IAM policy was missing the `ecs:DeregisterContainerInstance` action.

**2. Experiment sync SSL failure (CERTIFICATE_VERIFY_FAILED)**
Both `premium_manager.py` and `free_user_utils.py` construct HTTPS URLs using the raw ALB DNS name (`subscr-optinist-lb-*.elb.amazonaws.com`), but the ALB certificate is issued for the application domain. SSL verification fails on hostname mismatch. Since this is internal VPC traffic authenticated by `X-Internal-Secret`, disabling verification is appropriate.

**3. Instance readiness check (InvalidParameterException)**
`premium_cleanup.py` passes a raw EC2 instance ID (e.g., `i-0d6125c50ea223f98`) directly to `ecs.list_tasks(containerInstance=...)`, which expects an ECS container instance ARN. The correct pattern (already used in `premium_manager.py`) maps the EC2 ID to the ARN first.

---

## Verification

- After deploy: confirm no `AccessDeniedException` on `DeregisterContainerInstance` in premium-manager logs
- After deploy: confirm no `CERTIFICATE_VERIFY_FAILED` errors for experiment sync in premium-manager logs
- After deploy: confirm no `InvalidParameterException` for `instanceId length` in premium-cleanup logs
