### PR TITLE
Background task triggers download only in active instances

### DIFF
--- a/infrastructure/documentation/BACKGROUND_JOB_ARCHITECTURE.md
+++ b/infrastructure/documentation/BACKGROUND_JOB_ARCHITECTURE.md
@@ -28,25 +28,28 @@ Background jobs run in a dedicated ECS service, separate from the API process. T
 
 | Job | Interval | Purpose |
 |-----|----------|---------|
-| `PublishedExperimentSyncJob` | 5 min | Two-phase sync: thumbnails first, then metadata |
+| `PublishedExperimentSyncJob` | 5 min | Validate S3 files, update DB status, trigger API download via ALB |
 | `ThumbnailMigrationJob` | Daily | Generate PNG thumbnails for legacy experiments (temporary) |
 | `DataCleanupJob` | 60 min | Clean up data for logged-out free users |
 | `StorageReconciliationJob` | 60 min | Reconcile incremental tracking with S3 |
 
 All jobs are defined in `studio/app/common/core/background/`.
 
-### PublishedExperimentSyncJob: Two-Phase Sync
+### PublishedExperimentSyncJob: Validate + Proactive Download
 
-The sync job uses a two-phase strategy for faster Dataview thumbnail loading:
+The background ECS service has no shared filesystem and no port mappings -- nobody reads files from its local disk. The job validates experiments in S3, updates `local_sync_status` in the DB, then calls the ALB to trigger file downloads on an API instance.
 
-**Phase 1: Thumbnails (sync_mode="thumbnails_only")**
-- Downloads only PNG thumbnail files (~50-100KB each)
-- Higher throughput: 50+ experiments per run
-- Makes Dataview usable quickly
+**How it works:**
+1. Calls `validate_experiment_in_s3()` which uses S3 `ListObjectsV2`
+2. Checks that `experiment.yaml` and `workflow.yaml` exist under the experiment prefix (no file downloads on background instance)
+3. Updates DB status based on validation result (`pending` -> `synced` or `error`)
+4. On success, calls ALB `POST /system-internal/sync-experiment/{workspace_id}/{unique_id}` to trigger thumbnail + metadata download on an API instance
+- Limits: 50 experiments per run, 10 concurrent validations
 
-**Phase 2: Metadata (sync_mode="essential_only")**
-- Downloads remaining YAML/JSON files
-- Completes the sync for experiment listing
+**File downloads on API instances:**
+- **Proactive** (`_trigger_proactive_download`) -- background job triggers via ALB after validation. Pre-caches on one ALB-selected instance; other instances rely on startup sync or on-demand download.
+- **Startup sync** (`run_startup_sync`) -- downloads at API container boot
+- **On-demand** (`dataview.py:public_reproduce_experiment`) -- downloads from S3 when a user requests an experiment not yet local
 
 ### ThumbnailMigrationJob (Temporary)
 
@@ -71,7 +74,7 @@ One-time migration to generate PNG thumbnails for existing experiments.
 - **Task Definition**: 512 CPU, 768 MB memory, single worker
 - **ECS Service**: `desired_count=1` (only one instance needed)
 - **Environment**: `DISABLE_BACKGROUND_SCHEDULER=0` (scheduler enabled)
-- **No ALB**: Background service doesn't serve HTTP traffic
+- **No ALB target**: Background service doesn't serve HTTP traffic, but calls the ALB to trigger API downloads
 - **CloudWatch Alarms**: Task stopped, CPU high, memory high
 
 ### API Services (`compute.tf`)

--- a/infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md
+++ b/infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md
@@ -505,4 +505,4 @@ python test_data_sync.py status <user_id>       # Check system status
 
 - Branch: `feature/proactive-sync`
 - Parent branch: `feature/aws-autoscaling`
-- Related: `ALB_SECURITY_ROUTING_SUMMARY.md`, `PREMIUM_MANAGER_SUMMARY.md`
+- Related: `ALB_ROUTING_SECURITY.md`, `PREMIUM_MANAGER_ARCHITECTURE.md`

--- a/infrastructure/documentation/EBS_STORAGE_ARCHITECTURE.md
+++ b/infrastructure/documentation/EBS_STORAGE_ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Executive Summary
 
 - **EBS provides fast local storage** for Snakemake workflow execution with S3 as durable backup
-- **Background sync job** downloads published experiments to all instances every 5 minutes
+- **Background sync job** validates experiments in S3, updates DB status, and triggers proactive download on API instances every 5 minutes
 - **Data cleanup job** removes local data for logged-out users (1-hour grace period)
 - **Workflow protection** ensures cleanup only happens when `active_workflow_count = 0`
 - **S3 verification** guarantees backup exists before any local deletion
@@ -17,7 +17,7 @@ These are the fundamental constraints that the EBS implementation satisfies:
 1. **Multi-instance data accessibility**
    - Public visitors have no sticky session and can be routed to ANY instance by ALB
    - Published experiment data must be accessible from all instances simultaneously
-   - Solution: Background sync job downloads published experiments to all instances
+   - Solution: Background job validates S3, triggers proactive download via ALB; remaining instances use on-demand download
 
 2. **User rebalancing requires data portability**
    - Free Manager Lambda can migrate users between instances at any time
@@ -57,8 +57,8 @@ These are the fundamental constraints that the EBS implementation satisfies:
 └─────────────────┘
          ↓
 ┌─────────────────┐
-│ Background Sync │ → Download to all instances → DB: local_sync_status='synced'
-│ (every 5 min)   │
+│ Background Sync │ → Validate in S3 → DB: local_sync_status='synced'
+│ (every 5 min)   │   → Trigger proactive download on API instance via ALB
 └─────────────────┘
          ↓
 ┌─────────────────┐
@@ -129,9 +129,9 @@ These are the fundamental constraints that the EBS implementation satisfies:
 
 ## Edge Case Handling
 
-### 1. S3 Download Failures
+### 1. S3 Validation Failures
 
-**Implementation:** Exponential backoff retry (3 attempts: 1s, 2s, 4s delays)
+**Implementation:** Exponential backoff retry (3 attempts with 1s, 2s backoff delays)
 
 **Monitoring:**
 - CloudWatch metrics: `ExperimentsSynced`, `SyncErrors`, `SyncErrorRate`
@@ -164,17 +164,17 @@ These are the fundamental constraints that the EBS implementation satisfies:
 | Component | Tests | File |
 |-----------|-------|------|
 | Workflow Tracking | 11 | `test_workflow_tracking.py` |
-| Sync Job | 3 | `test_sync_job.py` |
+| Sync Job | 23 | `test_sync_job.py` |
 | Cleanup Job | 10 | `test_cleanup_job.py` |
 | Dataview Publish | 9 | `test_dataview_publish.py` |
 | Logout Endpoint | 5 | `test_users_me_logout.py` |
-| **Total** | **38** | **5 files** |
+| **Total** | **58** | **5 files** |
 
 ### Key Test Scenarios
 
 **Backend:**
 -  Workflow count increment/decrement
--  Exponential backoff on S3 failures
+-  Exponential backoff on S3 validation failures
 -  S3 backup verification before cleanup
 -  Orphaned data cleanup from terminated instances
 -  Optimistic locking on concurrent publish/unpublish
@@ -204,40 +204,45 @@ These are the fundamental constraints that the EBS implementation satisfies:
 sequenceDiagram
     participant User as Logged-in User
     participant Visitor as Public Visitor
-    participant Inst1 as Instance 1 (EBS)
-    participant Inst2 as Instance 2 (EBS)
+    participant API1 as API Instance 1 (EBS)
+    participant API2 as API Instance 2 (EBS)
+    participant BG as Background Service
     participant S3 as S3 Bucket
     participant DB as RDS Database
 
-    Note over User,Inst1: 1. Publish Flow
-    User->>Inst1: POST /dataview/publish/123/on
-    Inst1->>S3: Upload experiment files
-    Inst1->>DB: SET publish_status=1,<br/>local_sync_status='pending'
-    Inst1-->>User: Success
+    Note over User,API1: 1. Publish Flow
+    User->>API1: POST /dataview/publish/123/on
+    API1->>S3: Upload experiment files
+    API1->>DB: SET publish_status=1,<br/>local_sync_status='pending'
+    API1-->>User: Success
 
-    Note over Inst2,S3: 2. Background Sync (every 5 min)
-    Inst2->>DB: Query WHERE local_sync_status='pending'
-    DB-->>Inst2: [exp123, exp456]
-    Inst2->>S3: Download exp123 to local EBS
-    Inst2->>DB: SET local_sync_status='synced'
+    Note over BG,S3: 2. Background Validation + Proactive Download (every 5 min)
+    BG->>DB: Query WHERE local_sync_status='pending'
+    DB-->>BG: [exp123, exp456]
+    BG->>S3: Validate exp123 exists (ListObjectsV2)
+    BG->>DB: SET local_sync_status='synced'
+    BG->>API1: POST /system-internal/sync-experiment (via ALB)
+    Note over API1: Downloads thumbnails + metadata from S3<br/>(single ALB-selected instance; others use startup sync or on-demand)
 
-    Note over Visitor,Inst2: 3. Visitor Access (routed to any instance)
-    Visitor->>Inst2: GET /api/public/dataview/.../exp123
-    Inst2->>DB: Check publish_status & local_sync_status
-    DB-->>Inst2: publish_status=1, local_sync_status='synced'
+    Note over Visitor,API2: 3. Visitor Access (ALB routes to any API instance)
+    Visitor->>API2: GET /api/public/dataview/.../exp123
+    API2->>DB: Check publish_status & local_sync_status
 
-    alt Sync Complete (local_sync_status='synced')
-        Inst2->>Inst2: Read from local EBS
-        Inst2-->>Visitor:  Display experiment
+    alt Files exist locally (proactive download or startup sync)
+        API2->>API2: Read from local EBS
+        API2-->>Visitor: 200 Display experiment
+    else Files missing locally (status='synced' but no local files)
+        API2->>S3: On-demand download
+        API2-->>Visitor: 200 Display experiment
     else Sync Pending (local_sync_status='pending')
-        Inst2-->>Visitor: 202 Accepted - "Publishing in progress..."
+        API2-->>Visitor: 202 Accepted - "Publishing in progress..."
         Note over Visitor: Frontend shows loading state<br/>Auto-retries every 30 seconds
     else Sync Error (local_sync_status='error')
-        Inst2-->>Visitor: 503 Service Unavailable - "Temporarily unavailable"
+        API2-->>Visitor: 503 Service Unavailable - "Temporarily unavailable"
         Note over Visitor: Frontend shows error with retry button
     end
 
-    Note over Visitor,S3:  Solution: No EFS cost, eventual consistency (5 min)
+    Note over Visitor,S3: Solution: No EFS cost, eventual consistency (5 min)
 ```
 
 ### Data Cleanup Flow on Logout
@@ -282,7 +287,7 @@ sequenceDiagram
 
 ### Backend
 - `studio/app/common/core/workflow/workflow_tracking.py` - Workflow count tracking
-- `studio/app/common/core/background/sync_job.py` - Background sync (every 5 min)
+- `studio/app/common/core/background/sync_job.py` - Background S3 validation + proactive download trigger (every 5 min)
 - `studio/app/common/core/background/cleanup_job.py` - Data cleanup (every 60 min)
 - `studio/app/common/routers/dataview.py` - Publish/access endpoints
 - `studio/app/common/routers/users_me.py` - Logout endpoint
@@ -296,7 +301,7 @@ sequenceDiagram
 
 ### Testing
 - `studio/tests/app/common/core/workflow/test_workflow_tracking.py` (11 tests)
-- `studio/tests/app/common/core/background/test_sync_job.py` (3 tests)
+- `studio/tests/app/common/core/background/test_sync_job.py` (23 tests)
 - `studio/tests/app/common/core/background/test_cleanup_job.py` (10 tests)
 - `studio/tests/app/common/routers/test_dataview_publish.py` (9 tests)
 - `studio/tests/app/common/routers/test_users_me_logout.py` (5 tests)

--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -250,6 +250,10 @@ resource "aws_ecs_task_definition" "background" {
           name  = "INTERNAL_API_SECRET"
           value = random_password.internal_api_secret.result
         },
+        {
+          name  = "ALB_DNS_NAME"
+          value = aws_lb.autoscaling.dns_name
+        },
         # Background scheduler ENABLED - this service runs all background jobs
         {
           name  = "DISABLE_BACKGROUND_SCHEDULER"

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -1,19 +1,21 @@
 """
-Background job to sync published experiments from S3 to local storage.
+Background job to validate published experiments in S3.
 
-Runs every 5 minutes, downloads experiments with local_sync_status='pending'.
+Runs every 5 minutes, validates experiments with
+local_sync_status='pending' exist in S3, and updates DB status.
+The background instance has no shared filesystem -- actual file
+downloads happen on API instances via startup sync and on-demand.
 """
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudwatch import CloudWatchClient
 
-from filelock import FileLock, Timeout
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
@@ -26,9 +28,13 @@ from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
 
+# Tracks retry counts across job runs (in-memory, resets on restart)
+_retry_counts: Dict[int, int] = {}
+MAX_PERSISTENT_RETRIES = 9  # 3 attempts/run * 3 runs
+
 
 class SyncRetryError(Exception):
-    """Exception indicating sync should be retried"""
+    """Exception indicating validation should be retried"""
 
     def __init__(self, message: str):
         self.message = message
@@ -36,52 +42,33 @@ class SyncRetryError(Exception):
 
 
 class PublishedExperimentSyncJob:
-    """Background job to sync published experiments"""
+    """Background job to validate published experiments in S3"""
 
-    # Higher limit for thumbnail-only sync (thumbnails are small ~50-100KB)
-    THUMBNAIL_SYNC_LIMIT = 50
-    # Standard limit for metadata sync
-    METADATA_SYNC_LIMIT = SyncStatusConstants.MAX_SYNC_PER_RUN
-    # Concurrency limits for parallel downloads
+    # Validation is cheap (ListObjectsV2 only), so higher limits
+    VALIDATION_LIMIT = 50
+    VALIDATION_CONCURRENCY = 10
+
+    # Startup sync downloads files on API instances
     THUMBNAIL_CONCURRENCY = 10
     METADATA_CONCURRENCY = 3
 
     @classmethod
     async def run(cls):
         """
-        Main sync job execution with two-phase sync:
+        Main sync job: validate experiments exist in S3.
 
-        Phase 1: Sync thumbnail PNGs (fast, more per run)
-        - Thumbnails are ~50-100KB vs full TIFFs which can be 100MB+
-        - Can sync 50+ experiments' thumbnails per run
-        - Enables fast DataView loading immediately
-
-        Phase 2: Sync remaining metadata (YAML files)
-        - Sync experiment.yaml, workflow.yaml, snakemake_config.yaml
-        - Standard limit per run
-
-        Uses file locking to prevent concurrent runs.
+        Checks S3 for required files (experiment.yaml,
+        workflow.yaml) without downloading, then updates
+        local_sync_status in the DB.
         """
-        # Use FileLock for cross-platform file locking
-        # timeout=0 means non-blocking (skip if lock is already held)
-        lock = FileLock(SyncStatusConstants.LOCK_FILE, timeout=0)
-
         try:
-            with lock:
-                logger.info("Starting published experiment sync job (two-phase)")
-
-                # Phase 1: Sync thumbnails first (fast)
-                await cls._sync_thumbnails()
-
-                # Phase 2: Sync remaining metadata
-                await cls._run_sync_logic()
-
-        except Timeout:
-            # Another instance is already running
-            logger.debug("Sync job already running, skipping this execution")
-            return
+            logger.info("Starting published experiment validation job")
+            await cls._run_validation_logic()
         except Exception as e:
-            logger.error(f"Fatal error in sync job: {e}", exc_info=True)
+            logger.error(
+                f"Fatal error in sync job: {e}",
+                exc_info=True,
+            )
 
     @classmethod
     async def run_startup_sync(cls):
@@ -106,7 +93,7 @@ class PublishedExperimentSyncJob:
             await cls._sync_startup_thumbnails(missing, s3_controllers)
             await cls._sync_startup_metadata(missing, s3_controllers)
 
-            logger.info(f"Startup sync completed for {len(missing)}" f" experiments")
+            logger.info(f"Startup sync completed for" f" {len(missing)} experiments")
         except Exception as e:
             logger.error(f"Startup sync error: {e}", exc_info=True)
 
@@ -116,7 +103,7 @@ class PublishedExperimentSyncJob:
         bucket_name: str,
         controllers: dict[str, S3StorageController],
     ) -> S3StorageController:
-        """Cache S3 controllers per bucket to avoid duplicates."""
+        """Cache S3 controllers per bucket."""
         if bucket_name not in controllers:
             controllers[bucket_name] = S3StorageController(bucket_name)
         return controllers[bucket_name]
@@ -140,7 +127,7 @@ class PublishedExperimentSyncJob:
                         sync_mode="thumbnails_only",
                     )
                 except Exception as e:
-                    logger.warning(f"Startup thumb sync failed " f"{ws_id}/{uid}: {e}")
+                    logger.warning(f"Startup thumb sync failed" f" {ws_id}/{uid}: {e}")
 
         await asyncio.gather(
             *[dl_thumb(w, u, b) for w, u, _, b in experiments],
@@ -153,7 +140,7 @@ class PublishedExperimentSyncJob:
         experiments: List[Tuple[str, str, int, str]],
         s3_controllers: dict[str, S3StorageController],
     ):
-        """Phase 2: Download essential metadata (lower concurrency)."""
+        """Phase 2: Download essential metadata."""
         sem = asyncio.Semaphore(cls.METADATA_CONCURRENCY)
 
         async def dl_meta(ws_id, uid, bucket):
@@ -166,7 +153,7 @@ class PublishedExperimentSyncJob:
                         sync_mode="essential_only",
                     )
                 except Exception as e:
-                    logger.warning(f"Startup meta sync failed " f"{ws_id}/{uid}: {e}")
+                    logger.warning(f"Startup meta sync failed" f" {ws_id}/{uid}: {e}")
 
         await asyncio.gather(
             *[dl_meta(w, u, b) for w, u, _, b in experiments],
@@ -174,112 +161,66 @@ class PublishedExperimentSyncJob:
         )
 
     @classmethod
-    async def _sync_thumbnails(cls):
-        """
-        Phase 1: Download thumbnail PNGs for pending experiments.
-
-        This is fast because:
-        - Thumbnails are small (~50-100KB each)
-        - We use thumbnails_only sync mode
-        - We can process many more experiments per run
-        """
-        # Get pending experiments (use higher limit for thumbnails)
-        pending = cls._get_pending_experiments(limit=cls.THUMBNAIL_SYNC_LIMIT)
-
-        if not pending:
-            logger.debug("No pending experiments for thumbnail sync")
-            return
-
-        logger.info(f"Phase 1: Syncing thumbnails for {len(pending)} experiments")
-
-        s3_controllers: dict[str, S3StorageController] = {}
-
-        # Sync thumbnails with higher concurrency (they're small files)
-        semaphore = asyncio.Semaphore(cls.THUMBNAIL_CONCURRENCY)
-
-        async def sync_thumbnails_for_experiment(
-            workspace_id, unique_id, exp_id, bucket_name
-        ):
-            async with semaphore:
-                try:
-                    s3_controller = cls._get_s3_controller(bucket_name, s3_controllers)
-                    # Only download thumbnails
-                    await s3_controller.download_experiment(
-                        workspace_id, unique_id, sync_mode="thumbnails_only"
-                    )
-                    return (workspace_id, unique_id, exp_id, True)
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to sync thumbnails for {workspace_id}/{unique_id} "
-                        f"from bucket {bucket_name}: {e}"
-                    )
-                    return (workspace_id, unique_id, exp_id, False)
-
-        tasks = [sync_thumbnails_for_experiment(w, u, e, b) for w, u, e, b in pending]
-
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        # Count successes
-        success_count = sum(1 for r in results if not isinstance(r, Exception) and r[3])
-        logger.info(
-            f"Phase 1 complete: {success_count}/{len(pending)} thumbnails synced"
-        )
-
-    @classmethod
-    async def _run_sync_logic(cls):
-        """Execute the actual sync logic"""
+    async def _run_validation_logic(cls):
+        """Validate pending experiments exist in S3."""
         try:
-            # Get pending experiments (now includes bucket name)
-            pending_experiments = cls._get_pending_experiments()
+            pending = cls._get_pending_experiments(limit=cls.VALIDATION_LIMIT)
 
-            if not pending_experiments:
-                logger.debug("No pending experiments to sync")
+            if not pending:
+                logger.debug("No pending experiments to validate")
                 return
 
-            logger.info(f"Found {len(pending_experiments)} experiments to sync")
+            logger.info(f"Found {len(pending)} experiments to validate")
 
             s3_controllers: dict[str, S3StorageController] = {}
+            sem = asyncio.Semaphore(cls.VALIDATION_CONCURRENCY)
 
-            # Sync experiments in parallel with limited concurrency
-            semaphore = asyncio.Semaphore(cls.METADATA_CONCURRENCY)
-
-            async def sync_with_semaphore(workspace_id, unique_id, exp_id, bucket_name):
-                """Wrapper to limit concurrent downloads"""
-                async with semaphore:
+            async def validate_with_semaphore(
+                workspace_id, unique_id, exp_id, bucket_name
+            ):
+                async with sem:
                     try:
-                        s3_controller = cls._get_s3_controller(
-                            bucket_name, s3_controllers
+                        s3 = cls._get_s3_controller(bucket_name, s3_controllers)
+                        success = await cls._validate_experiment(
+                            s3,
+                            workspace_id,
+                            unique_id,
+                            exp_id,
+                            bucket_name,
                         )
-                        success = await cls._sync_experiment(
-                            s3_controller, workspace_id, unique_id, exp_id
+                        return (
+                            workspace_id,
+                            unique_id,
+                            exp_id,
+                            success,
+                            None,
                         )
-                        return (workspace_id, unique_id, exp_id, success, None)
                     except Exception as e:
                         logger.error(
-                            f"Error syncing experiment {workspace_id}/{unique_id} "
-                            f"from bucket {bucket_name}: {e}",
+                            f"Error validating"
+                            f" {workspace_id}/{unique_id}"
+                            f" from bucket"
+                            f" {bucket_name}: {e}",
                             exc_info=True,
                         )
                         cls._mark_sync_error(exp_id)
-                        return (workspace_id, unique_id, exp_id, False, e)
+                        return (
+                            workspace_id,
+                            unique_id,
+                            exp_id,
+                            False,
+                            e,
+                        )
 
-            # Create tasks for all pending experiments
-            tasks = [
-                sync_with_semaphore(workspace_id, unique_id, exp_id, bucket_name)
-                for workspace_id, unique_id, exp_id, bucket_name in pending_experiments
-            ]
-
-            # Execute all syncs in parallel (limited by semaphore)
+            tasks = [validate_with_semaphore(w, u, e, b) for w, u, e, b in pending]
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            # Count successes and errors
             synced_count = 0
             error_count = 0
 
             for result in results:
                 if isinstance(result, Exception):
-                    # Unexpected exception from gather
-                    logger.error(f"Unexpected error in sync task: {result}")
+                    logger.error("Unexpected error in" f" validation: {result}")
                     error_count += 1
                 else:
                     _, _, _, success, _ = result
@@ -289,32 +230,29 @@ class PublishedExperimentSyncJob:
                         error_count += 1
 
             logger.info(
-                f"Sync job completed: {synced_count} synced, {error_count} errors "
-                f"(parallel downloads with max {cls.METADATA_CONCURRENCY} concurrent)"
+                f"Validation job completed: "
+                f"{synced_count} synced, {error_count} errors "
+                f"(max {cls.VALIDATION_CONCURRENCY} concurrent)"
             )
 
-            # Publish CloudWatch metrics
             cls._publish_metrics(synced_count, error_count)
 
         except Exception as e:
-            logger.error(f"Error in sync logic: {e}", exc_info=True)
+            logger.error(
+                f"Error in validation logic: {e}",
+                exc_info=True,
+            )
 
     @classmethod
     def _get_pending_experiments(
         cls, limit: int = None
     ) -> List[Tuple[str, str, int, str]]:
         """
-        Query database for published experiments with pending or error sync status.
-
-        IMPORTANT: This now includes experiments with 'error' status to enable
-        automatic retry of failed syncs.
-
-        Args:
-            limit: Maximum number of experiments to return (defaults to
-                SyncStatusConstants.MAX_SYNC_PER_RUN)
+        Query DB for published experiments with pending/error
+        sync status.
 
         Returns:
-            List of tuples: (workspace_id, unique_id, experiment_record_id, bucket_name)
+            List of (workspace_id, unique_id, exp_id, bucket_name)
         """
         if limit is None:
             limit = SyncStatusConstants.MAX_SYNC_PER_RUN
@@ -329,7 +267,10 @@ class PublishedExperimentSyncJob:
                     ExperimentRecord.id,
                     User.attributes,
                 )
-                .join(Workspace, Workspace.id == ExperimentRecord.workspace_id)
+                .join(
+                    Workspace,
+                    Workspace.id == ExperimentRecord.workspace_id,
+                )
                 .join(User, User.id == Workspace.user_id)
                 .where(ExperimentRecord.publish_status == PublishStatus.on.value)
                 .where(
@@ -354,7 +295,6 @@ class PublishedExperimentSyncJob:
                 unique_id = row[1]
                 exp_id = row[2]
                 user_attributes = row[3]
-                # Get bucket name from user attributes, fall back to default
                 bucket_name = (
                     user_attributes.get("remote_bucket_name")
                     if user_attributes
@@ -406,9 +346,7 @@ class PublishedExperimentSyncJob:
         """
         Query ALL published experiments regardless of sync status.
 
-        Used by startup sync to check local file presence instead of
-        relying on DB sync status (which reflects background service,
-        not this container).
+        Used by startup sync to check local file presence.
 
         Returns:
             List of (workspace_id, unique_id, exp_id, bucket_name)
@@ -452,93 +390,74 @@ class PublishedExperimentSyncJob:
             return experiments
 
     @classmethod
-    async def _sync_experiment(
+    async def _validate_experiment(
         cls,
         s3_controller: S3StorageController,
         workspace_id: str,
         unique_id: str,
         exp_id: int,
+        bucket_name: str = "",
     ) -> bool:
         """
-        Download experiment from S3 to local storage with exponential backoff retry.
+        Validate experiment exists in S3 with exponential backoff.
 
-        Args:
-            s3_controller: S3 storage controller
-            workspace_id: Workspace ID
-            unique_id: Experiment unique ID
-            exp_id: Experiment record database ID
+        Checks that required files exist in S3 via
+        validate_experiment_in_s3() (no downloads). Updates DB
+        sync status based on the result.
 
         Returns:
-            True if sync successful, False otherwise
+            True if validation successful, False otherwise
         """
-        logger.info(f"Syncing experiment {workspace_id}/{unique_id} (id={exp_id})")
+        logger.info(
+            f"Validating experiment" f" {workspace_id}/{unique_id}" f" (id={exp_id})"
+        )
 
         try:
-            # Check if already exists locally
-            from studio.app.common.core.utils.filepath_creater import join_filepath
-
-            local_path = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
-
-            if os.path.exists(local_path):
-                # Already exists, check if complete
-                required_files = [DIRPATH.EXPERIMENT_YML, DIRPATH.WORKFLOW_YML]
-
-                all_exist = all(
-                    os.path.exists(os.path.join(local_path, f)) for f in required_files
-                )
-
-                if all_exist:
-                    logger.info(f"Experiment {workspace_id}/{unique_id} already synced")
-                    cls._mark_sync_complete(exp_id)
-                    return True
-
-            # Download from S3 with exponential backoff retry
             max_retries = 3
             for attempt in range(max_retries):
                 try:
                     logger.info(
-                        f"Downloading from S3 with selective sync "
-                        f"(attempt {attempt + 1}/{max_retries}): "
-                        f"{workspace_id}/{unique_id}"
+                        f"Validating in S3"
+                        f" (attempt"
+                        f" {attempt + 1}/{max_retries})"
+                        f": {workspace_id}/{unique_id}"
                     )
-                    success = await s3_controller.download_experiment(
-                        workspace_id, unique_id, sync_mode="essential_only"
+                    result = await s3_controller.validate_experiment_in_s3(
+                        workspace_id, unique_id
                     )
 
-                    if not success:
-                        raise SyncRetryError("Download returned failure status")
+                    if not result["valid"]:
+                        raise SyncRetryError(result["error"] or "Validation failed")
 
-                    # Validate that required files were actually downloaded
-                    required_files = [DIRPATH.EXPERIMENT_YML, DIRPATH.WORKFLOW_YML]
-                    missing = [
-                        f
-                        for f in required_files
-                        if not os.path.exists(os.path.join(local_path, f))
-                    ]
-
-                    if missing:
-                        raise SyncRetryError(
-                            f"Required files missing from S3: {missing}"
-                        )
-
-                    logger.info(f"Successfully synced {workspace_id}/{unique_id}")
+                    logger.info("Successfully validated" f" {workspace_id}/{unique_id}")
+                    has_thumbnails = result.get("has_thumbnails", True)
                     cls._mark_sync_complete(exp_id)
                     cls._clear_retry_count(exp_id)
+                    asyncio.create_task(
+                        cls._trigger_proactive_download(
+                            workspace_id,
+                            unique_id,
+                            bucket_name,
+                            has_thumbnails=has_thumbnails,
+                        )
+                    )
                     return True
 
                 except Exception as e:
-                    is_expected_retry = isinstance(e, SyncRetryError)
+                    is_expected = isinstance(e, SyncRetryError)
                     error_msg = str(e)
 
                     if attempt < max_retries - 1:
-                        wait_time = 2**attempt  # 1s, 2s, 4s
-                        logger.warning(f"{error_msg}, retrying in {wait_time}s...")
-                        await asyncio.sleep(wait_time)
+                        wait = 2**attempt
+                        logger.warning(f"{error_msg}," f" retrying in {wait}s...")
+                        await asyncio.sleep(wait)
                     else:
                         logger.error(
-                            f"Failed to sync {workspace_id}/{unique_id} "
-                            f"after {max_retries} attempts: {error_msg}",
-                            exc_info=not is_expected_retry,
+                            f"Failed to validate"
+                            f" {workspace_id}/{unique_id}"
+                            f" after {max_retries}"
+                            f" attempts: {error_msg}",
+                            exc_info=not is_expected,
                         )
 
             # All retries failed
@@ -549,11 +468,99 @@ class PublishedExperimentSyncJob:
 
         except Exception as e:
             logger.error(
-                f"Error syncing {workspace_id}/{unique_id}: {e}", exc_info=True
+                f"Error validating" f" {workspace_id}/{unique_id}: {e}",
+                exc_info=True,
             )
             cls._mark_sync_error(exp_id)
             cls._increment_retry_count(exp_id)
             return False
+
+    @classmethod
+    def _do_proactive_download_sync(
+        cls,
+        workspace_id: str,
+        unique_id: str,
+        bucket_name: str,
+        has_thumbnails: bool = True,
+    ) -> bool:
+        """Sync HTTP call to ALB (runs in executor)."""
+        import requests
+
+        alb_dns = os.environ.get("ALB_DNS_NAME")
+        internal_secret = os.environ.get("INTERNAL_API_SECRET")
+
+        if not alb_dns or not internal_secret:
+            return False
+
+        url = (
+            f"https://{alb_dns}"
+            f"/system-internal/sync-experiment"
+            f"/{workspace_id}/{unique_id}"
+        )
+        headers = {
+            "X-Internal-Secret": internal_secret,
+            "Content-Type": "application/json",
+        }
+        params = {
+            "bucket_name": bucket_name,
+            "has_thumbnails": str(has_thumbnails).lower(),
+        }
+
+        try:
+            # Skip SSL verification for internal VPC traffic;
+            # ALB cert doesn't match AWS-generated hostname
+            response = requests.post(
+                url,
+                headers=headers,
+                params=params,
+                timeout=10.0,
+                verify=False,
+            )
+            if response.status_code == 200:
+                logger.info(
+                    "Proactive download triggered" f" for {workspace_id}/{unique_id}"
+                )
+                return True
+            else:
+                logger.warning(
+                    "Proactive download request"
+                    f" failed for"
+                    f" {workspace_id}/{unique_id}:"
+                    f" status {response.status_code}"
+                )
+                return False
+        except Exception as e:
+            logger.warning(
+                "Proactive download trigger"
+                f" error for"
+                f" {workspace_id}/{unique_id}: {e}"
+            )
+            return False
+
+    @classmethod
+    async def _trigger_proactive_download(
+        cls,
+        workspace_id: str,
+        unique_id: str,
+        bucket_name: str,
+        has_thumbnails: bool = True,
+    ) -> bool:
+        """
+        Call ALB to trigger thumbnail/metadata download
+        on an API instance. Fire-and-forget.
+
+        Returns False silently if ALB config is missing
+        (non-cloud environments).
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None,
+            cls._do_proactive_download_sync,
+            workspace_id,
+            unique_id,
+            bucket_name,
+            has_thumbnails,
+        )
 
     @classmethod
     def _mark_sync_complete(cls, exp_id: int):
@@ -564,41 +571,47 @@ class PublishedExperimentSyncJob:
                 experiment.local_sync_status = LocalSyncStatus.synced.value
                 db.add(experiment)
                 db.commit()
-
-            logger.debug(f"Marked experiment {exp_id} as synced")
+                logger.debug(f"Marked experiment {exp_id} as synced")
+            else:
+                logger.warning(f"Experiment {exp_id} not found for sync status update")
 
     @classmethod
     def _mark_sync_error(cls, exp_id: int):
-        """Mark experiment sync as failed (will retry next run)"""
+        """Mark experiment sync as failed (retries next run)"""
         with session_scope() as db:
             experiment = db.get(ExperimentRecord, exp_id)
             if experiment:
                 experiment.local_sync_status = LocalSyncStatus.error.value
                 db.add(experiment)
                 db.commit()
-
-            logger.debug(f"Marked experiment {exp_id} as sync error")
+                logger.debug(f"Marked experiment {exp_id} as sync error")
+            else:
+                logger.warning(f"Experiment {exp_id} not found for sync error update")
 
     @classmethod
     def _increment_retry_count(cls, exp_id: int):
-        """Increment retry count for failed sync (stored in DB for persistence)"""
-        with session_scope() as db:
-            experiment = db.get(ExperimentRecord, exp_id)
-            if experiment:
-                # Use a custom field or metadata to track retries
-                # For now, log the retry attempt
-                logger.info(f"Incrementing retry count for experiment {exp_id}")
+        """Increment retry count for failed validation."""
+        _retry_counts[exp_id] = _retry_counts.get(exp_id, 0) + 1
+        logger.info(f"Retry count for experiment {exp_id}:" f" {_retry_counts[exp_id]}")
 
     @classmethod
     def _clear_retry_count(cls, exp_id: int):
-        """Clear retry count after successful sync"""
+        """Clear retry count after successful validation."""
+        _retry_counts.pop(exp_id, None)
         logger.debug(f"Cleared retry count for experiment {exp_id}")
 
     @classmethod
-    def _check_persistent_failure(cls, exp_id: int, workspace_id: str, unique_id: str):
-        """Check for persistent failures and alert operators"""
-        # Query how many times this experiment has failed
-        # For now, publish high-priority CloudWatch metric
+    def _check_persistent_failure(
+        cls,
+        exp_id: int,
+        workspace_id: str,
+        unique_id: str,
+    ):
+        """Alert operators only after MAX_PERSISTENT_RETRIES."""
+        count = _retry_counts.get(exp_id, 0)
+        if count < MAX_PERSISTENT_RETRIES:
+            return
+
         try:
             import boto3
 
@@ -612,27 +625,42 @@ class PublishedExperimentSyncJob:
                         "Unit": "Count",
                         "Timestamp": get_current_datetime(),
                         "Dimensions": [
-                            {"Name": "ExperimentId", "Value": str(exp_id)},
-                            {"Name": "WorkspaceId", "Value": workspace_id},
+                            {
+                                "Name": "ExperimentId",
+                                "Value": str(exp_id),
+                            },
+                            {
+                                "Name": "WorkspaceId",
+                                "Value": workspace_id,
+                            },
                         ],
                     }
                 ],
             )
             logger.error(
-                f"PERSISTENT SYNC FAILURE: Experiment {workspace_id}/{unique_id} "
-                f"(id={exp_id}) has failed multiple sync attempts. "
-                f"Manual intervention may be required."
+                "PERSISTENT SYNC FAILURE:"
+                f" {workspace_id}/{unique_id}"
+                f" (id={exp_id}) has failed"
+                f" {count} validation attempts."
+                " Manual intervention may be"
+                " required."
             )
         except Exception as e:
-            logger.warning(f"Failed to publish persistent failure metric: {e}")
+            logger.warning("Failed to publish persistent" f" failure metric: {e}")
+
+        # Reset so alert can re-fire if failure persists
+        _retry_counts.pop(exp_id, None)
 
     @classmethod
     def _publish_metrics(cls, synced_count: int, error_count: int):
-        """Publish sync job metrics to CloudWatch with alarm thresholds"""
+        """Publish sync job metrics to CloudWatch."""
         try:
             import boto3
 
             cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+
+            total = synced_count + error_count
+            error_rate = (error_count / total * 100) if total > 0 else 0
 
             cloudwatch.put_metric_data(
                 Namespace="OptiNiSt/BackgroundJobs",
@@ -651,29 +679,25 @@ class PublishedExperimentSyncJob:
                     },
                     {
                         "MetricName": "SyncErrorRate",
-                        "Value": (
-                            (error_count / (synced_count + error_count) * 100)
-                            if (synced_count + error_count) > 0
-                            else 0
-                        ),
+                        "Value": error_rate,
                         "Unit": "Percent",
                         "Timestamp": get_current_datetime(),
                     },
                 ],
             )
             logger.debug(
-                f"Published CloudWatch metrics: {synced_count} synced, "
-                f"{error_count} errors"
+                "Published CloudWatch metrics:"
+                f" {synced_count} synced,"
+                f" {error_count} errors"
             )
 
-            # Alert if error rate is high
-            if (synced_count + error_count) > 0:
-                error_rate = error_count / (synced_count + error_count) * 100
-                if error_rate > 50:  # More than 50% failures
-                    logger.error(
-                        f"HIGH SYNC ERROR RATE: {error_rate:.1f}% "
-                        f"({error_count}/{synced_count + error_count} failed). "
-                        f"Check S3 connectivity and permissions."
-                    )
+            if total > 0 and error_rate > 50:
+                logger.error(
+                    "HIGH SYNC ERROR RATE:"
+                    f" {error_rate:.1f}%"
+                    f" ({error_count}/{total} failed)."
+                    " Check S3 connectivity and"
+                    " permissions."
+                )
         except Exception as e:
             logger.warning(f"Failed to publish metrics: {e}")

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -53,6 +53,7 @@ class S3StorageController(BaseRemoteStorageController):
     S3_BASE_PATH = "app/studio_data"
     S3_INPUT_DIR = "input"
     S3_OUTPUT_DIR = "output"
+    VALIDATION_MAX_OBJECTS = 500
 
     def __init__(self, bucket_name: str):
         # init s3 bucket attributes
@@ -653,6 +654,100 @@ class S3StorageController(BaseRemoteStorageController):
             f"[{workspace_id}/{unique_id}]"
         )
         return True
+
+    async def validate_experiment_in_s3(
+        self, workspace_id: str, unique_id: str
+    ) -> dict:
+        """
+        Validate that an experiment exists in S3 without downloading.
+
+        Checks for required files (experiment.yaml, workflow.yaml) via
+        ListObjectsV2. Used by the background sync job to update DB
+        status without wasting bandwidth on downloads.
+
+        Returns:
+            dict with keys:
+                valid (bool): True if required files exist
+                has_thumbnails (bool): True if thumbnail PNGs found
+                error (str|None): Error message if validation failed
+        """
+        prefix = self.make_s3_output_prefix(workspace_id, unique_id)
+        required = {DIRPATH.EXPERIMENT_YML, DIRPATH.WORKFLOW_YML}
+
+        try:
+            found_files = set()
+            has_thumbnails = False
+
+            async with self.__get_s3_client() as s3_client:
+                continuation_token = None
+                total_listed = 0
+
+                while True:
+                    params = {
+                        "Bucket": self.bucket_name,
+                        "Prefix": prefix,
+                    }
+                    if continuation_token:
+                        params["ContinuationToken"] = continuation_token
+
+                    resp = await s3_client.list_objects_v2(**params)
+
+                    if not resp or resp.get("KeyCount", 0) == 0:
+                        break
+
+                    for obj in resp.get("Contents", []):
+                        key = obj["Key"]
+                        filename = key.rsplit("/", 1)[-1]
+                        file_size = obj.get("Size", 0)
+
+                        if filename in required:
+                            if file_size > 0:
+                                found_files.add(filename)
+                            else:
+                                logger.warning(
+                                    f"Required file {filename}"
+                                    f" is 0 bytes in S3: {key}"
+                                )
+
+                        if filename.endswith("_thumb.png"):
+                            has_thumbnails = True
+
+                    total_listed += resp.get("KeyCount", 0)
+                    if total_listed >= self.VALIDATION_MAX_OBJECTS:
+                        break
+
+                    if resp.get("IsTruncated"):
+                        continuation_token = resp.get("NextContinuationToken")
+                    else:
+                        break
+
+            if not found_files:
+                return {
+                    "valid": False,
+                    "has_thumbnails": False,
+                    "error": "No objects found in S3",
+                }
+
+            missing = required - found_files
+            if missing:
+                return {
+                    "valid": False,
+                    "has_thumbnails": has_thumbnails,
+                    "error": f"Missing required files: {sorted(missing)}",
+                }
+
+            return {
+                "valid": True,
+                "has_thumbnails": has_thumbnails,
+                "error": None,
+            }
+
+        except Exception as e:
+            return {
+                "valid": False,
+                "has_thumbnails": False,
+                "error": f"S3 validation error: {e}",
+            }
 
     async def __download_all_experiments_metas_via_aws_cli(self) -> bool:
         """

--- a/studio/app/common/routers/internal.py
+++ b/studio/app/common/routers/internal.py
@@ -11,7 +11,16 @@ import secrets
 import time
 from typing import Dict
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Header,
+    HTTPException,
+    Path,
+    Query,
+    status,
+)
 from sqlmodel import Session, select
 
 from studio.app.common.core.auth.auth_dependencies import _get_user_remote_bucket_name
@@ -20,9 +29,11 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteStorageSimpleReader,
 )
+from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.db.database import get_db, get_session
 from studio.app.common.models.user import User
 from studio.app.common.models.workspace import Workspace
+from studio.app.dir_path import DIRPATH
 
 router = APIRouter(prefix="/system-internal", tags=["system-internal"])
 
@@ -32,7 +43,15 @@ INTERNAL_API_SECRET = os.environ.get("INTERNAL_API_SECRET")
 
 # Rate limiting for internal endpoints (in-memory cache)
 _rate_limit_cache: Dict[int, float] = {}
-_RATE_LIMIT_SECONDS = 10  # Allow one sync request per user per 10 seconds
+_sync_rate_limit_cache: Dict[str, float] = {}
+_RATE_LIMIT_SECONDS = 10
+
+
+def _cleanup_rate_limit_cache(cache: Dict, cutoff: float) -> None:
+    """Remove rate-limit entries older than cutoff to prevent unbounded growth."""
+    expired = [k for k, v in cache.items() if v < cutoff]
+    for k in expired:
+        del cache[k]
 
 
 def verify_internal_secret(x_internal_secret: str = Header(...)) -> None:
@@ -78,6 +97,7 @@ async def sync_user_experiments(
     """
     # Rate limiting check
     current_time = time.time()
+    _cleanup_rate_limit_cache(_rate_limit_cache, current_time - _RATE_LIMIT_SECONDS * 2)
     last_request = _rate_limit_cache.get(user_id, 0)
     if current_time - last_request < _RATE_LIMIT_SECONDS:
         logger.warning(
@@ -111,6 +131,115 @@ async def sync_user_experiments(
     background_tasks.add_task(_download_experiments_for_user, bucket_name, user_id)
 
     return {"status": "sync_initiated", "user_id": user_id}
+
+
+@router.post("/sync-experiment/{workspace_id}/{unique_id}")
+async def sync_single_experiment(
+    workspace_id: str = Path(..., pattern=r"^\d+$"),
+    unique_id: str = Path(..., pattern=r"^[a-zA-Z0-9_-]+$"),
+    bucket_name: str = Query(
+        ...,
+        min_length=3,
+        max_length=63,
+        pattern=r"^[a-z0-9][a-z0-9.\-]*[a-z0-9]$",
+    ),
+    has_thumbnails: bool = Query(default=True),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+    _: None = Depends(verify_internal_secret),
+):
+    """
+    Trigger download of a single experiment on this
+    API instance.
+
+    Called by the background sync job after validating an
+    experiment in S3. Downloads thumbnails and essential
+    metadata so they are pre-cached before users request
+    them.
+    """
+    # Rate limiting per experiment
+    cache_key = f"{workspace_id}/{unique_id}"
+    current_time = time.time()
+    _cleanup_rate_limit_cache(
+        _sync_rate_limit_cache, current_time - _RATE_LIMIT_SECONDS * 2
+    )
+    last_req = _sync_rate_limit_cache.get(cache_key, 0)
+    if current_time - last_req < _RATE_LIMIT_SECONDS:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Sync request too frequent",
+        )
+    _sync_rate_limit_cache[cache_key] = current_time
+
+    logger.info(
+        f"Proactive sync requested for"
+        f" {workspace_id}/{unique_id}"
+        f" (bucket: {bucket_name})"
+    )
+
+    background_tasks.add_task(
+        _download_single_experiment,
+        bucket_name,
+        workspace_id,
+        unique_id,
+        has_thumbnails,
+    )
+
+    return {
+        "status": "sync_initiated",
+        "workspace_id": workspace_id,
+        "unique_id": unique_id,
+    }
+
+
+async def _download_single_experiment(
+    bucket_name: str,
+    workspace_id: str,
+    unique_id: str,
+    has_thumbnails: bool = True,
+) -> None:
+    """
+    Background task to download thumbnails and essential
+    metadata for a single experiment from S3.
+    """
+    if not RemoteStorageController.is_available():
+        logger.warning(
+            "Remote storage not available,"
+            " skipping proactive sync for"
+            f" {workspace_id}/{unique_id}"
+        )
+        return
+
+    # Skip if required files already exist locally
+    local_path = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
+    exp_yaml = os.path.join(local_path, DIRPATH.EXPERIMENT_YML)
+    wf_yaml = os.path.join(local_path, DIRPATH.WORKFLOW_YML)
+    if os.path.exists(exp_yaml) and os.path.exists(wf_yaml):
+        logger.info(
+            "Skipping proactive sync for"
+            f" {workspace_id}/{unique_id}:"
+            " files already exist locally"
+        )
+        return
+
+    try:
+        async with RemoteStorageSimpleReader(bucket_name) as controller:
+            if has_thumbnails:
+                await controller.download_experiment(
+                    workspace_id,
+                    unique_id,
+                    sync_mode="thumbnails_only",
+                )
+            await controller.download_experiment(
+                workspace_id,
+                unique_id,
+                sync_mode="essential_only",
+            )
+        logger.info("Proactive sync completed for" f" {workspace_id}/{unique_id}")
+    except Exception as e:
+        logger.error(
+            "Proactive sync failed for" f" {workspace_id}/{unique_id}: {e}",
+            exc_info=True,
+        )
 
 
 async def _download_experiments_for_user(bucket_name: str, user_id: int) -> None:

--- a/studio/tests/app/common/core/background/test_sync_job.py
+++ b/studio/tests/app/common/core/background/test_sync_job.py
@@ -1,179 +1,15 @@
 """
 Unit tests for published experiment sync job.
 
-Tests S3 download with exponential backoff and error handling.
+Tests S3 validation, proactive download trigger, and startup sync.
 """
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from studio.app.common.core.background.sync_job import PublishedExperimentSyncJob
-from studio.app.dir_path import DIRPATH
-
-
-def make_path_exists_mock(local_path_exists=False, required_files_exist=True):
-    """
-    Create a mock for os.path.exists that handles different paths.
-
-    Args:
-        local_path_exists: Whether the local experiment directory exists
-        required_files_exist: Whether required files exist after download
-    """
-    call_count = [0]
-
-    def path_exists(path):
-        call_count[0] += 1
-        # First call checks if local_path exists
-        if call_count[0] == 1:
-            return local_path_exists
-
-        # If local_path exists and we're checking required files
-        if local_path_exists:
-            return required_files_exist
-
-        # After download, check if required files exist
-        if DIRPATH.EXPERIMENT_YML in path or DIRPATH.WORKFLOW_YML in path:
-            return required_files_exist
-
-        return False
-
-    return path_exists
-
-
-class TestSyncExperiment:
-    """Test experiment sync with retry logic"""
-
-    @pytest.mark.asyncio
-    async def test_sync_experiment_success_first_attempt(self):
-        """Test successful sync on first attempt"""
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
-
-        with patch("studio.app.common.core.background.sync_job.session_scope"):
-            with patch(
-                "os.path.exists",
-                side_effect=make_path_exists_mock(
-                    local_path_exists=False, required_files_exist=True
-                ),
-            ):
-                result = await PublishedExperimentSyncJob._sync_experiment(
-                    mock_s3_controller, "workspace1", "exp123", 1
-                )
-
-        assert result is True
-        assert mock_s3_controller.download_experiment.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_sync_experiment_retry_on_failure(self):
-        """Test exponential backoff retry on failure"""
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(
-            side_effect=[False, False, True]
-        )
-
-        # Track calls to determine when files should "exist"
-        download_attempts = [0]
-
-        def path_exists_after_success(path):
-            # Local path doesn't exist initially
-            if download_attempts[0] == 0:
-                return False
-            # After successful download, files exist
-            if DIRPATH.EXPERIMENT_YML in path or DIRPATH.WORKFLOW_YML in path:
-                return download_attempts[0] >= 3  # Only after 3rd attempt (success)
-            return False
-
-        original_download = mock_s3_controller.download_experiment
-
-        async def track_download(*args, **kwargs):
-            download_attempts[0] += 1
-            return await original_download(*args, **kwargs)
-
-        mock_s3_controller.download_experiment = AsyncMock(side_effect=track_download)
-        mock_s3_controller.download_experiment.side_effect = None
-        mock_s3_controller.download_experiment = AsyncMock(
-            side_effect=[False, False, True]
-        )
-
-        with patch("studio.app.common.core.background.sync_job.session_scope"):
-            with patch(
-                "os.path.exists",
-                side_effect=make_path_exists_mock(
-                    local_path_exists=False, required_files_exist=True
-                ),
-            ):
-                with patch("asyncio.sleep") as mock_sleep:
-                    result = await PublishedExperimentSyncJob._sync_experiment(
-                        mock_s3_controller, "workspace1", "exp123", 1
-                    )
-
-        assert result is True
-        assert mock_s3_controller.download_experiment.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_sync_experiment_all_retries_fail(self):
-        """Test failure after all retries exhausted"""
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=False)
-
-        with patch("studio.app.common.core.background.sync_job.session_scope"):
-            with patch("os.path.exists", return_value=False):
-                with patch("asyncio.sleep"):
-                    result = await PublishedExperimentSyncJob._sync_experiment(
-                        mock_s3_controller, "workspace1", "exp123", 1
-                    )
-
-        assert result is False
-        assert mock_s3_controller.download_experiment.call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_sync_experiment_missing_required_files_in_s3(self):
-        """Test failure when required files are missing from S3 (corrupted data)"""
-        mock_s3_controller = MagicMock()
-        # Download returns True (S3 has some files) but required files are missing
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
-
-        with patch("studio.app.common.core.background.sync_job.session_scope"):
-            # Required files don't exist after download
-            with patch(
-                "os.path.exists",
-                side_effect=make_path_exists_mock(
-                    local_path_exists=False, required_files_exist=False
-                ),
-            ):
-                with patch("asyncio.sleep"):
-                    result = await PublishedExperimentSyncJob._sync_experiment(
-                        mock_s3_controller, "workspace1", "exp123", 1
-                    )
-
-        # Should fail because required files are missing
-        assert result is False
-        # Should retry 3 times before giving up
-        assert mock_s3_controller.download_experiment.call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_sync_experiment_skips_when_local_files_exist(self):
-        """Test sync skips download when local files already exist"""
-        mock_s3_controller = MagicMock()
-        mock_s3_controller.download_experiment = AsyncMock(return_value=True)
-
-        with patch("studio.app.common.core.background.sync_job.session_scope"):
-            # Local path exists and has required files
-            with patch(
-                "os.path.exists",
-                side_effect=make_path_exists_mock(
-                    local_path_exists=True, required_files_exist=True
-                ),
-            ):
-                result = await PublishedExperimentSyncJob._sync_experiment(
-                    mock_s3_controller, "workspace1", "exp123", 1
-                )
-
-        assert result is True
-        # Should NOT call download because local files exist
-        assert mock_s3_controller.download_experiment.call_count == 0
 
 
 class TestStartupSync:
@@ -240,3 +76,493 @@ class TestStartupSync:
         ):
             # Should not raise
             await PublishedExperimentSyncJob.run_startup_sync()
+
+
+class TestProactiveDownloadTrigger:
+    """Tests for _trigger_proactive_download ALB call"""
+
+    @pytest.mark.asyncio
+    async def test_trigger_success(self):
+        """Successful POST returns True"""
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret-123",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 200
+                mock_post.return_value = mock_resp
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is True
+                mock_post.assert_called_once()
+                call_url = mock_post.call_args[0][0]
+                assert "sync-experiment/ws1/uid1" in call_url
+                params = mock_post.call_args[1]["params"]
+                assert params["bucket_name"] == "bucket1"
+
+    @pytest.mark.asyncio
+    async def test_trigger_passes_has_thumbnails(self):
+        """has_thumbnails is passed to ALB request"""
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret-123",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 200
+                mock_post.return_value = mock_resp
+
+                await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1",
+                    "uid1",
+                    "bucket1",
+                    has_thumbnails=False,
+                )
+
+                params = mock_post.call_args[1]["params"]
+                assert params["has_thumbnails"] == "false"
+
+    @pytest.mark.asyncio
+    async def test_trigger_missing_config(self):
+        """Missing ALB_DNS_NAME returns False"""
+        env = {"ALB_DNS_NAME": "", "INTERNAL_API_SECRET": ""}
+        with patch.dict(os.environ, env, clear=False):
+            result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                "ws1", "uid1", "bucket1"
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_connection_error(self):
+        """ConnectionError returns False"""
+        import requests
+
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_post.side_effect = requests.exceptions.ConnectionError(
+                    "Network error"
+                )
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_api_error(self):
+        """500 response returns False"""
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 500
+                mock_post.return_value = mock_resp
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_timeout(self):
+        """Timeout returns False"""
+        import requests
+
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_post.side_effect = requests.exceptions.Timeout("Request timed out")
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_missing_only_alb(self):
+        """ALB set but no secret returns False"""
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                "ws1", "uid1", "bucket1"
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_missing_only_secret(self):
+        """Secret set but no ALB returns False"""
+        env = {
+            "ALB_DNS_NAME": "",
+            "INTERNAL_API_SECRET": "secret",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                "ws1", "uid1", "bucket1"
+            )
+
+            assert result is False
+
+
+class TestValidateExperiment:
+    """Tests for _validate_experiment with proactive trigger"""
+
+    @pytest.mark.asyncio
+    async def test_validate_success_triggers_download(self):
+        """Successful validation triggers proactive download"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            return_value={
+                "valid": True,
+                "has_thumbnails": True,
+            }
+        )
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_mark_sync_complete",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_clear_retry_count",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_trigger_proactive_download",
+            new_callable=AsyncMock,
+        ) as mock_trigger:
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is True
+            mock_trigger.assert_called_once_with(
+                "ws1",
+                "uid1",
+                "bucket1",
+                has_thumbnails=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_validate_passes_has_thumbnails_false(self):
+        """has_thumbnails=False is forwarded to trigger"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            return_value={
+                "valid": True,
+                "has_thumbnails": False,
+            }
+        )
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_mark_sync_complete",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_clear_retry_count",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_trigger_proactive_download",
+            new_callable=AsyncMock,
+        ) as mock_trigger:
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is True
+            mock_trigger.assert_called_once_with(
+                "ws1",
+                "uid1",
+                "bucket1",
+                has_thumbnails=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_validate_failure_no_trigger(self):
+        """Failed validation does not trigger download"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            return_value={
+                "valid": False,
+                "error": "Missing files",
+            }
+        )
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_mark_sync_error",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_increment_retry_count",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_check_persistent_failure",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_trigger_proactive_download",
+                new_callable=AsyncMock,
+            ) as mock_trigger,
+        ):
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is False
+            mock_trigger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_retry_then_succeed(self):
+        """Fail twice then succeed on third attempt"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            side_effect=[
+                {"valid": False, "error": "Transient error"},
+                {"valid": False, "error": "Transient error"},
+                {"valid": True, "has_thumbnails": True},
+            ]
+        )
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_mark_sync_complete",
+            ) as mock_complete,
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_clear_retry_count",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_trigger_proactive_download",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is True
+            assert mock_s3.validate_experiment_in_s3.call_count == 3
+            # 2 retries: 2^0=1, 2^1=2
+            assert mock_sleep.call_count == 2
+            mock_sleep.assert_any_call(1)
+            mock_sleep.assert_any_call(2)
+            mock_complete.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_validate_generic_exception_retries(self):
+        """Generic exception (not SyncRetryError) also retries"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            side_effect=[
+                RuntimeError("S3 timeout"),
+                {"valid": True, "has_thumbnails": False},
+            ]
+        )
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_mark_sync_complete",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_clear_retry_count",
+            ),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_trigger_proactive_download",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is True
+            assert mock_s3.validate_experiment_in_s3.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_validate_all_retries_exhausted(self):
+        """All 3 retries fail -> marks error + persistent failure"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            return_value={
+                "valid": False,
+                "error": "Missing",
+            }
+        )
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_mark_sync_error",
+            ) as mock_error,
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_increment_retry_count",
+            ) as mock_inc,
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_check_persistent_failure",
+            ) as mock_persist,
+        ):
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1, "bucket1"
+            )
+
+            assert result is False
+            assert mock_s3.validate_experiment_in_s3.call_count == 3
+            mock_error.assert_called_once_with(1)
+            mock_inc.assert_called_once_with(1)
+            mock_persist.assert_called_once_with(1, "ws1", "uid1")
+
+    @pytest.mark.asyncio
+    async def test_validate_outer_exception(self):
+        """Exception outside retry loop -> marks error"""
+        with (
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_mark_sync_error",
+            ) as mock_error,
+            patch.object(
+                PublishedExperimentSyncJob,
+                "_increment_retry_count",
+            ) as mock_inc,
+        ):
+            bad_s3 = MagicMock()
+            bad_s3.validate_experiment_in_s3 = AsyncMock(
+                side_effect=RuntimeError("broken")
+            )
+            with patch(
+                "builtins.range",
+                side_effect=RuntimeError("outer"),
+            ):
+                result = await PublishedExperimentSyncJob._validate_experiment(
+                    bad_s3, "ws1", "uid1", 1, "bucket1"
+                )
+
+            assert result is False
+            mock_error.assert_called_once_with(1)
+            mock_inc.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_validate_default_empty_bucket_name(self):
+        """Default bucket_name='' is passed to trigger"""
+        mock_s3 = MagicMock()
+        mock_s3.validate_experiment_in_s3 = AsyncMock(
+            return_value={
+                "valid": True,
+                "has_thumbnails": True,
+            }
+        )
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_mark_sync_complete",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_clear_retry_count",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_trigger_proactive_download",
+            new_callable=AsyncMock,
+        ) as mock_trigger:
+            result = await PublishedExperimentSyncJob._validate_experiment(
+                mock_s3, "ws1", "uid1", 1
+            )
+
+            assert result is True
+            mock_trigger.assert_called_once_with(
+                "ws1",
+                "uid1",
+                "",
+                has_thumbnails=True,
+            )
+
+
+class TestRetryCount:
+    """Tests for module-level retry count tracking"""
+
+    def setup_method(self):
+        """Reset retry counts before each test."""
+        from studio.app.common.core.background import sync_job
+
+        sync_job._retry_counts.clear()
+
+    def test_increment_retry_count(self):
+        """Incrementing tracks count per experiment"""
+        cls = PublishedExperimentSyncJob
+        cls._increment_retry_count(42)
+        cls._increment_retry_count(42)
+        cls._increment_retry_count(99)
+
+        from studio.app.common.core.background import sync_job
+
+        assert sync_job._retry_counts[42] == 2
+        assert sync_job._retry_counts[99] == 1
+
+    def test_clear_retry_count(self):
+        """Clearing removes entry entirely"""
+        cls = PublishedExperimentSyncJob
+        cls._increment_retry_count(42)
+        cls._clear_retry_count(42)
+
+        from studio.app.common.core.background import sync_job
+
+        assert 42 not in sync_job._retry_counts
+
+    def test_persistent_failure_below_threshold(self):
+        """Below MAX_PERSISTENT_RETRIES: no metric"""
+        from studio.app.common.core.background import sync_job
+
+        cls = PublishedExperimentSyncJob
+        for _ in range(sync_job.MAX_PERSISTENT_RETRIES - 1):
+            cls._increment_retry_count(42)
+
+        with patch("boto3.client") as mock_boto:
+            cls._check_persistent_failure(42, "ws1", "uid1")
+            mock_boto.assert_not_called()
+
+    def test_persistent_failure_at_threshold(self):
+        """At MAX_PERSISTENT_RETRIES: publishes metric"""
+        from studio.app.common.core.background import sync_job
+
+        cls = PublishedExperimentSyncJob
+        for _ in range(sync_job.MAX_PERSISTENT_RETRIES):
+            cls._increment_retry_count(42)
+
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+            cls._check_persistent_failure(42, "ws1", "uid1")
+            mock_cw.put_metric_data.assert_called_once()

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -587,3 +587,288 @@ class TestDownloadAllExperimentsMetasNoSuchBucket:
                 )
 
         assert "test-bucket" in str(exc_info.value)
+
+
+class TestValidateExperimentInS3:
+    """Tests for validate_experiment_in_s3 method"""
+
+    def setup_method(self):
+        self.controller = S3StorageController("test-bucket")
+        self.prefix = S3StorageController.make_s3_output_prefix("ws1", "uid1")
+
+    def _make_s3_client(self, responses):
+        """Create mock S3 client returning given responses."""
+        mock_client = AsyncMock()
+        if isinstance(responses, list):
+            mock_client.list_objects_v2.side_effect = responses
+        else:
+            mock_client.list_objects_v2.return_value = responses
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        return mock_client
+
+    def _make_obj(self, filename, size=100):
+        """Create an S3 object dict."""
+        return {"Key": f"{self.prefix}{filename}", "Size": size}
+
+    @pytest.mark.asyncio
+    async def test_valid_experiment(self):
+        """Both required files present -> valid"""
+        resp = {
+            "KeyCount": 2,
+            "Contents": [
+                self._make_obj("experiment.yaml"),
+                self._make_obj("workflow.yaml"),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is True
+        assert result["error"] is None
+        assert result["has_thumbnails"] is False
+
+    @pytest.mark.asyncio
+    async def test_valid_with_thumbnails(self):
+        """Detects thumbnail files"""
+        resp = {
+            "KeyCount": 3,
+            "Contents": [
+                self._make_obj("experiment.yaml"),
+                self._make_obj("workflow.yaml"),
+                self._make_obj("thumbnails/input_thumb.png"),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is True
+        assert result["has_thumbnails"] is True
+
+    @pytest.mark.asyncio
+    async def test_empty_prefix(self):
+        """No objects in S3 -> invalid"""
+        resp = {"KeyCount": 0}
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "No objects found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_workflow_yaml(self):
+        """Only experiment.yaml present -> invalid"""
+        resp = {
+            "KeyCount": 1,
+            "Contents": [
+                self._make_obj("experiment.yaml"),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "workflow.yaml" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_experiment_yaml(self):
+        """Only workflow.yaml present -> invalid"""
+        resp = {
+            "KeyCount": 1,
+            "Contents": [
+                self._make_obj("workflow.yaml"),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "experiment.yaml" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_s3_exception(self):
+        """S3 error -> invalid with error message"""
+        mock_client = AsyncMock()
+        mock_client.list_objects_v2.side_effect = RuntimeError("S3 unavailable")
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "S3 validation error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_pagination(self):
+        """Handles paginated responses"""
+        page1 = {
+            "KeyCount": 1,
+            "IsTruncated": True,
+            "NextContinuationToken": "token-abc",
+            "Contents": [
+                self._make_obj("experiment.yaml"),
+            ],
+        }
+        page2 = {
+            "KeyCount": 1,
+            "IsTruncated": False,
+            "Contents": [
+                self._make_obj("workflow.yaml"),
+            ],
+        }
+        mock_client = self._make_s3_client([page1, page2])
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is True
+        # Second call should include ContinuationToken
+        second_call = mock_client.list_objects_v2.call_args_list[1]
+        assert second_call[1]["ContinuationToken"] == "token-abc"
+
+    @pytest.mark.asyncio
+    async def test_max_objects_limit(self):
+        """Stops listing after VALIDATION_MAX_OBJECTS=500"""
+        # Single page claiming 500 objects (hits the limit)
+        contents = [self._make_obj(f"file_{i}.dat") for i in range(500)]
+        resp = {
+            "KeyCount": 500,
+            "IsTruncated": True,
+            "NextContinuationToken": "more",
+            "Contents": contents,
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        # Should stop after one page (500 >= VALIDATION_MAX_OBJECTS)
+        assert mock_client.list_objects_v2.call_count == 1
+        # No required files in dummy data
+        assert result["valid"] is False
+
+    @pytest.mark.asyncio
+    async def test_none_response(self):
+        """Handles None response from list_objects_v2"""
+        mock_client = self._make_s3_client(None)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "No objects found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_has_extra_files_still_valid(self):
+        """Extra files beyond required don't affect validity"""
+        resp = {
+            "KeyCount": 4,
+            "Contents": [
+                self._make_obj("experiment.yaml"),
+                self._make_obj("workflow.yaml"),
+                self._make_obj("cell_roi.json"),
+                self._make_obj("data.pkl"),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_zero_byte_required_file_invalid(self):
+        """Zero-byte required file treated as missing"""
+        resp = {
+            "KeyCount": 2,
+            "Contents": [
+                self._make_obj("experiment.yaml", size=0),
+                self._make_obj("workflow.yaml", size=100),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        assert "experiment.yaml" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_both_zero_byte_files_invalid(self):
+        """Both required files at 0 bytes -> invalid"""
+        resp = {
+            "KeyCount": 2,
+            "Contents": [
+                self._make_obj("experiment.yaml", size=0),
+                self._make_obj("workflow.yaml", size=0),
+            ],
+        }
+        mock_client = self._make_s3_client(resp)
+
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ):
+            result = await self.controller.validate_experiment_in_s3("ws1", "uid1")
+
+        assert result["valid"] is False
+        # Both 0-byte -> found_files empty -> "No objects found"
+        assert result["error"] is not None

--- a/studio/tests/app/common/routers/test_data_sync.py
+++ b/studio/tests/app/common/routers/test_data_sync.py
@@ -949,6 +949,277 @@ class TestInputDataSync:
 
 
 # ---------------------------------------------------------------------------
+# Single Experiment Sync
+# ---------------------------------------------------------------------------
+
+
+class TestSingleExperimentSync:
+    """Tests for /system-internal/sync-experiment endpoint."""
+
+    @pytest.fixture
+    def app_with_internal_router(self):
+        """Create a minimal FastAPI app with internal router."""
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        with patch.dict(
+            os.environ,
+            {"INTERNAL_API_SECRET": "test-secret-12345"},
+        ):
+            import importlib
+
+            import studio.app.common.routers.internal as mod
+
+            importlib.reload(mod)
+            app.include_router(mod.router)
+
+        return app
+
+    @pytest.fixture
+    def client(self, app_with_internal_router):
+        """Create test client."""
+        return TestClient(app_with_internal_router)
+
+    def test_sync_single_experiment_success(self, app_with_internal_router):
+        """POST with valid params returns 200."""
+        client = TestClient(app_with_internal_router)
+
+        response = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "sync_initiated"
+        assert data["workspace_id"] == "1"
+        assert data["unique_id"] == "uid1"
+
+    def test_sync_single_experiment_bad_secret(self, client):
+        """POST with wrong secret returns 403."""
+        response = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "wrong-secret"},
+        )
+
+        assert response.status_code == 403
+
+    def test_sync_single_experiment_missing_secret(self, client):
+        """POST without secret header returns 422."""
+        response = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=my-bucket",
+        )
+
+        assert response.status_code == 422
+
+    def test_sync_single_experiment_missing_bucket(self, client):
+        """POST without bucket_name query param returns 422."""
+        response = client.post(
+            "/system-internal/sync-experiment/1/uid1",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+
+        assert response.status_code == 422
+
+    def test_sync_single_experiment_bad_bucket(self, client):
+        """Invalid bucket name returns 422."""
+        response = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=AB",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert response.status_code == 422
+
+    def test_sync_single_experiment_invalid_workspace_id(self, client):
+        """Non-numeric workspace_id returns 422."""
+        response = client.post(
+            "/system-internal/sync-experiment" "/ws1/uid1?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert response.status_code == 422
+
+    def test_sync_single_experiment_invalid_unique_id(self, client):
+        """unique_id with special chars returns 422."""
+        response = client.post(
+            "/system-internal/sync-experiment"
+            "/1/uid%20with%20spaces?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert response.status_code == 422
+
+    def test_sync_single_experiment_rate_limited(self, app_with_internal_router):
+        """Rapid calls to same experiment return 429."""
+        client = TestClient(app_with_internal_router)
+
+        resp1 = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert resp1.status_code == 200
+
+        resp2 = client.post(
+            "/system-internal/sync-experiment" "/1/uid1?bucket_name=my-bucket",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert resp2.status_code == 429
+
+    def test_sync_single_experiment_has_thumbnails(self, client):
+        """has_thumbnails=false is accepted."""
+        import studio.app.common.routers.internal as mod
+
+        mod._sync_rate_limit_cache.clear()
+
+        response = client.post(
+            "/system-internal/sync-experiment"
+            "/1/uid1"
+            "?bucket_name=my-bucket"
+            "&has_thumbnails=false",
+            headers={"X-Internal-Secret": "test-secret-12345"},
+        )
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Download Single Experiment Background Task
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadSingleExperiment:
+    """Tests for _download_single_experiment background task."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_remote_storage_unavailable(self):
+        """Returns early when remote storage is not available."""
+        with patch(
+            "studio.app.common.routers.internal." "RemoteStorageController"
+        ) as mock_ctrl:
+            mock_ctrl.is_available.return_value = False
+
+            from studio.app.common.routers.internal import _download_single_experiment
+
+            # Should not raise
+            await _download_single_experiment("bucket1", "ws1", "uid1")
+
+            mock_ctrl.is_available.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_downloads_thumbnails_then_essential(self):
+        """Downloads thumbnails_only then essential_only."""
+        mock_reader = AsyncMock()
+        mock_reader.__aenter__.return_value = mock_reader
+        mock_reader.__aexit__.return_value = None
+
+        with patch(
+            "studio.app.common.routers.internal." "RemoteStorageController"
+        ) as mock_ctrl, patch(
+            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            return_value=mock_reader,
+        ), patch(
+            "os.path.exists", return_value=False
+        ):
+            mock_ctrl.is_available.return_value = True
+
+            from studio.app.common.routers.internal import _download_single_experiment
+
+            await _download_single_experiment(
+                "bucket1",
+                "ws1",
+                "uid1",
+                has_thumbnails=True,
+            )
+
+        assert mock_reader.download_experiment.call_count == 2
+        calls = mock_reader.download_experiment.call_args_list
+        assert calls[0] == (
+            ("ws1", "uid1"),
+            {"sync_mode": "thumbnails_only"},
+        )
+        assert calls[1] == (
+            ("ws1", "uid1"),
+            {"sync_mode": "essential_only"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_thumbnails_when_not_present(self):
+        """has_thumbnails=False skips thumbnail download."""
+        mock_reader = AsyncMock()
+        mock_reader.__aenter__.return_value = mock_reader
+        mock_reader.__aexit__.return_value = None
+
+        with patch(
+            "studio.app.common.routers.internal." "RemoteStorageController"
+        ) as mock_ctrl, patch(
+            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            return_value=mock_reader,
+        ), patch(
+            "os.path.exists", return_value=False
+        ):
+            mock_ctrl.is_available.return_value = True
+
+            from studio.app.common.routers.internal import _download_single_experiment
+
+            await _download_single_experiment(
+                "bucket1",
+                "ws1",
+                "uid1",
+                has_thumbnails=False,
+            )
+
+        assert mock_reader.download_experiment.call_count == 1
+        calls = mock_reader.download_experiment.call_args_list
+        assert calls[0] == (
+            ("ws1", "uid1"),
+            {"sync_mode": "essential_only"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_files_exist_locally(self):
+        """Early return when YAML files already present."""
+        mock_reader = AsyncMock()
+        mock_reader.__aenter__.return_value = mock_reader
+        mock_reader.__aexit__.return_value = None
+
+        with patch(
+            "studio.app.common.routers.internal." "RemoteStorageController"
+        ) as mock_ctrl, patch(
+            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            return_value=mock_reader,
+        ), patch(
+            "os.path.exists", return_value=True
+        ):
+            mock_ctrl.is_available.return_value = True
+
+            from studio.app.common.routers.internal import _download_single_experiment
+
+            await _download_single_experiment("bucket1", "ws1", "uid1")
+
+        assert mock_reader.download_experiment.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_download_exception(self):
+        """Exception during download is caught, not propagated."""
+        mock_reader = AsyncMock()
+        mock_reader.__aenter__.return_value = mock_reader
+        mock_reader.__aexit__.return_value = None
+        mock_reader.download_experiment.side_effect = RuntimeError("S3 error")
+
+        with patch(
+            "studio.app.common.routers.internal." "RemoteStorageController"
+        ) as mock_ctrl, patch(
+            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            return_value=mock_reader,
+        ), patch(
+            "os.path.exists", return_value=False
+        ):
+            mock_ctrl.is_available.return_value = True
+
+            from studio.app.common.routers.internal import _download_single_experiment
+
+            # Should not raise
+            await _download_single_experiment("bucket1", "ws1", "uid1")
+
+
+# ---------------------------------------------------------------------------
 # Run tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Refactor `PublishedExperimentSyncJob` from downloading files on the
background instance to a validate-then-trigger architecture. The
background service has no shared filesystem and no port mappings, so
downloading files to it was wasted work. Now the job:

1. Validates experiments in S3 via `ListObjectsV2` (no downloads)
2. Updates `local_sync_status` in the DB
3. Triggers proactive file download on an API instance via ALB POST

Also adds the `sync-experiment` internal endpoint on API instances
for the proactive download trigger, adds `validate_experiment_in_s3()`
to `S3StorageController`, and hardens the implementation with
rate-limit cache cleanup, path parameter validation, persistent
failure alerting, and fire-and-forget ALB calls.

---

## Changes by File

### Background sync job

`studio/app/common/core/background/sync_job.py`
- Replace two-phase download (thumbnails + metadata) with S3
  validation via `validate_experiment_in_s3()` (ListObjectsV2 only)
- Remove `filelock` dependency (background service is single-instance)
- Add `_trigger_proactive_download()` that POSTs to ALB after
  successful validation (fire-and-forget via `asyncio.create_task`)
- Add persistent failure tracking (`_retry_counts`) with CloudWatch
  metric after `MAX_PERSISTENT_RETRIES` (9 attempts across 3 runs);
  counter resets after alert fires so it can re-fire if failure persists
- Move log statements inside `if experiment:` blocks in
  `_mark_sync_complete` / `_mark_sync_error`; add warning in else branch
- Add startup sync (`run_startup_sync`) for API containers to download
  missing experiments at boot

### Internal API endpoints

`studio/app/common/routers/internal.py`
- Add `POST /system-internal/sync-experiment/{workspace_id}/{unique_id}`
  endpoint for proactive download trigger from background job
- Add `_cleanup_rate_limit_cache()` to prevent unbounded in-memory
  cache growth (removes entries older than `2 * _RATE_LIMIT_SECONDS`)
- Add path parameter validation: `workspace_id` must be numeric
  (`^\d+$`), `unique_id` must be alphanumeric with dashes/underscores
  (`^[a-zA-Z0-9_-]+$`)
- Add `_download_single_experiment()` background task that downloads
  thumbnails + essential metadata, skipping if files already exist

### S3 storage controller

`studio/app/common/core/storage/s3_storage_controller.py`
- Add `validate_experiment_in_s3()`: checks for required files
  (`experiment.yaml`, `workflow.yaml`) via ListObjectsV2 without
  downloading; also detects thumbnail presence
- Move `MAX_OBJECTS` from local variable to class-level
  `VALIDATION_MAX_OBJECTS = 500` constant

### Infrastructure

`infrastructure/terraform/background_service.tf`
- Add `ALB_DNS_NAME` environment variable to background ECS task
  definition (needed for proactive download trigger)

### Documentation

`infrastructure/documentation/BACKGROUND_JOB_ARCHITECTURE.md`
- Update sync job description from two-phase download to
  validate + proactive download architecture
- Clarify background service calls ALB but doesn't serve HTTP traffic

`infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md`
- Fix stale cross-reference filenames

`infrastructure/documentation/EBS_STORAGE_ARCHITECTURE.md`
- Fix backoff description: "3 attempts with 1s, 2s backoff delays"
- Fix test counts (sync job: 23, total: 58, file listing: 23)

### Tests

`studio/tests/app/common/core/background/test_sync_job.py`
- Rewrite tests for validate-then-trigger architecture (23 tests)
- Add tests for persistent failure alerting, retry count cleanup,
  fire-and-forget proactive download, startup sync

`studio/tests/app/common/core/storage/test_s3_storage_controller.py`
- Add tests for `validate_experiment_in_s3()`: required file
  detection, thumbnail detection, pagination, max object limit,
  zero-byte files, empty responses, error handling

`studio/tests/app/common/routers/test_data_sync.py`
- Add tests for `sync-experiment` endpoint: auth, rate limiting,
  bucket validation, path parameter validation (invalid workspace_id,
  invalid unique_id), has_thumbnails flag
- Add tests for `_download_single_experiment` background task

---

## Design Decisions

- **Validate-only on background instance**: The background ECS service
  has no shared filesystem and no ALB target group. Downloading files
  there was wasted bandwidth. ListObjectsV2 validation is cheap and
  sufficient to update DB status.
- **Proactive download via ALB**: After validation, the background job
  POSTs to the ALB which routes to one API instance. That instance
  pre-caches thumbnails and metadata. Other instances rely on startup
  sync or on-demand download.
- **Fire-and-forget ALB call**: The proactive download result is never
  checked by the caller, so `asyncio.create_task()` frees the
  semaphore slot immediately instead of holding it for up to 10s
  during the HTTP POST.
- **Rate-limit cache cleanup**: Follows the existing pattern from
  `PremiumAssignmentService._cleanup_old_attempts()`. Entries older
  than `2 * _RATE_LIMIT_SECONDS` are removed before each check.
- **Path parameter validation**: Defense-in-depth for an endpoint that
  constructs file paths from user input. `workspace_id` is BIGINT in
  the DB (numeric only), `unique_id` is alphanumeric with
  dashes/underscores.
- **Persistent failure reset**: `_retry_counts` is cleared after the
  CloudWatch alert fires, so the alert can re-fire every
  `MAX_PERSISTENT_RETRIES` runs if the issue persists, while keeping
  the dict bounded.

---

## Verification

- All 106 tests pass across the 3 test files (23 + 34 + 49)
- Pre-commit passes (black, flake8, isort, codespell)
- Test counts in documentation match actual test collection

---

## Risk Assessment

```
| Area                        | Risk | Notes                                         |
|-----------------------------|------|-----------------------------------------------|
| Sync job refactor           | Med  | Core behavior change; covered by 23 tests     |
| validate_experiment_in_s3   | Low  | Read-only S3 call (ListObjectsV2)             |
| sync-experiment endpoint    | Low  | Protected by internal secret + rate limiting   |
| Path parameter validation   | Low  | Stricter than before; rejects invalid input    |
| Fire-and-forget ALB call    | Low  | Non-critical; failure logged, not propagated   |
| ALB_DNS_NAME env var        | Low  | Required only for proactive download trigger   |
| Rate-limit cache cleanup    | Low  | Follows existing pattern; prevents memory leak |
```
