### PR TITLE
Update Billing Address Link to Production

### DIFF
--- a/frontend/src/pages/Invoice/index.tsx
+++ b/frontend/src/pages/Invoice/index.tsx
@@ -407,7 +407,7 @@ const InvoicesPage: FC = () => {
   const handleManageBilling = async (): Promise<void> => {
     if (!shouldShowLoader) {
       window.open(
-        "https://billing.stripe.com/p/login/test_5kQ9ATdaS2TbdknghI2wU00",
+        "https://billing.stripe.com/p/login/5kQ9ATdaS2TbdknghI2wU00",
         "_blank",
       )
     }


### PR DESCRIPTION
### Content

Update the Stripe billing address portal link from test mode to production

### Details         

  The billing management link in the Invoice page was pointing to the Stripe test environment (/test_5kQ9AT...). This change removes the test_ prefix to point to the production Stripe customer portal (/5kQ9AT...).

### Test plan

  - Verify the "Manage Billing" button opens the correct production Stripe billing portal