### PR TITLE
Fix race condition between observe_overall and post_process

### DIFF
--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -41,6 +42,33 @@ from studio.app.common.core.workspace.workspace_data_capacity_services import (
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
+
+LOCK_WAIT_MAX_SECONDS = 300
+LOCK_WAIT_POLL_INTERVAL = 2
+
+
+def _wait_for_lock_release(workspace_id: str, unique_id: str) -> bool:
+    """Wait for post_process upload lock to release."""
+    if not RemoteSyncLockFileUtil.check_sync_lock_file(workspace_id, unique_id):
+        return True
+
+    experiment = f"{workspace_id}/{unique_id}"
+    logger.info(f"Waiting for remote storage lock on [{experiment}]")
+    start = time.monotonic()
+
+    while time.monotonic() - start < LOCK_WAIT_MAX_SECONDS:
+        time.sleep(LOCK_WAIT_POLL_INTERVAL)
+        if not RemoteSyncLockFileUtil.check_sync_lock_file(workspace_id, unique_id):
+            elapsed = time.monotonic() - start
+            logger.info(f"Lock released on [{experiment}] " f"after {elapsed:.1f}s")
+            return True
+
+    elapsed = time.monotonic() - start
+    logger.warning(
+        f"Lock wait timeout on [{experiment}] "
+        f"after {elapsed:.1f}s, proceeding anyway"
+    )
+    return False
 
 
 def snakemake_execute(
@@ -183,6 +211,10 @@ def _snakemake_execute_process(
     # so that WorkflowResult.observe_overall() can access remote storage
     if not snakemake_result and RemoteStorageController.is_available():
         RemoteSyncLockFileUtil.delete_sync_lock_file(workspace_id, unique_id)
+
+    # Wait for post_process upload to release the lock
+    if snakemake_result and RemoteStorageController.is_available():
+        _wait_for_lock_release(workspace_id, unique_id)
 
     try:
         # Update workflow processing results

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -42,33 +41,6 @@ from studio.app.common.core.workspace.workspace_data_capacity_services import (
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
-
-LOCK_WAIT_MAX_SECONDS = 300
-LOCK_WAIT_POLL_INTERVAL = 2
-
-
-def _wait_for_lock_release(workspace_id: str, unique_id: str) -> bool:
-    """Wait for post_process upload lock to release."""
-    if not RemoteSyncLockFileUtil.check_sync_lock_file(workspace_id, unique_id):
-        return True
-
-    experiment = f"{workspace_id}/{unique_id}"
-    logger.info(f"Waiting for remote storage lock on [{experiment}]")
-    start = time.monotonic()
-
-    while time.monotonic() - start < LOCK_WAIT_MAX_SECONDS:
-        time.sleep(LOCK_WAIT_POLL_INTERVAL)
-        if not RemoteSyncLockFileUtil.check_sync_lock_file(workspace_id, unique_id):
-            elapsed = time.monotonic() - start
-            logger.info(f"Lock released on [{experiment}] " f"after {elapsed:.1f}s")
-            return True
-
-    elapsed = time.monotonic() - start
-    logger.warning(
-        f"Lock wait timeout on [{experiment}] "
-        f"after {elapsed:.1f}s, proceeding anyway"
-    )
-    return False
 
 
 def snakemake_execute(
@@ -214,7 +186,7 @@ def _snakemake_execute_process(
 
     # Wait for post_process upload to release the lock
     if snakemake_result and RemoteStorageController.is_available():
-        _wait_for_lock_release(workspace_id, unique_id)
+        RemoteSyncLockFileUtil.wait_for_lock_release(workspace_id, unique_id)
 
     try:
         # Update workflow processing results

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import time
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
 from enum import Enum
@@ -250,6 +251,9 @@ class RemoteSyncLockFileUtil:
     REMOTE_SYNC_LOCK_FILE = "remote_sync.lock"
     LOCK_FILE_EXPIRE_MINUTES = 60  # Fixed at 60 minutes
 
+    LOCK_WAIT_MAX_SECONDS = 300
+    LOCK_WAIT_POLL_INTERVAL = 2
+
     @classmethod
     def __make_sync_lock_file_path(cls, workspace_id: str, unique_id: str) -> str:
         """
@@ -330,6 +334,30 @@ class RemoteSyncLockFileUtil:
 
         if os.path.isfile(remote_sync_lock_file_path):
             os.remove(remote_sync_lock_file_path)
+
+    @classmethod
+    def wait_for_lock_release(cls, workspace_id: str, unique_id: str) -> bool:
+        """Wait for post_process upload lock to release."""
+        if not cls.check_sync_lock_file(workspace_id, unique_id):
+            return True
+
+        experiment = f"{workspace_id}/{unique_id}"
+        logger.info(f"Waiting for remote storage lock on [{experiment}]")
+        start = time.monotonic()
+
+        while time.monotonic() - start < cls.LOCK_WAIT_MAX_SECONDS:
+            time.sleep(cls.LOCK_WAIT_POLL_INTERVAL)
+            if not cls.check_sync_lock_file(workspace_id, unique_id):
+                elapsed = time.monotonic() - start
+                logger.info(f"Lock released on [{experiment}] " f"after {elapsed:.1f}s")
+                return True
+
+        elapsed = time.monotonic() - start
+        logger.warning(
+            f"Lock wait timeout on [{experiment}] "
+            f"after {elapsed:.1f}s, proceeding anyway"
+        )
+        return False
 
 
 class BaseRemoteStorageController(metaclass=ABCMeta):


### PR DESCRIPTION
### Context

After a workflow completes, two processes race for the same RemoteStorageWriter lock on experiment [workspace_id/unique_id]:

 - pid:69 (post_process.py) - The final snakemake rule. Uploads ALL experiment files to S3 while holding the lock. Runs as
 a subprocess.
 - pid:512 (snakemake_executor.py) - Calls observe_overall() after snakemake returns. Updates experiment.yaml with final
 status locally, creates visualization JSONs, then tries to upload them to S3.

- execute_workflow() returns before the post_process subprocess finishes uploading, so observe_overall() immediately hits
 the lock and fails. The result: S3 has a stale experiment.yaml (missing final success/finished_at) and is missing visualization JSON files created during observation.

>     File "/app/studio/app/common/core/snakemake/snakemake_executor.py", line 192, in _snakemake_execute_process         
>       asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())                                            
>     File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run                                               
>       return runner.run(main)                                                                                           
>              ^^^^^^^^^^^^^^^^                                                                                           
>     File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run                                               
>       return self._loop.run_until_complete(task)                                                                        
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                        
>     File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete                            
>       return future.result()                                                                                            
>              ^^^^^^^^^^^^^^^                                                                                            
>     File "/app/studio/app/common/core/workflow/workflow_result.py", line 122, in observe_overall                        
>       return await self.observe(observe_node_ids)                                                                       
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                       
>     File "/app/studio/app/common/core/workflow/workflow_result.py", line 85, in observe                                 
>       node_results = await self.__observe_nodes(                                                                        
>                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                        
>     File "/app/studio/app/common/core/workflow/workflow_result.py", line 188, in __observe_nodes                        
>       async with RemoteStorageWriter(                                                                                   
>                  ^^^^^^^^^^^^^^^^^^^^                                                                                   
>     File "/app/studio/app/common/core/storage/remote_storage_controller.py", line 894, in __init__                      
>       super().__init__(bucket_name, workspace_id, unique_id, RemoteSyncAction.UPLOAD)                                   
>     File "/app/studio/app/common/core/storage/remote_storage_controller.py", line 838, in __init__                      
>       raise RemoteStorageLockError(workspace_id, unique_id)                                                             
>   studio.app.common.core.storage.remote_storage_controller.RemoteStorageLockError: Remote data is temporary locked.     
>   [85/5f33839e] 

### Fix

 Add a wait-for-lock-release loop in snakemake_executor.py before calling observe_overall().

`File: studio/app/common/core/snakemake/snakemake_executor.py`

 1. Add a helper function _wait_for_lock_release near the top of the module:
 - Poll RemoteSyncLockFileUtil.check_sync_lock_file() every 2 seconds
 - Max wait: 5 minutes (post_process upload is typically seconds to low minutes)
 - Log when waiting starts and when lock releases (with elapsed time)
 - Log warning if timeout exceeded
 - Return bool indicating whether lock was released

 2. Call the helper between line 178 (smk_logger.clean_up()) and line 189 (the try block), only when snakemake_result is
 True and RemoteStorageController.is_available():

 `smk_logger.clean_up()`

 Wait for post_process upload to release the lock
```
 if snakemake_result and RemoteStorageController.is_available():
     _wait_for_lock_release(workspace_id, unique_id)

 try:
     asyncio.run(WorkflowResult(...).observe_overall())
     ...

 If timeout exceeded, still proceed with observe_overall() -- the local experiment.yaml update is valuable even if S3
 upload fails.
```
#### Constants

 - LOCK_WAIT_MAX_SECONDS = 300 (5 minutes)
 - LOCK_WAIT_POLL_INTERVAL = 2 (seconds)

#### Files Modified

`studio/app/common/core/snakemake/snakemake_executor.py` -- add wait loop (only file changed)