### PR TITLE
Fix Delete Modal Can Reclick Delete Button

### DIFF
--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -108,7 +108,10 @@ const Account = () => {
         "This action cannot be undone",
       ]
     }
-    return undefined
+    return [
+      "All your data (workspaces, experiments, files) will be permanently deleted",
+      "This action cannot be undone",
+    ]
   }
 
   const onConfirmDelete = async () => {

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -113,13 +113,18 @@ const Account = () => {
 
   const onConfirmDelete = async () => {
     if (!user) return
-    const data = await dispatch(deleteMe())
-    if (isRejectedWithValue(data)) {
+    try {
+      const data = await dispatch(deleteMe())
+      if (isRejectedWithValue(data)) {
+        handleClickVariant("error", "Account deleted failed!")
+      } else {
+        navigate("/login")
+      }
+    } catch {
       handleClickVariant("error", "Account deleted failed!")
-    } else {
-      navigate("/login")
+    } finally {
+      handleCloseDeleteComfirmModal()
     }
-    handleCloseDeleteComfirmModal()
   }
 
   const handleCloseChangePw = () => {
@@ -318,6 +323,7 @@ const Account = () => {
         description={getDeleteAccountDescription()}
         warningItems={getDeleteAccountWarnings()}
         iconType="warning"
+        loading={loading}
       />
       <ChangePasswordModal
         onSubmit={onConfirmChangePw}


### PR DESCRIPTION
### Content

Fix Delete Modal Can Reclick Delete Button.

### References

https://docs.google.com/spreadsheets/d/1bq0ySUQCnmSc9Lh5PUnfIKcS00fFCvpbDs_e797Z8W4/edit?gid=1676325858#gid=1676325858

### Testcase

- [x] Delete Free User. Warning Shows. After Delete Button is Clicked you cannot click the delete button again. User is deleted
- [x] Delete Premium User. Premium features Warning Shows. After Delete Button is Clicked you cannot click the delete button again. User is deleted