### PR TITLE
Fix/download experiment limit

### DIFF
--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -243,6 +243,9 @@ class S3StorageController(BaseRemoteStorageController):
                 )
                 return False
 
+            # Sort by directory depth (shallower files first)
+            all_s3_objects.sort(key=lambda obj: obj["Key"].count("/"))
+
             # do download data from remote storage
             target_files_count = len(all_s3_objects)
             for index, s3_object in enumerate(all_s3_objects):
@@ -824,6 +827,9 @@ class S3StorageController(BaseRemoteStorageController):
                     experiment_remote_path,
                 )
                 return False
+
+            # Sort by directory depth (shallower files first)
+            all_s3_objects.sort(key=lambda obj: obj["Key"].count("/"))
 
             logger.info(
                 f"Listed {len(all_s3_objects)} objects from S3 "

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -192,18 +192,50 @@ class S3StorageController(BaseRemoteStorageController):
             input_data_local_path,
         )
 
+        # Maximum number of files allowed for download
+        MAX_DOWNLOAD_FILES = 1000
+
         # ----------------------------------------
         # exec downloading
         # ----------------------------------------
 
         async with self.__get_s3_client() as __s3_client:
-            # request s3 list_objects
-            s3_list_objects = await __s3_client.list_objects_v2(
-                Bucket=self.bucket_name, Prefix=input_data_remote_path
-            )
+            # request s3 list_objects with pagination
+            all_s3_objects = []
+            continuation_token = None
+
+            while True:
+                list_params = {
+                    "Bucket": self.bucket_name,
+                    "Prefix": input_data_remote_path,
+                }
+                if continuation_token:
+                    list_params["ContinuationToken"] = continuation_token
+
+                s3_list_objects = await __s3_client.list_objects_v2(**list_params)
+
+                if not s3_list_objects or s3_list_objects.get("KeyCount", 0) == 0:
+                    break
+
+                all_s3_objects.extend(s3_list_objects.get("Contents", []))
+
+                # Check file count limit during listing
+                if len(all_s3_objects) > MAX_DOWNLOAD_FILES:
+                    raise RuntimeError(
+                        f"S3 object count exceeds the limit of "
+                        f"{MAX_DOWNLOAD_FILES}. "
+                        f"prefix={input_data_remote_path}, "
+                        f"found={len(all_s3_objects)}+ objects"
+                    )
+
+                # Check if there are more pages
+                if s3_list_objects.get("IsTruncated"):
+                    continuation_token = s3_list_objects.get("NextContinuationToken")
+                else:
+                    break
 
             # check copy source object
-            if not s3_list_objects or s3_list_objects.get("KeyCount", 0) == 0:
+            if not all_s3_objects:
                 logger.warning(
                     "remote data is not exists. [%s] [%s]",
                     self.bucket_name,
@@ -212,8 +244,8 @@ class S3StorageController(BaseRemoteStorageController):
                 return False
 
             # do download data from remote storage
-            target_files_count = len(s3_list_objects["Contents"])
-            for index, s3_object in enumerate(s3_list_objects["Contents"]):
+            target_files_count = len(all_s3_objects)
+            for index, s3_object in enumerate(all_s3_objects):
                 s3_file_path = s3_object["Key"]
                 file_size = s3_object["Size"]
 
@@ -742,24 +774,61 @@ class S3StorageController(BaseRemoteStorageController):
         # Initialize file filter and metrics tracking
         file_filter = FileSyncFilter()
 
+        # Maximum number of files allowed for download
+        MAX_DOWNLOAD_EXPERIMENT_FILES = 5000
+
         # ----------------------------------------
         # exec downloading
         # ----------------------------------------
 
         async with self.__get_s3_client() as __s3_client:
-            # request s3 list_objects
-            s3_list_objects = await __s3_client.list_objects_v2(
-                Bucket=self.bucket_name, Prefix=experiment_remote_path
-            )
+            # request s3 list_objects with pagination
+            all_s3_objects = []
+            continuation_token = None
+
+            while True:
+                list_params = {
+                    "Bucket": self.bucket_name,
+                    "Prefix": experiment_remote_path,
+                }
+                if continuation_token:
+                    list_params["ContinuationToken"] = continuation_token
+
+                s3_list_objects = await __s3_client.list_objects_v2(**list_params)
+
+                if not s3_list_objects or s3_list_objects.get("KeyCount", 0) == 0:
+                    break
+
+                all_s3_objects.extend(s3_list_objects.get("Contents", []))
+
+                # Check file count limit during listing
+                if len(all_s3_objects) > MAX_DOWNLOAD_EXPERIMENT_FILES:
+                    raise RuntimeError(
+                        "S3 object count exceeds the limit of "
+                        f"{MAX_DOWNLOAD_EXPERIMENT_FILES}. "
+                        f"prefix={experiment_remote_path}, "
+                        f"found={len(all_s3_objects)}+ objects"
+                    )
+
+                # Check if there are more pages
+                if s3_list_objects.get("IsTruncated"):
+                    continuation_token = s3_list_objects.get("NextContinuationToken")
+                else:
+                    break
 
             # check copy source directory
-            if not s3_list_objects or s3_list_objects.get("KeyCount", 0) == 0:
+            if not all_s3_objects:
                 logger.warning(
                     "remote data is not exists. [%s] [%s]",
                     self.bucket_name,
                     experiment_remote_path,
                 )
                 return False
+
+            logger.info(
+                f"Listed {len(all_s3_objects)} objects from S3 "
+                f"[{self.bucket_name}] [{experiment_remote_path}]"
+            )
 
             # cleaning data from local path (only for full sync, not partial syncs)
             # Partial syncs (visualization, essential_only) should preserve existing
@@ -768,7 +837,7 @@ class S3StorageController(BaseRemoteStorageController):
                 await self._clear_local_experiment_data(experiment_local_path)
 
             # do download data from remote storage
-            target_files_count = len(s3_list_objects["Contents"])
+            target_files_count = len(all_s3_objects)
 
             # Coordination files that should not be downloaded from S3
             coordination_files = {
@@ -776,7 +845,7 @@ class S3StorageController(BaseRemoteStorageController):
                 RemoteSyncStatusFileUtil.REMOTE_SYNC_STATUS_FILE,
             }
 
-            for index, s3_object in enumerate(s3_list_objects["Contents"]):
+            for index, s3_object in enumerate(all_s3_objects):
                 s3_file_path = s3_object["Key"]
                 file_size = s3_object["Size"]
 

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, List
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.utils.config_handler import ConfigReader
@@ -9,6 +9,8 @@ from studio.app.common.core.workflow.workflow import (
     Node,
     NodeData,
     NodePosition,
+    NodeType,
+    NodeTypeUtil,
     Style,
 )
 from studio.app.common.schemas.workflow import WorkflowConfig
@@ -94,3 +96,21 @@ class WorkflowConfigReader:
             )
             for key, value in config.items()
         }
+
+    @staticmethod
+    def extract_input_file_paths(config: WorkflowConfig) -> List[str]:
+        """Extract input file paths from workflow nodes."""
+        input_files = []
+
+        for node in config.nodeDict.values():
+            if NodeTypeUtil.check_nodetype(node.type) == NodeType.DATA:
+                if node.data and node.data.path:
+                    # path can be a string or list of strings
+                    paths = (
+                        node.data.path
+                        if isinstance(node.data.path, list)
+                        else [node.data.path]
+                    )
+                    input_files.extend(paths)
+
+        return input_files

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -47,7 +47,9 @@ from studio.app.common.core.workflow.workflow import (
     WorkflowRunStatus,
 )
 from studio.app.common.core.workflow.workflow_params import get_typecheck_params
+from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.common.schemas.workflow import WorkflowConfig
 from studio.app.const import ACCEPT_FILE_EXT, DATE_FORMAT, MetadataCacheFile
 from studio.app.dir_path import DIRPATH
 
@@ -143,29 +145,12 @@ class WorkflowRunner:
 
     def _extract_input_files(self) -> List[str]:
         """Extract input file paths from workflow nodes."""
-        input_files = []
-        data_node_types = {
-            NodeType.IMAGE,
-            NodeType.CSV,
-            NodeType.FLUO,
-            NodeType.BEHAVIOR,
-            NodeType.HDF5,
-            NodeType.MATLAB,
-            NodeType.MICROSCOPE,
-        }
-        for node in self.nodeDict.values():
-            if (
-                node.type in data_node_types
-                or NodeTypeUtil.check_nodetype(node.type) == NodeType.DATA
-            ):
-                if node.data and node.data.path:
-                    # path can be a string or list of strings
-                    paths = (
-                        node.data.path
-                        if isinstance(node.data.path, list)
-                        else [node.data.path]
-                    )
-                    input_files.extend(paths)
+        workflow_config = WorkflowConfig(
+            nodeDict=self.nodeDict,
+            edgeDict=self.edgeDict,
+        )
+        input_files = WorkflowConfigReader.extract_input_file_paths(workflow_config)
+
         return input_files
 
     async def _ensure_input_data_local(self) -> None:


### PR DESCRIPTION
## Content

#322 で報告されている、Dataview の不具合を対策
このPRでは以下を対策
> #### 異常ケース 1：必要なデータが S3->local へダウンロードされていない？

### 問題要因

S3StorageController の S3データダウロード関数で、Pagination が考慮されておらず、上限の 1,000 ファイルまでのダウンロードで中断されていた。
そのため、Dataviewへのデータ表示が欠損していた。

### 対策

S3データダウロード関数にPagination処理を追加
また一部細かなコード改善も適用（ダウンロード対象の優先順の制御など（上記階層のものから優先してダウンロード））

### Testcase

- [x] 1,000 件を超えるファイルが全てダウンロードされる
- [x] 1,000 件未満のファイルが全てダウンロードされる
- [x] ファイルのダウンロードは、上位階層のもの（config .yaml 関係）からダウンロードされる