### PR TITLE
Fix Sync Fail Because of Snakemake Config Empty

### DIFF
--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -91,7 +91,7 @@ class SmkUtils:
 
         input_paths = []
 
-        for node in smk_config["rules"].values():
+        for node in smk_config.get("rules", {}).values():
             if NodeTypeUtil.check_nodetype_from_filetype(node["type"]) == NodeType.DATA:
                 if node["type"] in [FILETYPE.IMAGE]:
                     if apply_basename:

--- a/studio/app/common/core/snakemake/snakemake_reader.py
+++ b/studio/app/common/core/snakemake/snakemake_reader.py
@@ -48,7 +48,8 @@ class SmkConfigReader:
     def read(cls, workspace_id: str, unique_id: str) -> dict:
         filepath = cls.get_config_yaml_path(workspace_id, unique_id)
         config = ConfigReader.read(filepath)
-        assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
+        if config is None:
+            config = {}
 
         return config
 


### PR DESCRIPTION
### Content

Fix Sync Fail Because of Snakemake Config Empty

Problem:
```
2026-01-29 09:29:38,351 ERROR:    [optinist] (pid:66) (client:205099bd84fd47e0) sync_remote_experiment():315 - Invalid config yaml file: [/app/studio_data/output/90/89dc9331/snakemake.yaml] [{}]
Traceback (most recent call last):
  File "/app/studio/app/common/routers/experiment.py", line 298, in sync_remote_experiment
    result = await remote_storage_controller.download_experiment(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/studio/app/common/core/storage/remote_storage_controller.py", line 644, in download_experiment
    raise e
  File "/app/studio/app/common/core/storage/remote_storage_controller.py", line 628, in download_experiment
    input_filenames = SmkUtils.get_datatypes_inputs(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/studio/app/common/core/snakemake/smk_utils.py", line 90, in get_datatypes_inputs
    smk_config = SmkConfigReader.read(workspace_id, unique_id)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/studio/app/common/core/snakemake/snakemake_reader.py", line 51, in read
    assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
           ^^^^^^
AssertionError: Invalid config yaml file: [/app/studio_data/output/90/89dc9331/snakemake.yaml] [{}]
2026-01-29 09:29:38,360 INFO:     [uvicorn.access] (pid:66) (client:205099bd84fd47e0) send():478 - 10.1.9.9:45980 - "GET /experiments/sync_remote/90/89dc9331 HTTP/1.1" 500
```

Root Cause:
- When `snakemake.yaml` in S3 contains `{}` (empty dict), `SmkConfigReader.read()` fails because `assert config` evaluates `{}` as falsy in Python, causing an `AssertionError`.
- This crashes the entire sync with a 500 error, even though all experiment files were already downloaded successfully.
- This also prevents the record from being deleted.

Fix:
- **`snakemake_reader.py`**: Replaced `assert config` with a `None` check. An empty dict `{}` is a valid config state (e.g., experiment uploaded before workflow config was fully written). Only `None` (file not found / empty file) needs to be guarded against.
- **`smk_utils.py`**: Changed `smk_config["rules"]` to `smk_config.get("rules", {})` so that an empty config doesn't raise a `KeyError`. When there are no rules, `get_datatypes_inputs` returns an empty list and the sync completes gracefully.

### Testcase

1. Find a record whose `snakemake.yaml` in S3 contains `{}` (empty dict)
2. Trigger sync via `GET /experiments/sync_remote/{workspace_id}/{unique_id}`
3. Verify the sync completes successfully (200) instead of returning 500
4. Verify the record can be deleted after sync