### PR TITLE
Add Public Repository Button and Change URL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,6 +68,7 @@ const App: FC = () => {
         <BrowserRouter>
           <Routes>
             {/* Landing page - outside Layout */}
+            <Route path="/" element={<LandingPage />} />
             <Route path="/landing" element={<LandingPage />} />
 
             {/* All other routes wrapped in Layout */}
@@ -83,10 +84,6 @@ const App: FC = () => {
                   ) : (
                     <Routes>
                       {/* Public routes */}
-                      <Route
-                        path="/"
-                        element={<Navigate replace to="/public" />}
-                      />
                       <Route path="/public" element={<PublicDataview />} />
                       <Route
                         path="/account-deleted"

--- a/frontend/src/pages/LandingPage/components/PublicRepository.tsx
+++ b/frontend/src/pages/LandingPage/components/PublicRepository.tsx
@@ -1,4 +1,6 @@
-import { Box, styled, Typography } from "@mui/material"
+import { useNavigate } from "react-router-dom"
+
+import { Box, Button, styled, Typography } from "@mui/material"
 
 interface Benefit {
   icon: string
@@ -28,6 +30,8 @@ const benefits: Benefit[] = [
 ]
 
 export const PublicRepository = () => {
+  const navigate = useNavigate()
+
   return (
     <PublicRepoSection id="public-repository">
       <Container>
@@ -74,6 +78,14 @@ export const PublicRepository = () => {
                 </PublicRepoBenefit>
               ))}
             </PublicRepoBenefits>
+            <Box sx={{ marginTop: "1.5rem" }}>
+              <GoToRepoButton
+                variant="contained"
+                onClick={() => navigate("/public")}
+              >
+                Go to Repository
+              </GoToRepoButton>
+            </Box>
           </PublicRepoContent>
           <PublicRepoVisual>
             <PublicRepoGlow />
@@ -193,6 +205,19 @@ const BenefitDescription = styled(Typography)({
   color: "rgba(255, 255, 255, 0.8)",
   margin: 0,
   lineHeight: 1.5,
+})
+
+const GoToRepoButton = styled(Button)({
+  backgroundColor: "white",
+  color: "#1e3a5f",
+  fontWeight: 700,
+  padding: "0.75rem 2rem",
+  borderRadius: 8,
+  textTransform: "none",
+  fontSize: "1rem",
+  "&:hover": {
+    backgroundColor: "rgba(255, 255, 255, 0.9)",
+  },
 })
 
 const PublicRepoVisual = styled(Box)({


### PR DESCRIPTION
### Content

Add Public Repository Button and Change URL

### Testcase

- [x] Click button for public repository. Redirect to optinist public repository
- [x] Change page when accessing top page. Changed to created Landing Page

<img width="1416" height="788" alt="Screenshot 2026-02-17 at 17 37 29" src="https://github.com/user-attachments/assets/fea36d04-9b9f-4bcd-b114-cd213160c263" />
<img width="771" height="411" alt="Screenshot 2026-02-17 at 17 37 17" src="https://github.com/user-attachments/assets/c5b3a163-e798-400b-9b7f-34bfa51c4ca2" />
