### PR TITLE
Adjusted S3StorageController.S3_BASE_PATH

### DIFF
--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -24,6 +24,7 @@ from sqlalchemy import func
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.core.subscription.constants import SyncStatusConstants
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -198,7 +199,10 @@ class DataCleanupJob:
 
             # Check if critical experiment files exist in S3
             critical_files = ["experiment.yaml", "workflow.yaml"]
-            s3_prefix = f"app/studio_data/output/{workspace_id}/{experiment_id}/"
+            s3_prefix = (
+                f"{S3StorageController.S3_BASE_PATH}"
+                f"/output/{workspace_id}/{experiment_id}/"
+            )
 
             for filename in critical_files:
                 s3_key = f"{s3_prefix}{filename}"

--- a/studio/app/common/core/cloud/s3_storage_monitor.py
+++ b/studio/app/common/core/cloud/s3_storage_monitor.py
@@ -100,9 +100,9 @@ class S3StorageMonitor:
             # Check both input and output directories for each workspace
             for workspace_id in workspace_ids:
                 prefixes = [
-                    f"app/studio_data/"
+                    f"{S3StorageController.S3_BASE_PATH}/"
                     f"{S3StorageController.S3_INPUT_DIR}/{workspace_id}/",
-                    f"app/studio_data/"
+                    f"{S3StorageController.S3_BASE_PATH}/"
                     f"{S3StorageController.S3_OUTPUT_DIR}/{workspace_id}/",
                 ]
 
@@ -243,9 +243,9 @@ class S3StorageMonitor:
             # Check both input and output directories for each workspace
             for workspace_id in workspace_ids:
                 prefixes = [
-                    f"app/studio_data/"
+                    f"{S3StorageController.S3_BASE_PATH}/"
                     f"{S3StorageController.S3_INPUT_DIR}/{workspace_id}/",
-                    f"app/studio_data/"
+                    f"{S3StorageController.S3_BASE_PATH}/"
                     f"{S3StorageController.S3_OUTPUT_DIR}/{workspace_id}/",
                 ]
 

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -50,7 +50,7 @@ class S3StorageController(BaseRemoteStorageController):
     S3 Storage Controller
     """
 
-    S3_BASE_PATH = "app/studio_data"
+    S3_BASE_PATH = os.environ.get("S3_BASE_PATH", "/app/studio_data").lstrip("/")
     S3_INPUT_DIR = "input"
     S3_OUTPUT_DIR = "output"
     VALIDATION_MAX_OBJECTS = 500
@@ -964,7 +964,7 @@ class S3StorageController(BaseRemoteStorageController):
 
                 # make paths
                 local_abs_path = os.path.join(
-                    os.path.dirname(DIRPATH.OUTPUT_DIR), s3_file_path
+                    os.path.dirname(DIRPATH.OUTPUT_DIR), s3_file_path.lstrip("/")
                 )
 
                 # Fix duplicate path issue

--- a/studio/app/common/core/utils/filepath_creater.py
+++ b/studio/app/common/core/utils/filepath_creater.py
@@ -25,10 +25,6 @@ def normalize_output_path(path: str) -> str:
     if path.startswith(DIRPATH.OUTPUT_DIR):
         return path[len(DIRPATH.OUTPUT_DIR) :].lstrip("/")
 
-    # Handle common Docker path prefix
-    if path.startswith("/app/studio_data/output/"):
-        return path[len("/app/studio_data/output/") :]
-
     return path
 
 

--- a/studio/config/.env.example
+++ b/studio/config/.env.example
@@ -17,12 +17,14 @@ USE_FIREBASE_EMAIL=True
 # MYSQL_DATABASE=studio
 # MYSQL_USER=studio_db_user
 # MYSQL_PASSWORD=studio_db_password
+# MYSQL_SSL_MODE=False
 # ECHO_SQL=False
 
 # Note: for Remote Data Storage config.
 REMOTE_STORAGE_TYPE="0"  # 0: No use, 1: Mock (for devel), 2: AWS S3
 MOCK_STORAGE_DIR="/tmp/optinist/mock-storage"
 S3_DEFAULT_BUCKET_NAME="{YOUR_S3_DEFAULT_BUCKET_NAME}"
+S3_BASE_PATH="{YOUR_S3_BASE_PATH}" # Data will be stored under this path in the S3 bucket. (default: /app/studio_data)
 
 # AWS environment variable definition
 # NOTE: In the production environment (AWS),

--- a/studio/scripts/run_sync_data_capacity_cloud.py
+++ b/studio/scripts/run_sync_data_capacity_cloud.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import boto3
 
+from studio.app.common.core.storage.s3_storage_controller import S3StorageController
+
 # Add the project root directory to the Python path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
@@ -59,8 +61,8 @@ class CloudWorkspaceDataCapacityService:
 
             # Check both input and output directories for the workspace
             prefixes = [
-                f"app/studio_data/input/{workspace_id}/",
-                f"app/studio_data/output/{workspace_id}/",
+                f"{S3StorageController.S3_BASE_PATH}/input/{workspace_id}/",
+                f"{S3StorageController.S3_BASE_PATH}/output/{workspace_id}/",
             ]
 
             logger.info(f"Calculating S3 usage for workspace {workspace_id}")
@@ -123,7 +125,9 @@ class CloudWorkspaceDataCapacityService:
 
         try:
             s3_client = boto3.client("s3")
-            prefix = f"app/studio_data/output/{workspace_id}/{unique_id}/"
+            prefix = (
+                f"{S3StorageController.S3_BASE_PATH}/output/{workspace_id}/{unique_id}/"
+            )
 
             # logger.debug(
             #     f"Calculating S3 usage for experiment {workspace_id}/{unique_id}"
@@ -205,7 +209,7 @@ class CloudWorkspaceDataCapacityService:
         # Get S3 input storage size
         try:
             s3_client = boto3.client("s3")
-            prefix = f"app/studio_data/input/{workspace_id}/"
+            prefix = f"{S3StorageController.S3_BASE_PATH}input/{workspace_id}/"
 
             paginator = s3_client.get_paginator("list_objects_v2")
             page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
@@ -265,7 +269,7 @@ class CloudWorkspaceDataCapacityService:
         s3_experiments = set()
         try:
             s3_client = boto3.client("s3")
-            prefix = f"app/studio_data/output/{workspace_id}/"
+            prefix = f"{S3StorageController.S3_BASE_PATH}/output/{workspace_id}/"
 
             response = s3_client.list_objects_v2(
                 Bucket=bucket_name, Prefix=prefix, Delimiter="/"
@@ -274,7 +278,7 @@ class CloudWorkspaceDataCapacityService:
             if "CommonPrefixes" in response:
                 for exp_prefix in response["CommonPrefixes"]:
                     # Extract experiment ID from prefix like
-                    # "app/studio_data/output/1/exp123/"
+                    # "{S3_BASE_PATH}/output/1/exp123/"
                     exp_id = exp_prefix["Prefix"].rstrip("/").split("/")[-1]
                     s3_experiments.add(exp_id)
 


### PR DESCRIPTION
## Contents

Adjusted S3StorageController.S3_BASE_PATH
- Added support for setting the value via environment variables (default value remains unchanged)
- Replaced hard-coded paths in locations corresponding to S3_BASE_PATH with references to S3_BASE_PATH

## Test case

Confirm that there are no problems with the areas affected by the corrections

- Prerequisites
  - Use the default value for S3_BASE_PATH ("/app/studio_data", keep the value before modification)

<!-- -->

- [x] studio/app/common/core/storage/s3_storage_controller.py
  - [x] upload experiment
  - [x] download experiment
  - [x] upload input (image)
  - [x] download input (image)
- [x] studio/app/common/core/utils/filepath_creater.py
  - [x] Plot of outputs successful (outputs API successful)
- [ ] studio/app/common/core/background/cleanup_job.py
  - Check in AWS environment
- [ ] studio/app/common/core/cloud/s3_storage_monitor.py
  - Check in AWS environment
- [x] studio/scripts/run_sync_data_capacity_cloud.py
  - \*Appears to be unused
