### PR TITLE
Publish experiments on Records page regardless of lock

### DIFF
--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -10,7 +10,10 @@ from studio.app.common.core.experiment.experiment import (
     ExptOutputPathIds,
 )
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.storage.remote_storage_controller import RemoteStorageReader
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+    RemoteStorageReader,
+)
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.datetime_utils import TIMEZONE_KEY
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -100,7 +103,10 @@ class ExptConfigReader:
 
         try:
             async with RemoteStorageReader(
-                remote_bucket_name, workspace_id, unique_id
+                remote_bucket_name,
+                workspace_id,
+                unique_id,
+                sync_mode=RemoteExperimentSyncMode.METADATA_ONLY,
             ) as controller:
                 # Download only this specific experiment's metadata (efficient)
                 await controller.download_experiment_meta(workspace_id, unique_id)

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -39,6 +39,25 @@ class ExptConfigReader:
         return path
 
     @classmethod
+    def get_local_experiment_uids(cls, workspace_id: str) -> set:
+        """Return set of experiment UIDs that exist locally on filesystem.
+
+        Uses glob to find experiment.yaml files and extracts UIDs from paths.
+        """
+        from glob import glob
+
+        config_paths = glob(cls.get_config_yaml_wild_path(workspace_id))
+        uids = set()
+        for path in config_paths:
+            try:
+                ids = ExptOutputPathIds(os.path.dirname(path))
+                if ids.unique_id:
+                    uids.add(ids.unique_id)
+            except Exception:
+                pass
+        return uids
+
+    @classmethod
     async def ensure_synced_async(
         cls,
         workspace_id: str,

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -54,6 +54,7 @@ class RemoteSyncAction(Enum):
 
 class RemoteExperimentSyncMode(Enum):
     ALL = "all"
+    METADATA_ONLY = "metadata_only"
     VISUALIZATION = "visualization"
     ESSENTIAL_ONLY = "essential_only"
     THUMBNAILS_ONLY = "thumbnails_only"

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -1,10 +1,11 @@
 import os
 from dataclasses import asdict
 from glob import glob
-from typing import Dict
+from typing import Dict, Set
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
+from sqlalchemy import select
 from sqlmodel import Session
 
 from studio.app.common.core.auth.auth_dependencies import get_user_remote_bucket_name
@@ -21,6 +22,9 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageSimpleReader,
     RemoteSyncStatusFileUtil,
 )
+from studio.app.common.models.experiment import ExperimentRecord
+from studio.app.common.models.workspace import Workspace
+from studio.app.common.schemas.dataview import PublishStatus
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
     is_workspace_owner,
@@ -33,6 +37,20 @@ router = APIRouter(prefix="/experiments", tags=["experiments"])
 logger = AppLogger.get_logger()
 
 
+def _get_published_uids(db: Session, workspace_id: str) -> Set[str]:
+    """Query DB for UIDs of published experiments in the given workspace."""
+    statement = (
+        select(ExperimentRecord.uid)
+        .join(Workspace, Workspace.id == ExperimentRecord.workspace_id)
+        .where(ExperimentRecord.workspace_id == int(workspace_id))
+        .where(ExperimentRecord.publish_status == PublishStatus.on.value)
+        .where(ExperimentRecord.success == 1)
+        .where(Workspace.deleted == 0)
+    )
+    result = db.execute(statement)
+    return {row[0] for row in result}
+
+
 @router.get(
     "/{workspace_id}",
     response_model=Dict[str, ExptExtConfig],
@@ -40,6 +58,7 @@ logger = AppLogger.get_logger()
 )
 async def get_experiments(
     workspace_id: str,
+    db: Session = Depends(get_db),
     remote_bucket_name: str = Depends(get_user_remote_bucket_name),
 ):
     # search EXPERIMENT_YMLs
@@ -48,19 +67,44 @@ async def get_experiments(
 
     is_remote_storage_available = RemoteStorageController.is_available()
 
-    # NOTE: If remote_storage is available and config_paths does not exist,
-    # assume that data may exist in remote_storage and execute download of metadata.
-    if is_remote_storage_available and not config_paths:
-        async with RemoteStorageSimpleReader(
-            remote_bucket_name
-        ) as remote_storage_controller:
-            await remote_storage_controller.download_all_experiments_metas(
-                [workspace_id]
+    if is_remote_storage_available:
+        if not config_paths:
+            # No local configs at all -- download all metadata from remote
+            async with RemoteStorageSimpleReader(
+                remote_bucket_name
+            ) as remote_storage_controller:
+                await remote_storage_controller.download_all_experiments_metas(
+                    [workspace_id]
+                )
+            config_paths = glob(
+                ExptConfigReader.get_config_yaml_wild_path(workspace_id)
             )
+        else:
+            # Per-experiment DB comparison: download metadata for experiments
+            # in DB but missing locally
+            try:
+                local_uids = ExptConfigReader.get_local_experiment_uids(
+                    workspace_id
+                )
+                published_uids = _get_published_uids(db, workspace_id)
+                missing_uids = published_uids - local_uids
 
-        # search EXPERIMENT_YMLs, again
-        exp_config = {}
-        config_paths = glob(ExptConfigReader.get_config_yaml_wild_path(workspace_id))
+                if missing_uids:
+                    async with RemoteStorageSimpleReader(
+                        remote_bucket_name
+                    ) as remote_storage_controller:
+                        for uid in missing_uids:
+                            await remote_storage_controller.download_experiment_meta(
+                                workspace_id, uid
+                            )
+                    # Re-glob to pick up newly downloaded files
+                    config_paths = glob(
+                        ExptConfigReader.get_config_yaml_wild_path(workspace_id)
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Per-experiment metadata sync failed: {e}", exc_info=True
+                )
 
     for path in config_paths:
         try:

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -22,14 +22,14 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageSimpleReader,
     RemoteSyncStatusFileUtil,
 )
-from studio.app.common.models.experiment import ExperimentRecord
-from studio.app.common.models.workspace import Workspace
-from studio.app.common.schemas.dataview import PublishStatus
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
     is_workspace_owner,
 )
 from studio.app.common.db.database import get_db
+from studio.app.common.models.experiment import ExperimentRecord
+from studio.app.common.models.workspace import Workspace
+from studio.app.common.schemas.dataview import PublishStatus
 from studio.app.common.schemas.experiment import CopyItem, DeleteItem, RenameItem
 
 router = APIRouter(prefix="/experiments", tags=["experiments"])
@@ -83,9 +83,7 @@ async def get_experiments(
             # Per-experiment DB comparison: download metadata for experiments
             # in DB but missing locally
             try:
-                local_uids = ExptConfigReader.get_local_experiment_uids(
-                    workspace_id
-                )
+                local_uids = ExptConfigReader.get_local_experiment_uids(workspace_id)
                 published_uids = _get_published_uids(db, workspace_id)
                 missing_uids = published_uids - local_uids
 

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -17,6 +17,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteExperimentNotFoundError,
+    RemoteExperimentSyncMode,
     RemoteStorageController,
     RemoteStorageLockError,
     RemoteStorageReader,
@@ -89,10 +90,13 @@ async def get_experiments(
                 missing_uids = published_uids - local_uids
 
                 if missing_uids:
-                    async with RemoteStorageSimpleReader(
-                        remote_bucket_name
-                    ) as remote_storage_controller:
-                        for uid in missing_uids:
+                    for uid in missing_uids:
+                        async with RemoteStorageReader(
+                            remote_bucket_name,
+                            workspace_id,
+                            uid,
+                            sync_mode=RemoteExperimentSyncMode.METADATA_ONLY,
+                        ) as remote_storage_controller:
                             await remote_storage_controller.download_experiment_meta(
                                 workspace_id, uid
                             )

--- a/studio/tests/app/common/core/experiment/test_experiment_reader_uids.py
+++ b/studio/tests/app/common/core/experiment/test_experiment_reader_uids.py
@@ -1,0 +1,69 @@
+"""
+Tests for ExptConfigReader.get_local_experiment_uids().
+
+Tests edge cases including silently swallowed exceptions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+
+
+class TestGetLocalExperimentUids:
+    """Edge case tests for get_local_experiment_uids."""
+
+    def test_returns_empty_set_when_no_configs(self):
+        """Returns empty set when no experiment.yaml files found."""
+        with patch("glob.glob", return_value=[]):
+            result = ExptConfigReader.get_local_experiment_uids("ws1")
+        assert result == set()
+
+    def test_extracts_uids_from_paths(self):
+        """Extracts UIDs from experiment config paths."""
+        paths = [
+            "/data/output/ws1/uid_abc/experiment.yaml",
+            "/data/output/ws1/uid_def/experiment.yaml",
+        ]
+        with patch("glob.glob", return_value=paths), patch(
+            "studio.app.common.core.experiment.experiment_reader.ExptOutputPathIds"
+        ) as mock_ids:
+            mock_id1 = MagicMock()
+            mock_id1.unique_id = "uid_abc"
+            mock_id2 = MagicMock()
+            mock_id2.unique_id = "uid_def"
+            mock_ids.side_effect = [mock_id1, mock_id2]
+
+            result = ExptConfigReader.get_local_experiment_uids("ws1")
+
+        assert result == {"uid_abc", "uid_def"}
+
+    def test_swallows_exception_for_invalid_path(self):
+        """Silently skips paths that raise exceptions during parsing."""
+        paths = [
+            "/data/output/ws1/good_uid/experiment.yaml",
+            "/data/output/ws1/bad_path/experiment.yaml",
+        ]
+        with patch("glob.glob", return_value=paths), patch(
+            "studio.app.common.core.experiment.experiment_reader.ExptOutputPathIds"
+        ) as mock_ids:
+            mock_good = MagicMock()
+            mock_good.unique_id = "good_uid"
+            mock_ids.side_effect = [mock_good, ValueError("bad path")]
+
+            result = ExptConfigReader.get_local_experiment_uids("ws1")
+
+        assert result == {"good_uid"}
+
+    def test_skips_entries_with_no_unique_id(self):
+        """Skips entries where ExptOutputPathIds returns None unique_id."""
+        paths = ["/data/output/ws1/uid1/experiment.yaml"]
+        with patch("glob.glob", return_value=paths), patch(
+            "studio.app.common.core.experiment.experiment_reader.ExptOutputPathIds"
+        ) as mock_ids:
+            mock_id = MagicMock()
+            mock_id.unique_id = None
+            mock_ids.return_value = mock_id
+
+            result = ExptConfigReader.get_local_experiment_uids("ws1")
+
+        assert result == set()

--- a/studio/tests/app/common/routers/test_experiment_sync.py
+++ b/studio/tests/app/common/routers/test_experiment_sync.py
@@ -88,7 +88,7 @@ class TestGetExperimentsMetadataSync:
             )
             mock_reader_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await get_experiments(
+            await get_experiments(
                 workspace_id="ws1",
                 db=mock_db,
                 remote_bucket_name="bucket1",
@@ -261,7 +261,7 @@ class TestGetExperimentsMetadataSync:
             )
             mock_reader_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await get_experiments(
+            await get_experiments(
                 workspace_id="ws1",
                 db=mock_db,
                 remote_bucket_name="bucket1",

--- a/studio/tests/app/common/routers/test_experiment_sync.py
+++ b/studio/tests/app/common/routers/test_experiment_sync.py
@@ -1,0 +1,271 @@
+"""
+Tests for experiment router per-experiment metadata sync behavior.
+
+Covers Issue C: Records page hides published experiments when any local
+experiment exists. Verifies per-experiment comparison logic in get_experiments().
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from studio.app.common.routers.experiment import get_experiments
+
+
+def _make_config(workspace_id, unique_id, name="test"):
+    """Create a minimal ExptConfig for testing."""
+    from studio.app.common.core.experiment.experiment import ExptConfig
+
+    return ExptConfig(
+        workspace_id=workspace_id,
+        unique_id=unique_id,
+        name=name,
+        started_at="2024-01-01",
+        finished_at="2024-01-01",
+        success=1,
+        hasNWB=False,
+        function={},
+        procs=None,
+        nwb=None,
+        snakemake=None,
+        data_usage=None,
+        timezone=None,
+    )
+
+
+class TestGetExperimentsMetadataSync:
+    """Tests for per-experiment metadata sync in get_experiments."""
+
+    @pytest.mark.asyncio
+    async def test_downloads_missing_experiment_metadata(self):
+        """Downloads metadata for DB-published experiments missing locally."""
+        mock_db = MagicMock()
+        mock_controller = AsyncMock()
+
+        config = _make_config("ws1", "uid1")
+
+        with patch(
+            "studio.app.common.routers.experiment.RemoteStorageController.is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.glob",
+            side_effect=[
+                # First glob: one local config exists
+                ["/data/output/ws1/uid1/experiment.yaml"],
+                # Second glob after download: now has both
+                [
+                    "/data/output/ws1/uid1/experiment.yaml",
+                    "/data/output/ws1/uid2/experiment.yaml",
+                ],
+            ],
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_config_yaml_wild_path",
+            return_value="/data/output/ws1/*/experiment.yaml",
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_local_experiment_uids",
+            return_value={"uid1"},
+        ), patch(
+            "studio.app.common.routers.experiment._get_published_uids",
+            return_value={"uid1", "uid2"},
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteStorageSimpleReader"
+        ) as mock_reader_cls, patch(
+            "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
+            return_value=config,
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteSyncStatusFileUtil."
+            "check_sync_status_success",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader."
+            "validate_experiment_config",
+            return_value=True,
+        ):
+            mock_reader_cls.return_value.__aenter__ = AsyncMock(
+                return_value=mock_controller
+            )
+            mock_reader_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await get_experiments(
+                workspace_id="ws1",
+                db=mock_db,
+                remote_bucket_name="bucket1",
+            )
+
+        # Should have called download_experiment_meta for the missing uid
+        mock_controller.download_experiment_meta.assert_called_once_with("ws1", "uid2")
+
+    @pytest.mark.asyncio
+    async def test_continues_on_sync_exception(self):
+        """get_experiments continues when per-experiment sync raises."""
+        mock_db = MagicMock()
+
+        config = _make_config("ws1", "uid1")
+
+        with patch(
+            "studio.app.common.routers.experiment.RemoteStorageController.is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.glob",
+            return_value=["/data/output/ws1/uid1/experiment.yaml"],
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_config_yaml_wild_path",
+            return_value="/data/output/ws1/*/experiment.yaml",
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_local_experiment_uids",
+            side_effect=RuntimeError("db explosion"),
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
+            return_value=config,
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteSyncStatusFileUtil."
+            "check_sync_status_success",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader."
+            "validate_experiment_config",
+            return_value=True,
+        ):
+            # Should not raise despite sync failure
+            result = await get_experiments(
+                workspace_id="ws1",
+                db=mock_db,
+                remote_bucket_name="bucket1",
+            )
+
+        # Should still return the locally available experiments
+        assert "uid1" in result
+
+    @pytest.mark.asyncio
+    async def test_skips_sync_when_no_remote_storage(self):
+        """get_experiments skips sync when remote storage unavailable."""
+        mock_db = MagicMock()
+
+        config = _make_config("ws1", "uid1")
+
+        with patch(
+            "studio.app.common.routers.experiment.RemoteStorageController.is_available",
+            return_value=False,
+        ), patch(
+            "studio.app.common.routers.experiment.glob",
+            return_value=["/data/output/ws1/uid1/experiment.yaml"],
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_config_yaml_wild_path",
+            return_value="/data/output/ws1/*/experiment.yaml",
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
+            return_value=config,
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader."
+            "validate_experiment_config",
+            return_value=True,
+        ):
+            result = await get_experiments(
+                workspace_id="ws1",
+                db=mock_db,
+                remote_bucket_name="bucket1",
+            )
+
+        assert "uid1" in result
+
+    @pytest.mark.asyncio
+    async def test_no_download_when_all_present(self):
+        """No download triggered when all published experiments exist locally."""
+        mock_db = MagicMock()
+
+        config = _make_config("ws1", "uid1")
+
+        with patch(
+            "studio.app.common.routers.experiment.RemoteStorageController.is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.glob",
+            return_value=["/data/output/ws1/uid1/experiment.yaml"],
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_config_yaml_wild_path",
+            return_value="/data/output/ws1/*/experiment.yaml",
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_local_experiment_uids",
+            return_value={"uid1"},
+        ), patch(
+            "studio.app.common.routers.experiment._get_published_uids",
+            return_value={"uid1"},
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteStorageSimpleReader"
+        ) as mock_reader_cls, patch(
+            "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
+            return_value=config,
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteSyncStatusFileUtil."
+            "check_sync_status_success",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader."
+            "validate_experiment_config",
+            return_value=True,
+        ):
+            result = await get_experiments(
+                workspace_id="ws1",
+                db=mock_db,
+                remote_bucket_name="bucket1",
+            )
+
+        # RemoteStorageSimpleReader should NOT have been instantiated
+        mock_reader_cls.assert_not_called()
+        assert "uid1" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_config_paths_downloads_all(self):
+        """Falls back to download_all_experiments_metas when no local configs."""
+        mock_db = MagicMock()
+        mock_controller = AsyncMock()
+
+        config = _make_config("ws1", "uid1")
+
+        with patch(
+            "studio.app.common.routers.experiment.RemoteStorageController.is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.glob",
+            side_effect=[
+                [],  # First glob: no local configs
+                ["/data/output/ws1/uid1/experiment.yaml"],  # After download
+            ],
+        ), patch(
+            "studio.app.common.routers.experiment"
+            ".ExptConfigReader.get_config_yaml_wild_path",
+            return_value="/data/output/ws1/*/experiment.yaml",
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteStorageSimpleReader"
+        ) as mock_reader_cls, patch(
+            "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
+            return_value=config,
+        ), patch(
+            "studio.app.common.routers.experiment.RemoteSyncStatusFileUtil."
+            "check_sync_status_success",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.experiment.ExptConfigReader."
+            "validate_experiment_config",
+            return_value=True,
+        ):
+            mock_reader_cls.return_value.__aenter__ = AsyncMock(
+                return_value=mock_controller
+            )
+            mock_reader_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await get_experiments(
+                workspace_id="ws1",
+                db=mock_db,
+                remote_bucket_name="bucket1",
+            )
+
+        # Should call download_all_experiments_metas (not per-experiment)
+        mock_controller.download_all_experiments_metas.assert_called_once_with(["ws1"])

--- a/studio/tests/app/common/routers/test_experiment_sync.py
+++ b/studio/tests/app/common/routers/test_experiment_sync.py
@@ -70,7 +70,7 @@ class TestGetExperimentsMetadataSync:
             "studio.app.common.routers.experiment._get_published_uids",
             return_value={"uid1", "uid2"},
         ), patch(
-            "studio.app.common.routers.experiment.RemoteStorageSimpleReader"
+            "studio.app.common.routers.experiment.RemoteStorageReader"
         ) as mock_reader_cls, patch(
             "studio.app.common.routers.experiment.ExptConfigReader.read_from_path",
             return_value=config,


### PR DESCRIPTION
### Content

#### Files changed
- `studio/app/common/core/experiment/experiment_reader.py` -- Add `get_local_experiment_uids()` classmethod that extracts experiment UIDs from local filesystem paths via glob + `ExptOutputPathIds`
- `studio/app/common/routers/experiment.py` -- Replace all-or-nothing metadata download with per-experiment DB comparison; add `_get_published_uids()` helper and `db` dependency to `get_experiments()`
- `studio/tests/app/common/core/experiment/test_experiment_reader_uids.py` -- New: unit tests for `get_local_experiment_uids()` edge cases (empty set, UID extraction, exception swallowing, null UID)
- `studio/tests/app/common/routers/test_experiment_sync.py` -- New: integration tests for per-experiment sync behavior (missing download, exception resilience, no-remote-storage skip, all-present no-op, empty-fallback)

#### Design Decisions
- **Per-experiment comparison instead of all-or-nothing:** The original code (`if not config_paths`) only downloaded metadata when zero local experiments existed. If even one experiment (e.g. a tutorial) existed locally, all other published experiments were silently hidden after ECS instance cycling. The new `else` branch queries the DB for published UIDs, compares against local UIDs, and downloads metadata only for what's missing.
- **Direct `RemoteStorageSimpleReader` instead of `DownloadCoordinator`:** Uses the existing `download_experiment_meta()` method directly rather than routing through the coordinator abstraction (planned for Stage 2). This keeps the change minimal and independently deployable.
- **Graceful degradation on failure:** The per-experiment comparison is wrapped in try/except. If the DB query or download fails, the page renders with whatever local data exists -- same behavior as today. The original `if not config_paths` fast path is preserved as the first branch for the zero-local-configs case.
- **`_get_published_uids()` as module-level helper:** Follows the query pattern used by `PublishedExperimentSyncJob._get_all_published_experiments()` but scoped to a single workspace. Filters on `publish_status=on`, `success=1`, and `Workspace.deleted=0`.

### References
- Issue C in `DATA_DOWNLOAD_REPORT.md` -- full investigation with code evidence
- PR 2 of 3 in staged fix plan (`DATA_DOWNLOAD_PLAN_2.md`)
- Related: PR 1 (`fix/startup-leader-election`) fixes the 5x startup sync race (Issue B)

### Manual Testcases
- Publish 3 experiments in a workspace
- Delete local files for 2 of them (simulate ECS instance cycling by removing their directories under `OUTPUT_DIR/{workspace_id}/`)
- Open Records page -- all 3 experiments should appear
- Verify no regression when zero local configs exist (delete all local experiment directories, reload Records page -- all published experiments should appear via the `download_all_experiments_metas` fallback)
- `pytest studio/tests/app/common/core/experiment/test_experiment_reader_uids.py studio/tests/app/common/routers/test_experiment_sync.py -v` -- all 9 tests pass

### Unit, Integration, Contract Test Coverage
- 4 unit tests for `get_local_experiment_uids()`: empty set, multi-UID extraction, exception swallowing for invalid paths, null UID skipping
- 5 integration tests for `get_experiments()` sync behavior: downloads missing metadata, continues on exception, skips when no remote storage, skips download when all present, falls back to `download_all_experiments_metas` when no local configs

### Others

#### Difficulties
None. The fix is a straightforward restructuring of the existing conditional with a DB comparison added.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `get_experiments()` endpoint | Low | Original all-or-nothing fallback preserved as first branch; new per-experiment logic only runs in `else` with full exception handling |
| DB query (`_get_published_uids`) | Low | Simple SELECT with existing indexes on `workspace_id`, `publish_status`, `success`; scoped to single workspace |
| `get_local_experiment_uids()` | Low | Pure read-only filesystem scan; silently swallows exceptions for invalid paths |
