### PR TITLE
Common User Manager Lambda error

### DIFF
--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -439,7 +439,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     2. Check and logout inactive users (both tiers)
     """
     print(f"Common user manager triggered: {json.dumps(event)}")
-    print(f"Lambda request ID: {context.request_id if context else 'N/A'}")
+    print(f"Lambda request ID: {context.aws_request_id if context else 'N/A'}")
 
     try:
         results = {}


### PR DESCRIPTION
### Content

Fixes a bug in the Common User Manager Lambda where context.request_id was used instead of the correct context.aws_request_id attribute. This was causing an AttributeError at runtime since the AWS Lambda context object exposes the request ID as aws_request_id. This caused the Common User Manager Lambda to malfunction as shown in cloudwatch logs. 
