### PR TITLE
Bug fixes found when running locally on docker

### DIFF
--- a/studio/alembic/versions/h901h9270022_add_standby_sentinel_user.py
+++ b/studio/alembic/versions/h901h9270022_add_standby_sentinel_user.py
@@ -5,8 +5,8 @@ Revises: g901g9260021
 Create Date: 2025-12-25 11:54:00.000000
 
 """
-import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.mysql import BIGINT as MYSQL_BIGINT
 
 # revision identifiers, used by Alembic.
 revision = "h901h9270022"
@@ -18,19 +18,19 @@ depends_on = None
 def upgrade() -> None:
     """Allow NULL user_id for standby premium instances."""
 
-    # Drop the existing unique constraint on user_id
-    op.drop_constraint("uq_premium_user_id", "premium_user_assignments", type_="unique")
-
     # Drop the existing foreign key constraint
     op.drop_constraint(
         "fk_premium_user", "premium_user_assignments", type_="foreignkey"
     )
 
+    # Drop the existing unique constraint on user_id
+    op.drop_constraint("uq_premium_user_id", "premium_user_assignments", type_="unique")
+
     # Modify user_id column to allow NULL
     op.alter_column(
         "premium_user_assignments",
         "user_id",
-        existing_type=sa.BIGINT(unsigned=True),
+        existing_type=MYSQL_BIGINT(unsigned=True),
         nullable=True,
     )
 
@@ -47,7 +47,6 @@ def upgrade() -> None:
         "premium_user_assignments",
         ["user_id"],
         unique=True,
-        mysql_length={"user_id": None},
     )
 
 
@@ -66,7 +65,7 @@ def downgrade() -> None:
     op.alter_column(
         "premium_user_assignments",
         "user_id",
-        existing_type=sa.BIGINT(unsigned=True),
+        existing_type=MYSQL_BIGINT(unsigned=True),
         nullable=False,
     )
 

--- a/studio/app/common/db/config.py
+++ b/studio/app/common/db/config.py
@@ -34,7 +34,7 @@ def build_mysql_url(
         port=port,
         query=query,
     )
-    return str(url)
+    return url.render_as_string(hide_password=False)
 
 
 def _ssl_required() -> bool:


### PR DESCRIPTION
## Summary

Fix two bugs that prevented the application from starting in any MySQL environment. These were not caught earlier because production deploys to a running database where migrations have already been applied, and the `build_mysql_url` refactor was not tested against a live MySQL connection.

---

## Changes by File

### `studio/app/common/db/config.py`

**Bug:** `build_mysql_url` returned `str(url)` where `url` is a SQLAlchemy `URL` object. In SQLAlchemy 2.0, `str(URL)` masks the password with `***` (this changed from 1.x where it included the real password). The returned string was then used directly as the connection URL, so every database connection attempted to authenticate with the literal password `***`.

**Impact:** Total failure to connect to any MySQL database -- affects Alembic migrations, application startup, background jobs, and all test scripts that use `build_mysql_url`.

**Fix:** Replace `str(url)` with `url.render_as_string(hide_password=False)` to include the real password in the connection URL. This restores the same behavior as the f-string approach used before the `a8064fd` refactor. There is no security implication -- the password was always a plaintext string in memory; SQLAlchemy's masking is a display convenience for logging, not a security mechanism.

### `studio/alembic/versions/h901h9270022_add_standby_sentinel_user.py`

Three fixes to migration `h901h9270022` ("allow_null_user_id_for_standby"):

1. **Foreign key before unique constraint:** The migration dropped `uq_premium_user_id` (unique index) before dropping `fk_premium_user` (foreign key that references that index). MySQL requires foreign keys to be dropped first. Swapped the order.

2. **MySQL-specific BIGINT type:** `sa.BIGINT(unsigned=True)` raises `TypeError: BIGINT() takes no arguments` in SQLAlchemy 2.0 because the generic `sa.BIGINT` does not accept dialect-specific arguments. Replaced with `sqlalchemy.dialects.mysql.BIGINT(unsigned=True)`.

3. **Invalid `mysql_length` parameter:** `mysql_length={"user_id": None}` passed `None` where MySQL's DDL compiler expects an integer, causing `TypeError: %d format: a real number is required, not NoneType`. Removed the parameter since no length prefix is needed on this index.

Also removed the unused `import sqlalchemy as sa`.

---

## Why these were only found in local Docker testing

Both bugs only manifest when running Alembic migrations against a real MySQL database from scratch:

- **Production** deploys via `cloud-startup.sh` which runs `alembic upgrade head` against an existing RDS database. Migration `h901h9270022` was already applied before the `build_mysql_url` refactor in `a8064fd`, so the migration errors were never re-triggered. The password masking bug in `build_mysql_url` was also introduced after the production database was already configured via the SSL creator path (`get_ssl_creator`), which bypasses the URL string entirely and calls `pymysql.connect()` directly with the real password.

- **Local Docker** starts with a fresh MySQL volume each time, requiring all migrations to run from scratch. This is the first path that exercises both `build_mysql_url` for the connection string AND the full migration chain including `h901h9270022`.

---

## Risk Assessment

```
| Area                  | Risk | Notes                                              |
|-----------------------|------|----------------------------------------------------|
| build_mysql_url fix   | Low  | Restores pre-refactor behavior; no security change  |
| Migration order swap  | Low  | Matches MySQL's DDL constraint requirements          |
| BIGINT type fix       | Low  | Uses correct dialect-specific type                   |
| mysql_length removal  | Low  | Parameter was invalid (None); index works without it |
```
