### PR TITLE
Fix storage usage bar

### DIFF
--- a/frontend/src/components/common/StorageAlert.tsx
+++ b/frontend/src/components/common/StorageAlert.tsx
@@ -46,26 +46,49 @@ const StorageAlert: React.FC<StorageAlertProps> = ({
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [dismissed, setDismissed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const fetchStorageAlert = async () => {
     try {
       setLoading(true)
-      const alertResponse = await getMyStorageAlertApi()
+      setError(null)
 
-      if (alertResponse.has_alert && alertResponse.alert) {
-        setAlert(alertResponse.alert)
-      } else {
-        setAlert(null)
+      // Fetch alert and usage independently so one failure doesn't block the other
+      const [alertResult, usageResult] = await Promise.allSettled([
+        getMyStorageAlertApi(),
+        showUsageDetails ? getMyStorageUsageApi() : Promise.resolve(null),
+      ])
+
+      if (alertResult.status === "fulfilled" && alertResult.value) {
+        const alertResponse = alertResult.value
+        if (alertResponse.has_alert && alertResponse.alert) {
+          setAlert(alertResponse.alert)
+        } else {
+          setAlert(null)
+        }
       }
 
-      if (showUsageDetails) {
-        const usageResponse = await getMyStorageUsageApi()
-        setUsage(usageResponse)
+      if (usageResult.status === "fulfilled" && usageResult.value) {
+        setUsage(usageResult.value)
       }
-    } catch (error) {
+
+      // If both failed, show error
+      if (
+        alertResult.status === "rejected" &&
+        usageResult.status === "rejected"
+      ) {
+        const msg =
+          alertResult.reason instanceof Error
+            ? alertResult.reason.message
+            : "Unknown error"
+        // eslint-disable-next-line no-console
+        console.error("Failed to fetch storage data:", msg)
+        setError("Unable to load storage information")
+      }
+    } catch (err) {
       // eslint-disable-next-line no-console
-      console.error("Failed to fetch storage alert:", error)
-      // Silently fail for storage alerts to not disrupt the main UI
+      console.error("Failed to fetch storage alert:", err)
+      setError("Unable to load storage information")
     } finally {
       setLoading(false)
     }
@@ -107,6 +130,22 @@ const StorageAlert: React.FC<StorageAlertProps> = ({
 
   if (dismissed || (!alert && !showUsageDetails)) {
     return null
+  }
+
+  if (error && !alert && !usage) {
+    return (
+      <Alert
+        severity="warning"
+        sx={{ mb: 2 }}
+        action={
+          <Button size="small" onClick={fetchStorageAlert}>
+            Retry
+          </Button>
+        }
+      >
+        {error}
+      </Alert>
+    )
   }
 
   const getSeverity = (alertLevel: string) => {
@@ -239,20 +278,9 @@ const StorageAlert: React.FC<StorageAlertProps> = ({
             justifyContent="space-between"
             mb={2}
           >
-            <Typography variant="h6" display="flex" alignItems="center" gap={1}>
-              <StorageIcon />
+            <Typography variant="body1" color="text.secondary">
               Storage Usage
             </Typography>
-            <Button
-              size="small"
-              startIcon={
-                refreshing ? <CircularProgress size={16} /> : <RefreshIcon />
-              }
-              onClick={handleRefresh}
-              disabled={refreshing}
-            >
-              Refresh
-            </Button>
           </Box>
 
           {usage.storage_quota_bytes ? (

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -33,11 +33,13 @@ import {
 } from "@mui/x-data-grid"
 import { isRejectedWithValue } from "@reduxjs/toolkit"
 
+import { refreshStorageUsageApi } from "api/storage/StorageAlerts"
 import { UserDTO } from "api/users/UsersApiDTO"
 import { refreshAllWorkspacesStorageApi } from "api/workspace"
 import DeleteConfirmModal from "components/common/DeleteConfirmModal"
 import Loading from "components/common/Loading"
 import PaginationCustom from "components/common/PaginationCustom"
+import StorageAlert from "components/common/StorageAlert"
 import PopupShare from "components/Workspace/PopupShare"
 import { selectCurrentUser } from "store/slice/User/UserSelector"
 import { resetVisualizeLayout } from "store/slice/VisualizeItem/VisualizeItemSlice"
@@ -364,6 +366,7 @@ const Workspaces = () => {
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({})
   const [searchParams, setParams] = useSearchParams()
   const [refreshing, setRefreshing] = useState(false)
+  const [storageRefreshKey, setStorageRefreshKey] = useState(0)
   const [operationWarning, setOperationWarning] = useState<{
     show: boolean
     operation?: string
@@ -587,8 +590,15 @@ const Workspaces = () => {
       // Call API to refresh all workspace storage usage
       const response = await refreshAllWorkspacesStorageApi()
 
+      // Also refresh user-level storage so the StorageAlert updates
+      await refreshStorageUsageApi()
+
       // Refresh the workspace list after storage sync
       await dispatch(getWorkspaceList(dataParams))
+
+      // Trigger StorageAlert to re-fetch with fresh data
+      setStorageRefreshKey((k) => k + 1)
+
       handleClickVariant(
         "success",
         `Storage refreshed for ${response.refreshed_workspaces} workspaces!`,
@@ -632,6 +642,11 @@ const Workspaces = () => {
           New
         </Button>
       </Box>
+      <StorageAlert
+        key={storageRefreshKey}
+        showUsageDetails={true}
+        compact={false}
+      />
       {user ? (
         <Box
           sx={{


### PR DESCRIPTION
## Content

Add the `StorageAlert` component to the Workspace page so users can see their storage usage at a glance, and improve error handling in `StorageAlert` for resilient API fetching.

---

## Changes

### 1. Add StorageAlert to Workspace page (`frontend/src/pages/Workspace/index.tsx`)

- Import and render `StorageAlert` with `showUsageDetails={true}` below the Reload/New button bar.
- Add `storageRefreshKey` state to force StorageAlert to re-fetch when the Reload button is clicked.
- Call `refreshStorageUsageApi()` in the Reload handler so user-level storage data is also refreshed.

### 2. Improve StorageAlert error handling (`frontend/src/components/common/StorageAlert.tsx`)

- Fetch alert and usage data independently using `Promise.allSettled` so one failure doesn't block the other.
- Add `error` state: when both API calls fail, display a warning alert with a Retry button.
- Remove the redundant Refresh button from the Storage Usage details panel (the Workspace page Reload button already covers this).
- Downsize the "Storage Usage" heading from `h6` with icon to `body1` text without icon, matching the style of surrounding labels.

---

## Risk Assessment

```
| Area                        | Risk | Notes                                          |
|-----------------------------|------|-------------------------------------------------|
| StorageAlert error handling | Low  | Graceful degradation; no change to happy path   |
| Workspace page layout       | Low  | Additive change; existing buttons unchanged     |
| Removed Refresh button      | Low  | Redundant with page-level Reload button          |
```
