### PR TITLE
Add ESC task ID to log

### DIFF
--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -1,9 +1,11 @@
 import hashlib
+import json
 import logging
 import logging.config
 import os
 import platform
 import traceback
+import urllib.request
 from contextvars import ContextVar
 from typing import Optional
 
@@ -19,6 +21,29 @@ LOGGING_CLIENT_ID_KEY = "client_id"
 _client_id_context: ContextVar[Optional[str]] = ContextVar(
     LOGGING_CLIENT_ID_KEY, default=None
 )
+
+NO_ECS_TASK_DEFAULT = "local"
+_ECS_METADATA_TIMEOUT = 2
+
+
+def _get_ecs_task_id() -> str:
+    """Fetch the short ECS task ID from the container metadata
+    endpoint (v4). Returns a default value outside ECS."""
+    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+    if not meta_uri:
+        return NO_ECS_TASK_DEFAULT
+    try:
+        req = urllib.request.Request(f"{meta_uri}/task")
+        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        # TaskARN: arn:aws:ecs:region:account:task/cluster/id
+        task_arn = data.get("TaskARN", "")
+        return task_arn.rsplit("/", 1)[-1] if "/" in task_arn else NO_ECS_TASK_DEFAULT
+    except Exception:
+        return NO_ECS_TASK_DEFAULT
+
+
+ECS_TASK_ID: str = _get_ecs_task_id()
 
 
 class LoggingConfigHelper:
@@ -180,7 +205,8 @@ class AppLogger:
 
     class ClientIdFilter(logging.Filter):
         """
-        Logging filter to inject client_id from context into log records
+        Logging filter to inject client_id and ecs_task_id
+        from context into log records.
         """
 
         # Alternate text to log if client_id is not obtained
@@ -194,6 +220,7 @@ class AppLogger:
                 if client_id is not None
                 else __class__.NO_CLIENT_ID_DEFAULT_VALUE
             )
+            record.ecs_task_id = ECS_TASK_ID
             return True
 
     @classmethod

--- a/studio/app/common/core/utils/log_reader.py
+++ b/studio/app/common/core/utils/log_reader.py
@@ -53,6 +53,7 @@ class LogRecordReader(ContentUnitReader):
             rb"(?:\x1b\[\d+m)?(?P<levelprefix>\w+)(?:\x1b\[0m)?:?\s+"
             rb"\[(?P<name>[^\]]+)\] "
             rb"\(pid:(?P<process>\w+)\) "
+            rb"\(task:(?P<ecs_task_id>[^\)]*)\) "
             rb"\(client:(?P<client_id>[^\)]*)\) "
             rb"(?P<funcName>\w+)\(\):(?P<lineno>\d+) - "
             rb"(?P<message>.*)",

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (task:%(ecs_task_id)s) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (task:%(ecs_task_id)s) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (task:%(ecs_task_id)s) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (task:%(ecs_task_id)s) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler


### PR DESCRIPTION
## Summary

### Problem

When multiple ECS tasks run across premium instances, there is no way to distinguish which task produced a given log line. This makes debugging multi-instance issues difficult.

### Solution

Added ECS task ID to the log format and updated the log reader regex to match the new format.

**Files:**
- `studio/app/common/core/logger.py`
- `studio/app/common/core/utils/log_reader.py`
- `studio/config/logging.yaml`
- `studio/config/logging.multiuser.yaml`

**Changes by category:**

1. **ECS task ID retrieval** (`logger.py`): Added `_get_ecs_task_id()` that reads `ECS_CONTAINER_METADATA_URI_V4`, fetches the `/task` endpoint (2s timeout), and extracts the short task ID from the TaskARN. Returns `"local"` outside ECS. Result cached in module-level `ECS_TASK_ID` constant

2. **Log record injection** (`logger.py`): `ClientIdFilter.filter()` sets `record.ecs_task_id = ECS_TASK_ID` on every log record

3. **Log format updated** (`logging.yaml`, `logging.multiuser.yaml`): Inserted `(task:%(ecs_task_id)s)` between `(pid:...)` and `(client:...)` in both default and access formatters

4. **Log reader regex fix** (`log_reader.py`): Added `\(task:(?P<ecs_task_id>[^\)]*)\)` to the parse pattern so the log viewer can match the new format

**Log format before/after:**

```
Before: ... (pid:%(process)d) (client:%(client_id)s) ...
After:  ... (pid:%(process)d) (task:%(ecs_task_id)s) (client:%(client_id)s) ...
```
