### PR TITLE
Check storage quota in RUN and RUN ALL

### DIFF
--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -39,6 +39,24 @@ router = APIRouter(prefix="/run", tags=["run"])
 logger = AppLogger.get_logger()
 
 
+async def _check_storage_quota(user_id: int) -> None:
+    """Raise 403 if user has exceeded their storage quota."""
+    current_usage = await get_current_user_storage_usage(user_id, force_live=False)
+    storage_info = get_user_storage_usage(user_id)
+
+    if storage_info and storage_info["storage_quota_bytes"] > 0:
+        quota_limit = storage_info["storage_quota_bytes"]
+        usage_percent = (current_usage / quota_limit) * 100
+
+        if usage_percent >= 100:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Cannot run job: Storage quota exceeded "
+                f"({usage_percent:.1f}% used). "
+                f"Please free up space before running jobs.",
+            )
+
+
 @router.post(
     "/{workspace_id}",
     response_model=str,
@@ -52,25 +70,7 @@ async def run(
     remote_bucket_name: str = Depends(get_user_remote_bucket_name),
 ):
     try:
-        # Check storage before running job - works for both S3 and local storage
-        # Use cached data to avoid ALB timeout on large S3 buckets
-        current_usage = await get_current_user_storage_usage(
-            current_user.id, force_live=False
-        )
-        storage_info = get_user_storage_usage(current_user.id)
-
-        if storage_info and storage_info["storage_quota_bytes"] > 0:
-            quota_limit = storage_info["storage_quota_bytes"]
-            storage_usage_percent = (current_usage / quota_limit) * 100
-
-            # Block workflow execution if over quota (100%)
-            if storage_usage_percent >= 100:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"Cannot run job: Storage quota exceeded "
-                    f"({storage_usage_percent:.1f}% used). "
-                    f"Please free up space before running jobs.",
-                )
+        await _check_storage_quota(current_user.id)
 
         unique_id = WorkflowRunner.create_workflow_unique_id()
         runner = WorkflowRunner(
@@ -128,6 +128,8 @@ async def run_id(
     current_user: User = Depends(get_current_user),
 ):
     try:
+        await _check_storage_quota(current_user.id)
+
         runner = WorkflowRunner(
             remote_bucket_name, workspace_id, uid, runItem, current_user.id
         )
@@ -137,6 +139,13 @@ async def run_id(
             await runner.ensure_input_data_local()
 
         runner.run_workflow(background_tasks)
+
+        # Refresh storage cache in background
+        background_tasks.add_task(
+            get_current_user_storage_usage,
+            current_user.id,
+            force_live=True,
+        )
 
         logger.info("run snakemake")
         logger.info("forcerun list: %s", runItem.forceRunList)


### PR DESCRIPTION
### Content

Extract frontend RUN block when storage over limit into `_check_storage_quota` function. 

Use _check_storage_quota for RUN and RUN ALL buttons

### References

Mentioned in https://github.com/arayabrain/optinist-for-cloud/issues/276

> Storage超過時のRunの実行制限が、機能していないケースがある（2/17時点） 1回目のRunはStorage超過でblockされるが そのまま2回目のRun or Run All を実行すると、blockが行われず、そのままRunが実行できている


### Testcase

<img width="1358" height="704" alt="Screenshot 2026-02-20 at 17 27 51" src="https://github.com/user-attachments/assets/069a4da6-4f89-47a3-8cd5-3289345ac4a7" />

