### PR TITLE
Landing page consistency

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ const App: FC = () => {
         <BrowserRouter>
           <Routes>
             {/* Landing page - outside Layout */}
-            <Route path="/landing" element={<LandingPage />} />
+            <Route path="/" element={<LandingPage />} />
 
             {/* All other routes wrapped in Layout */}
             <Route
@@ -83,10 +83,6 @@ const App: FC = () => {
                   ) : (
                     <Routes>
                       {/* Public routes */}
-                      <Route
-                        path="/"
-                        element={<Navigate replace to="/public" />}
-                      />
                       <Route path="/public" element={<PublicDataview />} />
                       <Route
                         path="/account-deleted"

--- a/frontend/src/pages/LandingPage/components/Audience.tsx
+++ b/frontend/src/pages/LandingPage/components/Audience.tsx
@@ -1,11 +1,22 @@
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LINE_HEIGHT,
+  TEXT_COLOR,
+  ACCENT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+  ICON_BOX,
+} from "pages/LandingPage/constants"
+
 interface AudienceCard {
   icon: string
   title: string
   description: string
   features: string[]
-  color: "primary" | "cyan" | "green"
+  color: "PRIMARY" | "CYAN" | "GREEN"
 }
 
 const audiences: AudienceCard[] = [
@@ -13,51 +24,57 @@ const audiences: AudienceCard[] = [
     icon: "psychology",
     title: "Neuroscience Labs",
     description:
-      "Analyze calcium imaging, electrophysiology, and behavioral data with specialized tools.",
+      "Analyze calcium imaging, electrophysiology, and behavioral " +
+      "data with specialized tools.",
     features: [
       "Calcium imaging pipelines",
       "ROI extraction & analysis",
       "NWB (Neurodata Without Borders) export",
     ],
-    color: "primary",
+    color: "PRIMARY",
   },
   {
     icon: "biotech",
     title: "Microscopy Researchers",
     description:
-      "Build image processing pipelines for various microscopes without coding.",
+      "Build image processing pipelines for various microscopes " +
+      "without coding.",
     features: [
       "Multi-format image support",
       "Batch processing",
       "LCCD cell detection algorithm",
     ],
-    color: "cyan",
+    color: "CYAN",
   },
   {
     icon: "school",
     title: "Educators & Students",
     description:
-      "Teach data analysis concepts using our sample data and tools. No coding required for you or your students.",
+      "Teach data analysis concepts using our sample data and " +
+      "tools. No coding required for you or your students.",
     features: [
       "Visual learning interface",
       "Shareable workspaces",
       "Focus on science, not syntax",
     ],
-    color: "green",
+    color: "GREEN",
   },
 ]
-
-const audienceColors = {
-  primary: { bg: "rgba(19, 91, 236, 0.1)", color: "#2563eb" },
-  cyan: { bg: "rgba(13, 148, 136, 0.1)", color: "#0d9488" },
-  green: { bg: "rgba(5, 150, 105, 0.1)", color: "#059669" },
-}
 
 export const Audience = () => {
   return (
     <AudienceSection id="audience">
       <Container>
         <SectionHeaderCenter>
+          <SectionLabel>
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: FONT_SIZE.CARD_TITLE }}
+            >
+              groups
+            </span>
+            Audience
+          </SectionLabel>
           <SectionTitle>Who It&apos;s For</SectionTitle>
           <SectionSubtitle>
             Empowering researchers and educators worldwide.
@@ -66,24 +83,28 @@ export const Audience = () => {
         <AudienceGrid>
           {audiences.map((audience, index) => (
             <AudienceCardWrapper key={index}>
-              <AudienceIcon
-                style={{
-                  backgroundColor: audienceColors[audience.color].bg,
-                  color: audienceColors[audience.color].color,
-                }}
-              >
-                <span className="material-symbols-outlined">
-                  {audience.icon}
-                </span>
-              </AudienceIcon>
-              <AudienceTitle>{audience.title}</AudienceTitle>
+              <AudienceHeader>
+                <AudienceIcon
+                  style={{
+                    backgroundColor: ACCENT_COLOR[audience.color].bg,
+                    color: ACCENT_COLOR[audience.color].color,
+                  }}
+                >
+                  <span className="material-symbols-outlined">
+                    {audience.icon}
+                  </span>
+                </AudienceIcon>
+                <AudienceTitle>{audience.title}</AudienceTitle>
+              </AudienceHeader>
               <AudienceDescription>{audience.description}</AudienceDescription>
               <AudienceFeatures>
                 {audience.features.map((feature, featureIndex) => (
                   <AudienceFeature key={featureIndex}>
                     <span
                       className="material-symbols-outlined"
-                      style={{ color: audienceColors[audience.color].color }}
+                      style={{
+                        color: ACCENT_COLOR[audience.color].color,
+                      }}
                     >
                       check_circle
                     </span>
@@ -100,7 +121,7 @@ export const Audience = () => {
 }
 
 const AudienceSection = styled("section")({
-  backgroundColor: "#f9fafb",
+  backgroundColor: BG_COLOR.PAGE,
   padding: "5rem 0",
 })
 
@@ -111,28 +132,37 @@ const Container = styled(Box)({
 })
 
 const SectionHeaderCenter = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
   textAlign: "center",
   marginBottom: "4rem",
 })
 
-const Label = styled(Typography)({
-  color: "#2563eb",
-  fontWeight: 700,
-  letterSpacing: "0.1em",
-  fontSize: "0.75rem",
-  textTransform: "uppercase",
+const SectionLabel = styled(Box)({
+  display: "inline-flex",
+  alignSelf: "flex-start",
+  alignItems: "center",
+  gap: "0.5rem",
+  backgroundColor: ACCENT_COLOR.PRIMARY.bg,
+  color: TEXT_COLOR.ACCENT,
+  fontWeight: FONT_WEIGHT.BOLD,
+  fontSize: FONT_SIZE.SMALL,
+  padding: "0.5rem 1rem",
+  borderRadius: 9999,
+  width: "fit-content",
 })
 
 const SectionTitle = styled(Typography)({
-  fontSize: "1.875rem",
-  fontWeight: 700,
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: "1rem 0 1rem",
   textAlign: "center",
 })
 
 const SectionSubtitle = styled(Typography)({
   textAlign: "center",
-  color: "#6b7280",
+  color: TEXT_COLOR.SECONDARY,
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
   margin: 0,
   maxWidth: 600,
   marginLeft: "auto",
@@ -152,39 +182,31 @@ const AudienceCardWrapper = styled(Box)({
   display: "flex",
   flexDirection: "column",
   gap: "1.5rem",
-  backgroundColor: "white",
+  backgroundColor: BG_COLOR.WHITE,
   padding: "2.5rem",
   borderRadius: 16,
-  border: "1px solid #e5e7eb",
-  transition: "box-shadow 0.3s",
-  "&:hover": {
-    boxShadow: "0 20px 40px -12px rgba(0, 0, 0, 0.1)",
-  },
+  border: `1px solid ${BORDER_COLOR.DEFAULT}`,
 })
 
-const AudienceIcon = styled(Box)({
-  width: 56,
-  height: 56,
-  borderRadius: "50%",
+const AudienceHeader = styled(Box)({
   display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  "& .material-symbols-outlined": {
-    fontSize: "1.875rem",
-  },
+  alignItems: "flex-start",
+  gap: "0.75rem",
 })
+
+const AudienceIcon = styled(Box)({ ...ICON_BOX })
 
 const AudienceTitle = styled(Typography)({
-  fontSize: "1.5rem",
-  fontWeight: 700,
+  fontSize: FONT_SIZE.CARD_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: 0,
 })
 
 const AudienceDescription = styled(Typography)({
-  fontSize: "0.875rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.BODY,
+  color: TEXT_COLOR.SECONDARY,
   margin: 0,
-  lineHeight: 1.6,
+  lineHeight: LINE_HEIGHT.NORMAL,
 })
 
 const AudienceFeatures = styled("ul")({
@@ -200,8 +222,8 @@ const AudienceFeature = styled("li")({
   display: "flex",
   alignItems: "center",
   gap: "0.75rem",
-  fontSize: "0.875rem",
+  fontSize: FONT_SIZE.SMALL,
   "& .material-symbols-outlined": {
-    fontSize: "1.125rem",
+    fontSize: FONT_SIZE.BODY,
   },
 })

--- a/frontend/src/pages/LandingPage/components/CTA.tsx
+++ b/frontend/src/pages/LandingPage/components/CTA.tsx
@@ -2,6 +2,16 @@ import { useNavigate } from "react-router-dom"
 
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  TEXT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+  ACCENT_COLOR,
+  BUTTON_BASE,
+} from "pages/LandingPage/constants"
+
 export const CTA = () => {
   const navigate = useNavigate()
 
@@ -45,11 +55,11 @@ const Container = styled(Box)({
 })
 
 const CTAWrapper = styled(Box)({
-  backgroundColor: "#2563eb",
+  backgroundColor: ACCENT_COLOR.PRIMARY.bg,
   borderRadius: 24,
   padding: "3rem",
   textAlign: "center",
-  color: "white",
+  color: TEXT_COLOR.PRIMARY,
   position: "relative",
   overflow: "hidden",
 })
@@ -62,7 +72,7 @@ const CTAGlow1 = styled(Box)({
   filter: "blur(60px)",
   top: 0,
   right: 0,
-  backgroundColor: "rgba(255, 255, 255, 0.1)",
+  backgroundColor: "rgba(37, 99, 235, 0.08)",
   transform: "translate(30%, -30%)",
 })
 
@@ -74,23 +84,23 @@ const CTAGlow2 = styled(Box)({
   filter: "blur(60px)",
   bottom: 0,
   left: 0,
-  backgroundColor: "rgba(13, 148, 136, 0.2)",
+  backgroundColor: ACCENT_COLOR.CYAN.bg,
   transform: "translate(-30%, 30%)",
 })
 
 const CTATitle = styled(Typography)({
-  fontSize: "2.5rem",
-  fontWeight: 900,
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: "0 0 1.5rem",
   position: "relative",
   zIndex: 10,
 })
 
 const CTADescription = styled(Typography)({
-  color: "rgba(255, 255, 255, 0.8)",
+  color: TEXT_COLOR.SECONDARY,
   maxWidth: 600,
   margin: "0 auto 2.5rem",
-  fontSize: "1.125rem",
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
   position: "relative",
   zIndex: 10,
 })
@@ -107,37 +117,27 @@ const CTAButtons = styled(Box)({
   },
 })
 
-const CTAPrimaryButton = styled("button")({
-  backgroundColor: "white",
-  color: "#2563eb",
-  fontWeight: 900,
+const ctaButtonBase = {
+  ...BUTTON_BASE,
   height: 56,
   padding: "0 2.5rem",
   borderRadius: 12,
-  border: "none",
-  cursor: "pointer",
-  transition: "background-color 0.2s",
-  "&:hover": {
-    backgroundColor: "#f3f4f6",
-  },
-})
-
-const CTASecondaryLink = styled("a")({
-  backgroundColor: "rgba(19, 91, 236, 0.5)",
-  backdropFilter: "blur(8px)",
-  border: "1px solid rgba(255, 255, 255, 0.3)",
-  color: "white",
-  fontWeight: 900,
-  height: 56,
-  padding: "0 2.5rem",
-  borderRadius: 12,
-  cursor: "pointer",
-  transition: "background-color 0.2s",
   textDecoration: "none",
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
+} as const
+
+const CTAPrimaryButton = styled("button")({
+  ...ctaButtonBase,
+})
+
+const CTASecondaryLink = styled("a")({
+  ...ctaButtonBase,
+  backgroundColor: BG_COLOR.WHITE,
+  color: TEXT_COLOR.ACCENT,
+  border: `1px solid ${BORDER_COLOR.DEFAULT}`,
   "&:hover": {
-    backgroundColor: "rgba(19, 91, 236, 0.6)",
+    backgroundColor: "#f3f4f6",
   },
 })

--- a/frontend/src/pages/LandingPage/components/Features.tsx
+++ b/frontend/src/pages/LandingPage/components/Features.tsx
@@ -1,12 +1,23 @@
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LINE_HEIGHT,
+  TEXT_COLOR,
+  ACCENT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+  ICON_BOX,
+} from "pages/LandingPage/constants"
+
 interface Feature {
   icon: string
   title: string
   description: string
   image: string
   imageAlt: string
-  iconColor: "primary" | "magenta" | "green" | "yellow"
+  iconColor: "PRIMARY" | "MAGENTA" | "GREEN" | "YELLOW"
 }
 
 const features: Feature[] = [
@@ -14,46 +25,49 @@ const features: Feature[] = [
     icon: "account_tree",
     title: "Visual Workflow Builder",
     description:
-      "Drag algorithm nodes onto a blank workflow, connect them visually, and configure parameters via a sidebar panel with text fields, dropdowns, and toggles. Run pipelines with one click.",
+      "Drag algorithm nodes onto a blank workflow, connect them " +
+      "visually, and configure parameters via a sidebar panel " +
+      "with text fields, dropdowns, and toggles. Run pipelines " +
+      "with one click.",
     image: "/images/landing-page/visualize_workflow_builder.png",
     imageAlt: "Visual Workflow Builder",
-    iconColor: "primary",
+    iconColor: "PRIMARY",
   },
   {
     icon: "analytics",
     title: "Rich Visualization",
     description:
-      "Heatmaps, time series, scatter plots, bar charts, histograms, and more. Customize colors, export publication-ready figures.",
+      "Heatmaps, time series, scatter plots, bar charts, " +
+      "histograms, and more. Customize colors, export " +
+      "publication-ready figures.",
     image: "/images/landing-page/rich_visualization.png",
     imageAlt: "Rich Visualization",
-    iconColor: "magenta",
+    iconColor: "MAGENTA",
   },
   {
     icon: "frame_inspect",
     title: "Cell ROI Analysis Tools",
     description:
-      "View, select, and analyze cell ROI overlaid on images. Perfect for calcium imaging and spatial analysis workflows.",
+      "View, select, and analyze cell ROI overlaid on images. " +
+      "Perfect for calcium imaging and spatial analysis " +
+      "workflows.",
     image: "/images/landing-page/roi_analysis_tools.png",
     imageAlt: "Cell ROI Analysis Tools",
-    iconColor: "green",
+    iconColor: "GREEN",
   },
   {
     icon: "science",
     title: "Experiment Management",
     description:
-      "Track all analysis workflows and results. Compare approaches. Re-run past analyses instantly. Export data to NWB (Neurodata Without Borders) or download workflow configs.",
+      "Track all analysis workflows and results. Compare " +
+      "approaches. Re-run past analyses instantly. Export data " +
+      "to NWB (Neurodata Without Borders) or download " +
+      "workflow configs.",
     image: "/images/landing-page/experiment_management.png",
     imageAlt: "Experiment Management",
-    iconColor: "yellow",
+    iconColor: "YELLOW",
   },
 ]
-
-const iconColors = {
-  primary: "#2563eb",
-  magenta: "#e11d48",
-  green: "#059669",
-  yellow: "#d97706",
-}
 
 export const Features = () => {
   return (
@@ -63,13 +77,15 @@ export const Features = () => {
           <SectionLabel>
             <span
               className="material-symbols-outlined"
-              style={{ fontSize: "1.25rem" }}
+              style={{ fontSize: FONT_SIZE.CARD_TITLE }}
             >
               widgets
             </span>
             Features
           </SectionLabel>
-          <SectionTitleLeft>Everything You Need to Analyze</SectionTitleLeft>
+          <SectionTitleCenter>
+            Everything You Need to Analyze
+          </SectionTitleCenter>
           <SectionDescription>
             Powerful tools that make complex data analysis accessible to
             everyone.
@@ -80,12 +96,16 @@ export const Features = () => {
             <FeatureCard key={index}>
               <FeatureContent>
                 <FeatureHeader>
-                  <span
-                    className="material-symbols-outlined"
-                    style={{ color: iconColors[feature.iconColor] }}
+                  <FeatureIcon
+                    style={{
+                      backgroundColor: ACCENT_COLOR[feature.iconColor].bg,
+                      color: ACCENT_COLOR[feature.iconColor].color,
+                    }}
                   >
-                    {feature.icon}
-                  </span>
+                    <span className="material-symbols-outlined">
+                      {feature.icon}
+                    </span>
+                  </FeatureIcon>
                   <FeatureTitle>{feature.title}</FeatureTitle>
                 </FeatureHeader>
                 <FeatureDescription>{feature.description}</FeatureDescription>
@@ -116,31 +136,38 @@ const FeaturesHeader = styled(Box)({
   flexDirection: "column",
   gap: "1rem",
   marginBottom: "4rem",
-  maxWidth: 700,
+  textAlign: "center",
 })
 
 const SectionLabel = styled(Box)({
   display: "inline-flex",
+  alignSelf: "flex-start",
   alignItems: "center",
   gap: "0.5rem",
-  backgroundColor: "rgba(37, 99, 235, 0.1)",
-  color: "#2563eb",
-  fontWeight: 700,
-  fontSize: "0.875rem",
+  backgroundColor: ACCENT_COLOR.PRIMARY.bg,
+  color: TEXT_COLOR.ACCENT,
+  fontWeight: FONT_WEIGHT.BOLD,
+  fontSize: FONT_SIZE.SMALL,
   padding: "0.5rem 1rem",
   borderRadius: 9999,
   width: "fit-content",
 })
 
-const SectionTitleLeft = styled(Typography)({
-  fontSize: "2.5rem",
-  fontWeight: 900,
+const SectionTitleCenter = styled(Typography)({
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: 0,
+  textAlign: "center",
 })
 
 const SectionDescription = styled(Typography)({
-  color: "#6b7280",
+  color: TEXT_COLOR.SECONDARY,
   margin: 0,
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
+  textAlign: "center",
+  maxWidth: 600,
+  marginLeft: "auto",
+  marginRight: "auto",
 })
 
 const FeaturesGrid = styled(Box)({
@@ -153,16 +180,12 @@ const FeaturesGrid = styled(Box)({
 })
 
 const FeatureCard = styled(Box)({
-  backgroundColor: "white",
-  border: "1px solid #e5e7eb",
+  backgroundColor: BG_COLOR.WHITE,
+  border: `1px solid ${BORDER_COLOR.DEFAULT}`,
   borderRadius: 12,
   overflow: "hidden",
   display: "flex",
   flexDirection: "column",
-  transition: "box-shadow 0.3s",
-  "&:hover": {
-    boxShadow: "0 20px 40px -12px rgba(0, 0, 0, 0.1)",
-  },
 })
 
 const FeatureContent = styled(Box)({
@@ -172,32 +195,34 @@ const FeatureContent = styled(Box)({
   gap: "0.5rem",
 })
 
+const FeatureIcon = styled(Box)({ ...ICON_BOX })
+
 const FeatureHeader = styled(Box)({
   display: "flex",
-  alignItems: "center",
+  alignItems: "flex-start",
   gap: "0.75rem",
   marginBottom: "0.5rem",
 })
 
 const FeatureTitle = styled(Typography)({
-  fontSize: "1.25rem",
-  fontWeight: 700,
+  fontSize: FONT_SIZE.CARD_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: 0,
 })
 
 const FeatureDescription = styled(Typography)({
-  fontSize: "0.875rem",
-  color: "#6b7280",
-  lineHeight: 1.6,
+  fontSize: FONT_SIZE.BODY,
+  color: TEXT_COLOR.SECONDARY,
+  lineHeight: LINE_HEIGHT.NORMAL,
   margin: 0,
 })
 
 const FeatureVisual = styled(Box)({
-  backgroundColor: "#f9fafb",
+  backgroundColor: BG_COLOR.CARD,
   height: 256,
   margin: "0 1.5rem 1.5rem",
   borderRadius: 8,
-  border: "1px solid #e5e7eb",
+  border: `1px solid ${BORDER_COLOR.DEFAULT}`,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",

--- a/frontend/src/pages/LandingPage/components/Footer.tsx
+++ b/frontend/src/pages/LandingPage/components/Footer.tsx
@@ -1,5 +1,15 @@
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LINE_HEIGHT,
+  LETTER_SPACING,
+  TEXT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+} from "pages/LandingPage/constants"
+
 export const Footer = () => {
   return (
     <FooterWrapper>
@@ -53,8 +63,8 @@ export const Footer = () => {
 }
 
 const FooterWrapper = styled("footer")({
-  backgroundColor: "white",
-  borderTop: "1px solid #e5e7eb",
+  backgroundColor: BG_COLOR.WHITE,
+  borderTop: `1px solid ${BORDER_COLOR.DEFAULT}`,
   padding: "3rem 0",
 })
 
@@ -84,21 +94,21 @@ const LogoIcon = styled(Box)({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  color: "#2563eb",
+  color: TEXT_COLOR.ACCENT,
 })
 
 const LogoText = styled(Typography)({
-  fontSize: "1.25rem",
-  fontWeight: 700,
-  letterSpacing: "-0.025em",
+  fontSize: FONT_SIZE.CARD_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
+  letterSpacing: LETTER_SPACING.TIGHT,
 })
 
 const FooterDescription = styled(Typography)({
-  fontSize: "0.875rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
   margin: "1rem 0",
   maxWidth: 400,
-  lineHeight: 1.6,
+  lineHeight: LINE_HEIGHT.NORMAL,
 })
 
 const FooterSocial = styled(Box)({
@@ -107,17 +117,17 @@ const FooterSocial = styled(Box)({
 })
 
 const SocialLink = styled("a")({
-  color: "#6b7280",
+  color: TEXT_COLOR.SECONDARY,
   transition: "color 0.2s",
   "&:hover": {
-    color: "#2563eb",
+    color: TEXT_COLOR.ACCENT,
   },
 })
 
 const FooterBottom = styled(Box)({
   marginTop: "2rem",
   paddingTop: "1.5rem",
-  borderTop: "1px solid #e5e7eb",
+  borderTop: `1px solid ${BORDER_COLOR.DEFAULT}`,
   display: "flex",
   flexDirection: "column",
   gap: "0.5rem",
@@ -126,12 +136,12 @@ const FooterBottom = styled(Box)({
 })
 
 const FooterAttribution = styled(Typography)({
-  fontSize: "0.75rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
   fontStyle: "italic",
 })
 
 const FooterCopyright = styled(Typography)({
-  fontSize: "0.75rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
 })

--- a/frontend/src/pages/LandingPage/components/FormatMarquee.tsx
+++ b/frontend/src/pages/LandingPage/components/FormatMarquee.tsx
@@ -1,5 +1,12 @@
 import { Box, styled, Typography, keyframes } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  TEXT_COLOR,
+  BG_COLOR,
+} from "pages/LandingPage/constants"
+
 const formats = [
   "HDF5",
   "MATLAB",
@@ -42,7 +49,7 @@ const marqueeScroll = keyframes`
 `
 
 const MarqueeSection = styled("section")({
-  backgroundColor: "#1f2937",
+  backgroundColor: BG_COLOR.DARK,
   padding: "3rem 0",
   overflow: "hidden",
 })
@@ -54,11 +61,9 @@ const Container = styled(Box)({
 })
 
 const MarqueeLabel = styled(Typography)({
-  color: "#9ca3af",
-  fontSize: "0.75rem",
-  fontWeight: 700,
-  textTransform: "uppercase",
-  letterSpacing: "0.2em",
+  color: TEXT_COLOR.MARQUEE_LABEL,
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   textAlign: "center",
   margin: "0 0 2rem",
 })
@@ -80,8 +85,8 @@ const MarqueeContent = styled(Box)({
 })
 
 const MarqueeItem = styled("span")({
-  color: "rgba(255, 255, 255, 0.6)",
-  fontWeight: 900,
-  fontSize: "1.5rem",
+  color: TEXT_COLOR.WHITE_MUTED,
+  fontWeight: FONT_WEIGHT.BLACK,
+  fontSize: FONT_SIZE.DISPLAY_SM,
   padding: "0 2.5rem",
 })

--- a/frontend/src/pages/LandingPage/components/Header.tsx
+++ b/frontend/src/pages/LandingPage/components/Header.tsx
@@ -3,6 +3,16 @@ import { useNavigate } from "react-router-dom"
 
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LETTER_SPACING,
+  TEXT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+  BUTTON_BASE,
+} from "pages/LandingPage/constants"
+
 export const Header = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const navigate = useNavigate()
@@ -72,8 +82,8 @@ const HeaderWrapper = styled("header")({
   top: 0,
   zIndex: 50,
   width: "100%",
-  borderBottom: "1px solid #e5e7eb",
-  backgroundColor: "#E1DEDB",
+  borderBottom: `1px solid ${BORDER_COLOR.DEFAULT}`,
+  backgroundColor: BG_COLOR.HEADER,
   backdropFilter: "blur(12px)",
 })
 
@@ -100,13 +110,13 @@ const LogoIcon = styled(Box)({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  color: "white",
+  color: TEXT_COLOR.WHITE,
 })
 
 const LogoText = styled(Typography)({
-  fontSize: "1.25rem",
-  fontWeight: 700,
-  letterSpacing: "-0.025em",
+  fontSize: FONT_SIZE.CARD_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
+  letterSpacing: LETTER_SPACING.TIGHT,
 })
 
 const Nav = styled("nav")({
@@ -119,13 +129,13 @@ const Nav = styled("nav")({
 })
 
 const NavLink = styled("a")({
-  fontSize: "0.875rem",
-  fontWeight: 500,
-  color: "#111827",
+  fontSize: FONT_SIZE.BODY,
+  fontWeight: FONT_WEIGHT.REGULAR,
+  color: TEXT_COLOR.PRIMARY,
   textDecoration: "none",
   transition: "color 0.2s",
   "&:hover": {
-    color: "#2563eb",
+    color: TEXT_COLOR.ACCENT,
   },
 })
 
@@ -136,7 +146,7 @@ const MobileMenuButton = styled("button")({
   background: "none",
   border: "none",
   cursor: "pointer",
-  color: "#6b7280",
+  color: TEXT_COLOR.SECONDARY,
   "@media (min-width: 768px)": {
     display: "none",
   },
@@ -147,30 +157,20 @@ const MobileNav = styled(Box)({
   flexDirection: "column",
   gap: "1rem",
   padding: "1rem 1.5rem 1.5rem",
-  borderTop: "1px solid #e5e7eb",
-  background: "white",
+  borderTop: `1px solid ${BORDER_COLOR.DEFAULT}`,
+  background: BG_COLOR.WHITE,
 })
 
 const MobileNavLink = styled("a")({
-  fontSize: "1rem",
-  fontWeight: 500,
-  color: "#111827",
+  fontSize: FONT_SIZE.BODY,
+  fontWeight: FONT_WEIGHT.REGULAR,
+  color: TEXT_COLOR.PRIMARY,
   textDecoration: "none",
   padding: "0.5rem 0",
 })
 
 const PrimaryButton = styled("button")({
-  backgroundColor: "#2563eb",
-  color: "white",
-  fontSize: "0.875rem",
-  fontWeight: 700,
+  ...BUTTON_BASE,
   height: 40,
   padding: "0 1.5rem",
-  borderRadius: 8,
-  border: "none",
-  cursor: "pointer",
-  transition: "background-color 0.2s",
-  "&:hover": {
-    backgroundColor: "#1d4ed8",
-  },
 })

--- a/frontend/src/pages/LandingPage/components/Hero.tsx
+++ b/frontend/src/pages/LandingPage/components/Hero.tsx
@@ -2,6 +2,16 @@ import { useNavigate } from "react-router-dom"
 
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LETTER_SPACING,
+  LINE_HEIGHT,
+  TEXT_COLOR,
+  ACCENT_COLOR,
+  BUTTON_BASE,
+} from "pages/LandingPage/constants"
+
 export const Hero = () => {
   const navigate = useNavigate()
 
@@ -33,7 +43,7 @@ export const Hero = () => {
             <Badge>
               <span
                 className="material-symbols-outlined"
-                style={{ color: "#059669" }}
+                style={{ color: ACCENT_COLOR.GREEN.color }}
               >
                 check_circle
               </span>
@@ -42,7 +52,7 @@ export const Hero = () => {
             <Badge>
               <span
                 className="material-symbols-outlined"
-                style={{ color: "#059669" }}
+                style={{ color: ACCENT_COLOR.GREEN.color }}
               >
                 check_circle
               </span>
@@ -90,26 +100,29 @@ const HeroText = styled(Box)({
 })
 
 const Label = styled(Typography)({
-  color: "#2563eb",
-  fontWeight: 700,
-  letterSpacing: "0.1em",
-  fontSize: "0.75rem",
+  color: TEXT_COLOR.ACCENT,
+  fontWeight: FONT_WEIGHT.BOLD,
+  letterSpacing: LETTER_SPACING.WIDE,
+  fontSize: FONT_SIZE.SMALL,
   textTransform: "uppercase",
 })
 
 const HeroTitle = styled("h1")({
-  fontSize: "3rem",
-  fontWeight: 900,
-  lineHeight: 1.1,
-  letterSpacing: "-0.03em",
+  fontSize: FONT_SIZE.HERO_TITLE,
+  fontWeight: FONT_WEIGHT.BLACK,
+  lineHeight: LINE_HEIGHT.TIGHT,
+  letterSpacing: LETTER_SPACING.TIGHT,
   margin: 0,
   "@media (min-width: 768px)": {
-    fontSize: "3.75rem",
+    fontSize: FONT_SIZE.HERO_TITLE_MD,
   },
 })
 
 const GradientText = styled("span")({
-  background: "linear-gradient(135deg, #2563eb 0%, #0d9488 50%, #059669 100%)",
+  background:
+    `linear-gradient(135deg, ${ACCENT_COLOR.PRIMARY.color} 0%, ` +
+    `${ACCENT_COLOR.CYAN.color} 50%, ` +
+    `${ACCENT_COLOR.GREEN.color} 100%)`,
   WebkitBackgroundClip: "text",
   WebkitTextFillColor: "transparent",
   backgroundClip: "text",
@@ -119,30 +132,32 @@ const HeroSubtitle = styled("div")({
   display: "flex",
   alignItems: "center",
   gap: "0.5rem",
-  fontSize: "1.5rem",
-  fontWeight: 500,
-  color: "#4b5563",
+  fontSize: FONT_SIZE.DISPLAY_SM,
+  fontWeight: FONT_WEIGHT.REGULAR,
+  color: TEXT_COLOR.MUTED,
   marginTop: "0.5rem",
   "@media (min-width: 768px)": {
-    fontSize: "2rem",
+    fontSize: FONT_SIZE.HERO_SUBTITLE_MD,
   },
 })
 
 const BrandText = styled("span")({
-  background: "linear-gradient(135deg, #0d9488 0%, #059669 100%)",
+  background:
+    `linear-gradient(135deg, ${ACCENT_COLOR.CYAN.color} 0%, ` +
+    `${ACCENT_COLOR.GREEN.color} 100%)`,
   WebkitBackgroundClip: "text",
   WebkitTextFillColor: "transparent",
   backgroundClip: "text",
-  fontWeight: 800,
-  letterSpacing: "-0.02em",
+  fontWeight: FONT_WEIGHT.BOLD,
+  letterSpacing: LETTER_SPACING.TIGHT,
 })
 
 const HeroDescription = styled(Typography)({
-  fontSize: "1.125rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
+  color: TEXT_COLOR.SECONDARY,
   maxWidth: 500,
   margin: 0,
-  lineHeight: 1.6,
+  lineHeight: LINE_HEIGHT.NORMAL,
 })
 
 const HeroButtons = styled(Box)({
@@ -155,19 +170,9 @@ const HeroButtons = styled(Box)({
 })
 
 const PrimaryButtonLg = styled("button")({
-  backgroundColor: "#2563eb",
-  color: "white",
-  fontWeight: 700,
+  ...BUTTON_BASE,
   height: 48,
   padding: "0 2rem",
-  fontSize: "1rem",
-  borderRadius: 8,
-  border: "none",
-  cursor: "pointer",
-  transition: "background-color 0.2s",
-  "&:hover": {
-    backgroundColor: "#1d4ed8",
-  },
 })
 
 const HeroBadges = styled(Box)({
@@ -181,8 +186,8 @@ const Badge = styled(Box)({
   display: "flex",
   alignItems: "center",
   gap: "0.5rem",
-  fontSize: "0.875rem",
-  color: "#6b7280",
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
 })
 
 const HeroVisual = styled(Box)({

--- a/frontend/src/pages/LandingPage/components/PublicRepository.tsx
+++ b/frontend/src/pages/LandingPage/components/PublicRepository.tsx
@@ -1,4 +1,16 @@
+import { useNavigate } from "react-router-dom"
+
 import { Box, styled, Typography } from "@mui/material"
+
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LINE_HEIGHT,
+  TEXT_COLOR,
+  BG_COLOR,
+  BUTTON_BASE,
+  ICON_BOX,
+} from "pages/LandingPage/constants"
 
 interface Benefit {
   icon: string
@@ -11,41 +23,56 @@ const benefits: Benefit[] = [
     icon: "science",
     title: "Standardized Analysis",
     description:
-      "Share workflows alongside your results so others can replicate your exact methods, eliminating methodological variability between studies.",
+      "Share workflows alongside your results so others can " +
+      "replicate your exact methods, eliminating methodological " +
+      "variability between studies.",
   },
   {
     icon: "compare",
     title: "Objective Comparisons",
     description:
-      "Compare results across labs with confidence—same methods, same parameters, truly comparable outcomes.",
+      "Compare results across labs with confidence\u2014same " +
+      "methods, same parameters, truly comparable outcomes.",
   },
   {
     icon: "group_work",
     title: "Invite Collaborators",
     description:
-      "Invite other labs to analyze their data using your exact workflow and display results side-by-side.",
+      "Invite other labs to analyze their data using your exact " +
+      "workflow and display results side-by-side.",
   },
 ]
 
 export const PublicRepository = () => {
+  const navigate = useNavigate()
+
   return (
     <PublicRepoSection id="public-repository">
       <Container>
+        <SectionHeader>
+          <SectionLabel>
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: FONT_SIZE.CARD_TITLE }}
+            >
+              public
+            </span>
+            Public Repository
+          </SectionLabel>
+          <SectionTitle>Araya OptiNiSt Public Repository</SectionTitle>
+          <SectionSubtitle>
+            Public data repositories exist, but they rarely ensure consistent
+            analysis methods across datasets. Araya OptiNiSt changes that.
+          </SectionSubtitle>
+        </SectionHeader>
         <PublicRepoGrid>
           <PublicRepoContent>
-            <SectionTitleLeft>
-              Araya OptiNiSt Public Repository
-            </SectionTitleLeft>
-            <PublicRepoDescription>
-              Public data repositories exist, but they rarely ensure consistent
-              analysis methods across datasets. Araya OptiNiSt changes that.
-            </PublicRepoDescription>
-            <PublicRepoDescription>
+            <PublicRepoBody>
               Labs can publish their analysis results alongside the exact
               workflows used—allowing other researchers to apply identical
               methods to their own data and contribute to a growing collection
               of directly comparable results.
-            </PublicRepoDescription>
+            </PublicRepoBody>
             <Attribution>
               Built on{" "}
               <a
@@ -81,6 +108,9 @@ export const PublicRepository = () => {
               src="/images/landing-page/optinist_public_repository.png"
               alt="OptiNiSt Public Repository"
             />
+            <RepoButton onClick={() => navigate("/public")}>
+              Explore the Public Repository
+            </RepoButton>
           </PublicRepoVisual>
         </PublicRepoGrid>
       </Container>
@@ -101,7 +131,14 @@ const PublicRepoSection = styled("section")({
     right: 0,
     bottom: 0,
     backgroundImage:
-      "url(\"data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E\")",
+      "url(\"data:image/svg+xml,%3Csvg width='60' height='60' " +
+      "viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'" +
+      "%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg " +
+      "fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath " +
+      "d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4" +
+      "h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H" +
+      "6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g" +
+      "%3E%3C/svg%3E\")",
     opacity: 0.5,
   },
 })
@@ -112,6 +149,44 @@ const Container = styled(Box)({
   padding: "0 1.5rem",
   position: "relative",
   zIndex: 1,
+})
+
+const SectionHeader = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  textAlign: "center",
+  marginBottom: "3rem",
+})
+
+const SectionLabel = styled(Box)({
+  display: "inline-flex",
+  alignSelf: "flex-start",
+  alignItems: "center",
+  gap: "0.5rem",
+  backgroundColor: BG_COLOR.BENEFIT_ICON,
+  color: TEXT_COLOR.WHITE,
+  fontWeight: FONT_WEIGHT.BOLD,
+  fontSize: FONT_SIZE.SMALL,
+  padding: "0.5rem 1rem",
+  borderRadius: 9999,
+  width: "fit-content",
+})
+
+const SectionTitle = styled(Typography)({
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
+  margin: "0 0 1rem",
+  color: TEXT_COLOR.WHITE,
+})
+
+const SectionSubtitle = styled(Typography)({
+  color: TEXT_COLOR.WHITE_SOFT,
+  margin: 0,
+  lineHeight: LINE_HEIGHT.NORMAL,
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
+  maxWidth: 600,
+  marginLeft: "auto",
+  marginRight: "auto",
 })
 
 const PublicRepoGrid = styled(Box)({
@@ -130,29 +205,22 @@ const PublicRepoContent = styled(Box)({
   gap: "1rem",
 })
 
-const SectionTitleLeft = styled(Typography)({
-  fontSize: "2.5rem",
-  fontWeight: 900,
+const PublicRepoBody = styled(Typography)({
+  color: TEXT_COLOR.WHITE_SOFT,
   margin: 0,
-  color: "white",
-})
-
-const PublicRepoDescription = styled(Typography)({
-  color: "rgba(255, 255, 255, 0.85)",
-  margin: 0,
-  lineHeight: 1.7,
-  fontSize: "1.05rem",
+  lineHeight: LINE_HEIGHT.NORMAL,
+  fontSize: FONT_SIZE.BODY,
 })
 
 const Attribution = styled(Typography)({
-  fontSize: "0.8rem",
-  color: "rgba(255, 255, 255, 0.6)",
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.WHITE_MUTED,
   fontStyle: "italic",
   "& a": {
-    color: "rgba(255, 255, 255, 0.8)",
+    color: TEXT_COLOR.WHITE_SOFT,
     textDecoration: "underline",
     "&:hover": {
-      color: "white",
+      color: TEXT_COLOR.WHITE,
     },
   },
 })
@@ -171,32 +239,32 @@ const PublicRepoBenefit = styled(Box)({
 })
 
 const BenefitIcon = styled(Box)({
+  ...ICON_BOX,
   width: 44,
   height: 44,
   borderRadius: 10,
-  backgroundColor: "rgba(255, 255, 255, 0.15)",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  flexShrink: 0,
-  color: "white",
+  backgroundColor: BG_COLOR.BENEFIT_ICON,
+  color: TEXT_COLOR.WHITE,
 })
 
 const BenefitTitle = styled(Typography)({
-  fontWeight: 700,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: "0 0 0.25rem",
-  color: "white",
+  color: TEXT_COLOR.WHITE,
 })
 
 const BenefitDescription = styled(Typography)({
-  fontSize: "0.875rem",
-  color: "rgba(255, 255, 255, 0.8)",
+  fontSize: FONT_SIZE.BODY,
+  color: TEXT_COLOR.WHITE_SOFT,
   margin: 0,
-  lineHeight: 1.5,
+  lineHeight: LINE_HEIGHT.NORMAL,
 })
 
 const PublicRepoVisual = styled(Box)({
   position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
 })
 
 const PublicRepoGlow = styled(Box)({
@@ -213,4 +281,17 @@ const PublicRepoImage = styled("img")({
   height: "auto",
   borderRadius: 12,
   boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+})
+
+const RepoButton = styled("button")({
+  ...BUTTON_BASE,
+  position: "relative",
+  height: 48,
+  padding: "0 2rem",
+  backgroundColor: BG_COLOR.WHITE,
+  color: TEXT_COLOR.ACCENT,
+  marginTop: "1.5rem",
+  "&:hover": {
+    backgroundColor: "#f3f4f6",
+  },
 })

--- a/frontend/src/pages/LandingPage/components/ValueProps.tsx
+++ b/frontend/src/pages/LandingPage/components/ValueProps.tsx
@@ -1,10 +1,21 @@
 import { Box, styled, Typography } from "@mui/material"
 
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  LINE_HEIGHT,
+  TEXT_COLOR,
+  ACCENT_COLOR,
+  BG_COLOR,
+  BORDER_COLOR,
+  ICON_BOX,
+} from "pages/LandingPage/constants"
+
 interface ValueProp {
   icon: string
   title: string
   description: string
-  color: "magenta" | "cyan" | "green" | "yellow"
+  color: "MAGENTA" | "CYAN" | "GREEN" | "YELLOW"
 }
 
 const valueProps: ValueProp[] = [
@@ -12,38 +23,38 @@ const valueProps: ValueProp[] = [
     icon: "drag_pan",
     title: "No Coding Required",
     description:
-      "Build complex analysis pipelines by dragging and dropping. Focus on science, not syntax.",
-    color: "magenta",
+      "Build complex analysis pipelines by dragging and dropping. " +
+      "Focus on science, not syntax.",
+    color: "MAGENTA",
   },
   {
     icon: "neurology",
     title: "NWB-Native",
     description:
-      "First-class support for NWB (Neurodata Without Borders). Import, analyze, and export in the standard format for neurophysiology data.",
-    color: "cyan",
+      "First-class support for NWB (Neurodata Without Borders). " +
+      "Import, analyze, and export in the standard format " +
+      "for neurophysiology data.",
+    color: "CYAN",
   },
   {
     icon: "analytics",
     title: "Complete Analysis Toolkit",
     description:
-      "From visual pipeline building to rich visualization and ROI analysis — everything you need to go from raw data to publishable results.",
-    color: "green",
+      "From visual pipeline building to rich visualization and " +
+      "ROI analysis \u2014 everything you need to go from raw " +
+      "data to publishable results.",
+    color: "GREEN",
   },
   {
     icon: "public",
     title: "Share & Collaborate",
     description:
-      "Share workspaces, publish analysis results, and let other labs reproduce your exact methods. Grow a community around comparable science.",
-    color: "yellow",
+      "Share workspaces, publish analysis results, and let other " +
+      "labs reproduce your exact methods. Grow a community " +
+      "around comparable science.",
+    color: "YELLOW",
   },
 ]
-
-const iconColors = {
-  magenta: { bg: "rgba(225, 29, 72, 0.1)", color: "#e11d48" },
-  cyan: { bg: "rgba(13, 148, 136, 0.1)", color: "#0d9488" },
-  green: { bg: "rgba(5, 150, 105, 0.1)", color: "#059669" },
-  yellow: { bg: "rgba(217, 119, 6, 0.1)", color: "#d97706" },
-}
 
 export const ValueProps = () => {
   return (
@@ -57,15 +68,17 @@ export const ValueProps = () => {
         <ValueGrid>
           {valueProps.map((prop, index) => (
             <ValueCard key={index}>
-              <ValueIcon
-                style={{
-                  backgroundColor: iconColors[prop.color].bg,
-                  color: iconColors[prop.color].color,
-                }}
-              >
-                <span className="material-symbols-outlined">{prop.icon}</span>
-              </ValueIcon>
-              <ValueTitle>{prop.title}</ValueTitle>
+              <ValueHeader>
+                <ValueIcon
+                  style={{
+                    backgroundColor: ACCENT_COLOR[prop.color].bg,
+                    color: ACCENT_COLOR[prop.color].color,
+                  }}
+                >
+                  <span className="material-symbols-outlined">{prop.icon}</span>
+                </ValueIcon>
+                <ValueTitle>{prop.title}</ValueTitle>
+              </ValueHeader>
               <ValueDescription>{prop.description}</ValueDescription>
             </ValueCard>
           ))}
@@ -76,7 +89,7 @@ export const ValueProps = () => {
 }
 
 const ValuePropsSection = styled("section")({
-  backgroundColor: "white",
+  backgroundColor: BG_COLOR.WHITE,
   padding: "5rem 0",
 })
 
@@ -87,15 +100,16 @@ const Container = styled(Box)({
 })
 
 const SectionTitle = styled(Typography)({
-  fontSize: "1.875rem",
-  fontWeight: 700,
+  fontSize: FONT_SIZE.SECTION_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: "0 0 1rem",
   textAlign: "center",
 })
 
 const SectionSubtitle = styled(Typography)({
   textAlign: "center",
-  color: "#6b7280",
+  color: TEXT_COLOR.SECONDARY,
+  fontSize: FONT_SIZE.SECTION_SUBTITLE,
   margin: "0 0 3rem",
   maxWidth: 600,
   marginLeft: "auto",
@@ -117,37 +131,28 @@ const ValueGrid = styled(Box)({
 const ValueCard = styled(Box)({
   padding: "2rem",
   borderRadius: 12,
-  border: "1px solid #e5e7eb",
-  backgroundColor: "#f9fafb",
-  transition: "box-shadow 0.3s",
-  "&:hover": {
-    boxShadow: "0 20px 40px -12px rgba(0, 0, 0, 0.1)",
-  },
+  border: `1px solid ${BORDER_COLOR.DEFAULT}`,
+  backgroundColor: BG_COLOR.CARD,
 })
 
-const ValueIcon = styled(Box)({
-  width: 48,
-  height: 48,
-  borderRadius: 8,
+const ValueHeader = styled(Box)({
   display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  marginBottom: "1.5rem",
-  transition: "transform 0.3s",
-  "& .material-symbols-outlined": {
-    fontSize: "1.875rem",
-  },
+  alignItems: "flex-start",
+  gap: "0.75rem",
+  marginBottom: "0.75rem",
 })
+
+const ValueIcon = styled(Box)({ ...ICON_BOX })
 
 const ValueTitle = styled(Typography)({
-  fontSize: "1.25rem",
-  fontWeight: 700,
+  fontSize: FONT_SIZE.CARD_TITLE,
+  fontWeight: FONT_WEIGHT.BOLD,
   margin: "0 0 0.75rem",
 })
 
 const ValueDescription = styled(Typography)({
-  fontSize: "0.875rem",
-  color: "#6b7280",
-  lineHeight: 1.6,
+  fontSize: FONT_SIZE.BODY,
+  color: TEXT_COLOR.SECONDARY,
+  lineHeight: LINE_HEIGHT.NORMAL,
   margin: 0,
 })

--- a/frontend/src/pages/LandingPage/constants.ts
+++ b/frontend/src/pages/LandingPage/constants.ts
@@ -1,0 +1,100 @@
+// Typography scale
+export const FONT_SIZE = {
+  HERO_TITLE: "3rem",
+  HERO_TITLE_MD: "3.75rem",
+  DISPLAY_SM: "1.5rem",
+  HERO_SUBTITLE_MD: "2rem",
+  SECTION_TITLE: "2rem",
+  SECTION_SUBTITLE: "1.125rem",
+  CARD_TITLE: "1.25rem",
+  BODY: "1rem",
+  SMALL: "0.875rem",
+  ICON_LG: "1.875rem",
+} as const
+
+// Font weights
+export const FONT_WEIGHT = {
+  REGULAR: 400,
+  BOLD: 700,
+  BLACK: 900,
+} as const
+
+// Line heights
+export const LINE_HEIGHT = {
+  TIGHT: 1.1,
+  NORMAL: 1.6,
+} as const
+
+// Letter spacing
+export const LETTER_SPACING = {
+  TIGHT: "-0.025em",
+  WIDE: "0.1em",
+} as const
+
+// Text colors
+export const TEXT_COLOR = {
+  PRIMARY: "#111827",
+  SECONDARY: "#6b7280",
+  MUTED: "#4b5563",
+  ACCENT: "#2563eb",
+  MARQUEE_LABEL: "#9ca3af",
+  WHITE: "white",
+  WHITE_SOFT: "rgba(255, 255, 255, 0.85)",
+  WHITE_MUTED: "rgba(255, 255, 255, 0.6)",
+} as const
+
+// Accent colors (for icons and highlights)
+export const ACCENT_COLOR = {
+  PRIMARY: { bg: "rgba(37, 99, 235, 0.1)", color: "#2563eb" },
+  MAGENTA: { bg: "rgba(225, 29, 72, 0.1)", color: "#e11d48" },
+  CYAN: { bg: "rgba(13, 148, 136, 0.1)", color: "#0d9488" },
+  GREEN: { bg: "rgba(5, 150, 105, 0.1)", color: "#059669" },
+  YELLOW: { bg: "rgba(217, 119, 6, 0.1)", color: "#d97706" },
+} as const
+
+// Background colors
+export const BG_COLOR = {
+  PAGE: "#f9fafb",
+  CARD: "#f9fafb",
+  WHITE: "white",
+  HEADER: "#E1DEDB",
+  DARK: "#1f2937",
+  BUTTON_PRIMARY: "#2563eb",
+  BUTTON_PRIMARY_HOVER: "#1d4ed8",
+  BENEFIT_ICON: "rgba(255, 255, 255, 0.15)",
+} as const
+
+// Borders
+export const BORDER_COLOR = {
+  DEFAULT: "#e5e7eb",
+} as const
+
+// Shared icon container style (48x48 rounded square)
+export const ICON_BOX = {
+  width: 48,
+  height: 48,
+  borderRadius: 8,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+  "& .material-symbols-outlined": {
+    fontSize: FONT_SIZE.ICON_LG,
+  },
+} as const
+
+// Shared button base style
+export const BUTTON_BASE = {
+  fontFamily: "inherit",
+  fontSize: FONT_SIZE.BODY,
+  fontWeight: FONT_WEIGHT.REGULAR,
+  borderRadius: 8,
+  border: "none",
+  cursor: "pointer",
+  transition: "background-color 0.2s",
+  backgroundColor: BG_COLOR.BUTTON_PRIMARY,
+  color: TEXT_COLOR.WHITE,
+  "&:hover": {
+    backgroundColor: BG_COLOR.BUTTON_PRIMARY_HOVER,
+  },
+} as const

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -153,6 +153,10 @@ class RemoteSyncStatusFileUtil:
             workspace_id, unique_id
         )
 
+        os.makedirs(
+            os.path.dirname(remote_sync_status_file_path),
+            exist_ok=True,
+        )
         with open(remote_sync_status_file_path, "w") as f:
             sync_status_data = {
                 "remote_bucket_name": remote_bucket_name,
@@ -312,6 +316,10 @@ class RemoteSyncLockFileUtil:
             workspace_id, unique_id
         )
 
+        os.makedirs(
+            os.path.dirname(remote_sync_lock_file_path),
+            exist_ok=True,
+        )
         with open(remote_sync_lock_file_path, "w") as f:
             file_data = {
                 "workspace_id": workspace_id,


### PR DESCRIPTION
## Summary

### Problem

The landing page had inconsistent typography across sections. Font sizes, weights, line heights, and card layouts varied between components with no clear design system, making the page feel disjointed.

13 different font sizes were in use, with no clear hierarchy:

| Size (rem) | ~px   | Usage                                          |
|------------|-------|-------------------------------------------------|
| 0.75       | 12px  | Labels, attribution, copyright, marquee label   |
| 0.8        | ~13px | PublicRepository attribution (italic)            |
| 0.875      | 14px  | Nav links, buttons, card descriptions            |
| 1          | 16px  | Mobile nav links, Hero "Get Started" button      |
| 1.05       | ~17px | PublicRepository description                     |
| 1.125      | 18px  | Hero description, CTA description, check icons   |
| 1.25       | 20px  | Logo text, card titles (ValueProps, Features)    |
| 1.5        | 24px  | Hero subtitle, marquee, Audience card title      |
| 1.875      | 30px  | Section titles (ValueProps, Audience), icons      |
| 2          | 32px  | Hero subtitle (desktop @md)                      |
| 2.5        | 40px  | Section titles (Features, PublicRepo, CTA)        |
| 3          | 48px  | Hero h1 (mobile)                                 |
| 3.75       | 60px  | Hero h1 (desktop @md)                            |

4 font weights used inconsistently:

| Weight | Usage                                              |
|--------|----------------------------------------------------|
| 500    | Nav links, Hero subtitle                           |
| 700    | Logo, labels, section titles, card titles, buttons |
| 800    | Brand text "OptiNiSt" in Hero                      |
| 900    | Hero h1, Features/PublicRepo/CTA titles, marquee   |

Other inconsistencies:
- Card icons placed above the title in some sections, inline in others
- Card icons in Features had no container box while ValueProps and Audience had styled icon containers
- Line heights varied (1.5, 1.6, 1.7) across similar elements
- Letter spacing had 4 nearly identical negative values (-0.03, -0.025, -0.02em)
- Cards had decorative hover shadows with no interactive purpose
- "Get Started" buttons had different sizes, weights, and colors across sections
- Nav links were smaller than button text in the header
- CTA background was the same blue as the button, making it invisible
- PublicRepository title was left-aligned inside the grid instead of centered above it
- Only Features had a section label pill; Audience and PublicRepository had none
- No centralized constants file; all values were inline magic numbers

### Solution

Created a centralized design system in `constants.ts` and applied it consistently across all 9 landing page components.

**Files:**
- `frontend/src/pages/LandingPage/constants.ts` (new)
- `frontend/src/pages/LandingPage/components/Audience.tsx`
- `frontend/src/pages/LandingPage/components/CTA.tsx`
- `frontend/src/pages/LandingPage/components/Features.tsx`
- `frontend/src/pages/LandingPage/components/Footer.tsx`
- `frontend/src/pages/LandingPage/components/FormatMarquee.tsx`
- `frontend/src/pages/LandingPage/components/Header.tsx`
- `frontend/src/pages/LandingPage/components/Hero.tsx`
- `frontend/src/pages/LandingPage/components/PublicRepository.tsx`
- `frontend/src/pages/LandingPage/components/ValueProps.tsx`

**Centralized constants (constants.ts):**

All typography, colors, and shared styles extracted into a single file.
Consolidated duplicate tokens during extraction:

- FONT_SIZE: 13 inline values -> 10 named tokens (merged BUTTON+ICON_SM into BODY, HERO_SUBTITLE+MARQUEE_ITEM into DISPLAY_SM)
- FONT_WEIGHT: 4 values -> 3 (merged EXTRA_BOLD 800 into BOLD 700)
- LINE_HEIGHT: 3 values -> 2 (merged 1.5/1.7 into NORMAL 1.6)
- LETTER_SPACING: 4 values -> 2 (merged TIGHT/SLIGHTLY_TIGHT/BRAND into TIGHT -0.025em)
- TEXT_COLOR: merged WHITE_85/WHITE_80 into WHITE_SOFT, WHITE_60 into WHITE_MUTED
- Shared style objects: ICON_BOX (48x48 rounded square), BUTTON_BASE (font, color, hover)

**Unified type scale:**

| Role              | Token            | Size      | Weight |
|------------|-------------|-----------|--------|
| Hero h1           | HERO_TITLE(_MD)  | 3/3.75rem | 900        |
| Hero subtitle     | DISPLAY_SM(_MD)  | 1.5/2rem  | 400      |
| Section titles    | SECTION_TITLE    | 2rem      | 700            |
| Section subtitles | SECTION_SUBTITLE | 1.125rem  | 400    |
| Marquee items     | DISPLAY_SM       | 1.5rem    | 900    |
| Card titles/Logo  | CARD_TITLE       | 1.25rem   | 700    |
| Card descriptions | BODY             | 1rem      | 400    |
| Buttons/Body      | BODY             | 1rem      | 400    |
| Small text/Labels | SMALL            | 0.875rem  | 400    |

**Changes by category:**

1. **Constants file created** (`constants.ts`): centralized all typography (FONT_SIZE, FONT_WEIGHT, LINE_HEIGHT, LETTER_SPACING), colors (TEXT_COLOR, ACCENT_COLOR, BG_COLOR, BORDER_COLOR), and shared styles (ICON_BOX, BUTTON_BASE). All 9 components rewritten to import from this file

2. **Section titles unified** (Features, PublicRepository, CTA, FormatMarquee): all set to SECTION_TITLE (2rem) / BOLD / centered

3. **Section subtitles unified** (Hero description, ValueProps, Features, Audience, PublicRepository, CTA): all set to SECTION_SUBTITLE (1.125rem) / centered with maxWidth 600

4. **Section label pills added** (Audience, PublicRepository): added icon+text pill badges matching Features style. All three pills are left-aligned (alignSelf: flex-start) above their centered titles. PublicRepository pill uses translucent white for dark background

5. **Card titles unified** (Audience): 1.5rem -> CARD_TITLE (1.25rem)

6. **Card descriptions unified** (ValueProps, Features, Audience, PublicRepository): SMALL (0.875rem) -> BODY (1rem) for better readability

7. **Card icon layout unified** (ValueProps, Audience): icons moved from above-title to inline-with-title, matching Features. Audience icon changed from 56px circle to 48px rounded square using ICON_BOX

8. **Card icon containers unified** (Features): added FeatureIcon styled component using ICON_BOX with colored backgrounds

9. **Nav links unified** (Header): SMALL (0.875rem) -> BODY (1rem) to match Get Started button size

10. **Buttons unified**: all Get Started buttons (Header, Hero, CTA) share BUTTON_BASE (1rem, weight 400, fontFamily inherit, bluebg/white text). CTA buttons extracted shared ctaButtonBase

11. **CTA section restyled**: background changed from solid blue (BG_COLOR.BUTTON_PRIMARY) to light blue (ACCENT_COLOR.PRIMARY.bg, 10% opacity) so the Get Started button is visible. Text changed to dark. View Documentation button gained a border for definition

12. **PublicRepository layout restructured**: title and first description centered above the grid. Added "Explore the Public Repository" button below the image, linking to /public

13. **Font weights consolidated**: merged 500 -> 400, merged 800 -> 700. 3 tiers: REGULAR (400), BOLD (700), BLACK (900)

14. **Letter spacing consolidated**: 4 values -> 2. TIGHT (-0.025em) and WIDE (0.1em)

15. **Hover shadows removed** (ValueProps, Features, Audience cards)

16. **Dead code removed**: unused Label styled component in Audience.tsx

------------------------------------------------

### Before:
<img width="1267" height="732" alt="Current_LP1" src="https://github.com/user-attachments/assets/bf73516b-158c-4caa-af2b-aa75c035ed6a" />
<img width="1221" height="607" alt="Current_LP2" src="https://github.com/user-attachments/assets/150a2e3c-1cdf-419f-9a84-571770282f52" />
<img width="1215" height="696" alt="Current_LP3" src="https://github.com/user-attachments/assets/16d13380-4f82-4196-b024-2e399b086fa1" />
<img width="1268" height="667" alt="Current_LP4" src="https://github.com/user-attachments/assets/a7ee1f1a-8aa7-4362-adb7-2d4625eea21c" />
<img width="1258" height="670" alt="Current_LP5" src="https://github.com/user-attachments/assets/85d42e91-248d-4491-84c1-3373d39bbab4" />
<img width="1226" height="628" alt="Current_LP6" src="https://github.com/user-attachments/assets/80aa547c-d91e-4745-808b-9b2390eb1bf1" />

### After:
<img width="1229" height="689" alt="New_LP1" src="https://github.com/user-attachments/assets/09dcbe5b-ed1a-4be1-99bd-9a3ec872eb14" />
<img width="1246" height="635" alt="New_LP2" src="https://github.com/user-attachments/assets/44e7f6ba-234a-4941-83a1-faf92784df94" />
<img width="1206" height="714" alt="New_LP3" src="https://github.com/user-attachments/assets/be5481c2-f112-49cf-94e8-fd8f5107cef4" />
<img width="1229" height="613" alt="New_LP4" src="https://github.com/user-attachments/assets/ad1c2a6d-886e-473c-96b3-14aa2316ef5b" />
<img width="1185" height="678" alt="New_LP5" src="https://github.com/user-attachments/assets/0adda77e-af20-4e8b-980e-2afa8f64afdf" />
<img width="1223" height="430" alt="New_LP6" src="https://github.com/user-attachments/assets/b7bfadd4-4726-4288-91db-d4ac9705d968" />
