### PR TITLE
Fix/mock storage mode

### DIFF
--- a/studio/app/common/core/experiment/experiment.py
+++ b/studio/app/common/core/experiment/experiment.py
@@ -121,6 +121,9 @@ class ExptOutputPathIds:
         """
         import re
 
+        from studio.app.common.core.storage.remote_storage_controller import (
+            RemoteStorageType,
+        )
         from studio.app.common.core.storage.s3_storage_controller import (
             S3StorageController,
         )
@@ -129,8 +132,13 @@ class ExptOutputPathIds:
 
         # Handle absolute paths starting with DIRPATH.OUTPUT_DIR
         # or the production S3 path (used in URLs)
-        s3_output_path = "/" + S3StorageController.make_s3_output_prefix().rstrip("/")
-        output_path_prefixes = [DIRPATH.OUTPUT_DIR, s3_output_path]
+        output_path_prefixes = [DIRPATH.OUTPUT_DIR]
+        if RemoteStorageType.get_activated_type() == RemoteStorageType.S3:
+            s3_output_path = "/" + S3StorageController.make_s3_output_prefix().rstrip(
+                "/"
+            )
+            output_path_prefixes.append(s3_output_path)
+
         for prefix in output_path_prefixes:
             if data_file_path.startswith(prefix):
                 relative_path = data_file_path[len(prefix) :].lstrip("/")

--- a/studio/app/common/core/storage/mock_storage_controller.py
+++ b/studio/app/common/core/storage/mock_storage_controller.py
@@ -13,6 +13,7 @@ from studio.app.common.core.utils.filepath_creater import (
     create_directory,
     join_filepath,
 )
+from studio.app.const import ThumbnailType
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -388,6 +389,28 @@ class MockStorageController(BaseRemoteStorageController):
             shutil.rmtree(experiment_remote_path)
 
         return True
+
+    async def download_thumbnail_source(
+        self,
+        workspace_id: str,
+        unique_id: str,
+        original_path: str,
+        thumb_type: ThumbnailType,
+    ) -> bool:
+        """
+        Download the source file needed to generate a thumbnail.
+        """
+        # Currently not implemented
+        pass
+
+    async def upload_thumbnail(
+        self, workspace_id: str, unique_id: str, thumbnail_path: str
+    ) -> bool:
+        """
+        Upload a generated thumbnail PNG to S3 for persistence.
+        """
+        # Currently not implemented
+        pass
 
     async def delete_workspace(
         self, workspace_id: str, directory_type: StorageDirectoryType

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -14,6 +14,7 @@ from studio.app.common.core.utils.datetime_utils import (
     get_current_datetime,
 )
 from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.const import ThumbnailType
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -494,6 +495,26 @@ class BaseRemoteStorageController(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def download_thumbnail_source(
+        self,
+        workspace_id: str,
+        unique_id: str,
+        original_path: str,
+        thumb_type: ThumbnailType,
+    ) -> bool:
+        """
+        Download the source file needed to generate a thumbnail.
+        """
+
+    @abstractmethod
+    async def upload_thumbnail(
+        self, workspace_id: str, unique_id: str, thumbnail_path: str
+    ) -> bool:
+        """
+        Upload a generated thumbnail PNG to S3 for persistence.
+        """
+
+    @abstractmethod
     async def delete_workspace(
         self, workspace_id: str, directory_type: StorageDirectoryType
     ) -> bool:
@@ -790,6 +811,30 @@ class RemoteStorageController(BaseRemoteStorageController):
             raise e
 
         return result
+
+    async def download_thumbnail_source(
+        self,
+        workspace_id: str,
+        unique_id: str,
+        original_path: str,
+        thumb_type: ThumbnailType,
+    ) -> bool:
+        """
+        Download the source file needed to generate a thumbnail.
+        """
+        return self.__controller.download_thumbnail_source(
+            workspace_id, unique_id, original_path, thumb_type
+        )
+
+    async def upload_thumbnail(
+        self, workspace_id: str, unique_id: str, thumbnail_path: str
+    ) -> bool:
+        """
+        Upload a generated thumbnail PNG to S3 for persistence.
+        """
+        return self.__controller.upload_thumbnail(
+            workspace_id, unique_id, thumbnail_path
+        )
 
     async def delete_workspace(
         self, workspace_id: str, directory_type: StorageDirectoryType

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -822,7 +822,7 @@ class RemoteStorageController(BaseRemoteStorageController):
         """
         Download the source file needed to generate a thumbnail.
         """
-        return self.__controller.download_thumbnail_source(
+        return await self.__controller.download_thumbnail_source(
             workspace_id, unique_id, original_path, thumb_type
         )
 
@@ -832,7 +832,7 @@ class RemoteStorageController(BaseRemoteStorageController):
         """
         Upload a generated thumbnail PNG to S3 for persistence.
         """
-        return self.__controller.upload_thumbnail(
+        return await self.__controller.upload_thumbnail(
             workspace_id, unique_id, thumbnail_path
         )
 

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -16,6 +16,8 @@ from studio.app.common.core.dataview.dataview_services import (
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
+    RemoteStorageSimpleReader,
+    RemoteStorageType,
 )
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.db.database import get_db
@@ -239,20 +241,24 @@ async def public_reproduce_experiment(
         owner_bucket = None
         if workspace and workspace.user:
             owner_bucket = getattr(workspace.user, "remote_bucket_name", None)
-        s3_bucket = owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
+        remote_bucket_name = owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
 
-        if s3_bucket:
+        async with RemoteStorageSimpleReader(
+            remote_bucket_name
+        ) as remote_storage_controller:
             logger.info(
                 f"Downloading published experiment {workspace_id}/{unique_id} "
-                f"from S3 bucket {s3_bucket}"
+                f"from remote bucket {remote_bucket_name}"
             )
-            s3_controller = S3StorageController(s3_bucket)
-            available = await s3_controller.download_experiment(workspace_id, unique_id)
+            available = await remote_storage_controller.download_experiment(
+                workspace_id,
+                unique_id,
+            )
 
             if not available:
                 logger.error(
                     f"Failed to download experiment {workspace_id}/{unique_id} "
-                    f"from S3 bucket {s3_bucket}"
+                    f"from remote bucket {remote_bucket_name}"
                 )
                 return JSONResponse(
                     status_code=503,
@@ -407,20 +413,25 @@ async def publish_dataview_records(
 
             # Validate S3 data exists before publishing
             if flag == PublishFlags.on:
-                bucket_name = current_user.remote_bucket_name or os.environ.get(
-                    "S3_DEFAULT_BUCKET_NAME"
-                )
-                if bucket_name:
-                    exists, error_msg = await _validate_experiment_exists_in_s3(
-                        str(record.workspace_id),
-                        record.uid,
-                        bucket_name,
+                remote_storage_type = RemoteStorageType.get_activated_type()
+                if remote_storage_type == RemoteStorageType.S3:
+                    bucket_name = current_user.remote_bucket_name or os.environ.get(
+                        "S3_DEFAULT_BUCKET_NAME"
                     )
-                    if not exists:
-                        raise HTTPException(
-                            status_code=400,
-                            detail=f"Cannot publish: {error_msg}",
+                    if bucket_name:
+                        exists, error_msg = await _validate_experiment_exists_in_s3(
+                            str(record.workspace_id),
+                            record.uid,
+                            bucket_name,
                         )
+                        if not exists:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Cannot publish: {error_msg}",
+                            )
+                else:
+                    # Currently not supported
+                    pass
 
             # Determine new sync status
             new_sync_status = (

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -14,9 +14,9 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteStorageReader,
     RemoteStorageSimpleReader,
+    RemoteStorageSimpleWriter,
     RemoteSyncStatusFileUtil,
 )
-from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.core.utils.file_reader import JsonReader, Reader
 from studio.app.common.core.utils.filepath_creater import (
     create_directory,
@@ -79,16 +79,16 @@ async def get_or_generate_thumbnail(
     For backward compatibility with experiments that don't have PNG thumbnails:
     1. Check if PNG thumbnail exists → return it
     2. If not, check if original file exists locally
-       - If not, download from S3
+       - If not, download from remote storage
     3. Generate PNG from the original file
-    4. Upload PNG to S3 for future use
+    4. Upload PNG to remote storage for future use
     5. Return PNG path
 
     Args:
         workspace_id: Workspace identifier
         unique_id: Experiment unique identifier
         original_path: Path to original TIFF or JSON file
-        remote_bucket_name: S3 bucket name for remote storage
+        remote_bucket_name: remote storage bucket name for remote storage
         thumb_type: ThumbnailType.INPUT (for TIFF) or ThumbnailType.ROI
             (for cell_roi.json)
 
@@ -115,12 +115,14 @@ async def get_or_generate_thumbnail(
         filename = os.path.basename(original_path)
         abs_original_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filename])
 
-    # Download from S3 if needed
+    # Download from remote storage if needed
     if not os.path.exists(abs_original_path) and RemoteStorageController.is_available():
-        s3_controller = S3StorageController(remote_bucket_name)
-        await s3_controller.download_thumbnail_source(
-            workspace_id, unique_id, original_path, thumb_type
-        )
+        async with RemoteStorageSimpleReader(
+            remote_bucket_name
+        ) as remote_storage_controller:
+            await remote_storage_controller.download_thumbnail_source(
+                workspace_id, unique_id, original_path, thumb_type
+            )
 
     # Generate thumbnail if original file now exists
     if os.path.exists(abs_original_path):
@@ -137,15 +139,19 @@ async def get_or_generate_thumbnail(
 
             logger.info(f"Lazy-generated thumbnail: {thumb_path}")
 
-            # Upload to S3 for future use (fire and forget)
+            # Upload to remote storage for future use (fire and forget)
             if RemoteStorageController.is_available():
                 try:
-                    s3_controller = S3StorageController(remote_bucket_name)
-                    await s3_controller.upload_thumbnail(
-                        workspace_id, unique_id, thumb_path
-                    )
+                    async with RemoteStorageSimpleWriter(
+                        remote_bucket_name
+                    ) as remote_storage_controller:
+                        await remote_storage_controller.upload_thumbnail(
+                            workspace_id, unique_id, thumb_path
+                        )
                 except Exception as e:
-                    logger.warning(f"Failed to upload generated thumbnail to S3: {e}")
+                    logger.warning(
+                        f"Failed to upload generated thumbnail to remote storage: {e}"
+                    )
 
             return normalize_output_path(thumb_path)
 
@@ -199,7 +205,8 @@ async def _background_full_sync(
     response_model=bool,
     dependencies=[Depends(is_workspace_available)],
     description="""
-    Sync visualization files (JSON, TIFF) from S3 for viewing experiment results.
+    Sync visualization files (JSON, TIFF)
+    from remote storage for viewing experiment results.
     Call this before loading visualization data to ensure files are available locally.
     Only syncs files needed for visualization, not large PKL/NWB files.
     Automatically triggers background sync for remaining files (PKL/NWB) for Edit ROI.
@@ -212,7 +219,7 @@ async def sync_visualization_files(
     remote_bucket_name: str = Depends(get_outputs_remote_bucket_name),
 ) -> bool:
     """
-    Lazy-load visualization files from S3.
+    Lazy-load visualization files from remote storage.
     Downloads only JSON and TIFF files needed for viewing results.
     Then triggers background download of PKL/NWB files for Edit ROI.
     """
@@ -227,7 +234,10 @@ async def sync_visualization_files(
     if not is_unsynced:
         return True  # Already fully synced
 
-    logger.info(f"Syncing visualization files for {workspace_id}/{unique_id} from S3")
+    logger.info(
+        f"Syncing visualization files for {workspace_id}/{unique_id} "
+        "from remote storage"
+    )
 
     # Use SimpleReader to avoid updating sync status - partial syncs should NOT
     # mark as synced, so background full sync can still run
@@ -264,7 +274,8 @@ async def sync_visualization_files(
     "/thumbnail/{workspace_id}/{unique_id}/{thumb_type}",
     description="""
     Get a thumbnail PNG image for an experiment.
-    Syncs from S3 if not available locally, or generates on-demand if needed.
+    Syncs from remote storage if not available locally,
+      or generates on-demand if needed.
 
     Args:
         workspace_id: Workspace identifier
@@ -285,7 +296,7 @@ async def get_thumbnail(
     Serve thumbnail PNG images for DataView.
 
     This endpoint handles:
-    1. Syncing thumbnails from S3 if not available locally
+    1. Syncing thumbnails from remote storage if not available locally
     2. Generating thumbnails on-demand from source files if needed
     3. Serving the PNG file with proper content type
     """
@@ -293,7 +304,7 @@ async def get_thumbnail(
     # Get the expected thumbnail path
     thumb_path = _get_thumbnail_png_path(workspace_id, unique_id, thumb_type)
 
-    # Try to sync thumbnail from S3 if not available locally
+    # Try to sync thumbnail from remote storage if not available locally
     if not os.path.exists(thumb_path) and RemoteStorageController.is_available():
         try:
             async with RemoteStorageSimpleReader(
@@ -303,7 +314,7 @@ async def get_thumbnail(
                     workspace_id, unique_id, sync_mode="thumbnails_only"
                 )
         except Exception as e:
-            logger.warning(f"Failed to sync thumbnail from S3: {e}")
+            logger.warning(f"Failed to sync thumbnail from remote storage: {e}")
 
     # If thumbnail still doesn't exist, try to generate it
     if not os.path.exists(thumb_path):
@@ -319,7 +330,7 @@ async def get_thumbnail(
                         workspace_id, unique_id, sync_mode="essential_only"
                     )
             except Exception as e:
-                logger.warning(f"Failed to sync config files from S3: {e}")
+                logger.warning(f"Failed to sync config files from remote storage: {e}")
 
         # Get the original file path for generation
         if thumb_type == ThumbnailType.INPUT:
@@ -360,7 +371,7 @@ async def get_thumbnail(
                     status_code=404, detail="Could not determine ROI file path"
                 )
 
-        # Generate thumbnail (may download source from S3 if needed)
+        # Generate thumbnail (may download source from remote storage if needed)
         # Note: get_or_generate_thumbnail returns a normalized (relative) path
         await get_or_generate_thumbnail(
             workspace_id, unique_id, original_path, remote_bucket_name, thumb_type
@@ -641,8 +652,12 @@ async def get_image(
                 and RemoteStorageController.is_available()
             ):
                 logger.info(f"On-demand sync for input file: {workspace_id}/{filename}")
-                s3_controller = S3StorageController(remote_bucket_name)
-                await s3_controller.download_input_data(workspace_id, filename + ext)
+                async with RemoteStorageSimpleReader(
+                    remote_bucket_name
+                ) as remote_storage_controller:
+                    await remote_storage_controller.download_input_data(
+                        workspace_id, filename + ext
+                    )
 
             # Return 404 if file still doesn't exist after sync attempt
             if not os.path.exists(abs_filepath):
@@ -670,7 +685,7 @@ async def get_image(
                 logger.warning(f"File not found after sync attempt: {json_filepath}")
                 # Distinguish between "syncing in progress" vs "file doesn't exist"
                 # If the experiment directory exists but the file doesn't, the file
-                # likely doesn't exist in S3 either (analysis incomplete)
+                # likely doesn't exist in remote storage either (analysis incomplete)
                 experiment_dir = os.path.dirname(os.path.dirname(json_filepath))
                 if os.path.exists(experiment_dir):
                     # Experiment dir exists but file missing -
@@ -706,8 +721,12 @@ async def get_csv(
     # On-demand sync for input files
     if not os.path.exists(filepath) and RemoteStorageController.is_available():
         logger.info(f"On-demand sync for input: {workspace_id}/{original_filename}")
-        s3_controller = S3StorageController(remote_bucket_name)
-        await s3_controller.download_input_data(workspace_id, original_filename)
+        async with RemoteStorageSimpleReader(
+            remote_bucket_name
+        ) as remote_storage_controller:
+            await remote_storage_controller.download_input_data(
+                workspace_id, original_filename
+            )
 
     filename, _ = os.path.splitext(os.path.basename(filepath))
     save_dirpath = join_filepath([os.path.dirname(filepath), filename])

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -20,10 +20,10 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageLockError,
     RemoteStorageReader,
     RemoteStorageSimpleReader,
+    RemoteStorageSimpleWriter,
     RemoteSyncStatusFileUtil,
     upload_experiment_wrapper,
 )
-from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.core.utils.filepath_creater import (
     create_directory,
     join_filepath,
@@ -243,92 +243,97 @@ async def import_sample_data(
         # ------------------------------------------------------------
         # Upload the input sample data to remote storage process.
         # ------------------------------------------------------------
+        async with RemoteStorageSimpleWriter(
+            remote_bucket_name,
+        ) as remote_storage_controller:
+            sample_data_dir = Path(
+                join_filepath(
+                    [DIRPATH.ROOT_DIR, sample_data_dir_name, category, "input"]
+                )
+            )
 
-        s3_controller = S3StorageController(remote_bucket_name)
-        sample_data_dir = Path(
-            join_filepath([DIRPATH.ROOT_DIR, sample_data_dir_name, category, "input"])
-        )
+            sample_data_subdir = sorted(
+                [
+                    p
+                    for p in sample_data_dir.iterdir()
+                    if p.is_file() and p.name.startswith("sample_")
+                ]
+            )
 
-        sample_data_subdir = sorted(
-            [
-                p
-                for p in sample_data_dir.iterdir()
-                if p.is_file() and p.name.startswith("sample_")
+            logger.info(f"Found {len(sample_data_subdir)} sample input subdirectories.")
+
+            if not sample_data_subdir:
+                logger.warning("No valid sample input subdirectories found for upload.")
+
+            tasks = [
+                remote_storage_controller.upload_input_data(workspace_id, filename.name)
+                for filename in sample_data_subdir
             ]
-        )
+            await asyncio.gather(*tasks)
 
-        logger.info(f"Found {len(sample_data_subdir)} sample input subdirectories.")
+            # Generate metadata files for various file types and upload to S3
 
-        if not sample_data_subdir:
-            logger.warning("No valid sample input subdirectories found for upload.")
+            # TIFF files: .image_shape.json
+            tiff_files = [
+                p
+                for p in sample_data_subdir
+                if p.name.endswith(tuple(ACCEPT_FILE_EXT.TIFF_EXT.value))
+            ]
+            if tiff_files:
+                for tiff_file in tiff_files:
+                    update_image_shape(workspace_id, tiff_file.name)
+                await remote_storage_controller.upload_input_data(
+                    workspace_id, MetadataCacheFile.IMAGE_SHAPE
+                )
 
-        tasks = [
-            s3_controller.upload_input_data(workspace_id, filename.name)
-            for filename in sample_data_subdir
-        ]
-        await asyncio.gather(*tasks)
+            # HDF5 files: .hdf5_structure.json
+            hdf5_files = [
+                p
+                for p in sample_data_subdir
+                if p.name.endswith(tuple(ACCEPT_FILE_EXT.HDF5_EXT.value))
+            ]
+            if hdf5_files:
+                for hdf5_file in hdf5_files:
+                    update_hdf5_structure(workspace_id, hdf5_file.name)
+                await remote_storage_controller.upload_input_data(
+                    workspace_id, MetadataCacheFile.HDF5_STRUCTURE
+                )
 
-        # Generate metadata files for various file types and upload to S3
+            # MATLAB files: .mat_structure.json
+            mat_files = [
+                p
+                for p in sample_data_subdir
+                if p.name.endswith(tuple(ACCEPT_FILE_EXT.MATLAB_EXT.value))
+            ]
+            if mat_files:
+                for mat_file in mat_files:
+                    update_mat_structure(workspace_id, mat_file.name)
+                await remote_storage_controller.upload_input_data(
+                    workspace_id, MetadataCacheFile.MAT_STRUCTURE
+                )
 
-        # TIFF files: .image_shape.json
-        tiff_files = [
-            p
-            for p in sample_data_subdir
-            if p.name.endswith(tuple(ACCEPT_FILE_EXT.TIFF_EXT.value))
-        ]
-        if tiff_files:
-            for tiff_file in tiff_files:
-                update_image_shape(workspace_id, tiff_file.name)
-            await s3_controller.upload_input_data(
-                workspace_id, MetadataCacheFile.IMAGE_SHAPE
+            # ------------------------------------------------------------
+            # Upload the output sample data to remote storage process.
+            # ------------------------------------------------------------
+
+            sample_data_output_dir = Path(
+                join_filepath(
+                    [DIRPATH.ROOT_DIR, sample_data_dir_name, category, "output"]
+                )
             )
 
-        # HDF5 files: .hdf5_structure.json
-        hdf5_files = [
-            p
-            for p in sample_data_subdir
-            if p.name.endswith(tuple(ACCEPT_FILE_EXT.HDF5_EXT.value))
-        ]
-        if hdf5_files:
-            for hdf5_file in hdf5_files:
-                update_hdf5_structure(workspace_id, hdf5_file.name)
-            await s3_controller.upload_input_data(
-                workspace_id, MetadataCacheFile.HDF5_STRUCTURE
+            sample_data_output_subdirs = sorted(
+                [p for p in sample_data_output_dir.iterdir() if p.is_dir()]
             )
 
-        # MATLAB files: .mat_structure.json
-        mat_files = [
-            p
-            for p in sample_data_subdir
-            if p.name.endswith(tuple(ACCEPT_FILE_EXT.MATLAB_EXT.value))
-        ]
-        if mat_files:
-            for mat_file in mat_files:
-                update_mat_structure(workspace_id, mat_file.name)
-            await s3_controller.upload_input_data(
-                workspace_id, MetadataCacheFile.MAT_STRUCTURE
-            )
+            if not sample_data_output_subdirs:
+                logger.warning("No valid sample output directories found for upload.")
 
-        # ------------------------------------------------------------
-        # Upload the output sample data to remote storage process.
-        # ------------------------------------------------------------
-
-        sample_data_output_dir = Path(
-            join_filepath([DIRPATH.ROOT_DIR, sample_data_dir_name, category, "output"])
-        )
-
-        sample_data_output_subdirs = sorted(
-            [p for p in sample_data_output_dir.iterdir() if p.is_dir()]
-        )
-
-        if not sample_data_output_subdirs:
-            logger.warning("No valid sample output directories found for upload.")
-
-        tasks = [
-            upload_experiment_wrapper(remote_bucket_name, workspace_id, p.name)
-            for p in sample_data_output_subdirs
-        ]
-        await asyncio.gather(*tasks)
+            tasks = [
+                upload_experiment_wrapper(remote_bucket_name, workspace_id, p.name)
+                for p in sample_data_output_subdirs
+            ]
+            await asyncio.gather(*tasks)
 
     return True
 

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -267,8 +267,12 @@ class TestPublicDataviewReproduceWorkflow:
         mock_record = MagicMock()
         mock_record.local_sync_status = LocalSyncStatus.pending.value
 
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
+        mock_remote_controller = MagicMock()
+        mock_remote_controller.download_experiment = AsyncMock(return_value=True)
+
+        mock_remote_reader = AsyncMock()
+        mock_remote_reader.__aenter__ = AsyncMock(return_value=mock_remote_controller)
+        mock_remote_reader.__aexit__ = AsyncMock(return_value=False)
 
         mock_validation = MagicMock()
         mock_validation.is_displayable = False
@@ -282,8 +286,8 @@ class TestPublicDataviewReproduceWorkflow:
             with patch("os.path.exists", return_value=True):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.S3StorageController",
-                        return_value=mock_s3_controller,
+                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        return_value=mock_remote_reader,
                     ):
                         with patch(
                             "studio.app.common.routers.dataview.PublishValidator."
@@ -307,8 +311,12 @@ class TestPublicDataviewReproduceWorkflow:
         mock_record = MagicMock()
         mock_record.local_sync_status = LocalSyncStatus.error.value
 
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
+        mock_remote_controller = MagicMock()
+        mock_remote_controller.download_experiment = AsyncMock(return_value=True)
+
+        mock_remote_reader = AsyncMock()
+        mock_remote_reader.__aenter__ = AsyncMock(return_value=mock_remote_controller)
+        mock_remote_reader.__aexit__ = AsyncMock(return_value=False)
 
         mock_validation = MagicMock()
         mock_validation.is_displayable = False
@@ -322,8 +330,8 @@ class TestPublicDataviewReproduceWorkflow:
             with patch("os.path.exists", return_value=True):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.S3StorageController",
-                        return_value=mock_s3_controller,
+                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        return_value=mock_remote_reader,
                     ):
                         with patch(
                             "studio.app.common.routers.dataview.PublishValidator."
@@ -347,9 +355,13 @@ class TestPublicDataviewReproduceWorkflow:
         mock_record = MagicMock()
         mock_record.local_sync_status = LocalSyncStatus.synced.value
 
-        mock_s3_controller = MagicMock()
+        mock_remote_controller = MagicMock()
         # Use AsyncMock for async method
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
+        mock_remote_controller.download_experiment = AsyncMock(return_value=True)
+
+        mock_remote_reader = AsyncMock()
+        mock_remote_reader.__aenter__ = AsyncMock(return_value=mock_remote_controller)
+        mock_remote_reader.__aexit__ = AsyncMock(return_value=False)
 
         mock_validation = MagicMock()
         mock_validation.is_displayable = True
@@ -362,8 +374,8 @@ class TestPublicDataviewReproduceWorkflow:
             with patch("os.path.exists", return_value=False):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.S3StorageController",
-                        return_value=mock_s3_controller,
+                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        return_value=mock_remote_reader,
                     ):
                         with patch(
                             "studio.app.common.routers.dataview.PublishValidator."
@@ -378,7 +390,7 @@ class TestPublicDataviewReproduceWorkflow:
                                     workspace_id="1", unique_id="exp123", db=MagicMock()
                                 )
 
-        mock_s3_controller.download_experiment.assert_called_once()
+        mock_remote_controller.download_experiment.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_reproduce_auto_updates_sync_status_when_data_available(self):
@@ -390,8 +402,12 @@ class TestPublicDataviewReproduceWorkflow:
         mock_record = MagicMock()
         mock_record.local_sync_status = LocalSyncStatus.error.value
 
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
+        mock_remote_controller = MagicMock()
+        mock_remote_controller.download_experiment = AsyncMock(return_value=True)
+
+        mock_remote_reader = AsyncMock()
+        mock_remote_reader.__aenter__ = AsyncMock(return_value=mock_remote_controller)
+        mock_remote_reader.__aexit__ = AsyncMock(return_value=False)
 
         mock_validation = MagicMock()
         mock_validation.is_displayable = True
@@ -406,8 +422,8 @@ class TestPublicDataviewReproduceWorkflow:
             with patch("os.path.exists", return_value=True):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.S3StorageController",
-                        return_value=mock_s3_controller,
+                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        return_value=mock_remote_reader,
                     ):
                         with patch(
                             "studio.app.common.routers.dataview.PublishValidator."


### PR DESCRIPTION
### Content

現時点の最新版（develop-subscription branch）では、Remote storage との同期処理の操作が、S3StorageController で hard coding されている箇所が、一定箇所見られた。

この影響により、ローカル開発モード（Mock mode）が、正常に動作しないパスが複数存在していた。

また、コードメンテナンスのメンテナンス性も考慮し、このPRでは、S3StorageController の直接の仕様箇所を RemoteStorageController へ置き換える修正を実施する。

### Testcase

各修正箇所が、S3 mode と Mock mode で正常動作することを確認する

- core.experiment.experiment
  - [x] ExptOutputPathIds.from_request_url
- routers.workflow
  - [x] import_sample_data
- routers.outputs
  - [x] get_or_generate_thumbnail
  - [x] _ensure_visualization_synced
  - [x] get_csv
- routers.dataview
  - [x] public_reproduce_experiment
- [x] `make test_backend`