### PR TITLE
Premium middleware, efs mount path, add tests

### DIFF
--- a/frontend/src/components/Premium/PremiumAssignmentManager.tsx
+++ b/frontend/src/components/Premium/PremiumAssignmentManager.tsx
@@ -5,27 +5,12 @@
  * Assignment logic is handled by PremiumAssignmentContext.
  */
 
-import { FC, useEffect, useRef } from "react"
+import { FC, useEffect } from "react"
 
 import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
 const PremiumAssignmentManager: FC = () => {
-  const { isPremiumUser, release, assignmentResult, error } =
-    usePremiumAssignment()
-
-  // Use ref to store the release function to avoid dependency issues
-  const releaseRef = useRef(release)
-  releaseRef.current = release
-
-  // Handle cleanup on component unmount (app close/logout)
-  useEffect(() => {
-    return () => {
-      if (isPremiumUser) {
-        // Don't await this - just fire and forget on unmount
-        releaseRef.current()
-      }
-    }
-  }, [isPremiumUser]) // Only depend on isPremiumUser, not the release function
+  const { assignmentResult, error } = usePremiumAssignment()
 
   // Log assignment status for debugging
   useEffect(() => {

--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -18,45 +18,28 @@ const PremiumNotificationManager: FC = () => {
   const [hasShownAssignmentSuccess, setHasShownAssignmentSuccess] =
     useState(false)
   const [hasShownError, setHasShownError] = useState(false)
-  const [hasShownTempAssignmentWarning, setHasShownTempAssignmentWarning] =
-    useState(false)
   const [lastAssignmentId, setLastAssignmentId] = useState<string | null>(null)
 
   // Store keys for dismissible notifications
-  const tempAssignmentKeyRef = useRef<string | number | null>(null)
-  const scalingKeyRef = useRef<string | number | null>(null)
+  const waitingKeyRef = useRef<string | number | null>(null)
+
+  const hasDedicatedInstance =
+    assignmentResult?.assigned && !assignmentResult?.is_shared
 
   // Show success notification when premium instance is assigned
   useEffect(() => {
-    // Show success when:
-    // 1. User has a premium assignment (assigned=true, is_shared=false)
-    // 2. Has an instance_id
-    // 3. Either: never shown before OR different instance than last time
-    // OR transitioning from temp
-    const isPremiumInstance =
-      assignmentResult?.assigned && !assignmentResult?.is_shared
     const hasNewInstance = assignmentResult?.instance_id !== lastAssignmentId
-    const isTransitioningFromTemp =
-      hasShownTempAssignmentWarning && !hasShownAssignmentSuccess
+    const wasWaiting = waitingKeyRef.current !== null
 
     if (
       isPremiumUser &&
-      isPremiumInstance &&
+      hasDedicatedInstance &&
       assignmentResult.instance_id &&
-      (hasNewInstance || isTransitioningFromTemp)
+      (hasNewInstance || wasWaiting)
     ) {
-      // Dismiss any pending temporary assignment or scaling notifications
-      if (tempAssignmentKeyRef.current) {
-        closeSnackbar(tempAssignmentKeyRef.current)
-        tempAssignmentKeyRef.current = null
-      }
-      if (scalingKeyRef.current) {
-        closeSnackbar(scalingKeyRef.current)
-        scalingKeyRef.current = null
-      }
-
       enqueueSnackbar(
-        "Premium instance assigned successfully! You now have dedicated compute resources.",
+        "Premium instance assigned successfully! " +
+          "You now have dedicated compute resources.",
         {
           variant: "success",
           autoHideDuration: 5000,
@@ -68,71 +51,49 @@ const PremiumNotificationManager: FC = () => {
     }
   }, [
     isPremiumUser,
+    hasDedicatedInstance,
     assignmentResult,
     hasShownAssignmentSuccess,
-    hasShownTempAssignmentWarning,
     lastAssignmentId,
+    enqueueSnackbar,
+  ])
+
+  // Show waiting snackbar when premium user does not have
+  // a dedicated instance (covers shared, scaling, not-yet-assigned)
+  useEffect(() => {
+    if (isPremiumUser && !hasDedicatedInstance && !isAssigning) {
+      if (!waitingKeyRef.current) {
+        const key = enqueueSnackbar(
+          "Please wait while your dedicated premium " +
+            "resource is being prepared.",
+          {
+            variant: "info",
+            persist: true,
+          },
+        )
+        waitingKeyRef.current = key
+      }
+    }
+
+    if (hasDedicatedInstance && waitingKeyRef.current) {
+      closeSnackbar(waitingKeyRef.current)
+      waitingKeyRef.current = null
+    }
+  }, [
+    isPremiumUser,
+    hasDedicatedInstance,
+    isAssigning,
     enqueueSnackbar,
     closeSnackbar,
   ])
 
-  // Show temporary assignment notification when user is assigned to main instance
-  useEffect(() => {
-    if (
-      isPremiumUser &&
-      assignmentResult?.assigned &&
-      assignmentResult.is_shared === true &&
-      !hasShownTempAssignmentWarning
-    ) {
-      const key = enqueueSnackbar(
-        "You've been temporarily assigned to the shared compute resources. " +
-          "Your dedicated premium resource will be ready shortly.",
-        {
-          variant: "info",
-          autoHideDuration: 10000, // Auto-dismiss after 10 seconds
-        },
-      )
-
-      // Store the key so we can dismiss this notification later if needed
-      tempAssignmentKeyRef.current = key
-
-      setHasShownTempAssignmentWarning(true)
-    }
-  }, [
-    isPremiumUser,
-    assignmentResult,
-    hasShownTempAssignmentWarning,
-    enqueueSnackbar,
-  ])
-
-  // Show scaling notification when capacity is being scaled up
-  useEffect(() => {
-    if (
-      isPremiumUser &&
-      assignmentResult?.scaling_in_progress &&
-      !assignmentResult.assigned &&
-      isAssigning
-    ) {
-      const key = enqueueSnackbar(
-        "Premium capacity is scaling up. Your dedicated instance will be ready shortly.",
-        {
-          variant: "info",
-          autoHideDuration: 8000,
-        },
-      )
-
-      // Store the key so we can dismiss this notification later if needed
-      scalingKeyRef.current = key
-    }
-  }, [isPremiumUser, assignmentResult, isAssigning, enqueueSnackbar])
-
   // Show error notification for assignment failures
   useEffect(() => {
     if (isPremiumUser && error && !hasShownError) {
-      // Only show critical errors, not scaling-related ones
       if (!error.includes("scaling") && !error.includes("retry")) {
         enqueueSnackbar(
-          `Premium assignment issue: ${error}. Falling back to shared resources.`,
+          "Premium assignment issue: " +
+            `${error}. Falling back to shared resources.`,
           {
             variant: "warning",
             autoHideDuration: 10000,
@@ -157,18 +118,15 @@ const PremiumNotificationManager: FC = () => {
     }
   }, [assignmentResult])
 
-  // Reset temp assignment warning when user is no longer on temporary instance
+  // Cleanup waiting notification on unmount
   useEffect(() => {
-    if (!assignmentResult?.assigned || !assignmentResult.is_shared) {
-      setHasShownTempAssignmentWarning(false)
-      // Clear the notification key reference
-      if (tempAssignmentKeyRef.current) {
-        tempAssignmentKeyRef.current = null
+    return () => {
+      if (waitingKeyRef.current) {
+        closeSnackbar(waitingKeyRef.current)
       }
     }
-  }, [assignmentResult])
+  }, [closeSnackbar])
 
-  // This component doesn't render anything - it's just for notifications
   return null
 }
 

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -26,6 +26,7 @@ import {
   PremiumStatusResult,
   RoutingInfo,
 } from "api/premium/PremiumAssignmentApi"
+import { BASE_URL } from "const/API"
 import { PlanName, SubscriptionStatus } from "const/Subscription"
 import { useSleepDetection } from "hooks/useSleepDetection"
 import { selectLogoutGeneration } from "store/slice/User/UserSelector"
@@ -39,10 +40,15 @@ import {
 } from "utils/crossTabSync"
 import { routingService } from "utils/routing/RoutingService"
 
+// Absolute URL for sendBeacon (must target the API server directly).
+const BEACON_RELEASE_URL = `${BASE_URL}/users/me/premium/release-beacon`
+const BEACON_CONTENT_TYPE = "text/plain"
+
 // Polling configuration constants
-const INITIAL_POLL_INTERVAL_MS = 5000
+// Backend rate limit is 30s, so initial interval must be >= 30s
+const INITIAL_POLL_INTERVAL_MS = 30000
 const MAX_POLL_INTERVAL_MS = 60000
-const MAX_POLL_ATTEMPTS = 120 // ~10 minutes at initial rate
+const MAX_POLL_ATTEMPTS = 40
 const BACKOFF_MULTIPLIER = 1.5
 const ERROR_BACKOFF_MULTIPLIER = 2
 
@@ -456,9 +462,9 @@ export const PremiumAssignmentProvider: React.FC<{
     if (beaconTokenRef.current) {
       const blob = new Blob(
         [JSON.stringify({ token: beaconTokenRef.current })],
-        { type: "application/json" },
+        { type: BEACON_CONTENT_TYPE },
       )
-      navigator.sendBeacon("/api/users/me/premium/release-beacon", blob)
+      navigator.sendBeacon(BEACON_RELEASE_URL, blob)
       beaconTokenRef.current = null
     }
     setState((prev) => ({
@@ -675,9 +681,9 @@ export const PremiumAssignmentProvider: React.FC<{
       if (state.assignmentResult?.instance_id && beaconTokenRef.current) {
         const blob = new Blob(
           [JSON.stringify({ token: beaconTokenRef.current })],
-          { type: "application/json" },
+          { type: BEACON_CONTENT_TYPE },
         )
-        navigator.sendBeacon("/api/users/me/premium/release-beacon", blob)
+        navigator.sendBeacon(BEACON_RELEASE_URL, blob)
       }
     }
 

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -31,18 +31,23 @@ const axios = axiosLibrary.create({
 
 axios.interceptors.request.use(
   async (config) => {
-    // Add authentication headers
+    // Add authentication headers (skip if null to avoid "Bearer null")
     const token = getToken()
     const exToken = getExToken()
 
-    config.headers!.Authorization = `Bearer ${token}`
+    if (token) {
+      config.headers!.Authorization = `Bearer ${token}`
+    }
     if (exToken) {
       config.headers!.ExToken = exToken
     }
 
     // Add premium routing headers for ALB-based routing
-    const routingHeaders = routingService.getRoutingHeaders()
-    Object.assign(config.headers!, routingHeaders)
+    // Skip if this is a free-tier fallback retry
+    if (!(config as CustomAxiosRequestConfig)._retryWithoutPremium) {
+      const routingHeaders = routingService.getRoutingHeaders()
+      Object.assign(config.headers!, routingHeaders)
+    }
 
     // Check whether the access is to public output data (HTTP header setting)
     if (config.url && isDataviewPublicOutputsRequest(config.url)) {
@@ -208,24 +213,19 @@ const handlePremiumRoutingError = async (
     return Promise.reject(error)
   }
 
-  // Premium instance not ready, falling back to free tier
+  // Premium instance not ready, falling back to free tier.
   const retryConfig = { ...originalRequest }
-
-  // Remove premium routing headers for free tier fallback
   delete retryConfig.headers[RoutingHeaders.USER_TIER]
   delete retryConfig.headers[RoutingHeaders.ROUTING_ID]
-
-  // Mark as retry to prevent infinite loops
   retryConfig._retryWithoutPremium = true
 
   try {
     // eslint-disable-next-line no-console
     console.log("Using free tier while premium instance provisions")
-    return await axiosLibrary(retryConfig)
+    return await axios(retryConfig)
   } catch (retryError) {
     // eslint-disable-next-line no-console
     console.error("Free tier fallback also failed:", retryError)
-    // Let the original error bubble up
     return Promise.reject(error)
   }
 }
@@ -246,10 +246,11 @@ axios.interceptors.response.use(
       return handleUnauthorizedError(error)
     }
 
-    if (
-      error?.response?.status === 503 &&
-      routingService.requiresPremiumRouting()
-    ) {
+    // ALB 503 when premium instance is unavailable.
+    // Also handle network errors (ERR_FAILED / no response)
+    const is503 = error?.response?.status === 503
+    const isNetworkError = !error?.response && !!error?.config
+    if ((is503 || isNetworkError) && routingService.requiresPremiumRouting()) {
       return handlePremiumRoutingError(error)
     }
 

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -985,7 +985,7 @@ resource "aws_ecs_task_definition" "premium" {
       mountPoints = [
         {
           sourceVolume  = "subscr-premium-optinist-cloud-snmk-volume"
-          containerPath = "/efs"
+          containerPath = "/app/.snakemake"
           readOnly      = false
         }
       ]

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -73,6 +73,9 @@ CREATE_RUNNING_LOCK = "create_running_lock"
 MIGRATE_USERS_LOCK = "migrate_users_lock"
 LOCK_TIMEOUT_SECONDS = 60
 
+# Wait before first migration attempt to let instances boot
+MIGRATION_INITIAL_DELAY_SECONDS = 60
+
 
 def generate_routing_id(uid: str, secret_key: str) -> str:
     """Generate non-reversible routing ID from UID using HMAC-SHA256
@@ -1815,6 +1818,13 @@ def _handle_migrate_shared_users(event):
         elapsed = 0
         migration_result: Dict[str, Any] = {}
 
+        # Let instances boot before first attempt
+        print(
+            f"Waiting {MIGRATION_INITIAL_DELAY_SECONDS}s " f"for instances to boot..."
+        )
+        time.sleep(MIGRATION_INITIAL_DELAY_SECONDS)
+        elapsed += MIGRATION_INITIAL_DELAY_SECONDS
+
         while elapsed < max_wait_seconds:
             update_premium_service_desired_count()
 
@@ -2194,7 +2204,9 @@ def get_next_available_priority(listener_arn: str, start_priority: int = 100) ->
 
 
 def assign_premium_user(
-    user_id: int, event: Dict[str, Any], user_uid: str = ""
+    user_id: int,
+    event: Dict[str, Any],
+    user_uid: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Enhanced assignment with standby pool support -
     prefer stopped instances for fast startup"""
@@ -2717,6 +2729,10 @@ def assign_premium_user(
             )
 
         # Create ALB listener rule for user routing
+        if not user_uid:
+            raise ValueError(
+                "user_uid is required to generate routing ID"
+            )
         routing_secret_key = get_required_env_var("ROUTING_SECRET_KEY")
         routing_id = generate_routing_id(user_uid, routing_secret_key)
         print(
@@ -2947,8 +2963,6 @@ def scale_premium_instances_if_needed():
         running_creating = is_creation_lock_held(CREATE_RUNNING_LOCK)
 
         effective_capacity = running_count + launching_count
-        if running_creating:
-            effective_capacity += 1
 
         print("Enhanced premium instance analysis:")
         print(f"- Running instances: {running_count}")
@@ -2962,17 +2976,20 @@ def scale_premium_instances_if_needed():
         print(f"- Premium subscribers: {total_subscribers}")
 
         if launching_count > 0:
-            print(f"Scaling blocked: {launching_count} " f"instances already launching")
+            print(
+                f"Scaling blocked: {launching_count} "
+                f"instances already launching"
+            )
             return False
 
+        # Block scaling while another Lambda is creating instances;
+        # we can't know the exact count, so let it finish first.
         if running_creating:
-            print("Running instance creation already in progress")
-            if effective_capacity >= active_users:
-                print(
-                    f"No scaling needed: effective capacity "
-                    f"{effective_capacity} >= {active_users}"
-                )
-                return False
+            print(
+                "Scaling blocked: running instance "
+                "creation already in progress"
+            )
+            return False
 
         # Key decision: Scale based on ACTIVE ASSIGNMENTS, not subscribers
         # This represents current demand (logged-in users) vs available capacity

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -70,6 +70,7 @@ DEFAULT_IDLE_TIMEOUT_HOURS = 3  # Hours before idle instances become standby
 # MySQL GET_LOCK names for preventing concurrent instance creation
 CREATE_STANDBY_LOCK = "create_standby_lock"
 CREATE_RUNNING_LOCK = "create_running_lock"
+MIGRATE_USERS_LOCK = "migrate_users_lock"
 LOCK_TIMEOUT_SECONDS = 60
 
 
@@ -1225,7 +1226,7 @@ def try_reserve_instance_for_migration_transaction(
             (instance_id,),
         )
 
-        print(f"Reserved instance {instance_id} for migration of user {user_id}")
+        print(f"Reserved instance {instance_id} " f"for migration of user {user_id}")
         return True
 
 
@@ -1786,22 +1787,86 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
         }
 
 
+def _handle_migrate_shared_users(event):
+    """Run migration loop under a distributed lock."""
+    with distributed_lock(MIGRATE_USERS_LOCK) as acquired:
+        if not acquired:
+            print("Another Lambda is already running " "migrations, skipping")
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"message": "Migration skipped - lock held"}),
+            }
+
+        max_wait_seconds = event.get("max_wait_seconds", 60)
+        retry_interval = event.get("retry_interval", 10)
+
+        print(
+            f"Async migration triggered, will retry "
+            f"every {retry_interval}s "
+            f"for up to {max_wait_seconds}s..."
+        )
+
+        migrations_performed = 0
+        elapsed = 0
+        migration_result: Dict[str, Any] = {}
+
+        while elapsed < max_wait_seconds:
+            update_premium_service_desired_count()
+
+            migration_result = process_shared_instance_optimization()
+            migrations_performed = migration_result.get("migrations_performed", 0)
+
+            print(
+                f"Migration attempt at {elapsed}s: "
+                f"{migrations_performed} migrations"
+            )
+
+            autoscaling_users = get_assigned_users_for_instance(
+                PremiumAssignment.AUTOSCALING_POOL
+            )
+            remaining_users = len(autoscaling_users)
+
+            if migrations_performed > 0:
+                print(
+                    f"Migrated {migrations_performed} users, "
+                    f"{remaining_users} still on "
+                    f"autoscaling pool"
+                )
+
+            if remaining_users == 0:
+                print(
+                    f"Migration completed after {elapsed}s"
+                    f" - all users migrated from "
+                    f"autoscaling pool"
+                )
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps(
+                        {
+                            "message": (f"Migration completed " f"after {elapsed}s"),
+                            "result": migration_result,
+                        }
+                    ),
+                }
+
+            time.sleep(retry_interval)
+            elapsed += retry_interval
+
+        print(f"Migration timeout after {elapsed}s, " f"no instances ready")
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "message": ("Migration timeout - " "instances not ready yet"),
+                    "result": migration_result,
+                }
+            ),
+        }
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     Handle premium user assignment lifecycle events and scheduled cleanup
-
-    Event structure for API calls:
-    {
-        "httpMethod": "GET" | "POST",
-        "body": '{"action": "assign" | "release", "user_id": "123", "tier": "premium"}'
-    }
-
-    Event structure for scheduled cleanup:
-    {
-        "source": "aws.events",
-        "detail-type": "Scheduled Event",
-        "detail": {"action": "cleanup"}
-    }
     """
 
     print(f"Premium manager received event: {json.dumps(event)}")
@@ -1810,73 +1875,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         # Handle async migration invocation
         if event.get("action") == "migrate_shared_users":
-            max_wait_seconds = event.get("max_wait_seconds", 60)
-            retry_interval = event.get("retry_interval", 10)
-
-            print(
-                f"Async migration triggered, will retry every {retry_interval}s "
-                f"for up to {max_wait_seconds}s..."
-            )
-
-            migrations_performed = 0
-            elapsed = 0
-
-            # Retry migration until successful or timeout
-            while elapsed < max_wait_seconds:
-                time.sleep(retry_interval)
-                elapsed += retry_interval
-
-                # Update ECS service desired count before checking for migrations
-                # This ensures tasks are being placed on new instances
-                update_premium_service_desired_count()
-
-                migration_result = process_shared_instance_optimization()
-                migrations_performed = migration_result.get("migrations_performed", 0)
-
-                print(
-                    f"Migration attempt at {elapsed}s: "
-                    f"{migrations_performed} migrations"
-                )
-
-                # Check if there are still users on autoscaling pool needing migration
-                autoscaling_users = get_assigned_users_for_instance(
-                    PremiumAssignment.AUTOSCALING_POOL
-                )
-                remaining_users = len(autoscaling_users)
-
-                if migrations_performed > 0:
-                    print(
-                        f"Migrated {migrations_performed} users, "
-                        f"{remaining_users} still on autoscaling pool"
-                    )
-
-                # Only exit if all autoscaling pool users have been migrated
-                if remaining_users == 0:
-                    print(
-                        f"Migration completed after {elapsed}s "
-                        f"- all users migrated from autoscaling pool"
-                    )
-                    return {
-                        "statusCode": 200,
-                        "body": json.dumps(
-                            {
-                                "message": f"Migration completed after {elapsed}s",
-                                "result": migration_result,
-                            }
-                        ),
-                    }
-
-            # Timeout - no migrations performed
-            print(f"Migration timeout after {elapsed}s, no instances ready")
-            return {
-                "statusCode": 200,
-                "body": json.dumps(
-                    {
-                        "message": "Migration timeout - instances not ready yet",
-                        "result": migration_result,
-                    }
-                ),
-            }
+            return _handle_migrate_shared_users(event)
 
         # Handle fix_shared_flags action (one-time data cleanup)
         if event.get("action") == "fix_shared_flags":
@@ -2867,10 +2866,13 @@ def assign_premium_user(
 
 def invoke_migration_async():
     """
-    Invoke this same Lambda function asynchronously to handle migration.
-    Uses Event InvocationType to avoid blocking the current request.
-    Lambda will retry for 180 seconds until instances are ready, then migrate users.
+    Invoke this Lambda asynchronously for migration.
+    Skips invocation if a migration Lambda already holds the lock.
     """
+    if is_creation_lock_held(MIGRATE_USERS_LOCK):
+        print("Migration Lambda already running, skipping")
+        return
+
     try:
         lambda_client: "LambdaClient" = boto3.client("lambda")
         function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
@@ -3464,21 +3466,23 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                 cursor.execute(
                     """SELECT instance_id, target_group_arn,
                        alb_rule_arn, active_workflow_count
-                       FROM premium_user_assignments WHERE user_id = %s""",
+                       FROM premium_user_assignments
+                       WHERE user_id = %s""",
                     (user_id,),
                 )
                 assignment = cursor.fetchone()
 
                 if not assignment:
-                    print(f"No assignment found for user {user_id}")
+                    print(f"No assignment found for " f"user {user_id}")
                     return False
 
                 # Double-check workflow count (defense in depth)
                 active_workflows = assignment.get("active_workflow_count", 0) or 0
                 if active_workflows > 0:
                     print(
-                        f"Cannot migrate user {user_id}: {active_workflows} "
-                        f"active workflows detected in assignment record"
+                        f"Cannot migrate user {user_id}: "
+                        f"{active_workflows} active workflows"
+                        f" detected in assignment record"
                     )
                     return False
 
@@ -3576,14 +3580,21 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         new_rule_arn = rule_response["Rules"][0]["RuleArn"]
                         print(f"Created new ALB rule: {new_rule_arn}")
 
-                    # Update assignment with new target group and rule ARN
+                    # Update assignment with new target group
                     cursor.execute(
                         """UPDATE premium_user_assignments
-                           SET instance_id = %s, target_group_arn = %s,
+                           SET instance_id = %s,
+                               target_group_arn = %s,
                                alb_rule_arn = %s,
-                               is_shared = 0, last_state_check = NOW()
+                               is_shared = 0,
+                               last_state_check = NOW()
                            WHERE user_id = %s""",
-                        (new_instance_id, new_target_group_arn, new_rule_arn, user_id),
+                        (
+                            new_instance_id,
+                            new_target_group_arn,
+                            new_rule_arn,
+                            user_id,
+                        ),
                     )
                 else:
                     # Normal migration: deregister from old, register to new
@@ -3609,22 +3620,28 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         Targets=[{"Id": new_instance_id, "Port": 8000}],
                     )
 
-                    # Update RDS assignment (include target_group_arn in case recreated)
+                    # Update RDS assignment
                     cursor.execute(
                         """UPDATE premium_user_assignments
-                           SET instance_id = %s, target_group_arn = %s,
-                               is_shared = 0, last_state_check = NOW()
+                           SET instance_id = %s,
+                               target_group_arn = %s,
+                               is_shared = 0,
+                               last_state_check = NOW()
                            WHERE user_id = %s""",
-                        (new_instance_id, old_target_group_arn, user_id),
+                        (
+                            new_instance_id,
+                            old_target_group_arn,
+                            user_id,
+                        ),
                     )
 
-                connection.commit()  # Commit the migration
+                connection.commit()
 
                 print(
-                    f"Migrated user {user_id} from {old_instance_id} to "
-                    f"{new_instance_id}"
+                    f"Migrated user {user_id} from "
+                    f"{old_instance_id} to {new_instance_id}"
                 )
-                # Trigger experiment sync on new instance (fire-and-forget)
+                # Trigger experiment sync (fire-and-forget)
                 trigger_experiment_sync(user_id)
                 return True
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -272,7 +272,11 @@ def get_user_id_from_uid(connection, user_uid: str) -> int:
         ValueError: If user not found
     """
     with connection.cursor() as cursor:
-        cursor.execute("""SELECT id FROM users WHERE uid = %s""", (user_uid,))
+        cursor.execute(
+            """SELECT id FROM users
+               WHERE uid = %s AND active = 1""",
+            (user_uid,),
+        )
         result = cursor.fetchone()
 
         if not result:
@@ -288,7 +292,8 @@ def get_user_uid_from_id(connection, user_id: int) -> str:
     """
     with connection.cursor() as cursor:
         cursor.execute(
-            """SELECT uid FROM users WHERE id = %s""",
+            """SELECT uid FROM users
+               WHERE id = %s AND active = 1""",
             (user_id,),
         )
         result = cursor.fetchone()

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -67,6 +67,11 @@ if TYPE_CHECKING:
 DEFAULT_DEVELOPMENT_CAPACITY = 3  # Fallback capacity for dev/testing
 DEFAULT_IDLE_TIMEOUT_HOURS = 3  # Hours before idle instances become standby
 
+# MySQL GET_LOCK names for preventing concurrent instance creation
+CREATE_STANDBY_LOCK = "create_standby_lock"
+CREATE_RUNNING_LOCK = "create_running_lock"
+LOCK_TIMEOUT_SECONDS = 60
+
 
 def generate_routing_id(uid: str, secret_key: str) -> str:
     """Generate non-reversible routing ID from UID using HMAC-SHA256
@@ -166,6 +171,72 @@ def get_db_connection(auto_commit=False):
                     print(f" Warning: Error closing database connection: {str(e)}")
 
     return connection_context()
+
+
+def distributed_lock(lock_name, timeout=LOCK_TIMEOUT_SECONDS):
+    """Acquire a MySQL GET_LOCK held for the block's lifetime.
+
+    GET_LOCK is session-scoped: the connection that acquired it
+    must stay open or the lock is silently released.  This context
+    manager keeps a dedicated connection alive until the caller
+    exits the ``with`` block.
+
+    Yields ``True`` if the lock was acquired, ``False`` otherwise.
+    The caller should check the value and skip work when False.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _lock_context():
+        conn = None
+        acquired = False
+        try:
+            rds_host = get_required_env_var("RDS_HOST")
+            host = rds_host.split(":")[0] if ":" in rds_host else rds_host
+            conn = pymysql.connect(
+                host=host,
+                port=DatabaseConfig.DEFAULT_PORT,
+                user=get_required_env_var("RDS_USER"),
+                password=get_required_env_var("RDS_PASSWORD"),
+                database=get_required_env_var("RDS_DATABASE"),
+                charset="utf8mb4",
+                cursorclass=pymysql.cursors.DictCursor,
+                autocommit=True,
+            )
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "SELECT GET_LOCK(%s, %s) as lock_result",
+                    (lock_name, timeout),
+                )
+                result = cursor.fetchone()
+                acquired = result["lock_result"] == 1
+
+            if acquired:
+                print(f"Acquired distributed lock '{lock_name}'")
+            else:
+                print(
+                    f"Failed to acquire lock '{lock_name}' "
+                    f"(held by another session)"
+                )
+            yield acquired
+        finally:
+            if acquired and conn:
+                try:
+                    with conn.cursor() as cursor:
+                        cursor.execute(
+                            "SELECT RELEASE_LOCK(%s)",
+                            (lock_name,),
+                        )
+                    print(f"Released lock '{lock_name}'")
+                except Exception as e:
+                    print(f"Failed to release lock " f"'{lock_name}': {e}")
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    return _lock_context()
 
 
 def with_transaction(func):
@@ -403,7 +474,7 @@ def _store_user_assignment_transaction(
 
 
 def store_user_assignment(
-    user_id: int | str,
+    user_id: Optional[int],
     instance_id: str,
     target_group_arn: str,
     rule_arn: str,
@@ -808,158 +879,29 @@ def get_standby_count():
         return 0
 
 
-def count_pending_standby_creations():
-    """Count standby instances currently being created (pending state)"""
+def is_creation_lock_held(lock_name: str) -> bool:
+    """Check if a creation lock is currently held by another session.
+
+    Fail-closed: returns True on error so callers assume a lock
+    is held rather than risk duplicate creation.
+    """
     try:
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
-                # Count assignments with user_id starting with 'creating-standby-'
-                # These are placeholders for standbys being created
                 cursor.execute(
-                    """SELECT COUNT(*) as count FROM premium_user_assignments
-                       WHERE user_id LIKE 'creating-standby-%'
-                       AND is_standby = 1
-                       AND status = 'active'"""
+                    "SELECT IS_FREE_LOCK(%s) as is_free",
+                    (lock_name,),
                 )
                 result = cursor.fetchone()
-                pending_count = result["count"] if result else 0
-
-                if pending_count > 0:
-                    print(f"Found {pending_count} pending standby creation(s)")
-
-                return pending_count
+                # IS_FREE_LOCK returns 1=free, 0=held, NULL=error
+                # Treat NULL as held (fail-closed)
+                is_held = result["is_free"] != 1
+                if is_held:
+                    print(f"Lock '{lock_name}' is held")
+                return is_held
     except Exception as e:
-        print(f"Error counting pending standby creations: {str(e)}")
-        return 0
-
-
-def count_pending_running_creations():
-    """Count running instances currently being created (pending state)"""
-    try:
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                # Count assignments with user_id starting with 'creating-running-'
-                # These are placeholders for running instances being created
-                cursor.execute(
-                    """SELECT COUNT(*) as count FROM premium_user_assignments
-                       WHERE user_id LIKE 'creating-running-%'
-                       AND is_standby = 0
-                       AND status = 'active'"""
-                )
-                result = cursor.fetchone()
-                pending_count = result["count"] if result else 0
-
-                if pending_count > 0:
-                    print(f"Found {pending_count} pending running instance creation(s)")
-
-                return pending_count
-    except Exception as e:
-        print(f"Error counting pending running creations: {str(e)}")
-        return 0
-
-
-def register_pending_standby_creation():
-    """
-    Register that a standby creation is in progress.
-    Returns a unique ID for this creation attempt.
-    """
-    import uuid
-
-    creation_id = str(uuid.uuid4())[:8]
-
-    try:
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                # Insert placeholder for standby being created
-                cursor.execute(
-                    """INSERT INTO premium_user_assignments
-                       (user_id, instance_id, target_group_arn, alb_rule_arn,
-                        status, instance_state, is_shared, is_standby,
-                        assignment_attempts, last_state_check, standby_created_at)
-                       VALUES (%s, %s, %s, %s, 'active', 'pending', 0, 1, 1,
-                       NOW(), NOW())
-                    """,
-                    (
-                        f"creating-standby-{creation_id}",
-                        f"pending-{creation_id}",
-                        InstanceState.PENDING,
-                        InstanceState.PENDING,
-                    ),
-                )
-                connection.commit()
-                print(f"Registered pending standby creation: {creation_id}")
-                return creation_id
-    except Exception as e:
-        print(f"Error registering pending standby creation: {str(e)}")
-        return None
-
-
-def unregister_pending_standby_creation(creation_id: str):
-    """Remove the pending standby creation placeholder"""
-    try:
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    """DELETE FROM premium_user_assignments
-                       WHERE user_id = %s""",
-                    (f"creating-standby-{creation_id}",),
-                )
-                connection.commit()
-                print(f"Unregistered pending standby creation: {creation_id}")
-    except Exception as e:
-        print(f"Error unregistering pending standby creation: {str(e)}")
-
-
-def register_pending_running_creation():
-    """
-    Register that a running instance creation is in progress.
-    Returns a unique ID for this creation attempt.
-    """
-    import uuid
-
-    creation_id = str(uuid.uuid4())[:8]
-
-    try:
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                # Insert placeholder for running instance being created
-                cursor.execute(
-                    """INSERT INTO premium_user_assignments
-                       (user_id, instance_id, target_group_arn, alb_rule_arn,
-                        status, instance_state, is_shared, is_standby,
-                        assignment_attempts, last_state_check, standby_created_at)
-                       VALUES (%s, %s, %s, %s, 'active', 'pending', 0, 0, 1,
-                       NOW(), NOW())
-                    """,
-                    (
-                        f"creating-running-{creation_id}",
-                        f"pending-{creation_id}",
-                        InstanceState.PENDING,
-                        InstanceState.PENDING,
-                    ),
-                )
-                connection.commit()
-                print(f"Registered pending running instance creation: {creation_id}")
-                return creation_id
-    except Exception as e:
-        print(f"Error registering pending running creation: {str(e)}")
-        return None
-
-
-def unregister_pending_running_creation(creation_id: str):
-    """Remove the pending running instance creation placeholder"""
-    try:
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    """DELETE FROM premium_user_assignments
-                       WHERE user_id = %s""",
-                    (f"creating-running-{creation_id}",),
-                )
-                connection.commit()
-                print(f"Unregistered pending running instance creation: {creation_id}")
-    except Exception as e:
-        print(f"Error unregistering pending running creation: {str(e)}")
+        print(f"Error checking lock '{lock_name}': {e}")
+        return True
 
 
 def get_available_standby_instances():
@@ -1153,6 +1095,31 @@ def create_running_instance():
         return None
 
 
+def _create_running_instances_locked(count: int) -> bool:
+    """Create running instances under a distributed lock."""
+    with distributed_lock(CREATE_RUNNING_LOCK) as acquired:
+        if not acquired:
+            print("Another Lambda is already creating " "running instances, skipping")
+            return False
+
+        try:
+            created_any = False
+            for i in range(count):
+                instance_id = create_running_instance()
+                if instance_id:
+                    print(f"Created running instance " f"{instance_id}")
+                    created_any = True
+                else:
+                    print(
+                        "Failed to create running instance" ", falling back to standby"
+                    )
+                    create_and_stop_standby_instance()
+            return created_any
+        except Exception as e:
+            print(f"Error in locked running creation: {e}")
+            return False
+
+
 @with_transaction
 def try_reserve_instance_transaction(
     connection, instance_id: str, user_id: int
@@ -1189,7 +1156,7 @@ def try_reserve_instance_transaction(
                 PremiumAssignment.RESERVING,
                 PremiumAssignment.RESERVING,
                 PremiumAssignment.ACTIVE,
-                PremiumAssignment.RESERVING,
+                InstanceState.LAUNCHING,
             ),
         )
         print(f"Reserved instance {instance_id} for user {user_id}")
@@ -1274,194 +1241,152 @@ def try_reserve_instance_for_migration(instance_id: str, user_id: int) -> bool:
 def create_and_stop_standby_instance():
     """
     Create instance and immediately stop it for standby use.
-    Uses database-level locking to prevent concurrent Lambda executions
-    from creating duplicate standbys.
+    Uses database-level locking to prevent concurrent Lambda
+    executions from creating duplicate standbys.
     """
     ec2: "EC2Client" = boto3.client("ec2")
-    lock_acquired = False
-    lock_name = "create_standby_lock"
-    lock_timeout = 60  # seconds
-    creation_id = None
 
-    try:
-        # DISTRIBUTED LOCK: Use MySQL GET_LOCK to prevent race conditions
-        # Must acquire lock BEFORE registering pending creation to prevent
-        # multiple Lambdas from registering and then each creating an instance
-        with get_db_connection() as connection:
-            with connection.cursor() as cursor:
-                # Try to acquire lock (returns 1 if successful,
-                # 0 if already locked)
-                cursor.execute(
-                    "SELECT GET_LOCK(%s, %s) as lock_result", (lock_name, lock_timeout)
-                )
-                lock_result = cursor.fetchone()
-                lock_acquired = lock_result["lock_result"] == 1
+    with distributed_lock(CREATE_STANDBY_LOCK) as acquired:
+        if not acquired:
+            print("Another Lambda is already creating a " "standby instance, skipping")
+            return None
 
-                if not lock_acquired:
-                    print(
-                        "Another Lambda is already creating a standby instance, "
-                        "skipping"
-                    )
-                    return None
+        try:
+            standby_count = get_standby_count()
+            standby_pool_size = int(os.environ.get("PREMIUM_STANDBY_POOL_SIZE", "1"))
 
-                print("Acquired distributed lock for standby creation")
-
-                # Register pending creation AFTER acquiring lock
-                # This ensures only one Lambda registers at a time
-                creation_id = register_pending_standby_creation()
-                if not creation_id:
-                    print("Failed to register pending standby creation")
-                    cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
-                    return None
-
-                # STANDBY COUNT CHECK: Re-check after acquiring lock
-                standby_count = get_standby_count()
-                standby_pool_size = int(
-                    os.environ.get("PREMIUM_STANDBY_POOL_SIZE", "1")
-                )
-
-                if standby_count >= standby_pool_size:
-                    print(
-                        f"Standby pool already full "
-                        f"({standby_count}/{standby_pool_size}), "
-                        f"another Lambda already created one"
-                    )
-                    # Release lock before returning
-                    cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
-                    # Clean up pending registration
-                    if creation_id:
-                        unregister_pending_standby_creation(creation_id)
-                    return None
-
+            if standby_count >= standby_pool_size:
                 print(
-                    f"Standby pool has capacity "
-                    f"({standby_count}/{standby_pool_size}), "
-                    f"proceeding with creation"
+                    f"Standby pool already full "
+                    f"({standby_count}/{standby_pool_size})"
+                    f", another Lambda already created one"
                 )
+                return None
 
-        # Get launch template ID from environment
-        launch_template_id = get_required_env_var("PREMIUM_LAUNCH_TEMPLATE_ID")
-
-        # Get subnet IDs from environment
-        subnet_ids = get_required_env_var("SUBNET_IDS").split(",")
-
-        # Try each subnet (different AZ) until one succeeds
-        instance_id = None
-        for i, subnet_id in enumerate(subnet_ids):
-            try:
-                print(
-                    f"Attempting to launch standby instance in subnet {subnet_id} "
-                    f"(attempt {i + 1}/{len(subnet_ids)})"
-                )
-
-                # Launch instance using the premium launch template
-                response = ec2.run_instances(
-                    LaunchTemplate={
-                        "LaunchTemplateId": launch_template_id,
-                        "Version": "$Latest",
-                    },
-                    InstanceType="t3.large",
-                    SubnetId=subnet_id,
-                    MinCount=1,
-                    MaxCount=1,
-                    TagSpecifications=[
-                        {
-                            "ResourceType": "instance",
-                            "Tags": [
-                                {"Key": "Name", "Value": "subscr-premium-standby"},
-                                {"Key": "Type", "Value": "Premium-Instance"},
-                                {"Key": "Tier", "Value": "premium"},
-                                {"Key": "Service", "Value": "premium-tier"},
-                            ],
-                        }
-                    ],
-                )
-
-                instance_id = response["Instances"][0]["InstanceId"]
-                print(
-                    f"Successfully created standby instance {instance_id} in "
-                    f"subnet {subnet_id}, waiting to stop..."
-                )
-                break  # Success, exit retry loop
-
-            except ClientError as e:
-                error_code = e.response["Error"]["Code"]
-                if error_code == "InsufficientInstanceCapacity":
-                    print(
-                        f"InsufficientInstanceCapacity in subnet {subnet_id}, "
-                        f"trying next subnet..."
-                    )
-                    continue
-                else:
-                    # For other errors, don't retry - fail immediately
-                    print(f"Non-capacity error ({error_code}), not retrying: {str(e)}")
-                    raise
-
-        # Check if instance was created
-        if not instance_id:
-            raise Exception(
-                f"Failed to launch standby instance in all {len(subnet_ids)} "
-                f"available subnets due to insufficient capacity"
+            print(
+                f"Standby pool has capacity "
+                f"({standby_count}/{standby_pool_size}), "
+                f"proceeding with creation"
             )
 
-        # Wait for running then stop
-        waiter = ec2.get_waiter("instance_running")
-        waiter.wait(
-            InstanceIds=[instance_id], WaiterConfig={"Delay": 15, "MaxAttempts": 40}
-        )
+            launch_template_id = get_required_env_var("PREMIUM_LAUNCH_TEMPLATE_ID")
+            subnet_ids = get_required_env_var("SUBNET_IDS").split(",")
 
-        ec2.stop_instances(InstanceIds=[instance_id])
+            instance_id = None
+            for i, subnet_id in enumerate(subnet_ids):
+                try:
+                    print(
+                        f"Attempting to launch standby "
+                        f"instance in subnet {subnet_id} "
+                        f"(attempt {i + 1}"
+                        f"/{len(subnet_ids)})"
+                    )
 
-        waiter = ec2.get_waiter("instance_stopped")
-        waiter.wait(
-            InstanceIds=[instance_id], WaiterConfig={"Delay": 15, "MaxAttempts": 20}
-        )
+                    response = ec2.run_instances(
+                        LaunchTemplate={
+                            "LaunchTemplateId": (launch_template_id),
+                            "Version": "$Latest",
+                        },
+                        InstanceType="t3.large",
+                        SubnetId=subnet_id,
+                        MinCount=1,
+                        MaxCount=1,
+                        TagSpecifications=[
+                            {
+                                "ResourceType": "instance",
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": ("subscr-premium" "-standby"),
+                                    },
+                                    {
+                                        "Key": "Type",
+                                        "Value": ("Premium-Instance"),
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    },
+                                    {
+                                        "Key": "Service",
+                                        "Value": ("premium-tier"),
+                                    },
+                                ],
+                            }
+                        ],
+                    )
 
-        # Store in assignments table as standby with is_standby flag
-        # Use NULL for standby instances (no real user assigned)
-        store_user_assignment(
-            user_id=None,
-            instance_id=instance_id,
-            target_group_arn=PremiumAssignment.STANDBY,
-            rule_arn=PremiumAssignment.STANDBY,
-            instance_state=InstanceState.STOPPED,
-            is_shared=False,
-            is_standby=True,
-        )
+                    instance_id = response["Instances"][0]["InstanceId"]
+                    print(
+                        f"Successfully created standby "
+                        f"instance {instance_id} in "
+                        f"subnet {subnet_id}, "
+                        f"waiting to stop..."
+                    )
+                    break
 
-        # Release lock before returning success
-        if lock_acquired:
-            with get_db_connection() as connection:
-                with connection.cursor() as cursor:
-                    cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
-                    print("Released distributed lock for standby creation")
+                except ClientError as e:
+                    error_code = e.response["Error"]["Code"]
+                    if error_code == ("InsufficientInstanceCapacity"):
+                        print(
+                            f"InsufficientInstanceCapacity"
+                            f" in subnet {subnet_id}, "
+                            f"trying next subnet..."
+                        )
+                        continue
+                    else:
+                        print(
+                            f"Non-capacity error "
+                            f"({error_code}), "
+                            f"not retrying: {e}"
+                        )
+                        raise
 
-        # Clean up pending registration - actual standby is now registered
-        if creation_id:
-            unregister_pending_standby_creation(creation_id)
+            if not instance_id:
+                raise Exception(
+                    f"Failed to launch standby instance "
+                    f"in all {len(subnet_ids)} available "
+                    f"subnets due to insufficient capacity"
+                )
 
-        print(f"Successfully created and stopped standby instance {instance_id}")
-        return instance_id
+            waiter = ec2.get_waiter("instance_running")
+            waiter.wait(
+                InstanceIds=[instance_id],
+                WaiterConfig={
+                    "Delay": 15,
+                    "MaxAttempts": 40,
+                },
+            )
 
-    except Exception as e:
-        print(f"Error creating standby instance: {str(e)}")
-        # Clean up pending registration on error
-        if creation_id:
-            try:
-                unregister_pending_standby_creation(creation_id)
-            except Exception as cleanup_error:
-                print(f"Failed to cleanup pending registration: {cleanup_error}")
+            ec2.stop_instances(InstanceIds=[instance_id])
 
-        # Release lock on error
-        if lock_acquired:
-            try:
-                with get_db_connection() as connection:
-                    with connection.cursor() as cursor:
-                        cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
-                        print("Released distributed lock after error")
-            except Exception as lock_error:
-                print(f"Failed to release lock after error: {lock_error}")
-        return None
+            waiter = ec2.get_waiter("instance_stopped")
+            waiter.wait(
+                InstanceIds=[instance_id],
+                WaiterConfig={
+                    "Delay": 15,
+                    "MaxAttempts": 20,
+                },
+            )
+
+            store_user_assignment(
+                user_id=None,
+                instance_id=instance_id,
+                target_group_arn=PremiumAssignment.STANDBY,
+                rule_arn=PremiumAssignment.STANDBY,
+                instance_state=InstanceState.STOPPED,
+                is_shared=False,
+                is_standby=True,
+            )
+
+            print(
+                f"Successfully created and stopped " f"standby instance {instance_id}"
+            )
+            return instance_id
+
+        except Exception as e:
+            print(f"Error creating standby instance: " f"{str(e)}")
+            return None
 
 
 ECS_CHECKPOINT_PATH = "/var/lib/ecs/data/agent.db"
@@ -3010,43 +2935,35 @@ def scale_premium_instances_if_needed():
         # Get subscriber count for comparison
         total_subscribers = count_total_premium_users()
 
-        # Count pending instance creations to prevent over-provisioning
-        pending_standby_count = count_pending_standby_creations()
-        pending_running_count = count_pending_running_creations()
+        # Check if creation locks are held (another Lambda creating)
+        standby_creating = is_creation_lock_held(CREATE_STANDBY_LOCK)
+        running_creating = is_creation_lock_held(CREATE_RUNNING_LOCK)
 
-        # Calculate effective capacity:
-        # Running + launching + pending RUNNING instances
-        # (Standbys will be stopped, so don't count for active capacity)
-        effective_capacity = running_count + launching_count + pending_running_count
+        effective_capacity = running_count + launching_count
+        if running_creating:
+            effective_capacity += 1
 
         print("Enhanced premium instance analysis:")
         print(f"- Running instances: {running_count}")
         print(f"- Launching instances: {launching_count}")
-        print(f"- Pending standby creations: {pending_standby_count}")
-        print(f"- Pending running creations: {pending_running_count}")
+        print(f"- Standby creation in progress: {standby_creating}")
+        print(f"- Running creation in progress: {running_creating}")
         print(f"- Effective capacity: {effective_capacity}")
         print(f"- Total instances: {total_instances}")
         print(f"- Maximum capacity: {max_capacity}")
-        print(f"- Active assignments (logged-in users): {active_users}")
-        print(f"- Premium subscribers (capacity planning): {total_subscribers}")
+        print(f"- Active assignments: {active_users}")
+        print(f"- Premium subscribers: {total_subscribers}")
 
-        # NO SCALING CONDITIONS:
         if launching_count > 0:
-            print(f"Scaling blocked: {launching_count} instances already launching")
+            print(f"Scaling blocked: {launching_count} " f"instances already launching")
             return False
 
-        # Check if pending running instances will satisfy demand
-        if pending_running_count > 0:
-            print(
-                f"Running instance creation in progress: {pending_running_count} "
-                f"instance(s) being created"
-            )
-            # If pending running instances will satisfy demand, don't create more
+        if running_creating:
+            print("Running instance creation already in progress")
             if effective_capacity >= active_users:
                 print(
                     f"No scaling needed: effective capacity "
-                    f"{effective_capacity} >= {active_users} active users "
-                    f"(including {pending_running_count} pending running)"
+                    f"{effective_capacity} >= {active_users}"
                 )
                 return False
 
@@ -3111,52 +3028,23 @@ def scale_premium_instances_if_needed():
 
                 return True
             else:
-                # No stopped instances available, check if we can create new ones
-                if total_instances + needed_capacity <= max_capacity:
-                    print(
-                        f"No stopped instances available, need to create "
-                        f"{needed_capacity} new running instances"
-                    )
-                    for _ in range(needed_capacity):
-                        # Register pending instance creation to prevent duplicates
-                        creation_id = register_pending_running_creation()
-
-                        # Create and start instances for immediate use
-                        # when scaling up for active users
-                        instance_id = create_running_instance()
-
-                        if instance_id:
-                            print(
-                                f"Successfully created and started "
-                                f"instance {instance_id}"
-                            )
-                            # Clean up pending registration
-                            if creation_id:
-                                unregister_pending_running_creation(creation_id)
-                        else:
-                            print(
-                                "Failed to create running instance, "
-                                "falling back to standby creation"
-                            )
-                            # Clean up pending registration before creating standby
-                            if creation_id:
-                                unregister_pending_running_creation(creation_id)
-                            create_and_stop_standby_instance()
-
-                    # Invoke this Lambda asynchronously to handle migration
-                    # after instances are ready (avoids blocking the user's request)
-                    invoke_migration_async()
-
-                    # Update ECS service desired count to match instance count
-                    update_premium_service_desired_count()
-
-                    return True
-                else:
+                if total_instances + needed_capacity > max_capacity:
                     print(
                         f"Cannot scale: would exceed max capacity "
-                        f"({total_instances + needed_capacity} > {max_capacity})"
+                        f"({total_instances + needed_capacity} "
+                        f"> {max_capacity})"
                     )
                     return False
+
+                print(
+                    f"No stopped instances available, creating "
+                    f"{needed_capacity} new running instance(s)"
+                )
+                created = _create_running_instances_locked(needed_capacity)
+                if created:
+                    invoke_migration_async()
+                    update_premium_service_desired_count()
+                return created
 
         elif total_instances >= max_capacity:
             print(
@@ -4460,10 +4348,12 @@ def process_shared_instance_optimization() -> Dict[str, Any]:
                     f"{len(real_users)} real users"
                 )
 
-                # Use short timeout for migration checks - don't block waiting
-                # If instance not ready quickly, skip it and use ready ones
+                # Short timeout: don't block waiting for
+                # unready instances during migration checks
                 if not real_users and check_instance_readiness_with_retry(
-                    instance_id, max_wait_seconds=30, retry_interval=10
+                    instance_id,
+                    max_wait_seconds=30,
+                    retry_interval=10,
                 ):
                     available_instances.append(instance_id)
                     print(f"Instance {instance_id} is available for migration")

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1119,10 +1119,12 @@ def _create_running_instances_locked(count: int) -> bool:
                     print(f"Created running instance " f"{instance_id}")
                     created_any = True
                 else:
+                    # No standby fallback here (nested lock)
                     print(
-                        "Failed to create running instance" ", falling back to standby"
+                        "Failed to create running instance, "
+                        "standby replenishment deferred to "
+                        "scheduled monitoring"
                     )
-                    create_and_stop_standby_instance()
             return created_any
         except Exception as e:
             print(f"Error in locked running creation: {e}")
@@ -1758,6 +1760,26 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # 9. Stop orphaned EC2 instances not in ECS cluster
             cleanup_orphaned_ec2_instances()
 
+            # 10. Optimize shared instances (safety net)
+            try:
+                shared_result = process_shared_instance_optimization()
+                shared_migrations = shared_result.get("migrations_performed", 0)
+                shared_found = shared_result.get("shared_instances_found", 0)
+                if shared_found > 0 or shared_migrations > 0:
+                    print(
+                        f"Shared optimization: "
+                        f"{shared_migrations} migrations, "
+                        f"{shared_found} shared instances"
+                    )
+                if shared_found > 0 and shared_migrations == 0:
+                    print(
+                        "Shared users found but no instances "
+                        "ready, triggering async migration..."
+                    )
+                    invoke_migration_async()
+            except Exception as shared_error:
+                print(f"Shared optimization error: " f"{str(shared_error)}")
+
             return {
                 "statusCode": 200,
                 "body": json.dumps(
@@ -1805,7 +1827,7 @@ def _handle_migrate_shared_users(event):
                 "body": json.dumps({"message": "Migration skipped - lock held"}),
             }
 
-        max_wait_seconds = event.get("max_wait_seconds", 60)
+        max_wait_seconds = event.get("max_wait_seconds", 600)
         retry_interval = event.get("retry_interval", 10)
 
         print(
@@ -1839,21 +1861,19 @@ def _handle_migrate_shared_users(event):
             autoscaling_users = get_assigned_users_for_instance(
                 PremiumAssignment.AUTOSCALING_POOL
             )
-            remaining_users = len(autoscaling_users)
+            remaining_autoscaling = len(autoscaling_users)
+            remaining_shared = migration_result.get("shared_instances_found", 0)
 
             if migrations_performed > 0:
                 print(
                     f"Migrated {migrations_performed} users, "
-                    f"{remaining_users} still on "
-                    f"autoscaling pool"
+                    f"{remaining_autoscaling} on autoscaling "
+                    f"pool, {remaining_shared} shared "
+                    f"instances remaining"
                 )
 
-            if remaining_users == 0:
-                print(
-                    f"Migration completed after {elapsed}s"
-                    f" - all users migrated from "
-                    f"autoscaling pool"
-                )
+            if remaining_autoscaling == 0 and remaining_shared == 0:
+                print(f"Migration completed after {elapsed}s" f" - all users migrated")
                 return {
                     "statusCode": 200,
                     "body": json.dumps(
@@ -2236,11 +2256,16 @@ def assign_premium_user(
                 f"instance {existing_instance_id}"
             )
 
-            # Trigger migration if user is stuck on autoscaling-pool
-            if existing_instance_id == PremiumAssignment.AUTOSCALING_POOL:
+            # Trigger migration for autoscaling-pool or shared
+            if (
+                existing_instance_id == PremiumAssignment.AUTOSCALING_POOL
+                or existing_assignment.get("is_shared")
+            ):
                 print(
-                    f"User {user_id} is on autoscaling-pool, "
-                    f"triggering migration check..."
+                    f"User {user_id} needs migration "
+                    f"(instance={existing_instance_id}, "
+                    f"shared={existing_assignment.get('is_shared')})"
+                    f", triggering migration check..."
                 )
                 invoke_migration_async()
 
@@ -2730,9 +2755,7 @@ def assign_premium_user(
 
         # Create ALB listener rule for user routing
         if not user_uid:
-            raise ValueError(
-                "user_uid is required to generate routing ID"
-            )
+            raise ValueError("user_uid is required to generate routing ID")
         routing_secret_key = get_required_env_var("ROUTING_SECRET_KEY")
         routing_id = generate_routing_id(user_uid, routing_secret_key)
         print(
@@ -2976,19 +2999,13 @@ def scale_premium_instances_if_needed():
         print(f"- Premium subscribers: {total_subscribers}")
 
         if launching_count > 0:
-            print(
-                f"Scaling blocked: {launching_count} "
-                f"instances already launching"
-            )
+            print(f"Scaling blocked: {launching_count} " f"instances already launching")
             return False
 
         # Block scaling while another Lambda is creating instances;
         # we can't know the exact count, so let it finish first.
         if running_creating:
-            print(
-                "Scaling blocked: running instance "
-                "creation already in progress"
-            )
+            print("Scaling blocked: running instance " "creation already in progress")
             return False
 
         # Key decision: Scale based on ACTIVE ASSIGNMENTS, not subscribers

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -209,6 +209,24 @@ def get_user_id_from_uid(connection, user_uid: str) -> int:
         return result["id"]
 
 
+def get_user_uid_from_id(connection, user_id: int) -> str:
+    """Reverse lookup: get Firebase UID from numeric DB user_id.
+
+    Needed when only numeric ID is available (e.g. migration).
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT uid FROM users WHERE id = %s""",
+            (user_id,),
+        )
+        result = cursor.fetchone()
+
+        if not result:
+            raise ValueError(f"User not found with ID: {user_id}")
+
+        return result["uid"]
+
+
 @with_transaction
 def _increment_assignment_attempts_transaction(connection, user_id: int) -> int:
     """Internal function: Increment assignment attempts for
@@ -1803,6 +1821,9 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # (deregister container instances where EC2 is stopped/terminated)
             cleanup_ghost_ecs_registrations()
 
+            # 9. Stop orphaned EC2 instances not in ECS cluster
+            cleanup_orphaned_ec2_instances()
+
             return {
                 "statusCode": 200,
                 "body": json.dumps(
@@ -2004,7 +2025,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 }
 
             if action == "assign":
-                return assign_premium_user(user_id, body_data)
+                return assign_premium_user(user_id, body_data, user_uid)
             elif action == "release":
                 return release_premium_user(user_id)
             elif action == "update_activity":
@@ -2243,7 +2264,9 @@ def get_next_available_priority(listener_arn: str, start_priority: int = 100) ->
         raise
 
 
-def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
+def assign_premium_user(
+    user_id: int, event: Dict[str, Any], user_uid: str = ""
+) -> Dict[str, Any]:
     """Enhanced assignment with standby pool support -
     prefer stopped instances for fast startup"""
 
@@ -2766,7 +2789,7 @@ def assign_premium_user(user_id: int, event: Dict[str, Any]) -> Dict[str, Any]:
 
         # Create ALB listener rule for user routing
         routing_secret_key = get_required_env_var("ROUTING_SECRET_KEY")
-        routing_id = generate_routing_id(str(user_id), routing_secret_key)
+        routing_id = generate_routing_id(user_uid, routing_secret_key)
         print(
             f"Generated routing_id for user: {routing_id[:8]}... "
             f"(truncated for security)"
@@ -3401,7 +3424,6 @@ def update_premium_service_desired_count():
         service_name = get_required_env_var("PREMIUM_SERVICE_NAME")
 
         ecs: "ECSClient" = boto3.client("ecs")
-        ec2: "EC2Client" = boto3.client("ec2")
 
         # Get current service status
         service_response = ecs.describe_services(
@@ -3409,29 +3431,31 @@ def update_premium_service_desired_count():
         )
 
         if not service_response.get("services"):
-            print(f"Premium service {service_name} not found in cluster {cluster_name}")
+            print(
+                f"Premium service {service_name} not found "
+                f"in cluster {cluster_name}"
+            )
             return
 
         current_desired_count = service_response["services"][0]["desiredCount"]
         current_running_count = service_response["services"][0]["runningCount"]
 
-        # Count running premium instances
-        response = ec2.describe_instances(
-            Filters=[
-                {"Name": "instance-state-name", "Values": [InstanceState.RUNNING]},
-                {"Name": "tag:Tier", "Values": ["premium", "Premium"]},
-            ]
+        # Count ACTIVE ECS container instances (not EC2 instances,
+        # which may include orphans that never joined the cluster)
+        ci_response = ecs.list_container_instances(
+            cluster=cluster_name,
+            filter="attribute:tier == premium",
+            status="ACTIVE",
         )
-
-        running_premium_count = sum(
-            len(reservation["Instances"]) for reservation in response["Reservations"]
-        )
+        ci_arns = ci_response.get("containerInstanceArns", [])
+        running_premium_count = len(ci_arns)
 
         print(
-            f"ECS Service Status: desired={current_desired_count}, "
+            f"ECS Service Status: "
+            f"desired={current_desired_count}, "
             f"running={current_running_count}"
         )
-        print(f"Premium EC2 Instances: {running_premium_count} running")
+        print(f"Premium ECS container instances: " f"{running_premium_count} active")
 
         # Update service desired count if different from instance count
         if running_premium_count != current_desired_count:
@@ -3625,9 +3649,8 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         # Create new ALB rule for this user
                         alb_listener_arn = get_required_env_var("ALB_LISTENER_ARN")
                         routing_secret_key = get_required_env_var("ROUTING_SECRET_KEY")
-                        routing_id = generate_routing_id(
-                            str(user_id), routing_secret_key
-                        )
+                        user_uid = get_user_uid_from_id(connection, user_id)
+                        routing_id = generate_routing_id(user_uid, routing_secret_key)
 
                         # Get next available priority
                         priority = get_next_available_priority(
@@ -4245,6 +4268,83 @@ def cleanup_ghost_ecs_registrations():
 
     except Exception as e:
         print(f"Error cleaning up ghost ECS registrations: {str(e)}")
+
+
+ORPHAN_GRACE_PERIOD_MINUTES = 15
+
+
+def cleanup_orphaned_ec2_instances():
+    """Stop EC2 instances tagged Tier=premium that are running
+    but not registered as ECS container instances.
+
+    Orphaned instances inflate desiredCount and waste resources.
+    A 15-minute grace period avoids stopping instances that are
+    still booting and haven't joined ECS yet.
+    """
+    try:
+        cluster_name = get_required_env_var("CLUSTER_NAME")
+        ecs: "ECSClient" = boto3.client("ecs")
+        ec2: "EC2Client" = boto3.client("ec2")
+
+        # Collect EC2 IDs of all ACTIVE ECS container instances
+        ci_response = ecs.list_container_instances(
+            cluster=cluster_name, status="ACTIVE"
+        )
+        ci_arns = ci_response.get("containerInstanceArns", [])
+
+        ecs_ec2_ids: set = set()
+        if ci_arns:
+            desc = ecs.describe_container_instances(
+                cluster=cluster_name,
+                containerInstances=ci_arns,
+            )
+            for ci in desc.get("containerInstances", []):
+                ecs_ec2_ids.add(ci["ec2InstanceId"])
+
+        # List all running premium-tagged EC2 instances
+        ec2_response = ec2.describe_instances(
+            Filters=[
+                {
+                    "Name": "instance-state-name",
+                    "Values": [InstanceState.RUNNING],
+                },
+                {
+                    "Name": "tag:Tier",
+                    "Values": ["premium", "Premium"],
+                },
+            ]
+        )
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        stopped_count = 0
+
+        for reservation in ec2_response["Reservations"]:
+            for instance in reservation["Instances"]:
+                iid = instance["InstanceId"]
+                if iid in ecs_ec2_ids:
+                    continue
+
+                launch_time = instance.get("LaunchTime")
+                if launch_time:
+                    age_minutes = (now - launch_time).total_seconds() / 60
+                    if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
+                        print(
+                            f"Orphan {iid} running "
+                            f"{age_minutes:.0f}m, "
+                            f"within grace period"
+                        )
+                        continue
+
+                print(f"Stopping orphaned EC2 instance {iid}")
+                ec2.stop_instances(InstanceIds=[iid])
+                stopped_count += 1
+
+        print(f"Orphan cleanup: stopped {stopped_count} " f"instance(s)")
+
+    except Exception as e:
+        print(f"Error cleaning up orphaned EC2 instances: " f"{str(e)}")
 
 
 def get_premium_system_status() -> Dict[str, Any]:

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -189,6 +189,7 @@ app.include_router(
 )
 app.include_router(users_admin.router, dependencies=[Depends(get_admin_user)])
 app.include_router(users_me.router, dependencies=[Depends(get_current_user)])
+app.include_router(users_me.beacon_router)
 app.include_router(users_search.router, dependencies=[Depends(get_current_user)])
 app.include_router(workflow.router, dependencies=[Depends(get_current_user)])
 app.include_router(workspace.router, dependencies=[Depends(get_current_user)])

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -218,6 +218,7 @@ if MODE.IS_STANDALONE:
     app.dependency_overrides[is_workspace_owner] = skip_dependencies
     app.dependency_overrides[is_workspace_available] = skip_dependencies
 
+app.add_middleware(SecureRoutingMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -225,22 +226,14 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["x-user-tier", "x-routing-id"],
 )
 
-# Add SPARoutingMiddleware to handle browser navigation to SPA routes
-# This must be added before other middleware to intercept browser requests early
 app.add_middleware(SPARoutingMiddleware)
 
-# Add LoggingMiddleware to capture client_id for logging
 app.add_middleware(ClientIdLoggingMiddleware)
 
-# Add UserActivityMiddleware to track activity for both free and premium users
-# - Free users: enables intelligent load balancing and migration
-# - Premium users: prevents stale assignment cleanup for active users
 app.add_middleware(UserActivityMiddleware)
-
-# Add SecureRoutingMiddleware to add routing headers based on JWT validation
-app.add_middleware(SecureRoutingMiddleware)
 
 
 @app.get("/is_standalone", response_model=bool, tags=["others"])

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -458,6 +458,11 @@ class PremiumAssignmentService:
 
             if status_code == 200:
                 body = json.loads(response_payload.get("body", "{}"))
+                logger.debug(
+                    "Premium status result for user %s: %s",
+                    user_id,
+                    body,
+                )
                 return body
             elif status_code == 404:
                 # User not assigned

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -30,6 +30,8 @@ from studio.app.common.models import FreeUserAssignment
 from studio.app.common.schemas.users import SelfUserUpdate, User, UserPasswordUpdate
 
 router = APIRouter(prefix="/users/me", tags=["users/me"])
+
+beacon_router = APIRouter(prefix="/users/me", tags=["users/me"])
 logger = AppLogger.get_logger()
 
 
@@ -184,7 +186,7 @@ async def get_beacon_token(
     return {"token": token}
 
 
-@router.post("/premium/release-beacon", response_model=Dict)
+@beacon_router.post("/premium/release-beacon", response_model=Dict)
 async def release_premium_beacon(request: Request, db: Session = Depends(get_db)):
     """
     Beacon endpoint for reliable cleanup on browser close.

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -303,6 +303,14 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
             current_user.id, current_user.uid
         )
 
+        logger.debug(
+            "Premium status for user %s: " "assigned=%s, is_shared=%s, instance=%s",
+            current_user.id,
+            status_info is not None,
+            status_info.get("is_shared") if status_info else None,
+            status_info.get("instance_id") if status_info else None,
+        )
+
         return {
             "user_id": current_user.uid,
             "subscription_type": current_user.subscription_type,

--- a/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
@@ -30,6 +30,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from starlette.middleware.cors import CORSMiddleware
 
 # Test data
 TEST_UID = "test_user_12345"
@@ -668,6 +669,57 @@ class TestMiddlewareIntegration:
             # Should not verify JWT for websocket
             mock_extract.assert_not_called()
             mock_app.assert_called_once()
+
+
+class TestCORSConfiguration:
+    """RC1: CORS must expose routing headers so the browser
+    can read them, and SecureRoutingMiddleware must run before
+    CORS in the response path (LIFO order means it is added
+    after CORS in the source)."""
+
+    def test_cors_exposes_routing_headers(self):
+        """CORSMiddleware must list x-user-tier and
+        x-routing-id in expose_headers."""
+        from studio.__main_unit__ import app
+
+        cors_mw = None
+        for mw in app.user_middleware:
+            if mw.cls is CORSMiddleware:
+                cors_mw = mw
+                break
+
+        assert cors_mw is not None, "CORSMiddleware not found in app middleware"
+        exposed = cors_mw.options.get("expose_headers", [])
+        assert "x-user-tier" in exposed
+        assert "x-routing-id" in exposed
+
+    def test_secure_routing_added_before_cors(self):
+        """SecureRoutingMiddleware must be inner relative to
+        CORS so it adds headers on the response path before
+        CORS exposes them. Starlette inserts at index 0, so
+        the middleware added first has the highest index
+        (innermost) and processes responses first."""
+        from starlette.middleware.cors import CORSMiddleware
+
+        from studio.__main_unit__ import app
+        from studio.app.common.core.middleware import SecureRoutingMiddleware
+
+        classes = [mw.cls for mw in app.user_middleware]
+
+        assert (
+            SecureRoutingMiddleware in classes
+        ), "SecureRoutingMiddleware not in middleware stack"
+        assert CORSMiddleware in classes, "CORSMiddleware not in middleware stack"
+
+        sr_idx = classes.index(SecureRoutingMiddleware)
+        cors_idx = classes.index(CORSMiddleware)
+        # Higher index = innermost = processes response first
+        assert sr_idx > cors_idx, (
+            "SecureRoutingMiddleware must be innermost "
+            "relative to CORS (higher index in "
+            "user_middleware) so it adds headers before "
+            "CORS exposes them"
+        )
 
 
 if __name__ == "__main__":

--- a/studio/tests/infrastructure/test_compute_config.py
+++ b/studio/tests/infrastructure/test_compute_config.py
@@ -1,0 +1,59 @@
+"""RC3: EFS mount path regression tests for compute.tf.
+
+Ensures the snakemake volume containerPath is correct and
+consistent across all ECS task definitions.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Locate compute.tf relative to the project root
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+COMPUTE_TF = PROJECT_ROOT / "infrastructure" / "terraform" / "compute.tf"
+
+EXPECTED_MOUNT_PATH = "/app/.snakemake"
+
+# Matches mountPoints blocks that reference a snakemake volume
+_MOUNT_BLOCK_RE = re.compile(
+    r"mountPoints\s*=\s*\[\s*\{[^}]*?"
+    r"sourceVolume\s*=\s*\"[^\"]*snmk-volume\"[^}]*?"
+    r"containerPath\s*=\s*\"([^\"]+)\"",
+    re.DOTALL,
+)
+
+
+class TestEFSMountPaths:
+    """RC3: Verify EFS mount paths in compute.tf."""
+
+    @pytest.fixture(autouse=True)
+    def _load_tf(self):
+        assert COMPUTE_TF.exists(), f"compute.tf not found at {COMPUTE_TF}"
+        self.tf_content = COMPUTE_TF.read_text()
+
+    def test_premium_mount_path(self):
+        """Premium task definition must mount snakemake
+        volume at /app/.snakemake (was /efs before fix)."""
+        # Find premium task definition section
+        premium_section = re.search(
+            r'resource\s+"aws_ecs_task_definition"\s+'
+            r'"premium".*?(?=resource\s+"aws_)',
+            self.tf_content,
+            re.DOTALL,
+        )
+        assert premium_section, "Premium task definition not found in compute.tf"
+        match = _MOUNT_BLOCK_RE.search(premium_section.group())
+        assert match, "snakemake mountPoints not found in premium " "task definition"
+        assert match.group(1) == EXPECTED_MOUNT_PATH
+
+    def test_asg_and_premium_mount_paths_match(self):
+        """All snakemake volume containerPaths must be
+        identical across task definitions."""
+        paths = _MOUNT_BLOCK_RE.findall(self.tf_content)
+        assert len(paths) >= 2, (
+            f"Expected at least 2 snakemake mount blocks, " f"found {len(paths)}"
+        )
+        assert all(
+            p == EXPECTED_MOUNT_PATH for p in paths
+        ), f"Mount path mismatch: {paths}"

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -340,19 +340,19 @@ class TestPremiumManagerEvents:
 
         from premium_manager import store_user_assignment, update_instance_state
 
-        for enum_state, description in enum_states:
+        for i, (enum_state, description) in enumerate(enum_states):
             print(f"Testing enum state: '{enum_state}' " f"({description})")
 
             with patch.dict("os.environ", mock_env_vars_premium), patch(
                 "pymysql.connect"
             ) as mock_pymysql:
-                test_user = f"{TEST_USER_ID}_{enum_state}"
+                test_user_id = 1000 + i
 
                 mock_connection = setup_db_mock()
                 mock_pymysql.return_value = mock_connection
 
                 store_user_assignment(
-                    user_id=test_user,
+                    user_id=test_user_id,
                     instance_id=TEST_INSTANCE_ID,
                     target_group_arn="arn:test",
                     rule_arn="arn:test2",
@@ -361,7 +361,7 @@ class TestPremiumManagerEvents:
                 )
                 print(f"store_user_assignment with " f"'{enum_state}' - SUCCESS")
 
-                update_instance_state(test_user, enum_state)
+                update_instance_state(test_user_id, enum_state)
                 print(f"update_instance_state to " f"'{enum_state}' - SUCCESS")
 
     def test_error_handling(self, mock_env_vars_premium):

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1,8 +1,10 @@
 """Tests for premium_manager Lambda function."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
 from aws_constants import ECSTaskStatus
 from conftest import MockRow, setup_db_mock
 
@@ -47,6 +49,7 @@ class TestPremiumManagerEvents:
         ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
             mock_connection = setup_db_mock(
                 fetchone_values=[
+                    MockRow({"id": 123}),
                     None,
                     MockRow({"count": 1}),
                     MockRow({"count": 0}),
@@ -422,7 +425,9 @@ class TestEarlyCheckAndCleanup:
 
             from premium_manager import assign_premium_user
 
-            result = assign_premium_user(test_user_id, {"tier": "premium"})
+            result = assign_premium_user(
+                test_user_id, {"tier": "premium"}, "firebase_uid_123"
+            )
 
             status_code = result["statusCode"]
             response_body = json.loads(result["body"])
@@ -690,7 +695,9 @@ class TestEarlyCheckAndCleanup:
                 mock_boto3.side_effect = boto3_client_side_effect
 
                 result = premium_manager.assign_premium_user(
-                    test_user_id, {"tier": "premium"}
+                    test_user_id,
+                    {"tier": "premium"},
+                    "firebase_uid_456",
                 )
 
                 status_code = result["statusCode"]
@@ -1209,3 +1216,509 @@ class TestClearEcsAgentCheckpoint:
             result = clear_ecs_agent_checkpoint("i-test4")
 
             assert result is False
+
+
+class TestDesiredCountUsesECS:
+    """RC4: update_premium_service_desired_count uses ECS
+    container instance count, not EC2 instance count."""
+
+    def test_updates_from_ecs_count(self, mock_env_vars_premium):
+        """desiredCount is set from ECS container instances."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 4, "runningCount": 1}]
+            }
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
+            }
+
+            from premium_manager import update_premium_service_desired_count
+
+            update_premium_service_desired_count()
+
+            mock_ecs.update_service.assert_called_once()
+            call_kwargs = mock_ecs.update_service.call_args[1]
+            assert call_kwargs["desiredCount"] == 1
+
+    def test_no_update_when_counts_match(self, mock_env_vars_premium):
+        """No update when desired already matches ECS count."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 2, "runningCount": 2}]
+            }
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [
+                    "arn:aws:ecs:us-east-1:123:ci/a",
+                    "arn:aws:ecs:us-east-1:123:ci/b",
+                ]
+            }
+
+            from premium_manager import update_premium_service_desired_count
+
+            update_premium_service_desired_count()
+
+            mock_ecs.update_service.assert_not_called()
+
+    def test_does_not_use_ec2_describe_instances(self, mock_env_vars_premium):
+        """RC4: update_premium_service_desired_count must not
+        call ec2.describe_instances (old counting method)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 2, "runningCount": 2}]
+            }
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [
+                    "arn:aws:ecs:us-east-1:123:ci/a",
+                    "arn:aws:ecs:us-east-1:123:ci/b",
+                ]
+            }
+
+            from premium_manager import update_premium_service_desired_count
+
+            update_premium_service_desired_count()
+
+            mock_ec2.describe_instances.assert_not_called()
+
+
+class TestRoutingIdContract:
+    """RC2: Lambda and middleware must produce identical
+    routing IDs for the same Firebase UID + secret."""
+
+    def test_handler_passes_firebase_uid_to_assign(self, mock_env_vars_premium):
+        """handler() must pass the original Firebase UID
+        string (not the numeric DB ID) as user_uid to
+        assign_premium_user."""
+        event = {
+            "httpMethod": "POST",
+            "path": "/premium/assign",
+            "body": json.dumps(
+                {
+                    "action": "assign",
+                    "user_id": "firebase_xyz_999",
+                    "tier": "premium",
+                }
+            ),
+            "requestContext": {"requestId": "req-1"},
+        }
+        mock_context = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql, patch(
+            "premium_manager.assign_premium_user",
+            return_value={
+                "statusCode": 200,
+                "body": "{}",
+            },
+        ) as mock_assign:
+            mock_connection = setup_db_mock(
+                fetchone_values=[{"id": 42}],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import handler
+
+            handler(event, mock_context)
+
+            mock_assign.assert_called_once()
+            _, _, user_uid_arg = mock_assign.call_args[0]
+            assert user_uid_arg == "firebase_xyz_999"
+
+    def test_migration_uses_firebase_uid_for_routing(self, mock_env_vars_premium):
+        """migrate_user_to_dedicated_instance must call
+        get_user_uid_from_id and pass the result to
+        generate_routing_id (not str(user_id))."""
+        import sys
+
+        # premium_user_utils is deployed in a Lambda Layer
+        mock_utils = MagicMock()
+        mock_utils.can_migrate_user = MagicMock(return_value=True)
+        sys.modules["premium_user_utils"] = mock_utils
+
+        try:
+            with patch.dict("os.environ", mock_env_vars_premium), patch(
+                "boto3.client"
+            ) as mock_boto3, patch("pymysql.connect") as mock_pymysql, patch(
+                "premium_manager." "try_reserve_instance_for_migration",
+                return_value=True,
+            ), patch(
+                "premium_manager.get_user_uid_from_id",
+                return_value="firebase_migrated_uid",
+            ) as mock_uid_lookup, patch(
+                "premium_manager.generate_routing_id",
+                return_value="abcd1234abcd1234",
+            ) as mock_gen, patch(
+                "premium_manager." "create_or_get_target_group",
+                return_value="arn:aws:tg/migrated",
+            ), patch(
+                "premium_manager." "get_next_available_priority",
+                return_value=200,
+            ), patch(
+                "premium_manager." "trigger_experiment_sync"
+            ):
+                mock_connection = setup_db_mock(
+                    fetchone_values=[
+                        {
+                            "instance_id": ("autoscaling-pool"),
+                            "target_group_arn": "",
+                            "alb_rule_arn": "",
+                            "active_workflow_count": 0,
+                        },
+                    ],
+                )
+                mock_pymysql.return_value = mock_connection
+
+                mock_elbv2 = MagicMock()
+                mock_elbv2.create_rule.return_value = {
+                    "Rules": [{"RuleArn": ("arn:aws:rule/migrated")}]
+                }
+
+                def boto3_client_side_effect(service):
+                    if service == "elbv2":
+                        return mock_elbv2
+                    return MagicMock()
+
+                mock_boto3.side_effect = boto3_client_side_effect
+
+                from premium_manager import migrate_user_to_dedicated_instance
+
+                migrate_user_to_dedicated_instance(42, "i-dedicated1")
+
+                mock_uid_lookup.assert_called_once()
+                mock_gen.assert_called_once_with(
+                    "firebase_migrated_uid",
+                    mock_env_vars_premium["ROUTING_SECRET_KEY"],
+                )
+        finally:
+            sys.modules.pop("premium_user_utils", None)
+
+    def test_same_routing_id_for_firebase_uid(self):
+        """Both implementations produce identical output
+        for the same Firebase UID + secret."""
+        from premium_manager import generate_routing_id as lambda_gen
+
+        from studio.app.common.core.middleware.secure_routing_middleware import (  # noqa: E501
+            generate_routing_id as middleware_gen,
+        )
+
+        uid = "firebase_user_abc123"
+        secret = "shared-secret-key"
+
+        assert lambda_gen(uid, secret) == middleware_gen(uid, secret)
+
+    def test_numeric_id_differs_from_firebase_uid(self):
+        """Numeric DB ID and Firebase UID produce different
+        routing IDs -- the root cause of RC2."""
+        from premium_manager import generate_routing_id
+
+        secret = "test-secret"
+        numeric_id = generate_routing_id("123", secret)
+        firebase_uid = generate_routing_id("firebaseXYZ", secret)
+
+        assert numeric_id != firebase_uid
+
+    def test_assign_uses_firebase_uid_for_routing(self, mock_env_vars_premium):
+        """assign_premium_user passes the Firebase UID (not
+        the numeric user_id) to generate_routing_id."""
+        patches = {
+            "premium_manager.get_existing_user_assignment": None,
+            "premium_manager." "register_orphaned_stopped_instances": None,
+            "premium_manager."
+            "get_all_premium_instances_with_states": [
+                {
+                    "instance_id": "i-test1",
+                    "state": "running",
+                }
+            ],
+            "premium_manager.count_active_premium_users": 0,
+            "premium_manager." "get_available_standby_instances": [],
+            "premium_manager." "check_instance_readiness_with_retry": True,
+            "premium_manager.try_reserve_instance": True,
+            "premium_manager." "cleanup_duplicate_rules_for_routing_id": 0,
+            "premium_manager." "get_next_available_priority": 100,
+        }
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql, patch(
+            "premium_manager.generate_routing_id",
+            return_value="abcd1234abcd1234",
+        ) as mock_gen:
+            for target, rv in patches.items():
+                patcher = patch(target, return_value=rv)
+                patcher.start()
+                self._patchers = getattr(self, "_patchers", [])
+                self._patchers.append(patcher)
+
+            try:
+                mock_connection = setup_db_mock(
+                    fetchone_values=[
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    ],
+                    fetchall_values=[[], [], []],
+                )
+                mock_pymysql.return_value = mock_connection
+
+                mock_elbv2 = MagicMock()
+                mock_elbv2.create_target_group.return_value = {
+                    "TargetGroups": [{"TargetGroupArn": ("arn:aws:tg/new")}]
+                }
+                mock_elbv2.create_rule.return_value = {
+                    "Rules": [{"RuleArn": "arn:aws:rule/new"}]
+                }
+
+                def boto3_client_side_effect(service):
+                    if service == "elbv2":
+                        return mock_elbv2
+                    return MagicMock()
+
+                mock_boto3.side_effect = boto3_client_side_effect
+
+                from premium_manager import assign_premium_user
+
+                assign_premium_user(42, {"tier": "premium"}, "firebase_abc")
+
+                mock_gen.assert_called_once_with(
+                    "firebase_abc",
+                    mock_env_vars_premium["ROUTING_SECRET_KEY"],
+                )
+            finally:
+                for p in getattr(self, "_patchers", []):
+                    p.stop()
+                self._patchers = []
+
+
+class TestCleanupOrphanedEC2Instances:
+    """RC4: cleanup_orphaned_ec2_instances stops unregistered
+    instances past the grace period and skips the rest."""
+
+    def test_stops_orphaned_past_grace_period(self, mock_env_vars_premium):
+        """EC2 instance running 20 min and NOT in ECS
+        container instances gets stopped."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": []
+            }
+
+            # 20 minutes ago -- past grace period
+            launch_time = datetime.now(timezone.utc) - timedelta(minutes=20)
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-orphan1",
+                                "State": {"Name": "running"},
+                                "LaunchTime": launch_time,
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_orphaned_ec2_instances
+
+            cleanup_orphaned_ec2_instances()
+
+            mock_ec2.stop_instances.assert_called_once_with(InstanceIds=["i-orphan1"])
+
+    def test_skips_instance_within_grace_period(self, mock_env_vars_premium):
+        """EC2 instance running 5 min is within grace period
+        and must NOT be stopped."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": []
+            }
+
+            # 5 minutes ago -- within grace period
+            launch_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-young1",
+                                "State": {"Name": "running"},
+                                "LaunchTime": launch_time,
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_orphaned_ec2_instances
+
+            cleanup_orphaned_ec2_instances()
+
+            mock_ec2.stop_instances.assert_not_called()
+
+    def test_skips_instance_registered_in_ecs(self, mock_env_vars_premium):
+        """EC2 instance registered as ECS container instance
+        must NOT be stopped even if old."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": ["arn:aws:ecs:r:a:ci/registered"]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ("arn:aws:ecs:r:a:ci/registered"),
+                        "ec2InstanceId": "i-healthy1",
+                    }
+                ]
+            }
+
+            # 60 minutes ago -- old but healthy
+            launch_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-healthy1",
+                                "State": {"Name": "running"},
+                                "LaunchTime": launch_time,
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_orphaned_ec2_instances
+
+            cleanup_orphaned_ec2_instances()
+
+            mock_ec2.stop_instances.assert_not_called()
+
+
+class TestGetUserUidFromId:
+    """RC4: Reverse UID lookup from numeric DB ID."""
+
+    def test_returns_firebase_uid(self, mock_env_vars_premium):
+        """Returns the Firebase UID for a known user_id."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[{"uid": "firebase_abc"}],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import get_user_uid_from_id
+
+            result = get_user_uid_from_id(mock_connection, 42)
+            assert result == "firebase_abc"
+
+    def test_raises_for_unknown_id(self, mock_env_vars_premium):
+        """Raises ValueError when user_id is not found."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock(
+                fetchone_values=[None],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import get_user_uid_from_id
+
+            with pytest.raises(ValueError, match="not found"):
+                get_user_uid_from_id(mock_connection, 9999)


### PR DESCRIPTION
## Summary

### Problem

Premium user 2 was assigned to dedicated instance `i-02533f43955503b1b`, but
all requests (including `POST /run/7` snakemake workflow) executed on the ASG
shared instance instead. The workflow output only exists on the ASG container's
ephemeral storage. Four independent root causes were found:

1. CORS blocked the browser from reading `x-routing-id` response headers
2. Lambda and middleware generated different HMAC routing IDs for the same user
3. Premium EFS mounted at `/efs` instead of `/app/.snakemake`
4. `update_premium_service_desired_count()` counted EC2 instances instead of
   ECS container instances, inflating desiredCount with orphaned instances

### Cause

**RC1 -- CORS blocks routing headers (`__main_unit__.py`):**
`CORSMiddleware` had no `expose_headers` configured, so the browser blocked
JavaScript from reading `x-routing-id`. Additionally, `SecureRoutingMiddleware`
was added last (outermost in ASGI), so it added headers AFTER CORS already
processed the response. `routing_id` stayed `null` in localStorage, and the
axios interceptor never sent routing headers to the ALB.

**RC2 -- Routing ID HMAC input mismatch (`premium_manager.py`):**
The Lambda passed `str(user_id)` (DB integer `"2"`) to `generate_routing_id`,
while the middleware passed the Firebase UID (`"9YuPzEve...QDH2"`). Both use
the same HMAC-SHA256 function but with different inputs, producing permanently
mismatched routing IDs. The ALB rule expected `f94b07de1345409d` but the
browser sent `5f7bd410a13634b5`.

**RC3 -- EFS mount path (`compute.tf`):**
The premium task definition mounted EFS at `/efs` while the app writes conda
environments to `/app/.snakemake/conda`. The mount was wasted and conda envs
went to ephemeral container storage, causing ~10+ min first-run downloads and
data loss on restart.

**RC4 -- Orphaned instances inflate desiredCount (`premium_manager.py`):**
`update_premium_service_desired_count()` counted running EC2 instances by
`Tier=premium` tag instead of active ECS container instances. Three orphaned
EC2 instances (running but never registered with the ECS cluster) inflated
`desiredCount` to 4 when only 1 container instance existed, causing perpetual
"Unable to place task" errors.

### Solution

**Files:**
- `studio/__main_unit__.py`
- `infrastructure/terraform/premium_manager_package/premium_manager.py`
- `infrastructure/terraform/compute.tf`
- `studio/tests/infrastructure/test_premium_manager.py`
- `studio/tests/infrastructure/test_compute_config.py` (new)
- `studio/tests/app/common/core/middleware/test_secure_routing_middleware.py`

**RC1 -- Reorder middleware and expose routing headers:**

Reordered middleware so `SecureRoutingMiddleware` is innermost (added first via
`add_middleware`, which is LIFO) and `CORSMiddleware` is outermost (added
last). Added `expose_headers=["x-user-tier", "x-routing-id"]` to CORS config.
Removed stale comments that described the old ordering.

Response path: App -> SecureRouting (adds headers) -> CORS (exposes headers)

**RC2 -- Use Firebase UID for HMAC routing ID generation:**

- `assign_premium_user`: added `user_uid` parameter, passed from the handler
  which already has the Firebase UID. Changed `generate_routing_id(str(user_id),
  ...)` to `generate_routing_id(user_uid, ...)`
- `migrate_user_to_dedicated_instance`: added `get_user_uid_from_id()` reverse
  lookup to retrieve the Firebase UID from the DB integer ID, then passed it to
  `generate_routing_id`
- `handler`: passes `user_uid` to `assign_premium_user`

**RC3 -- Fix EFS mount path:**

Changed `containerPath` from `"/efs"` to `"/app/.snakemake"` in the premium
task definition, matching the ASG task definition and the app's
`SNAKEMAKE_CONDA_ENV_DIR` derivation.

**RC4 -- Count ECS container instances instead of EC2 instances:**

- `update_premium_service_desired_count`: replaced `ec2.describe_instances`
  (tag-based) with `ecs.list_container_instances` (cluster-based with
  `attribute:tier == premium` filter). Removed unused `ec2` client
- Added `cleanup_orphaned_ec2_instances()`: stops running EC2 instances with
  `Tier=premium` tag that have no matching ECS container instance registration,
  with a 15-minute grace period for instances still booting
- Hooked `cleanup_orphaned_ec2_instances()` into the scheduled monitoring
  handler

**Tests:**
- Updated `assign_premium_user` call sites to pass `user_uid` argument
- Added `MockRow({"id": 123})` for the new `get_user_id_from_uid` DB query
- Added `TestDesiredCountUsesECS` class with two tests:
  - `test_updates_from_ecs_count`: verifies desiredCount is set from ECS
    container instance count, not EC2 instance count
  - `test_no_update_when_counts_match`: verifies no update call when desired
    already matches ECS count

**Regression tests for all 4 root causes (13 new tests):**

*RC1 -- `TestCORSConfiguration` (test_secure_routing_middleware.py):*
- `test_cors_exposes_routing_headers`: asserts `expose_headers` contains
  `x-user-tier` and `x-routing-id`
- `test_secure_routing_added_before_cors`: asserts SecureRoutingMiddleware is
  innermost relative to CORS so it adds headers before CORS exposes them

*RC2 -- `TestRoutingIdContract` (test_premium_manager.py):*
- `test_handler_passes_firebase_uid_to_assign`: verifies `handler()` passes the
  original Firebase UID string (not numeric DB ID) to `assign_premium_user`
- `test_migration_uses_firebase_uid_for_routing`: verifies
  `migrate_user_to_dedicated_instance` calls `get_user_uid_from_id` and passes
  the result to `generate_routing_id` (not `str(user_id)`)
- `test_same_routing_id_for_firebase_uid`: both Lambda and middleware
  `generate_routing_id` produce identical output for the same UID + secret
- `test_numeric_id_differs_from_firebase_uid`: documents that numeric DB IDs
  and Firebase UIDs produce different routing IDs (the root cause)
- `test_assign_uses_firebase_uid_for_routing`: verifies `assign_premium_user`
  passes the Firebase UID (not numeric user_id) to `generate_routing_id`

*RC3 -- `TestEFSMountPaths` (test_compute_config.py, new file):*
- `test_premium_mount_path`: parses compute.tf and asserts the premium task
  definition mounts snakemake volume at `/app/.snakemake`
- `test_asg_and_premium_mount_paths_match`: asserts all snakemake volume
  containerPaths across task definitions are identical

*RC4 -- (test_premium_manager.py):*
- `TestDesiredCountUsesECS::test_does_not_use_ec2_describe_instances`: asserts
  `update_premium_service_desired_count` never calls `ec2.describe_instances`
- `TestCleanupOrphanedEC2Instances::test_stops_orphaned_past_grace_period`:
  EC2 instance running 20 min and not in ECS gets stopped
- `TestCleanupOrphanedEC2Instances::test_skips_instance_within_grace_period`:
  EC2 instance running 5 min is not stopped (still booting)
- `TestCleanupOrphanedEC2Instances::test_skips_instance_registered_in_ecs`:
  healthy registered instance is not stopped
- `TestGetUserUidFromId::test_returns_firebase_uid`: reverse lookup returns
  correct Firebase UID
- `TestGetUserUidFromId::test_raises_for_unknown_id`: raises ValueError for
  unknown user_id

### Evidence

Discovered via AWS CLI, CloudWatch logs, browser console, and source code
review on 2026-02-18. Full investigation documented in
`PREMIUM_INVESTIGATION.md` (29 items checked).

Browser confirmation (pre-fix):
```
localStorage.getItem('routing_id')      -> null      BROKEN
localStorage.getItem('premium_assigned') -> 'true'    OK
localStorage.getItem('routing_tier')    -> 'premium'  OK
```

CloudWatch confirmed zero user 2 traffic on the premium ECS task -- all 50
log entries were `/health` checks. All `POST /run/7` requests landed on the
ASG container (`17652889cdcd`) instead of the premium container
(`ba711b6a87f7`).

ECS service events showed the orphaned instance impact:
```
10:14:04 JST  Unable to place task - insufficient CPU
09:15:25 JST  Reached steady state (1/4 tasks)
```
