### PR TITLE
Premium lambda assignment and lambda tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           make test_run
 
+      - name: Run Lambda unit tests
+        shell: bash
+        run: |
+          make test_lambda
+
       - name: Run API contract tests
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ test_frontend:
 	docker compose -f docker-compose.test.yml build test_studio_frontend
 	docker compose -f docker-compose.test.yml run test_studio_frontend
 
+.PHONY: test_lambda
+test_lambda:
+	docker compose -f docker-compose.test.yml build test_studio_backend
+	docker compose -f docker-compose.test.yml run test_studio_backend \
+		$(PYTEST) studio/tests/infrastructure/ -v
+
 .PHONY: contract-test
 contract-test:
 	# API contract tests - validates backend responses match frontend TypeScript interfaces

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -10,6 +10,25 @@ echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
 echo ECS_INSTANCE_ATTRIBUTES='{"tier":"${tier}"}' >> /etc/ecs/ecs.config
 
+# Systemd service to clear stale ECS agent checkpoint on every boot.
+cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
+[Unit]
+Description=Clear stale ECS agent checkpoint before startup
+Before=ecs.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db
+
+[Install]
+WantedBy=multi-user.target
+UNIT_EOF
+
+systemctl daemon-reload
+systemctl enable ecs-clear-checkpoint.service
+
 # Install packages
 yum update -y
 yum install -y amazon-ssm-agent mysql amazon-efs-utils nc mysql-client git docker amazon-cloudwatch-agent awscli

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -482,6 +482,15 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Effect   = "Allow"
         Action   = "lambda:InvokeFunction"
         Resource = aws_lambda_function.premium_manager.arn
+      },
+      # SSM for clearing stale ECS agent checkpoints on instance start
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:SendCommand",
+          "ssm:GetCommandInvocation"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -153,7 +153,7 @@ def get_db_connection(auto_commit=False):
                 f"- environment configuration error: {str(e)}"
             )
             raise
-        except Exception as e:
+        except pymysql.MySQLError as e:
             print(f" Database connection failed - connection error: {str(e)}")
             raise
         finally:
@@ -180,7 +180,7 @@ def with_transaction(func):
             except Exception as e:
                 conn.rollback()
                 print(f"Transaction rolled back due to error: {e}")
-                raise e
+                raise
 
     return wrapper
 
@@ -223,7 +223,7 @@ def _increment_assignment_attempts_transaction(connection, user_id: int) -> int:
         existing = cursor.fetchone()
 
         if existing:
-            current_attempts = existing[0] if existing[0] is not None else 1
+            current_attempts = existing.get("assignment_attempts") or 1
             new_attempts = current_attempts + 1
 
             cursor.execute(
@@ -302,7 +302,7 @@ def _store_user_assignment_transaction(
 
             if existing:
                 # User already has assignment - increment attempts counter
-                current_attempts = existing[1] if existing[1] is not None else 1
+                current_attempts = existing.get("assignment_attempts") or 1
                 new_attempts = current_attempts + 1
 
                 cursor.execute(
@@ -2012,7 +2012,10 @@ def cleanup_duplicate_rules_for_routing_id(listener_arn: str, routing_id: str) -
                             for action in rule.get("Actions", []):
                                 if action.get("Type") == "forward":
                                     tg_arn = action.get("TargetGroupArn")
-                                    if tg_arn:
+                                    autoscaling_tg = os.environ.get(
+                                        "AUTOSCALING_TARGET_GROUP_ARN"
+                                    )
+                                    if tg_arn and tg_arn != autoscaling_tg:
                                         try:
                                             elbv2.delete_target_group(
                                                 TargetGroupArn=tg_arn
@@ -2852,7 +2855,7 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as db_cleanup_error:
             print(f"Failed to cleanup DB assignment: {str(db_cleanup_error)}")
 
-        raise e
+        raise
 
 
 def invoke_migration_async():
@@ -4000,6 +4003,7 @@ def terminate_standby_instance(instance_id: str):
                     "WHERE instance_id = %s AND is_standby = 1",
                     (instance_id,),
                 )
+                connection.commit()
 
         print(f"Successfully terminated standby instance {instance_id}")
         return True
@@ -4041,6 +4045,7 @@ def cleanup_failed_standby_instances():
                         cleanup_count += 1
 
                 if cleanup_count > 0:
+                    connection.commit()
                     print(f"Cleaned up {cleanup_count} failed standby instance entries")
 
     except Exception as e:
@@ -4438,15 +4443,16 @@ def fix_incorrect_is_shared_flags(connection) -> Dict[str, Any]:
     with connection.cursor() as cursor:
         # Find users with is_shared=1 who are the only active user on their instance
         cursor.execute(
-            f"""
+            """
             SELECT pa.user_id, pa.instance_id
             FROM premium_user_assignments pa
             WHERE pa.is_shared = 1 AND pa.status = 'active' AND pa.is_standby = 0
-              AND pa.instance_id != '{PremiumAssignment.AUTOSCALING_POOL}'
+              AND pa.instance_id != %s
               AND (SELECT COUNT(*) FROM premium_user_assignments pa2
                    WHERE pa2.instance_id = pa.instance_id
                    AND pa2.status = 'active' AND pa2.is_standby = 0) = 1
-        """
+        """,
+            (PremiumAssignment.AUTOSCALING_POOL,),
         )
         users_to_fix = cursor.fetchall()
 
@@ -4546,6 +4552,7 @@ def update_user_activity(user_id: int) -> bool:
                     (user_id,),
                 )
 
+                connection.commit()
                 if cursor.rowcount > 0:
                     print(f" Updated activity timestamp for user {user_id}")
                     return True

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1446,6 +1446,62 @@ def create_and_stop_standby_instance():
         return None
 
 
+ECS_CHECKPOINT_PATH = "/var/lib/ecs/data/agent.db"
+SSM_POLL_INTERVAL_SECONDS = 5
+SSM_POLL_MAX_WAIT_SECONDS = 30
+
+
+def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
+    """Clear stale ECS agent checkpoint via SSM to allow re-registration.
+
+    Non-fatal: returns False on failure so the caller can proceed
+    (the readiness check will catch unregistered instances).
+    """
+    ssm = boto3.client("ssm")
+    command = f"rm -f {ECS_CHECKPOINT_PATH} && systemctl restart ecs"
+    try:
+        resp = ssm.send_command(
+            InstanceIds=[instance_id],
+            DocumentName="AWS-RunShellScript",
+            Parameters={"commands": [command]},
+            TimeoutSeconds=SSM_POLL_MAX_WAIT_SECONDS,
+        )
+        command_id = resp["Command"]["CommandId"]
+        print(
+            f"Sent SSM checkpoint cleanup to {instance_id}" f" (command={command_id})"
+        )
+
+        elapsed = 0
+        while elapsed < SSM_POLL_MAX_WAIT_SECONDS:
+            time.sleep(SSM_POLL_INTERVAL_SECONDS)
+            elapsed += SSM_POLL_INTERVAL_SECONDS
+            try:
+                result = ssm.get_command_invocation(
+                    CommandId=command_id,
+                    InstanceId=instance_id,
+                )
+            except ssm.exceptions.InvocationDoesNotExist:
+                continue
+
+            status = result["Status"]
+            if status == "Success":
+                print(f"ECS checkpoint cleared on {instance_id}")
+                return True
+            if status in ("Failed", "TimedOut", "Cancelled"):
+                print(
+                    f"SSM command {status} on {instance_id}: "
+                    f"{result.get('StandardErrorContent', '')}"
+                )
+                return False
+
+        print(f"SSM command timed out waiting for {instance_id}")
+        return False
+
+    except ClientError as e:
+        print(f"SSM checkpoint cleanup failed for " f"{instance_id}: {e}")
+        return False
+
+
 def start_standby_instance(instance_id: str):
     """Start a stopped standby instance and prepare for user assignment"""
     ec2: "EC2Client" = boto3.client("ec2")
@@ -1460,8 +1516,11 @@ def start_standby_instance(instance_id: str):
         waiter = ec2.get_waiter("instance_running")
         waiter.wait(
             InstanceIds=[instance_id],
-            WaiterConfig={"Delay": 5, "MaxAttempts": 24},  # 2 minutes max
+            WaiterConfig={"Delay": 5, "MaxAttempts": 24},
         )
+
+        # Clear stale ECS agent checkpoint so it re-registers
+        clear_ecs_agent_checkpoint(instance_id)
 
         # Update state in database (only for non-standby assignments)
         with get_db_connection() as connection:
@@ -3003,6 +3062,22 @@ def scale_premium_instances_if_needed():
                     f" {instance_ids_to_start}"
                 )
                 ec2.start_instances(InstanceIds=instance_ids_to_start)
+
+                # Wait for instances to be running, then clear
+                # stale ECS agent checkpoints so they re-register
+                waiter = ec2.get_waiter("instance_running")
+                try:
+                    waiter.wait(
+                        InstanceIds=instance_ids_to_start,
+                        WaiterConfig={
+                            "Delay": 5,
+                            "MaxAttempts": 24,
+                        },
+                    )
+                    for iid in instance_ids_to_start:
+                        clear_ecs_agent_checkpoint(iid)
+                except Exception as e:
+                    print(f"Waiter/checkpoint cleanup error: {e}")
 
                 # Invoke this Lambda asynchronously to handle migration
                 # after instances are ready (avoids blocking the user's request)

--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -58,6 +58,7 @@ COPY infrastructure/aws_constants.py /app/
 COPY infrastructure/terraform/premium_manager_package /app/terraform/premium_manager_package
 COPY infrastructure/terraform/premium_cleanup_package /app/terraform/premium_cleanup_package
 COPY infrastructure/terraform/free_manager_package /app/terraform/free_manager_package
+COPY infrastructure/terraform/free_cleanup_package /app/terraform/free_cleanup_package
 COPY infrastructure/terraform/common_user_manager_package /app/terraform/common_user_manager_package
 COPY main.py alembic.ini ./
 

--- a/studio/tests/app/common/routers/test_data_sync.py
+++ b/studio/tests/app/common/routers/test_data_sync.py
@@ -22,20 +22,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-
 # ---------------------------------------------------------------------------
 # Mock aws_constants for Lambda tests (aws_constants is only available in Lambda)
+# Only install if not already loaded (e.g., by infrastructure test conftest)
 # ---------------------------------------------------------------------------
-class MockDatabaseConfig:
-    DEFAULT_PORT = 3306
+if "aws_constants" not in sys.modules:
 
+    class MockDatabaseConfig:
+        DEFAULT_PORT = 3306
 
-class MockAwsConstants:
-    DatabaseConfig = MockDatabaseConfig
+    class MockAwsConstants:
+        DatabaseConfig = MockDatabaseConfig
 
-
-# Install mock before any Lambda package imports
-sys.modules["aws_constants"] = MockAwsConstants
+    sys.modules["aws_constants"] = MockAwsConstants
 
 # ---------------------------------------------------------------------------
 # Test Case 1: Internal API Security

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -1,0 +1,137 @@
+"""Shared fixtures and path setup for Lambda infrastructure tests."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Compute project root from conftest location:
+# conftest is at studio/tests/infrastructure/conftest.py
+# project root is 3 levels up
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+TERRAFORM_DIR = PROJECT_ROOT / "infrastructure" / "terraform"
+
+# Add Lambda package directories to sys.path so imports work
+_LAMBDA_PATHS = [
+    TERRAFORM_DIR / "premium_manager_package",
+    TERRAFORM_DIR / "premium_cleanup_package",
+    TERRAFORM_DIR / "free_manager_package",
+    TERRAFORM_DIR / "free_cleanup_package",
+    TERRAFORM_DIR / "common_user_manager_package",
+    TERRAFORM_DIR / "aws_constants_layer" / "python",
+]
+
+for p in _LAMBDA_PATHS:
+    p_str = str(p)
+    if p_str not in sys.path:
+        sys.path.insert(0, p_str)
+
+
+class MockRow:
+    """Mock database row that supports both dict and index access."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return list(self.data.values())[key]
+        return self.data.get(key)
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+
+# Base mock environment variables shared across premium test files
+MOCK_ENV_VARS_BASE = {
+    "RDS_HOST": "test-db.example.com:3306",
+    "RDS_USER": "test_user",
+    "RDS_PASSWORD": "test_pass",
+    "RDS_DATABASE": "test_db",
+    "VPC_ID": "vpc-test123",
+    "ALB_LISTENER_ARN": (
+        "arn:aws:elasticloadbalancing:region:account:" "listener/test"
+    ),
+    "ROUTING_SECRET_KEY": "test-secret-key-12345",
+}
+
+MOCK_ENV_VARS_PREMIUM = {
+    **MOCK_ENV_VARS_BASE,
+    "AUTOSCALING_TARGET_GROUP_ARN": (
+        "arn:aws:elasticloadbalancing:region:account:" "targetgroup/asg"
+    ),
+    "CLUSTER_NAME": "test-cluster",
+    "PREMIUM_SERVICE_NAME": "subscr-optinist-premium-service",
+    "PREMIUM_INSTANCE_IDS": "i-test1,i-test2,i-test3",
+    "PREMIUM_STANDBY_POOL_SIZE": "2",
+    "PREMIUM_IDLE_TIMEOUT_HOURS": "3",
+    "PREMIUM_SAFETY_BUFFER": "1",
+    "ABSOLUTE_MAX": "10",
+}
+
+MOCK_ENV_VARS_FREE = {
+    **MOCK_ENV_VARS_BASE,
+    "CLUSTER_NAME": "test-cluster",
+    "FREE_SERVICE_NAME": "subscr-optinist-cloud-service",
+    "ASG_NAME": "test-free-asg",
+    "FREE_USER_THRESHOLD": "5",
+    "FREE_IDLE_THRESHOLD_MINUTES": "10",
+    "MAX_FREE_INSTANCES": "10",
+}
+
+MOCK_ENV_VARS_COMMON = {
+    **MOCK_ENV_VARS_BASE,
+    "AUTOSCALING_TARGET_GROUP_ARN": (
+        "arn:aws:elasticloadbalancing:region:account:" "targetgroup/asg"
+    ),
+    "FREE_IDLE_TIMEOUT_HOURS": "2",
+    "PREMIUM_IDLE_TIMEOUT_HOURS": "2",
+}
+
+
+@pytest.fixture
+def mock_env_vars_premium():
+    return {**MOCK_ENV_VARS_PREMIUM}
+
+
+@pytest.fixture
+def mock_env_vars_free():
+    return {**MOCK_ENV_VARS_FREE}
+
+
+@pytest.fixture
+def mock_env_vars_common():
+    return {**MOCK_ENV_VARS_COMMON}
+
+
+def setup_db_mock(fetchone_values=None, fetchall_values=None):
+    """
+    Create a properly configured database mock.
+
+    Args:
+        fetchone_values: List of values for fetchone() calls
+        fetchall_values: List of values for fetchall() calls
+
+    Returns:
+        A mock connection object
+    """
+    mock_cursor = MagicMock()
+    mock_cursor.rowcount = 1
+
+    if fetchone_values is not None:
+        mock_cursor.fetchone.side_effect = fetchone_values
+    else:
+        mock_cursor.fetchone.side_effect = lambda: None
+
+    if fetchall_values is not None:
+        mock_cursor.fetchall.side_effect = fetchall_values
+    else:
+        mock_cursor.fetchall.side_effect = lambda: []
+
+    mock_connection = MagicMock()
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    return mock_connection

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -29,12 +29,8 @@ _PACKAGE_NAMES = [
 # Add Lambda package directories to sys.path so imports work
 _LAMBDA_PATHS = [TERRAFORM_DIR / name for name in _PACKAGE_NAMES]
 
-# aws_constants: layer subdir (local) or project root (Docker)
-_AWS_CONST_LAYER = TERRAFORM_DIR / "aws_constants_layer" / "python"
-if _AWS_CONST_LAYER.exists():
-    _LAMBDA_PATHS.append(_AWS_CONST_LAYER)
-else:
-    _LAMBDA_PATHS.append(PROJECT_ROOT)
+# aws_constants lives at infrastructure/aws_constants.py
+_LAMBDA_PATHS.append(PROJECT_ROOT / "infrastructure")
 
 for p in _LAMBDA_PATHS:
     p_str = str(p)

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -10,22 +10,42 @@ import pytest
 # conftest is at studio/tests/infrastructure/conftest.py
 # project root is 3 levels up
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Support both local dev and Docker layouts:
+#   Local: PROJECT_ROOT/infrastructure/terraform/<package>
+#   Docker: PROJECT_ROOT/terraform/<package>
 TERRAFORM_DIR = PROJECT_ROOT / "infrastructure" / "terraform"
+if not TERRAFORM_DIR.exists():
+    TERRAFORM_DIR = PROJECT_ROOT / "terraform"
+
+_PACKAGE_NAMES = [
+    "premium_manager_package",
+    "premium_cleanup_package",
+    "free_manager_package",
+    "free_cleanup_package",
+    "common_user_manager_package",
+]
 
 # Add Lambda package directories to sys.path so imports work
-_LAMBDA_PATHS = [
-    TERRAFORM_DIR / "premium_manager_package",
-    TERRAFORM_DIR / "premium_cleanup_package",
-    TERRAFORM_DIR / "free_manager_package",
-    TERRAFORM_DIR / "free_cleanup_package",
-    TERRAFORM_DIR / "common_user_manager_package",
-    TERRAFORM_DIR / "aws_constants_layer" / "python",
-]
+_LAMBDA_PATHS = [TERRAFORM_DIR / name for name in _PACKAGE_NAMES]
+
+# aws_constants: layer subdir (local) or project root (Docker)
+_AWS_CONST_LAYER = TERRAFORM_DIR / "aws_constants_layer" / "python"
+if _AWS_CONST_LAYER.exists():
+    _LAMBDA_PATHS.append(_AWS_CONST_LAYER)
+else:
+    _LAMBDA_PATHS.append(PROJECT_ROOT)
 
 for p in _LAMBDA_PATHS:
     p_str = str(p)
     if p_str not in sys.path:
         sys.path.insert(0, p_str)
+
+# Ensure the real aws_constants module is loaded from the paths above.
+# Other test files may install a limited mock into sys.modules;
+# remove it first so we get the real module.
+sys.modules.pop("aws_constants", None)
+import aws_constants  # noqa: E402, F401
 
 
 class MockRow:

--- a/studio/tests/infrastructure/test_common_user_manager.py
+++ b/studio/tests/infrastructure/test_common_user_manager.py
@@ -1,0 +1,379 @@
+"""Tests for common_user_manager Lambda function."""
+
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+
+class TestRecoverStaleWorkflowCounts:
+    """SQLAlchemy-based workflow recovery tests."""
+
+    def test_no_stale_workflows(self, mock_env_vars_common):
+        """No stale workflows returns all zeros."""
+        with patch.dict("os.environ", mock_env_vars_common):
+            import common_user_manager
+
+            with patch.object(
+                common_user_manager,
+                "get_sqlalchemy_session",
+            ) as mock_ctx:
+                mock_session = MagicMock()
+                mock_ctx.return_value.__enter__ = Mock(return_value=mock_session)
+                mock_ctx.return_value.__exit__ = Mock(return_value=False)
+
+                mock_result = MagicMock()
+                mock_result.rowcount = 0
+                mock_session.execute.return_value = mock_result
+
+                result = common_user_manager.recover_stale_workflow_counts()
+
+                assert result["recovered"] == 0
+                assert result["free"] == 0
+                assert result["premium"] == 0
+                assert "error" not in result
+                assert mock_session.execute.call_count == 2
+
+    def test_recovers_stale_workflows(self, mock_env_vars_common):
+        """Stale workflows found and reset."""
+        with patch.dict("os.environ", mock_env_vars_common):
+            import common_user_manager
+
+            with patch.object(
+                common_user_manager,
+                "get_sqlalchemy_session",
+            ) as mock_ctx:
+                mock_session = MagicMock()
+                mock_ctx.return_value.__enter__ = Mock(return_value=mock_session)
+                mock_ctx.return_value.__exit__ = Mock(return_value=False)
+
+                mock_free = MagicMock()
+                mock_free.rowcount = 2
+                mock_premium = MagicMock()
+                mock_premium.rowcount = 1
+                mock_session.execute.side_effect = [
+                    mock_free,
+                    mock_premium,
+                ]
+
+                result = common_user_manager.recover_stale_workflow_counts()
+
+                assert result["recovered"] == 3
+                assert result["free"] == 2
+                assert result["premium"] == 1
+                assert "error" not in result
+
+    def test_database_error(self, mock_env_vars_common):
+        """DB error returns recovered=0 with error key."""
+        with patch.dict("os.environ", mock_env_vars_common):
+            import common_user_manager
+
+            with patch.object(
+                common_user_manager,
+                "get_sqlalchemy_session",
+            ) as mock_ctx:
+                mock_session = MagicMock()
+                mock_ctx.return_value.__enter__ = Mock(return_value=mock_session)
+                mock_ctx.return_value.__exit__ = Mock(return_value=False)
+
+                mock_session.execute.side_effect = Exception("Connection refused")
+
+                result = common_user_manager.recover_stale_workflow_counts()
+
+                assert result["recovered"] == 0
+                assert "Connection refused" in result["error"]
+
+
+class TestCheckFreeUserInactivity:
+    """Pymysql-based free user inactivity tests."""
+
+    def _setup_db_mock(self, mock_env_vars_common):
+        """Return patched env + mock connection/cursor."""
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = Mock(return_value=mock_conn)
+        mock_conn.__exit__ = Mock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = Mock(return_value=False)
+        return mock_conn, mock_cursor
+
+    def test_no_inactive_users(self, mock_env_vars_common):
+        """Empty fetchall returns logged_out=0."""
+        mock_conn, mock_cursor = self._setup_db_mock(mock_env_vars_common)
+        mock_cursor.fetchall.return_value = []
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db:
+            mock_db.return_value = mock_conn
+
+            from common_user_manager import check_free_user_inactivity
+
+            result = check_free_user_inactivity()
+
+            assert result["logged_out"] == 0
+            assert "error" not in result
+
+    def test_logout_inactive_users(self, mock_env_vars_common):
+        """Inactive users deleted and committed."""
+        mock_conn, mock_cursor = self._setup_db_mock(mock_env_vars_common)
+        mock_cursor.fetchall.return_value = [
+            {"user_id": "user1", "instance_id": "i-123"},
+            {"user_id": "user2", "instance_id": "i-456"},
+        ]
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db:
+            mock_db.return_value = mock_conn
+
+            from common_user_manager import check_free_user_inactivity
+
+            result = check_free_user_inactivity()
+
+            assert result["logged_out"] == 2
+            assert "error" not in result
+            # SELECT + DELETE
+            assert mock_cursor.execute.call_count == 2
+            mock_conn.commit.assert_called_once()
+
+    def test_database_error(self, mock_env_vars_common):
+        """DB error returns logged_out=0 with error."""
+        mock_conn, mock_cursor = self._setup_db_mock(mock_env_vars_common)
+        mock_cursor.fetchall.side_effect = Exception("Query failed")
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db:
+            mock_db.return_value = mock_conn
+
+            from common_user_manager import check_free_user_inactivity
+
+            result = check_free_user_inactivity()
+
+            assert result["logged_out"] == 0
+            assert "error" in result
+
+
+class TestCheckPremiumUserInactivity:
+    """Pymysql + ALB cleanup tests for premium inactivity."""
+
+    def _setup_db_mock(self):
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = Mock(return_value=mock_conn)
+        mock_conn.__exit__ = Mock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = Mock(return_value=False)
+        return mock_conn, mock_cursor
+
+    def test_no_inactive_users(self, mock_env_vars_common):
+        """Empty fetchall returns logged_out=0."""
+        mock_conn, mock_cursor = self._setup_db_mock()
+        mock_cursor.fetchall.return_value = []
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db, patch("common_user_manager.boto3"):
+            mock_db.return_value = mock_conn
+
+            from common_user_manager import check_premium_user_inactivity
+
+            result = check_premium_user_inactivity()
+
+            assert result["logged_out"] == 0
+            assert "error" not in result
+
+    def test_logout_with_alb_cleanup(self, mock_env_vars_common):
+        """Inactive premium user triggers ALB rule + TG delete."""
+        mock_conn, mock_cursor = self._setup_db_mock()
+        mock_cursor.fetchall.return_value = [
+            {
+                "user_id": "premium1",
+                "target_group_arn": "arn:aws:tg/user-tg",
+                "alb_rule_arn": "arn:aws:rule/user-rule",
+            }
+        ]
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db, patch("common_user_manager.boto3") as mock_boto3:
+            mock_db.return_value = mock_conn
+            mock_elbv2 = MagicMock()
+            mock_boto3.client.return_value = mock_elbv2
+
+            from common_user_manager import check_premium_user_inactivity
+
+            result = check_premium_user_inactivity()
+
+            assert result["logged_out"] == 1
+            assert result.get("failed", 0) == 0
+            mock_elbv2.delete_rule.assert_called_once()
+            mock_elbv2.delete_target_group.assert_called_once()
+            mock_conn.commit.assert_called_once()
+
+    def test_skips_standby_markers(self, mock_env_vars_common):
+        """Standby/reserving markers skip ALB cleanup."""
+        mock_conn, mock_cursor = self._setup_db_mock()
+        mock_cursor.fetchall.return_value = [
+            {
+                "user_id": "standby_user",
+                "target_group_arn": "standby",
+                "alb_rule_arn": "standby",
+            }
+        ]
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db, patch("common_user_manager.boto3") as mock_boto3:
+            mock_db.return_value = mock_conn
+            mock_elbv2 = MagicMock()
+            mock_boto3.client.return_value = mock_elbv2
+
+            from common_user_manager import check_premium_user_inactivity
+
+            result = check_premium_user_inactivity()
+
+            assert result["logged_out"] == 1
+            mock_elbv2.delete_rule.assert_not_called()
+            mock_elbv2.delete_target_group.assert_not_called()
+
+    def test_skips_autoscaling_tg(self, mock_env_vars_common):
+        """Autoscaling TG is never deleted during cleanup."""
+        mock_conn, mock_cursor = self._setup_db_mock()
+        asg_tg = mock_env_vars_common["AUTOSCALING_TARGET_GROUP_ARN"]
+        mock_cursor.fetchall.return_value = [
+            {
+                "user_id": "asg_user",
+                "target_group_arn": asg_tg,
+                "alb_rule_arn": "arn:aws:rule/asg-rule",
+            }
+        ]
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db, patch("common_user_manager.boto3") as mock_boto3:
+            mock_db.return_value = mock_conn
+            mock_elbv2 = MagicMock()
+            mock_boto3.client.return_value = mock_elbv2
+
+            from common_user_manager import check_premium_user_inactivity
+
+            result = check_premium_user_inactivity()
+
+            assert result["logged_out"] == 1
+            mock_elbv2.delete_rule.assert_called_once()
+            mock_elbv2.delete_target_group.assert_not_called()
+
+    def test_partial_failure(self, mock_env_vars_common):
+        """One user fails, other succeeds."""
+        mock_conn, mock_cursor = self._setup_db_mock()
+        mock_cursor.fetchall.return_value = [
+            {
+                "user_id": "user1",
+                "target_group_arn": "arn:aws:tg/u1",
+                "alb_rule_arn": "arn:aws:rule/u1",
+            },
+            {
+                "user_id": "user2",
+                "target_group_arn": "arn:aws:tg/u2",
+                "alb_rule_arn": "arn:aws:rule/u2",
+            },
+        ]
+
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.get_db_connection"
+        ) as mock_db, patch("common_user_manager.boto3") as mock_boto3:
+            mock_db.return_value = mock_conn
+            mock_elbv2 = MagicMock()
+            mock_elbv2.delete_rule.side_effect = [
+                None,
+                Exception("ALB error"),
+            ]
+            mock_boto3.client.return_value = mock_elbv2
+
+            from common_user_manager import check_premium_user_inactivity
+
+            result = check_premium_user_inactivity()
+
+            assert result["logged_out"] == 1
+            assert result["failed"] == 1
+
+
+class TestHandler:
+    """Lambda handler orchestration tests."""
+
+    def test_successful_execution(self, mock_env_vars_common):
+        """Handler returns 200 with results from all steps."""
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.recover_stale_workflow_counts"
+        ) as mock_recover, patch(
+            "common_user_manager.check_free_user_inactivity"
+        ) as mock_free, patch(
+            "common_user_manager.check_premium_user_inactivity"
+        ) as mock_premium:
+            mock_recover.return_value = {"recovered": 2}
+            mock_free.return_value = {"logged_out": 1}
+            mock_premium.return_value = {"logged_out": 0}
+
+            from common_user_manager import handler
+
+            event = {"source": "aws.events"}
+            context = MagicMock()
+            context.aws_request_id = "test-123"
+
+            result = handler(event, context)
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert "results" in body
+            mock_recover.assert_called_once()
+            mock_free.assert_called_once()
+            mock_premium.assert_called_once()
+
+    def test_handler_error_returns_500(self, mock_env_vars_common):
+        """Unhandled exception returns 500."""
+        with patch.dict("os.environ", mock_env_vars_common), patch(
+            "common_user_manager.recover_stale_workflow_counts"
+        ) as mock_recover:
+            mock_recover.side_effect = RuntimeError("Unexpected crash")
+
+            from common_user_manager import handler
+
+            event = {"source": "aws.events"}
+            context = MagicMock()
+            context.aws_request_id = "test-456"
+
+            result = handler(event, context)
+
+            assert result["statusCode"] == 500
+            body = json.loads(result["body"])
+            assert "Unexpected crash" in body["error"]
+
+
+class TestGetRequiredEnvVar:
+    """Environment variable validation tests."""
+
+    def test_missing_var_raises(self):
+        """Missing env var without default raises ValueError."""
+        import common_user_manager
+        import pytest
+
+        with pytest.raises(ValueError, match="Missing required"):
+            common_user_manager.get_required_env_var("NONEXISTENT_VAR_XYZ")
+
+    def test_default_value(self):
+        """Missing env var with default returns default."""
+        import common_user_manager
+
+        result = common_user_manager.get_required_env_var(
+            "NONEXISTENT_VAR_XYZ", "fallback"
+        )
+        assert result == "fallback"
+
+    def test_empty_var_raises(self, mock_env_vars_common):
+        """Empty string env var raises ValueError."""
+        import common_user_manager
+        import pytest
+
+        with patch.dict("os.environ", {"EMPTY_TEST": ""}):
+            with pytest.raises(ValueError, match="Missing required"):
+                common_user_manager.get_required_env_var("EMPTY_TEST")

--- a/studio/tests/infrastructure/test_free_cleanup.py
+++ b/studio/tests/infrastructure/test_free_cleanup.py
@@ -1,0 +1,154 @@
+"""Tests for free_cleanup Lambda function."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from conftest import MockRow, setup_db_mock
+
+
+class TestFreeCleanupHandler:
+    """Handler-level tests for free_cleanup Lambda."""
+
+    def test_unknown_action(self, mock_env_vars_free):
+        """Unknown action returns 400."""
+        event = {"action": "nonexistent_action"}
+        mock_context = MagicMock()
+        mock_context.function_name = "subscr-free-cleanup"
+
+        with patch.dict("os.environ", mock_env_vars_free):
+            from free_cleanup import handler
+
+            result = handler(event, mock_context)
+
+            assert result["statusCode"] == 400
+            body = json.loads(result["body"])
+            assert "unknown action" in body["error"].lower()
+
+    def test_missing_params(self, mock_env_vars_free):
+        """simulate_user_activity without user_id returns 400."""
+        event = {
+            "action": "simulate_user_activity",
+            "instance_id": "i-123",
+        }
+        mock_context = MagicMock()
+        mock_context.function_name = "subscr-free-cleanup"
+
+        with patch.dict("os.environ", mock_env_vars_free):
+            from free_cleanup import handler
+
+            result = handler(event, mock_context)
+
+            assert result["statusCode"] == 400
+            body = json.loads(result["body"])
+            assert "missing" in body["error"].lower()
+
+
+class TestCleanupTestUserSessions:
+    """Tests for cleanup_test_user_sessions."""
+
+    def test_empty_emails(self, mock_env_vars_free):
+        """Empty email list returns success=False."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            from free_cleanup import cleanup_test_user_sessions
+
+            result = cleanup_test_user_sessions([])
+            assert result["success"] is False
+            assert result["sessions_deleted"] == 0
+
+    def test_no_users_found(self, mock_env_vars_free):
+        """Emails don't match any DB users."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from free_cleanup import cleanup_test_user_sessions
+
+            result = cleanup_test_user_sessions(["nobody@test.com"])
+            assert result["success"] is True
+            assert result["sessions_deleted"] == 0
+
+    def test_deletes_sessions(self, mock_env_vars_free):
+        """Found users, deletes sessions, returns count."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 1,
+                                "email": "user1@test.com",
+                            }
+                        ),
+                        MockRow(
+                            {
+                                "id": 2,
+                                "email": "user2@test.com",
+                            }
+                        ),
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            mock_cursor.rowcount = 3
+
+            from free_cleanup import cleanup_test_user_sessions
+
+            result = cleanup_test_user_sessions(["user1@test.com", "user2@test.com"])
+            assert result["success"] is True
+            assert result["sessions_deleted"] == 3
+            assert result["users_cleaned"] == 2
+
+
+class TestCleanupAllTestUsers:
+    """Tests for cleanup_all_test_users."""
+
+    def test_no_users(self, mock_env_vars_free):
+        """No matching users returns 0."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from free_cleanup import cleanup_all_test_users
+
+            result = cleanup_all_test_users()
+            assert result["success"] is True
+            assert result["sessions_deleted"] == 0
+
+
+class TestCountActiveUsers:
+    """Tests for count_active_users."""
+
+    def test_returns_correct_count(self, mock_env_vars_free):
+        """Returns correct count from DB."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow({"count": 15}),
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from free_cleanup import count_active_users
+
+            result = count_active_users(activity_threshold_minutes=10)
+            assert result["success"] is True
+            assert result["active_user_count"] == 15

--- a/studio/tests/infrastructure/test_free_manager.py
+++ b/studio/tests/infrastructure/test_free_manager.py
@@ -1,7 +1,12 @@
 """Tests for free_manager Lambda function."""
 
 import json
+import os
 from unittest.mock import MagicMock, patch
+
+# free_manager creates boto3 clients at module level;
+# AWS_DEFAULT_REGION must be set before import to avoid NoRegionError
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 
 
 class TestFreeManagerHandler:

--- a/studio/tests/infrastructure/test_free_manager.py
+++ b/studio/tests/infrastructure/test_free_manager.py
@@ -1,0 +1,213 @@
+"""Tests for free_manager Lambda function."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+class TestFreeManagerHandler:
+    """Handler routing tests."""
+
+    def test_handler_routes_scheduled_event(self, mock_env_vars_free):
+        """Scheduled event routes to handle_scheduled_monitoring."""
+        event = {
+            "source": "aws.events",
+            "detail-type": "Scheduled Event",
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ), patch("free_manager.autoscaling_client"), patch(
+            "free_manager.cloudwatch_client"
+        ), patch(
+            "free_manager.ec2_client"
+        ), patch(
+            "free_manager.handle_scheduled_monitoring"
+        ) as mock_scheduled:
+            mock_scheduled.return_value = {
+                "statusCode": 200,
+                "body": json.dumps({"status": "ok"}),
+            }
+
+            from free_manager import handler
+
+            handler(event, mock_context)
+            mock_scheduled.assert_called_once_with(event, mock_context)
+
+    def test_handler_routes_asg_event(self, mock_env_vars_free):
+        """ASG event routes to handle_asg_event."""
+        event = {
+            "source": "aws.autoscaling",
+            "detail-type": "EC2 Instance Launch Successful",
+            "detail": {
+                "AutoScalingGroupName": "test-free-asg",
+            },
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ), patch("free_manager.autoscaling_client"), patch(
+            "free_manager.cloudwatch_client"
+        ), patch(
+            "free_manager.ec2_client"
+        ), patch(
+            "free_manager.handle_asg_event"
+        ) as mock_asg:
+            mock_asg.return_value = {
+                "statusCode": 200,
+                "body": json.dumps({"status": "ok"}),
+            }
+
+            from free_manager import handler
+
+            handler(event, mock_context)
+            mock_asg.assert_called_once_with(event, mock_context)
+
+
+class TestHandleAsgEvent:
+    """ASG event handler tests."""
+
+    def test_ignores_wrong_asg(self, mock_env_vars_free):
+        """ASG name mismatch returns 200 with 'Event ignored'."""
+        event = {
+            "source": "aws.autoscaling",
+            "detail-type": "EC2 Instance Launch Successful",
+            "detail": {
+                "AutoScalingGroupName": "other-asg",
+            },
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ), patch("free_manager.autoscaling_client"), patch(
+            "free_manager.cloudwatch_client"
+        ), patch(
+            "free_manager.ec2_client"
+        ):
+            from free_manager import handle_asg_event
+
+            result = handle_asg_event(event, mock_context)
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert "ignored" in body["message"].lower()
+
+    def test_syncs_ecs(self, mock_env_vars_free):
+        """ASG desired != ECS desired triggers update_service."""
+        event = {
+            "source": "aws.autoscaling",
+            "detail-type": "EC2 Instance Launch Successful",
+            "detail": {
+                "AutoScalingGroupName": "test-free-asg",
+            },
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ) as mock_ecs, patch("free_manager.autoscaling_client") as mock_asg, patch(
+            "free_manager.cloudwatch_client"
+        ), patch(
+            "free_manager.ec2_client"
+        ):
+            mock_asg.describe_auto_scaling_groups.return_value = {
+                "AutoScalingGroups": [{"DesiredCapacity": 3}]
+            }
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 1}]
+            }
+
+            from free_manager import handle_asg_event
+
+            result = handle_asg_event(event, mock_context)
+
+            assert result["statusCode"] == 200
+            mock_ecs.update_service.assert_called_once_with(
+                cluster="test-cluster",
+                service="subscr-optinist-cloud-service",
+                desiredCount=3,
+            )
+
+    def test_already_synced(self, mock_env_vars_free):
+        """ASG == ECS desired, no update call."""
+        event = {
+            "source": "aws.autoscaling",
+            "detail-type": "EC2 Instance Launch Successful",
+            "detail": {
+                "AutoScalingGroupName": "test-free-asg",
+            },
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ) as mock_ecs, patch("free_manager.autoscaling_client") as mock_asg, patch(
+            "free_manager.cloudwatch_client"
+        ), patch(
+            "free_manager.ec2_client"
+        ):
+            mock_asg.describe_auto_scaling_groups.return_value = {
+                "AutoScalingGroups": [{"DesiredCapacity": 2}]
+            }
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 2}]
+            }
+
+            from free_manager import handle_asg_event
+
+            result = handle_asg_event(event, mock_context)
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert "sync" in body["message"].lower()
+            mock_ecs.update_service.assert_not_called()
+
+
+class TestIsDistributionBalanced:
+    """Pure function tests for is_distribution_balanced."""
+
+    def test_balanced(self):
+        """Balanced distribution returns True."""
+        from free_user_utils import is_distribution_balanced
+
+        dist = {"i-1": 5, "i-2": 5, "i-3": 4}
+        assert is_distribution_balanced(dist, tolerance=1)
+
+    def test_imbalanced(self):
+        """Imbalanced distribution returns False."""
+        from free_user_utils import is_distribution_balanced
+
+        dist = {"i-1": 10, "i-2": 2, "i-3": 1}
+        assert not is_distribution_balanced(dist, tolerance=1)
+
+    def test_empty(self):
+        """Empty dict returns True."""
+        from free_user_utils import is_distribution_balanced
+
+        assert is_distribution_balanced({})
+
+
+class TestPublishActiveUserMetric:
+    """Test CloudWatch metric publishing."""
+
+    def test_publishes_metric(self, mock_env_vars_free):
+        """Calls cloudwatch_client.put_metric_data."""
+        with patch.dict("os.environ", mock_env_vars_free), patch(
+            "free_manager.ecs_client"
+        ), patch("free_manager.autoscaling_client"), patch(
+            "free_manager.cloudwatch_client"
+        ) as mock_cw, patch(
+            "free_manager.ec2_client"
+        ):
+            from free_manager import publish_active_user_metric
+
+            publish_active_user_metric(42)
+
+            mock_cw.put_metric_data.assert_called_once()
+            call_kwargs = mock_cw.put_metric_data.call_args[1]
+            assert call_kwargs["Namespace"] == "OptiNiSt/FreeUsers"
+            metric = call_kwargs["MetricData"][0]
+            assert metric["MetricName"] == "ActiveLogins"
+            assert metric["Value"] == 42

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -1,0 +1,611 @@
+"""Tests for premium_cleanup Lambda function."""
+
+from unittest.mock import MagicMock, patch
+
+from aws_constants import ECSTaskStatus, PremiumAssignment, RoutingHeaders
+from conftest import MockRow, setup_db_mock
+
+TEST_INSTANCE_ID = "i-testlambda123"
+
+
+class TestPremiumCleanupHandler:
+    """Handler-level tests for premium_cleanup Lambda."""
+
+    def test_scheduled_event(self, mock_env_vars_premium):
+        """Test premium_cleanup Lambda with scheduled event."""
+        print("Testing Premium Cleanup Lambda - Scheduled Event")
+        print("=" * 50)
+
+        scheduled_event = {
+            "source": "aws.events",
+            "detail-type": "Scheduled Event",
+            "detail": {"action": "cleanup"},
+            "time": "2025-09-17T10:00:00Z",
+        }
+
+        mock_context = MagicMock()
+        mock_context.function_name = "subscr-premium-cleanup"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    MockRow({"count": 3}),
+                    MockRow({"count": 0}),
+                ],
+                fetchall_values=[
+                    [],
+                    [],
+                    [],
+                    [],
+                    [
+                        MockRow(
+                            {
+                                "instance_id": TEST_INSTANCE_ID,
+                                "state": "running",
+                            }
+                        )
+                    ],
+                    [],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": TEST_INSTANCE_ID,
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "premium-instance",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_cleanup import handler
+
+            result = handler(scheduled_event, mock_context)
+
+            assert isinstance(result, dict)
+            assert result["statusCode"] == 200
+
+
+class TestCheckInstanceReadiness:
+    """TC-25..27: check_instance_readiness tests."""
+
+    def test_success(self, mock_env_vars_premium):
+        """TC-25: Running premium ECS task returns True."""
+        test_inst = "i-ready123"
+        ci_arn = "arn:aws:ecs:us-east-1:123:container-instance/ci1"
+        task_arn = "arn:aws:ecs:us-east-1:123:task/t1"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": test_inst,
+                    }
+                ]
+            }
+            mock_ecs.list_tasks.return_value = {"taskArns": [task_arn]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "taskDefinitionArn": (
+                            "arn:aws:ecs:us-east-1:123:"
+                            "task-definition/optinist-premium"
+                        ),
+                        "lastStatus": ECSTaskStatus.RUNNING,
+                        "desiredStatus": ECSTaskStatus.RUNNING,
+                    }
+                ]
+            }
+
+            from premium_cleanup import check_instance_readiness
+
+            result = check_instance_readiness(test_inst)
+            assert result is True
+
+    def test_no_tasks(self, mock_env_vars_premium):
+        """TC-26: No tasks on container returns False."""
+        test_inst = "i-notasks123"
+        ci_arn = "arn:aws:ecs:us-east-1:123:container-instance/ci2"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": test_inst,
+                    }
+                ]
+            }
+            mock_ecs.list_tasks.return_value = {"taskArns": []}
+
+            from premium_cleanup import check_instance_readiness
+
+            result = check_instance_readiness(test_inst)
+            assert result is False
+
+    def test_no_container(self, mock_env_vars_premium):
+        """TC-27: No container instance returns False."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": []
+            }
+
+            from premium_cleanup import check_instance_readiness
+
+            result = check_instance_readiness("i-nocontainer")
+            assert result is False
+
+
+class TestCleanupStaleAssignments:
+    """TC-28..30: cleanup_stale_assignments tests."""
+
+    def test_no_stale_assignments(self, mock_env_vars_premium):
+        """TC-28: No stale assignments returns 0 cleaned."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql, patch("boto3.client"):
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_stale_assignments
+
+            result = cleanup_stale_assignments()
+            assert result["cleaned_assignments"] == 0
+
+    def test_deletes_alb_and_db(self, mock_env_vars_premium):
+        """TC-29: Stale assignment triggers ALB + DB cleanup."""
+        rule_arn = "arn:aws:rule/stale-rule"
+        tg_arn = "arn:aws:tg/stale-tg"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "user_id": 999,
+                                "instance_id": "i-stale1",
+                                "target_group_arn": tg_arn,
+                                "alb_rule_arn": rule_arn,
+                                "last_activity": "2025-01-01",
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_cleanup import cleanup_stale_assignments
+
+            result = cleanup_stale_assignments()
+
+            assert result["cleaned_assignments"] == 1
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
+            mock_elbv2.delete_target_group.assert_called_once_with(
+                TargetGroupArn=tg_arn
+            )
+
+    def test_skips_autoscaling_tg(self, mock_env_vars_premium):
+        """TC-30: Autoscaling TG not deleted on stale cleanup."""
+        rule_arn = "arn:aws:rule/stale-asg-rule"
+        asg_tg_arn = mock_env_vars_premium["AUTOSCALING_TARGET_GROUP_ARN"]
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "user_id": 888,
+                                "instance_id": "i-asg1",
+                                "target_group_arn": asg_tg_arn,
+                                "alb_rule_arn": rule_arn,
+                                "last_activity": "2025-01-01",
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_cleanup import cleanup_stale_assignments
+
+            result = cleanup_stale_assignments()
+
+            assert result["cleaned_assignments"] == 1
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
+            assert not mock_elbv2.delete_target_group.called
+
+
+class TestCleanupOrphanedAlbResources:
+    """TC-31..33: cleanup_orphaned_alb_resources tests."""
+
+    def test_no_orphans(self, mock_env_vars_premium):
+        """TC-31: All ALB rules match DB, no orphans."""
+        valid_rule_arn = "arn:aws:rule/valid-in-db"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": valid_rule_arn,
+                        "Priority": "100",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.ROUTING_ID),
+                                    "Values": ["rid-123"],
+                                },
+                            },
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.USER_TIER),
+                                    "Values": ["premium"],
+                                },
+                            },
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/v1"),
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "alb_rule_arn": valid_rule_arn,
+                                "target_group_arn": ("arn:aws:tg/v1"),
+                                "user_id": 100,
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_orphaned_alb_resources
+
+            result = cleanup_orphaned_alb_resources()
+
+            assert result["orphaned_rules_deleted"] == 0
+            assert not mock_elbv2.delete_rule.called
+
+    def test_deletes_orphan(self, mock_env_vars_premium):
+        """TC-32: Orphaned ALB rule (not in DB) deleted."""
+        orphan_arn = "arn:aws:rule/orphan-no-db"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": orphan_arn,
+                        "Priority": "200",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.ROUTING_ID),
+                                    "Values": ["rid-orphan"],
+                                },
+                            },
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.USER_TIER),
+                                    "Values": ["premium"],
+                                },
+                            },
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/orph"),
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_orphaned_alb_resources
+
+            result = cleanup_orphaned_alb_resources()
+
+            assert result["orphaned_rules_deleted"] == 1
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=orphan_arn)
+
+    def test_skips_default_rule(self, mock_env_vars_premium):
+        """TC-33: Default ALB rule is never deleted."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": "arn:aws:rule/default",
+                        "Priority": "default",
+                        "Conditions": [],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/dflt"),
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_orphaned_alb_resources
+
+            result = cleanup_orphaned_alb_resources()
+
+            assert result["orphaned_rules_deleted"] == 0
+            assert not mock_elbv2.delete_rule.called
+
+
+class TestReconcileInstanceStates:
+    """TC-34..36: reconcile_instance_states tests."""
+
+    def test_cleans_terminated_instance(self, mock_env_vars_premium):
+        """TC-34: Terminated instance assignment cleaned."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_cleanup" ".get_all_premium_instances_with_states"
+        ) as mock_aws, patch("boto3.client") as mock_boto3, patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_aws.return_value = []
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 1,
+                                "user_id": 100,
+                                "instance_id": "i-gone",
+                                "instance_state": "running",
+                                "status": "active",
+                                "target_group_arn": "standby",
+                                "alb_rule_arn": "standby",
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_instance_states
+
+            result = reconcile_instance_states()
+            assert result["cleanup_count"] == 1
+
+    def test_updates_state_mismatch(self, mock_env_vars_premium):
+        """TC-35: DB state updated when AWS state differs."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_cleanup" ".get_all_premium_instances_with_states"
+        ) as mock_aws, patch("boto3.client") as mock_boto3, patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_aws.return_value = [
+                {
+                    "instance_id": "i-1",
+                    "instance_type": "t3.large",
+                    "state": "stopped",
+                    "launch_time": None,
+                }
+            ]
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 2,
+                                "user_id": 200,
+                                "instance_id": "i-1",
+                                "instance_state": "running",
+                                "status": "active",
+                                "target_group_arn": ("arn:aws:tg/u200"),
+                                "alb_rule_arn": ("arn:aws:rule/u200"),
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_instance_states
+
+            result = reconcile_instance_states()
+            assert result["update_count"] == 1
+
+    def test_skips_autoscaling_pool(self, mock_env_vars_premium):
+        """TC-36: autoscaling-pool rows are skipped."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_cleanup" ".get_all_premium_instances_with_states"
+        ) as mock_aws, patch("boto3.client") as mock_boto3, patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_aws.return_value = []
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 3,
+                                "user_id": 300,
+                                "instance_id": (PremiumAssignment.AUTOSCALING_POOL),
+                                "instance_state": "running",
+                                "status": "active",
+                                "target_group_arn": ("arn:aws:tg/asg"),
+                                "alb_rule_arn": ("arn:aws:rule/asg"),
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_instance_states
+
+            result = reconcile_instance_states()
+            assert result["cleanup_count"] == 0
+            assert result["update_count"] == 0

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1,0 +1,1124 @@
+"""Tests for premium_manager Lambda function."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from aws_constants import ECSTaskStatus
+from conftest import MockRow, setup_db_mock
+
+TEST_USER_ID = "test_user_12345"
+TEST_INSTANCE_ID = "i-testlambda123"
+
+
+class TestPremiumManagerEvents:
+    """Handler-level tests with realistic API Gateway events."""
+
+    def test_assign_event(self, mock_env_vars_premium):
+        """Test premium_manager Lambda with assignment event."""
+        print("Testing Premium Manager Lambda - Assignment Event")
+        print("=" * 50)
+
+        api_gateway_event = {
+            "httpMethod": "POST",
+            "path": "/premium/assign",
+            "headers": {
+                "Authorization": "Bearer test-token",
+                "Content-Type": "application/json",
+            },
+            "body": json.dumps(
+                {
+                    "action": "assign",
+                    "user_id": TEST_USER_ID,
+                    "tier": "premium",
+                }
+            ),
+            "requestContext": {
+                "requestId": "test-request-123",
+                "stage": "prod",
+            },
+        }
+
+        mock_context = MagicMock()
+        mock_context.function_name = "subscr-premium-manager"
+        mock_context.aws_request_id = "test-lambda-123"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    None,
+                    MockRow({"count": 1}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    None,
+                    MockRow({"count": 1}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    None,
+                    None,
+                    MockRow({"priority": 100}),
+                ],
+                fetchall_values=[
+                    [],
+                    [
+                        MockRow(
+                            {
+                                "instance_id": TEST_INSTANCE_ID,
+                                "state": "running",
+                            }
+                        )
+                    ],
+                    [],
+                    [],
+                    [],
+                    [],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_ec2 = MagicMock()
+            mock_elbv2 = MagicMock()
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                elif service == "elbv2":
+                    return mock_elbv2
+                elif service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": TEST_INSTANCE_ID,
+                                "State": {"Name": "running"},
+                                "InstanceType": "t3.large",
+                                "LaunchTime": "2025-09-17T10:00:00Z",
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "premium-instance-1",
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    },
+                                    {
+                                        "Key": "Type",
+                                        "Value": "Premium-Instance",
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [
+                    "arn:aws:ecs:region:account:" "container-instance/test"
+                ]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": (
+                            "arn:aws:ecs:region:account:" "container-instance/test"
+                        ),
+                        "ec2InstanceId": TEST_INSTANCE_ID,
+                    }
+                ]
+            }
+            mock_ecs.list_tasks.return_value = {
+                "taskArns": ["arn:aws:ecs:region:account:task/test"]
+            }
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "taskDefinitionArn": (
+                            "arn:aws:ecs:region:account:"
+                            "task-definition/optinist-premium"
+                        ),
+                        "lastStatus": ECSTaskStatus.RUNNING,
+                        "desiredStatus": ECSTaskStatus.RUNNING,
+                    }
+                ]
+            }
+
+            mock_elbv2.create_target_group.return_value = {
+                "TargetGroups": [
+                    {
+                        "TargetGroupArn": (
+                            "arn:aws:elasticloadbalancing:"
+                            "region:account:targetgroup/test"
+                        )
+                    }
+                ]
+            }
+            mock_elbv2.create_rule.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": (
+                            "arn:aws:elasticloadbalancing:"
+                            "region:account:listener-rule/test"
+                        )
+                    }
+                ]
+            }
+
+            from premium_manager import handler
+
+            result = handler(api_gateway_event, mock_context)
+
+            assert isinstance(result, dict)
+            assert "statusCode" in result
+            assert "body" in result
+
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            print(f"Status Code: {status_code}")
+            print(f"Response: {json.dumps(response_body, indent=2)}")
+
+            if status_code == 200:
+                assert "instance_id" in response_body
+                assert response_body["instance_id"] == TEST_INSTANCE_ID
+            elif status_code == 202:
+                assert "retry_after" in response_body
+
+    def test_heartbeat_event(self, mock_env_vars_premium):
+        """Test premium_manager Lambda with heartbeat event."""
+        print("Testing Premium Manager Lambda - Heartbeat Event")
+        print("=" * 50)
+
+        heartbeat_event = {
+            "httpMethod": "POST",
+            "path": "/premium/heartbeat",
+            "body": json.dumps(
+                {
+                    "action": "update_activity",
+                    "user_id": TEST_USER_ID,
+                    "tier": "premium",
+                }
+            ),
+            "requestContext": {"requestId": "test-heartbeat-123"},
+        }
+
+        mock_context = MagicMock()
+        mock_context.function_name = "subscr-premium-manager"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow({"id": 12345}),
+                    MockRow(
+                        {
+                            "user_id": 12345,
+                            "instance_id": TEST_INSTANCE_ID,
+                            "instance_state": "running",
+                        }
+                    ),
+                ],
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import handler
+
+            result = handler(heartbeat_event, mock_context)
+
+            assert isinstance(result, dict)
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            print(f"Status Code: {status_code}")
+            assert status_code == 200
+            assert "user_id" in response_body
+            assert response_body["user_id"] == 12345
+
+    def test_release_event(self, mock_env_vars_premium):
+        """Test premium_manager Lambda with release event."""
+        print("Testing Premium Manager Lambda - Release Event")
+        print("=" * 50)
+
+        release_event = {
+            "httpMethod": "POST",
+            "path": "/premium/release",
+            "body": json.dumps(
+                {
+                    "action": "release",
+                    "user_id": TEST_USER_ID,
+                    "tier": "premium",
+                }
+            ),
+        }
+
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow(
+                        {
+                            "user_id": TEST_USER_ID,
+                            "instance_id": TEST_INSTANCE_ID,
+                            "target_group_arn": (
+                                "arn:aws:elasticloadbalancing:"
+                                "region:account:targetgroup/test"
+                            ),
+                            "alb_rule_arn": (
+                                "arn:aws:elasticloadbalancing:"
+                                "region:account1:"
+                                "listener-rule/test"
+                            ),
+                        }
+                    ),
+                    MockRow({"count": 1}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    MockRow({"count": 3}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                    MockRow({"count": 0}),
+                    MockRow({"count": 1}),
+                ],
+                fetchall_values=[[], [], []],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_elbv2 = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                elif service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ec2.describe_instances.return_value = {"Reservations": []}
+
+            from premium_manager import handler
+
+            result = handler(release_event, mock_context)
+
+            assert isinstance(result, dict)
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            print(f"Status Code: {status_code}")
+            assert status_code == 200
+            assert "released_instance" in response_body
+
+    def test_enum_values_in_lambda_operations(self, mock_env_vars_premium):
+        """Test Lambda operations work with enum values."""
+        print("Testing Lambda with Fixed Enum Values")
+        print("=" * 50)
+
+        enum_states = [
+            ("launching", "Instance starting up"),
+            ("running", "Instance active"),
+            ("stopping", "Instance shutting down"),
+            ("stopped", "Instance in standby"),
+            ("terminating", "Instance being destroyed"),
+        ]
+
+        from premium_manager import store_user_assignment, update_instance_state
+
+        for enum_state, description in enum_states:
+            print(f"Testing enum state: '{enum_state}' " f"({description})")
+
+            with patch.dict("os.environ", mock_env_vars_premium), patch(
+                "pymysql.connect"
+            ) as mock_pymysql:
+                test_user = f"{TEST_USER_ID}_{enum_state}"
+
+                mock_connection = setup_db_mock()
+                mock_pymysql.return_value = mock_connection
+
+                store_user_assignment(
+                    user_id=test_user,
+                    instance_id=TEST_INSTANCE_ID,
+                    target_group_arn="arn:test",
+                    rule_arn="arn:test2",
+                    instance_state=enum_state,
+                    is_shared=False,
+                )
+                print(f"store_user_assignment with " f"'{enum_state}' - SUCCESS")
+
+                update_instance_state(test_user, enum_state)
+                print(f"update_instance_state to " f"'{enum_state}' - SUCCESS")
+
+    def test_error_handling(self, mock_env_vars_premium):
+        """Test Lambda error handling for malformed events."""
+        print("Testing Lambda Error Handling")
+        print("=" * 50)
+
+        malformed_event = {
+            "httpMethod": "POST",
+            "body": "invalid json {{",
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_premium):
+            from premium_manager import handler
+
+            result = handler(malformed_event, mock_context)
+
+            assert isinstance(result, dict)
+            assert "statusCode" in result
+            assert result["statusCode"] >= 400
+
+
+class TestEarlyCheckAndCleanup:
+    """TC-1, TC-2, TC-4, TC-5: Assignment early check and
+    cleanup tests."""
+
+    def test_early_check_returns_existing_assignment(self, mock_env_vars_premium):
+        """TC-1: assign_premium_user returns existing assignment
+        without creating new ALB rules."""
+        print("Testing Early Check Returns Existing Assignment")
+        print("=" * 50)
+
+        test_user_id = 12345
+
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": TEST_INSTANCE_ID,
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_existing:
+            mock_get_existing.return_value = existing_assignment
+
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(test_user_id, {"tier": "premium"})
+
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            print(f"Status Code: {status_code}")
+            assert status_code == 200
+            assert (
+                "already assigned" in response_body.get("message", "").lower()
+                or response_body.get("assignment_source") == "existing"
+            )
+            assert not mock_elbv2.create_rule.called
+            mock_get_existing.assert_called_once_with(test_user_id)
+
+    def test_exception_handler_cleans_up_alb_rule(self, mock_env_vars_premium):
+        """TC-2: Exception handler cleans up ALB rule."""
+        print("Testing Exception Handler ALB Rule Cleanup")
+        print("=" * 50)
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    None,
+                    None,
+                    MockRow({"count": 0}),
+                ],
+                fetchall_values=[
+                    [],
+                    [
+                        MockRow(
+                            {
+                                "instance_id": TEST_INSTANCE_ID,
+                                "state": "running",
+                            }
+                        )
+                    ],
+                    [],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            mock_elbv2 = MagicMock()
+            mock_ec2 = MagicMock()
+
+            created_rule_arn = "arn:aws:rule/test-created-rule"
+            mock_elbv2.create_rule.return_value = {
+                "Rules": [{"RuleArn": created_rule_arn}]
+            }
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": "arn:aws:rule/duplicate1",
+                        "Priority": "100",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": ("X-Routing-ID"),
+                                    "Values": ["test123abc"],
+                                },
+                            }
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/orphaned"),
+                            }
+                        ],
+                    },
+                    {
+                        "RuleArn": "arn:aws:rule/duplicate2",
+                        "Priority": "101",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": ("X-Routing-ID"),
+                                    "Values": ["test123abc"],
+                                },
+                            }
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/orphaned2"),
+                            }
+                        ],
+                    },
+                ]
+            }
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                elif service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": TEST_INSTANCE_ID,
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "premium-instance",
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_duplicate_rules_for_routing_id
+
+            test_listener_arn = mock_env_vars_premium["ALB_LISTENER_ARN"]
+
+            deleted_count = cleanup_duplicate_rules_for_routing_id(
+                test_listener_arn, "test123abc"
+            )
+
+            print(f"Deleted {deleted_count} duplicate rules")
+            assert mock_elbv2.delete_rule.call_count == 2
+
+    def test_cleanup_duplicate_alb_rules_scheduled(self, mock_env_vars_premium):
+        """TC-4: Scheduled duplicate cleanup in
+        premium_cleanup Lambda."""
+        print("Testing Scheduled Duplicate ALB Rules Cleanup")
+        print("=" * 50)
+
+        valid_rule_arn = "arn:aws:rule/valid-in-db"
+        duplicate_rule_arn = "arn:aws:rule/duplicate-not-in-db"
+        routing_id = "test-routing-id-123"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_cleanup.get_db_connection") as mock_get_db:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = [{"alb_rule_arn": valid_rule_arn}]
+
+            mock_connection = MagicMock()
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_connection.__enter__.return_value = mock_connection
+            mock_connection.__exit__.return_value = None
+
+            mock_get_db.return_value.__enter__.return_value = mock_connection
+            mock_get_db.return_value.__exit__.return_value = None
+
+            mock_elbv2 = MagicMock()
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": "default",
+                        "Priority": "default",
+                    },
+                    {
+                        "RuleArn": valid_rule_arn,
+                        "Priority": "100",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": ("X-Routing-ID"),
+                                    "Values": [routing_id],
+                                },
+                            },
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": "arn:tg/1",
+                            }
+                        ],
+                    },
+                    {
+                        "RuleArn": duplicate_rule_arn,
+                        "Priority": "101",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": ("X-Routing-ID"),
+                                    "Values": [routing_id],
+                                },
+                            },
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": "arn:tg/2",
+                            }
+                        ],
+                    },
+                ]
+            }
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_cleanup import cleanup_duplicate_alb_rules
+
+            result = cleanup_duplicate_alb_rules()
+
+            print(f"Cleanup result: {result}")
+            assert "duplicates_deleted" in result
+
+            delete_calls = mock_elbv2.delete_rule.call_args_list
+            deleted_arns = [call[1]["RuleArn"] for call in delete_calls]
+
+            assert valid_rule_arn not in deleted_arns
+            assert duplicate_rule_arn in deleted_arns
+
+    def test_autoscaling_pool_triggers_migration_retry(self, mock_env_vars_premium):
+        """TC-5: Autoscaling-pool assignment triggers
+        migration retry."""
+        print("Testing Autoscaling-Pool Assignment " "Triggers Migration Retry")
+        print("=" * 50)
+
+        test_user_id = 12345
+
+        existing_autoscaling_assignment = {
+            "user_id": test_user_id,
+            "instance_id": "autoscaling-pool",
+            "target_group_arn": "arn:aws:tg/autoscaling",
+            "alb_rule_arn": "arn:aws:rule/autoscaling",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 1,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            with patch.object(
+                premium_manager,
+                "get_existing_user_assignment",
+            ) as mock_get_existing, patch.object(
+                premium_manager, "invoke_migration_async"
+            ) as mock_invoke_migration, patch(
+                "boto3.client"
+            ) as mock_boto3:
+                mock_get_existing.return_value = existing_autoscaling_assignment
+
+                mock_elbv2 = MagicMock()
+
+                def boto3_client_side_effect(service):
+                    if service == "elbv2":
+                        return mock_elbv2
+                    return MagicMock()
+
+                mock_boto3.side_effect = boto3_client_side_effect
+
+                result = premium_manager.assign_premium_user(
+                    test_user_id, {"tier": "premium"}
+                )
+
+                status_code = result["statusCode"]
+                response_body = json.loads(result["body"])
+
+                assert status_code == 200
+                assert response_body.get("instance_id") == "autoscaling-pool"
+                assert response_body.get("assignment_source") == "existing"
+                assert mock_invoke_migration.called
+                mock_get_existing.assert_called_once_with(test_user_id)
+                assert not mock_elbv2.create_rule.called
+
+
+class TestDictCursorFix:
+    """TC-6..8: DictCursor fix tests."""
+
+    def test_increment_attempts(self, mock_env_vars_premium):
+        """TC-6: _increment_assignment_attempts_transaction
+        uses dict-style access."""
+        print("Testing DictCursor Fix - Increment Attempts")
+        print("=" * 50)
+
+        test_user_id = 99
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    {"assignment_attempts": 3},
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import _increment_assignment_attempts_transaction
+
+            result = _increment_assignment_attempts_transaction(test_user_id)
+
+            assert result == 4
+            print(f"Correctly incremented attempts: 3 -> {result}")
+
+    def test_store_existing_assignment(self, mock_env_vars_premium):
+        """TC-7: _store_user_assignment_transaction uses
+        dict-style access on existing assignment."""
+        print("Testing DictCursor Fix - " "Store Existing Assignment")
+        print("=" * 50)
+
+        test_user_id = 99
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    {
+                        "user_id": test_user_id,
+                        "assignment_attempts": 1,
+                    },
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import _store_user_assignment_transaction
+
+            try:
+                _store_user_assignment_transaction(
+                    user_id=test_user_id,
+                    instance_id=TEST_INSTANCE_ID,
+                    target_group_arn="arn:test",
+                    rule_arn="arn:test2",
+                )
+                # Should raise, not reach here
+                assert False, "Expected exception not raised"
+            except KeyError:
+                assert False, (
+                    "REGRESSION: KeyError - still using " "tuple indexing on DictCursor"
+                )
+            except Exception as e:
+                assert "already has a premium assignment" in str(e)
+                print(f"Correctly raised: {e}")
+
+    def test_increment_none_attempts(self, mock_env_vars_premium):
+        """TC-8: None assignment_attempts defaults to 1."""
+        print("Testing DictCursor Fix - None Attempts Default")
+        print("=" * 50)
+
+        test_user_id = 99
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    {"assignment_attempts": None},
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import _increment_assignment_attempts_transaction
+
+            result = _increment_assignment_attempts_transaction(test_user_id)
+
+            assert result == 2
+            print(f"Correctly defaulted None to 1, " f"incremented to {result}")
+
+
+class TestGenerateRoutingId:
+    """TC-9..12: generate_routing_id pure function tests."""
+
+    def test_deterministic(self):
+        """TC-9: Same uid+key always returns the same ID."""
+        from premium_manager import generate_routing_id
+
+        uid = "user_abc_123"
+        key = "secret-key-xyz"
+        result1 = generate_routing_id(uid, key)
+        result2 = generate_routing_id(uid, key)
+
+        assert result1 == result2
+        print(f"Deterministic: '{result1}' == '{result2}'")
+
+    def test_length(self):
+        """TC-10: Output is exactly 16 hex characters."""
+        from premium_manager import generate_routing_id
+
+        result = generate_routing_id("user_1", "key_1")
+
+        assert len(result) == 16
+        assert all(c in "0123456789abcdef" for c in result)
+        print(f"Valid 16-char hex: '{result}'")
+
+    def test_different_keys(self):
+        """TC-11: Different keys produce different IDs."""
+        from premium_manager import generate_routing_id
+
+        uid = "same_user"
+        id1 = generate_routing_id(uid, "key_alpha")
+        id2 = generate_routing_id(uid, "key_beta")
+
+        assert id1 != id2
+        print(f"key_alpha -> '{id1}', key_beta -> '{id2}'")
+
+    def test_different_uids(self):
+        """TC-12: Different UIDs produce different IDs."""
+        from premium_manager import generate_routing_id
+
+        key = "same_key"
+        id1 = generate_routing_id("user_aaa", key)
+        id2 = generate_routing_id("user_bbb", key)
+
+        assert id1 != id2
+        print(f"user_aaa -> '{id1}', user_bbb -> '{id2}'")
+
+
+class TestCountTotalPremiumUsers:
+    """TC-13..15: count_total_premium_users tests."""
+
+    def test_subscription_table(self, mock_env_vars_premium):
+        """TC-13: Primary path returns subscriber count."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[MockRow({"count": 7})],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import count_total_premium_users
+
+            result = count_total_premium_users()
+            assert result == 7
+            print(f"Subscription table returned: {result}")
+
+    def test_fallback(self, mock_env_vars_premium):
+        """TC-14: Subscription query fails, falls back."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            mock_cursor.execute.side_effect = [
+                Exception("Table not found"),
+                None,
+            ]
+            mock_cursor.fetchone.side_effect = [
+                MockRow({"count": 3}),
+            ]
+
+            from premium_manager import count_total_premium_users
+
+            result = count_total_premium_users()
+            assert result == 3
+            print(f"Fallback returned: {result}")
+
+    def test_all_fail(self, mock_env_vars_premium):
+        """TC-15: Both queries fail, returns default."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            mock_cursor.execute.side_effect = [
+                Exception("Subscription table error"),
+                Exception("Assignments table error"),
+            ]
+
+            from premium_manager import (
+                DEFAULT_DEVELOPMENT_CAPACITY,
+                count_total_premium_users,
+            )
+
+            result = count_total_premium_users()
+            assert result == DEFAULT_DEVELOPMENT_CAPACITY
+            print(
+                f"All-fail fallback returned: {result} "
+                f"(DEFAULT_DEVELOPMENT_CAPACITY)"
+            )
+
+
+class TestTryReserveInstance:
+    """TC-16..17: try_reserve_instance tests."""
+
+    def test_success(self, mock_env_vars_premium):
+        """TC-16: No existing assignment, reservation inserted."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[None],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import try_reserve_instance
+
+            result = try_reserve_instance("i-new123", 42)
+            assert result is True
+
+    def test_already_reserved(self, mock_env_vars_premium):
+        """TC-17: Existing assignment found, returns False."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow({"instance_id": "i-existing"}),
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import try_reserve_instance
+
+            result = try_reserve_instance("i-existing", 42)
+            assert result is False
+
+
+class TestDatabaseCommits:
+    """TC-18..20: Verify commit is called after operations."""
+
+    def test_terminate_standby_instance_commits(self, mock_env_vars_premium):
+        """TC-18: Verify commit is called after DELETE."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            from premium_manager import terminate_standby_instance
+
+            result = terminate_standby_instance("i-standby1")
+
+            assert result is True
+            mock_connection.commit.assert_called()
+
+    def test_cleanup_failed_standby_commits(self, mock_env_vars_premium):
+        """TC-19: Verify commit is called after cleanup."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager" ".get_all_premium_instances_with_states"
+        ) as mock_aws, patch("pymysql.connect") as mock_pymysql:
+            mock_aws.return_value = []
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [MockRow({"instance_id": "i-gone"})],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import cleanup_failed_standby_instances
+
+            cleanup_failed_standby_instances()
+            mock_connection.commit.assert_called()
+
+    def test_update_user_activity_commits(self, mock_env_vars_premium):
+        """TC-20: Verify commit is called after UPDATE."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            mock_cursor.rowcount = 1
+
+            from premium_manager import update_user_activity
+
+            result = update_user_activity(42)
+
+            assert result is True
+            mock_connection.commit.assert_called()
+
+
+class TestGetAllPremiumInstances:
+    """TC-21..22: get_all_premium_instances tests."""
+
+    def test_filters_by_tags(self, mock_env_vars_premium):
+        """TC-21: Only premium-tagged instances returned."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-premium1",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "premium-inst-1",
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    },
+                                ],
+                            },
+                            {
+                                "InstanceId": "i-other1",
+                                "InstanceType": "t3.micro",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "web-server",
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+
+            assert len(result) == 1
+            assert result[0]["instance_id"] == "i-premium1"
+
+    def test_empty(self, mock_env_vars_premium):
+        """TC-22: No instances returns empty list."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_ec2.describe_instances.return_value = {"Reservations": []}
+
+            from premium_manager import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert result == []
+
+
+class TestStartStandbyInstance:
+    """TC-23..24: start_standby_instance tests."""
+
+    def test_success(self, mock_env_vars_premium):
+        """TC-23: EC2 start + waiter + DB update."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_waiter = MagicMock()
+            mock_ec2.get_waiter.return_value = mock_waiter
+
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import start_standby_instance
+
+            result = start_standby_instance("i-standby1")
+
+            assert result is True
+            mock_ec2.start_instances.assert_called_once_with(InstanceIds=["i-standby1"])
+            mock_waiter.wait.assert_called_once()
+            mock_connection.commit.assert_called()
+
+    def test_waiter_fails(self, mock_env_vars_premium):
+        """TC-24: EC2 waiter timeout returns False."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_waiter = MagicMock()
+            mock_waiter.wait.side_effect = Exception(
+                "Waiter instance_running timed out"
+            )
+            mock_ec2.get_waiter.return_value = mock_waiter
+
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import start_standby_instance
+
+            result = start_standby_instance("i-standby2")
+            assert result is False

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1081,14 +1081,17 @@ class TestStartStandbyInstance:
     """TC-23..24: start_standby_instance tests."""
 
     def test_success(self, mock_env_vars_premium):
-        """TC-23: EC2 start + waiter + DB update."""
+        """TC-23: EC2 start + waiter + checkpoint clear + DB update."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
-        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql, patch(
+            "premium_manager.clear_ecs_agent_checkpoint"
+        ) as mock_clear:
             mock_ec2 = MagicMock()
             mock_boto3.return_value = mock_ec2
             mock_waiter = MagicMock()
             mock_ec2.get_waiter.return_value = mock_waiter
+            mock_clear.return_value = True
 
             mock_connection = setup_db_mock()
             mock_pymysql.return_value = mock_connection
@@ -1100,6 +1103,7 @@ class TestStartStandbyInstance:
             assert result is True
             mock_ec2.start_instances.assert_called_once_with(InstanceIds=["i-standby1"])
             mock_waiter.wait.assert_called_once()
+            mock_clear.assert_called_once_with("i-standby1")
             mock_connection.commit.assert_called()
 
     def test_waiter_fails(self, mock_env_vars_premium):
@@ -1121,4 +1125,87 @@ class TestStartStandbyInstance:
             from premium_manager import start_standby_instance
 
             result = start_standby_instance("i-standby2")
+            assert result is False
+
+
+class TestClearEcsAgentCheckpoint:
+    """Tests for clear_ecs_agent_checkpoint SSM helper."""
+
+    def test_success(self, mock_env_vars_premium):
+        """SSM command succeeds on first poll."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_manager.time.sleep"):
+            mock_ssm = MagicMock()
+            mock_boto3.return_value = mock_ssm
+            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-123"}}
+            mock_ssm.get_command_invocation.return_value = {
+                "Status": "Success",
+            }
+
+            from premium_manager import clear_ecs_agent_checkpoint
+
+            result = clear_ecs_agent_checkpoint("i-test1")
+
+            assert result is True
+            mock_ssm.send_command.assert_called_once()
+            mock_ssm.get_command_invocation.assert_called_once_with(
+                CommandId="cmd-123", InstanceId="i-test1"
+            )
+
+    def test_command_fails(self, mock_env_vars_premium):
+        """SSM command returns Failed status."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_manager.time.sleep"):
+            mock_ssm = MagicMock()
+            mock_boto3.return_value = mock_ssm
+            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-456"}}
+            mock_ssm.get_command_invocation.return_value = {
+                "Status": "Failed",
+                "StandardErrorContent": "permission denied",
+            }
+
+            from premium_manager import clear_ecs_agent_checkpoint
+
+            result = clear_ecs_agent_checkpoint("i-test2")
+
+            assert result is False
+
+    def test_send_command_client_error(self, mock_env_vars_premium):
+        """SSM send_command raises ClientError."""
+        from botocore.exceptions import ClientError
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ssm = MagicMock()
+            mock_boto3.return_value = mock_ssm
+            mock_ssm.send_command.side_effect = ClientError(
+                {"Error": {"Code": "InvalidInstanceId"}},
+                "SendCommand",
+            )
+
+            from premium_manager import clear_ecs_agent_checkpoint
+
+            result = clear_ecs_agent_checkpoint("i-test3")
+
+            assert result is False
+
+    def test_timeout(self, mock_env_vars_premium):
+        """SSM polling exhausts max wait time."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_manager.time.sleep"):
+            mock_ssm = MagicMock()
+            mock_boto3.return_value = mock_ssm
+            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-789"}}
+            mock_ssm.get_command_invocation.return_value = {
+                "Status": "InProgress",
+            }
+
+            from premium_manager import clear_ecs_agent_checkpoint
+
+            result = clear_ecs_agent_checkpoint("i-test4")
+
             assert result is False


### PR DESCRIPTION
# Summary

### Problem occurrence

On Feb 16, 2026 at ~16:17 UTC, premium user assignment for user 43 failed with
cryptic error messages showing just `1`. From CloudWatch logs:

```
[1771226231524] Transaction rolled back due to error: 1
[1771226231524] Database connection failed - connection error: 1
[1771226231524] Error assigning premium user: 1
```

### Cause

Three layers combined to produce the failure:

```
| Layer             | Commit   | Issue                                             |
|-------------------|----------|----------------------------------------------------|
| Latent bug        | 3cf98c75 | existing[1] on DictCursor dict raises KeyError(1) |
| Trigger           | b0105a53 | Retry logic creates concurrent Lambda invocations |
| Misleading errors | eb6e9bca | get_db_connection catches app errors as "connection error" |
```

**Root cause:** The connection uses `pymysql.cursors.DictCursor`, so query results
are dicts like `{'user_id': 43, 'assignment_attempts': 1}`. The code indexed them
with `existing[0]` and `existing[1]` (tuple-style), which raises `KeyError(1)`.
`str(KeyError(1))` = `"1"` -- the cryptic error.

This code path was never reached until commit b0105a53 (Feb 6) added retry logic
with `asyncio.wait_for` + `run_in_executor`. When the timeout fires, the asyncio
task is cancelled but the underlying thread keeps running, so two Lambda invocations
race on the same user_id. The second invocation finds the existing assignment stored
by the first and hits the `existing[1]` KeyError.

**Timeline at 16:17 UTC:**

1. Lambda #1 starts for user 43, checks existing assignment -> none found
2. Lambda #2 starts 7.4s later (retry), checks existing assignment -> none found
3. Lambda #1 stores assignment to autoscaling-pool (SUCCESS) at +22s
4. Lambda #2 reaches `_store_user_assignment_transaction`, finds existing record,
   hits `existing[1]` -> `KeyError(1)`
5. Lambda #2 error cleanup tries to delete the shared autoscaling target group
   -> `ResourceInUse` error

**Additional audit** found that several functions using raw `get_db_connection()`
(which defaults to `auto_commit=False`) were missing `connection.commit()` calls,
making them silent no-ops: terminated standby instances stayed in the DB, cleanup
functions cleaned nothing, and activity timestamps never persisted.

### Solution

**File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`

**CRITICAL Fix 1 -- DictCursor indexing bugs (Critical):**
- Line 226: `existing[0]` -> `existing.get("assignment_attempts") or 1`
- Line 305: `existing[1]` -> `existing.get("assignment_attempts") or 1`

**LOW Fix 2 -- Narrow exception handling (Medium):**
- Line 156: `except Exception` -> `except pymysql.MySQLError` in `get_db_connection`
- Prevents app-level errors (KeyError, ValueError) from being mislabeled as "Database connection failed"

**MEDIUM Fix 3 -- Protect autoscaling target group in cleanup (High):**
- Lines 2015-2018: Added guard `tg_arn != autoscaling_tg` in `cleanup_duplicate_rules_for_routing_id` before deleting target groups
- Matches existing pattern at line 3686 in `release_premium_user`

**MEDIUM Fix 4 -- Missing connection.commit() calls (High):**
Discovered during debugging when terminated instances remained in DB.
- `terminate_standby_instance`: DELETE never committed, phantom DB rows persisted
- `cleanup_failed_standby_instances`: DELETEs never committed, cleanup was a no-op
- `update_user_activity`: UPDATE never committed, activity timestamps never persisted

**LOW Fix 5 -- SQL parameterization (Low):**
- `fix_incorrect_is_shared_flags`: Replaced f-string interpolation with
  parameterized `%s` query

**LOW Fix 6 -- Preserve tracebacks (Low):**
- `with_transaction` decorator and `assign_premium_user` error handler:
  `raise e` -> `raise` to preserve original stack traces

**CRITICAL Fix 7 -- Stale ECS agent checkpoint prevents instance registration (Critical):**

Premium standby instances that are stopped and later started fail to register
their ECS agent with the cluster. The ECS agent stores its container instance
ARN in `/var/lib/ecs/data/agent.db` (BoltDB). When the instance is stopped,
ECS deregisters the container instance. On restart, the agent reads the stale
ARN, ECS rejects it, and the agent terminally exits (exit code 5). This blocks
all user migration from shared instances to dedicated ones.

Three-layer fix:

1. **User data script** (`infrastructure/scripts/ecs-user-data.sh`):
   Added a systemd one-shot service (`ecs-clear-checkpoint.service`) that runs
   `Before=ecs.service` on every boot, deleting the stale `agent.db`. Protects
   all future instances launched from the template.

2. **Lambda SSM cleanup** (`infrastructure/terraform/premium_manager_package/premium_manager.py`):
   Added `clear_ecs_agent_checkpoint(instance_id)` helper that uses
   `ssm:SendCommand` to run `rm -f agent.db && systemctl restart ecs` on
   the instance, with polling (max 30s). Integrated into:
   - `start_standby_instance()`: called after EC2 running waiter completes
   - `scale_premium_instances_if_needed()`: called for each started instance
     after batch waiter completes
   This protects ALL instances including Terraform-created ones with no user data.

3. **IAM permissions** (`infrastructure/terraform/premium_manager.tf`):
   Added `ssm:SendCommand` and `ssm:GetCommandInvocation` to the
   `premium_manager_permissions` policy.

---

## Tests / Verification

After realising several of these bugs (DictCursor indexing, missing commits, silent
no-ops) could have been caught earlier with unit tests, we added a pytest-based test
suite for all five Lambda functions. These run in CI via `make test_lambda`.

**New test files** (`studio/tests/infrastructure/`):

```
| File                       | Tests | Coverage                                                |
|----------------------------|-------|---------------------------------------------------------|
| conftest.py                | --    | Shared fixtures, MockRow, setup_db_mock, env vars       |
| test_premium_manager.py    | 32    | Handler events, DictCursor fix, routing ID, DB commits, |
|                            |       | early check, autoscaling-pool migration, reservations,  |
|                            |       | ECS agent checkpoint cleanup (SSM success/fail/timeout) |
| test_premium_cleanup.py    | 12    | Instance readiness, stale cleanup, orphaned ALB rules,  |
|                            |       | reconcile states, autoscaling-pool skip                 |
| test_free_manager.py       | 7     | Handler routing, ASG sync, distribution balance,        |
|                            |       | CloudWatch metrics                                      |
| test_free_cleanup.py       | 5     | Handler validation, session cleanup, active user count  |
| test_common_user_manager.py| 16    | Workflow recovery (SQLAlchemy), free/premium inactivity, |
|                            |       | ALB cleanup, autoscaling TG skip, partial failure       |
```

**CI integration:**
- `.github/workflows/tests.yml`: Added "Run Lambda unit tests" step
- `Makefile`: Added `test_lambda` target (`pytest studio/tests/infrastructure/ -v`)

**Manual verification:**
- [x] `terraform apply` to deploy updated Lambda package
- [x] Assign a premium user and verify successful assignment in CloudWatch logs
- [x] Verify `existing.get("assignment_attempts")` works correctly in logs.git
  Look for these messages on concurrent/retry invocations:
  - `Incremented assignment attempts for user {id} to {n}`
  - `User {id} already has assignment, incremented attempts to {n}`
  Previously these would show `Transaction rolled back due to error: 1`