### PR TITLE
Fix/duplicate s3 experiment download

### DIFF
--- a/frontend/src/components/Dataview/BaseNodesView.tsx
+++ b/frontend/src/components/Dataview/BaseNodesView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, ReactElement, memo, useState } from "react"
+import { useCallback, useEffect, memo, ReactElement } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import CloseIcon from "@mui/icons-material/Close"
@@ -22,6 +22,8 @@ import {
   CircularProgress,
 } from "@mui/material"
 
+import { SyncStatusView } from "components/Dataview/SyncStatusView"
+import { useSyncRetry } from "components/Dataview/useSyncRetry"
 import { DisplayDataItem } from "components/Workspace/Visualize/DisplayDataItem"
 import { WORKSPACE_TYPE } from "const/Workspace"
 import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
@@ -148,22 +150,19 @@ const BaseNodesView = ({
   emptyMessage,
 }: NodesViewProps) => {
   const dispatch = useDispatch<AppDispatch>()
-  const [isSyncing, setIsSyncing] = useState(false)
 
-  useEffect(() => {
-    if (open && uid && workspaceId) {
-      // Show syncing overlay while loading visualization data
-      setIsSyncing(true)
-      const api = is_public
-        ? publicDataviewReproduceWorkflow
-        : reproduceWorkflow
-      dispatch(api({ workspaceId, uid })).finally(() => {
-        setIsSyncing(false)
-      })
-    } else {
-      setIsSyncing(false)
-    }
-  }, [open, is_public, uid, workspaceId, dispatch])
+  const fetchFn = useCallback(() => {
+    const api = is_public ? publicDataviewReproduceWorkflow : reproduceWorkflow
+    return dispatch(api({ workspaceId: workspaceId!, uid: uid! })).unwrap()
+  }, [dispatch, is_public, workspaceId, uid])
+
+  const { loading, syncStatus, handleRetry } = useSyncRetry({
+    is_public,
+    fetchFn,
+    shouldFetch: open && !!uid && !!workspaceId,
+  })
+
+  const hasSyncStatus = syncStatus.pending || syncStatus.error
 
   useEffect(() => {
     const handleClosePopup = (event: KeyboardEvent) => {
@@ -207,7 +206,7 @@ const BaseNodesView = ({
         }}
       >
         {/* Loading overlay while syncing visualization data */}
-        {isSyncing && (
+        {loading && !hasSyncStatus && (
           <SyncOverlay>
             <CircularProgress size={48} />
             <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 2 }}>
@@ -237,7 +236,9 @@ const BaseNodesView = ({
               />
             )}
           </TitleHeader>
-          {data.length > 0 ? (
+          {hasSyncStatus ? (
+            <SyncStatusView syncStatus={syncStatus} onRetry={handleRetry} />
+          ) : data.length > 0 ? (
             <List>{renderData()}</List>
           ) : (
             <EmptyMessage>{emptyMessage}</EmptyMessage>

--- a/frontend/src/components/Dataview/SyncStatusView.tsx
+++ b/frontend/src/components/Dataview/SyncStatusView.tsx
@@ -1,0 +1,74 @@
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline"
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty"
+import { Alert, Box, Button, Typography } from "@mui/material"
+
+import { SyncStatus } from "components/Dataview/useSyncRetry"
+
+interface SyncStatusViewProps {
+  syncStatus: SyncStatus
+  onRetry: () => void
+}
+
+export const SyncStatusView = ({
+  syncStatus,
+  onRetry,
+}: SyncStatusViewProps) => {
+  if (syncStatus.pending) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          py: 4,
+          gap: 2,
+        }}
+      >
+        <HourglassEmptyIcon
+          sx={{
+            fontSize: 40,
+            color: "warning.main",
+            animation: "spin 1.5s ease-in-out infinite",
+            "@keyframes spin": {
+              "0%": { transform: "rotate(0deg)" },
+              "50%": { transform: "rotate(180deg)" },
+              "100%": { transform: "rotate(360deg)" },
+            },
+          }}
+        />
+        <Alert severity="info" sx={{ width: "100%" }}>
+          <Typography variant="body1" gutterBottom>
+            {syncStatus.message}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            This page will auto-retry.
+          </Typography>
+        </Alert>
+      </Box>
+    )
+  }
+
+  if (syncStatus.error) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          py: 4,
+          gap: 2,
+        }}
+      >
+        <ErrorOutlineIcon sx={{ fontSize: 48, color: "error.main" }} />
+        <Alert severity="error" sx={{ width: "100%" }}>
+          <Typography variant="body1">{syncStatus.message}</Typography>
+        </Alert>
+        <Button variant="outlined" onClick={onRetry}>
+          Retry
+        </Button>
+      </Box>
+    )
+  }
+
+  return null
+}

--- a/frontend/src/components/Dataview/WorkflowDetailsView.tsx
+++ b/frontend/src/components/Dataview/WorkflowDetailsView.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined"
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline"
-import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty"
 import {
-  Alert,
   Box,
   Button,
   Chip,
@@ -24,6 +21,8 @@ import {
 } from "@mui/material"
 
 import Loading from "components/common/Loading"
+import { SyncStatusView } from "components/Dataview/SyncStatusView"
+import { useSyncRetry } from "components/Dataview/useSyncRetry"
 import { WORKSPACE_TYPE } from "const/Workspace"
 import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
 import { DataviewType } from "store/slice/Dataview/DataviewType"
@@ -63,13 +62,6 @@ export const WorkflowDetailsView = ({
 }: WorkflowDetailsViewProps) => {
   const dispatch = useDispatch<AppDispatch>()
   const flowNodes = useSelector(selectFlowNodes)
-  const [loading, setLoading] = useState(false)
-  const [syncStatus, setSyncStatus] = useState<{
-    pending: boolean
-    error: boolean
-    message: string
-  }>({ pending: false, error: false, message: "" })
-  const [retryCount, setRetryCount] = useState(0)
   const [paramsDialog, setParamsDialog] = useState<{
     open: boolean
     params: Record<string, unknown> | null
@@ -82,78 +74,23 @@ export const WorkflowDetailsView = ({
     functionName: "",
   })
 
-  useEffect(() => {
-    if (open && dataviewRecord) {
-      setLoading(true)
-      setSyncStatus({ pending: false, error: false, message: "" })
-      const api = is_public
-        ? publicDataviewReproduceWorkflow
-        : reproduceWorkflow
-      dispatch(
-        api({
-          workspaceId: dataviewRecord.workspace.id,
-          uid: dataviewRecord.uid,
-        }),
-      )
-        .unwrap()
-        .then(() => {
-          setLoading(false)
-        })
-        .catch((error) => {
-          setLoading(false)
-          // Handle errors for public dataview
-          if (is_public) {
-            if (error?.response) {
-              const status = error.response.status
-              const data = error.response.data
+  const fetchFn = useCallback(() => {
+    const api = is_public ? publicDataviewReproduceWorkflow : reproduceWorkflow
+    return dispatch(
+      api({
+        workspaceId: dataviewRecord!.workspace.id,
+        uid: dataviewRecord!.uid,
+      }),
+    ).unwrap()
+  }, [dispatch, is_public, dataviewRecord])
 
-              if (status === 202) {
-                // Experiment is published but not yet synced
-                setSyncStatus({
-                  pending: true,
-                  error: false,
-                  message:
-                    data?.message ||
-                    "Publishing in progress, check back in a few minutes.",
-                })
-                // Auto-retry after 30 seconds (max 10 retries = 5 minutes)
-                if (retryCount < 10) {
-                  setTimeout(() => {
-                    setRetryCount(retryCount + 1)
-                  }, 30000)
-                }
-              } else if (status === 503) {
-                // Sync failed or download error
-                setSyncStatus({
-                  pending: false,
-                  error: true,
-                  message:
-                    data?.message ||
-                    "Experiment temporarily unavailable, please try again later.",
-                })
-              } else {
-                // Handle other HTTP errors (500, 404, etc.)
-                setSyncStatus({
-                  pending: false,
-                  error: true,
-                  message:
-                    data?.message ||
-                    `Failed to load experiment (${status}). Please try again.`,
-                })
-              }
-            } else {
-              // Network error - no response (blocked, offline, timeout, etc.)
-              setSyncStatus({
-                pending: false,
-                error: true,
-                message:
-                  "Failed to load experiment. Please check your connection and try again.",
-              })
-            }
-          }
-        })
-    }
-  }, [open, dataviewRecord, is_public, dispatch, retryCount])
+  const { loading, syncStatus, handleRetry } = useSyncRetry({
+    is_public,
+    fetchFn,
+    shouldFetch: open && !!dataviewRecord,
+  })
+
+  const hasSyncStatus = syncStatus.pending || syncStatus.error
 
   // Extract algorithm nodes from flowNodes
   const nodeDetails: NodeDetails[] = flowNodes
@@ -269,53 +206,8 @@ export const WorkflowDetailsView = ({
           </Box>
         </DialogTitle>
         <DialogContent dividers>
-          {syncStatus.pending ? (
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                py: 4,
-                gap: 2,
-              }}
-            >
-              <HourglassEmptyIcon
-                sx={{ fontSize: 48, color: "warning.main" }}
-              />
-              <Alert severity="info" sx={{ width: "100%" }}>
-                <Typography variant="body1" gutterBottom>
-                  {syncStatus.message}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Experiments are typically available within 5 minutes. This
-                  page will auto-retry.
-                </Typography>
-              </Alert>
-            </Box>
-          ) : syncStatus.error ? (
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                py: 4,
-                gap: 2,
-              }}
-            >
-              <ErrorOutlineIcon sx={{ fontSize: 48, color: "error.main" }} />
-              <Alert severity="error" sx={{ width: "100%" }}>
-                <Typography variant="body1">{syncStatus.message}</Typography>
-              </Alert>
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  setRetryCount(0)
-                  setSyncStatus({ pending: false, error: false, message: "" })
-                }}
-              >
-                Retry
-              </Button>
-            </Box>
+          {hasSyncStatus ? (
+            <SyncStatusView syncStatus={syncStatus} onRetry={handleRetry} />
           ) : loading || flowNodes.length === 0 ? (
             <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
               <Loading loading={loading} />

--- a/frontend/src/components/Dataview/useSyncRetry.ts
+++ b/frontend/src/components/Dataview/useSyncRetry.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from "react"
+
+export interface SyncStatus {
+  pending: boolean
+  error: boolean
+  message: string
+}
+
+const INITIAL_SYNC_STATUS: SyncStatus = {
+  pending: false,
+  error: false,
+  message: "",
+}
+
+const RETRY_MAX_COUNT = 30
+const RETRY_INTERVAL = 10000
+
+interface UseSyncRetryParams {
+  is_public: boolean
+  fetchFn: () => Promise<unknown>
+  shouldFetch: boolean
+}
+
+export const useSyncRetry = ({
+  is_public,
+  fetchFn,
+  shouldFetch,
+}: UseSyncRetryParams) => {
+  const [loading, setLoading] = useState(false)
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>(INITIAL_SYNC_STATUS)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (!shouldFetch) return
+
+    setLoading(true)
+    setSyncStatus(INITIAL_SYNC_STATUS)
+
+    fetchFn()
+      .then(() => {
+        setLoading(false)
+      })
+      .catch((error) => {
+        setLoading(false)
+
+        if (is_public && error?.response) {
+          const status = error.response.status
+          const data = error.response.data
+
+          switch (status) {
+            case 202:
+            case 423:
+              // Experiment is published but not yet synced
+              setSyncStatus({
+                pending: true,
+                error: false,
+                message:
+                  data?.message ||
+                  "Loading in progress, check back in a few minutes.",
+              })
+              // Auto-retry
+              if (retryCount < RETRY_MAX_COUNT) {
+                setTimeout(() => {
+                  setRetryCount(retryCount + 1)
+                }, RETRY_INTERVAL)
+              } else {
+                // Timeout: stop retrying and show error
+                setSyncStatus({
+                  pending: false,
+                  error: true,
+                  message:
+                    data?.message ||
+                    "Loading is taking longer than expected. Please try again later.",
+                })
+              }
+              break
+            case 503:
+              // Sync failed or download error
+              setSyncStatus({
+                pending: false,
+                error: true,
+                message:
+                  data?.message ||
+                  "Experiment temporarily unavailable, please try again later.",
+              })
+              break
+            default:
+              // Handle other HTTP errors (500, 404, etc.)
+              setSyncStatus({
+                pending: false,
+                error: true,
+                message:
+                  data?.message ||
+                  `Failed to load experiment (${status}). Please try again.`,
+              })
+              break
+          }
+        } else {
+          // Network error - no response (blocked, offline, timeout, etc.)
+          setSyncStatus({
+            pending: false,
+            error: true,
+            message:
+              "Failed to load experiment. Please check your connection and try again.",
+          })
+        }
+      })
+  }, [shouldFetch, is_public, fetchFn, retryCount])
+
+  const handleRetry = useCallback(() => {
+    setSyncStatus(INITIAL_SYNC_STATUS)
+    setRetryCount((prev) => prev + 1)
+  }, [])
+
+  return { loading, syncStatus, handleRetry }
+}

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+)
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.core.subscription.constants import SyncStatusConstants
 from studio.app.common.db.database import session_scope
@@ -124,7 +127,7 @@ class PublishedExperimentSyncJob:
                     await s3.download_experiment(
                         ws_id,
                         uid,
-                        sync_mode="thumbnails_only",
+                        sync_mode=RemoteExperimentSyncMode.THUMBNAILS_ONLY,
                     )
                 except Exception as e:
                     logger.warning(f"Startup thumb sync failed" f" {ws_id}/{uid}: {e}")
@@ -150,7 +153,7 @@ class PublishedExperimentSyncJob:
                     await s3.download_experiment(
                         ws_id,
                         uid,
-                        sync_mode="essential_only",
+                        sync_mode=RemoteExperimentSyncMode.ESSENTIAL_ONLY,
                     )
                 except Exception as e:
                     logger.warning(f"Startup meta sync failed" f" {ws_id}/{uid}: {e}")

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -10,6 +10,7 @@ from studio.app.common.core.experiment.experiment import (
     ExptOutputPathIds,
 )
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.storage.remote_storage_controller import RemoteStorageReader
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.datetime_utils import TIMEZONE_KEY
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -61,7 +62,6 @@ class ExptConfigReader:
         """
         from studio.app.common.core.storage.remote_storage_controller import (
             RemoteStorageController,
-            RemoteStorageSimpleReader,
         )
 
         config_path = cls.get_config_yaml_path(workspace_id, unique_id)
@@ -80,7 +80,9 @@ class ExptConfigReader:
         )
 
         try:
-            async with RemoteStorageSimpleReader(remote_bucket_name) as controller:
+            async with RemoteStorageReader(
+                remote_bucket_name, workspace_id, unique_id
+            ) as controller:
                 # Download only this specific experiment's metadata (efficient)
                 await controller.download_experiment_meta(workspace_id, unique_id)
             return os.path.exists(config_path)

--- a/studio/app/common/core/storage/file_filter.py
+++ b/studio/app/common/core/storage/file_filter.py
@@ -1,3 +1,6 @@
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+)
 from studio.app.const import (
     ESSENTIAL_SYNC_PATTERNS,
     LARGE_FILE_PATTERNS,
@@ -10,34 +13,33 @@ class FileSyncFilter:
     """Filter files for selective syncing."""
 
     def should_sync_file(
-        self, file_path: str, sync_mode: str = "all"
+        self,
+        file_path: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
     ) -> tuple[bool, str]:
         """
         Determine if a file should be synced based on sync mode.
 
         Args:
             file_path: Path to the file
-            sync_mode:
-                - 'all': sync everything
-                - 'essential_only': skip large files, sync yaml/json
-                - 'visualization': sync only json and tiff (for viewing results)
+            sync_mode: RemoteExperimentSyncMode enum value
 
         Returns:
             (should_sync, reason)
         """
-        if sync_mode == "all":
+        if sync_mode == RemoteExperimentSyncMode.ALL:
             return (True, "sync_mode=all")
 
         file_lower = file_path.lower()
 
         # Thumbnails only mode: sync only PNG thumbnail files for fast DataView loading
-        if sync_mode == "thumbnails_only":
+        if sync_mode == RemoteExperimentSyncMode.THUMBNAILS_ONLY:
             if any(pattern in file_lower for pattern in ThumbnailConst.FILE_PATTERNS):
                 return (True, "thumbnail file")
             return (False, "not needed for thumbnails")
 
         # Visualization mode: only sync JSON and TIFF files needed for viewing
-        if sync_mode == "visualization":
+        if sync_mode == RemoteExperimentSyncMode.VISUALIZATION:
             if any(
                 file_lower.endswith(pattern) for pattern in VISUALIZATION_SYNC_PATTERNS
             ):

--- a/studio/app/common/core/storage/mock_storage_controller.py
+++ b/studio/app/common/core/storage/mock_storage_controller.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     BaseRemoteStorageController,
+    RemoteExperimentSyncMode,
     StorageDirectoryType,
 )
 from studio.app.common.core.utils.filepath_creater import (
@@ -285,7 +286,10 @@ class MockStorageController(BaseRemoteStorageController):
         return True
 
     async def download_experiment(
-        self, workspace_id: str, unique_id: str, sync_mode: str = "all"
+        self,
+        workspace_id: str,
+        unique_id: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
     ) -> bool:
         # make paths
         experiment_local_path = self._make_experiment_local_path(

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -151,6 +151,7 @@ class RemoteSyncStatusFileUtil:
         check remote storage sync status file. (is success)
         """
         sync_status = cls.check_sync_status_file(workspace_id, unique_id)
+
         return sync_status == RemoteSyncStatus.SUCCESS
 
     @classmethod
@@ -160,13 +161,7 @@ class RemoteSyncStatusFileUtil:
         """
         sync_status = cls.check_sync_status_file(workspace_id, unique_id)
 
-        return sync_status not in [
-            # Note: 'PROCESSING' is actually not yet synced (sync in progress),
-            #   but it is not clearly in an unsynced state (such as Error),
-            #   so it is treated as a synced state here.
-            RemoteSyncStatus.PROCESSING,
-            RemoteSyncStatus.SUCCESS,
-        ]
+        return sync_status != RemoteSyncStatus.SUCCESS
 
     @classmethod
     def create_sync_status_file(

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -51,6 +51,13 @@ class RemoteSyncAction(Enum):
     DELETE = "delete"
 
 
+class RemoteExperimentSyncMode(Enum):
+    ALL = "all"
+    VISUALIZATION = "visualization"
+    ESSENTIAL_ONLY = "essential_only"
+    THUMBNAILS_ONLY = "thumbnails_only"
+
+
 class StorageDirectoryType(Enum):
     INPUT = "input"
     OUTPUT = "output"
@@ -471,7 +478,12 @@ class BaseRemoteStorageController(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def download_experiment(self, workspace_id: str, unique_id: str) -> bool:
+    def download_experiment(
+        self,
+        workspace_id: str,
+        unique_id: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
+    ) -> bool:
         """
         download experiment data from remote storage.
         """
@@ -681,7 +693,10 @@ class RemoteStorageController(BaseRemoteStorageController):
         return await self.__controller.download_experiment_meta(workspace_id, unique_id)
 
     async def download_experiment(
-        self, workspace_id: str, unique_id: str, sync_mode: str = "all"
+        self,
+        workspace_id: str,
+        unique_id: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
     ) -> bool:
         """
         Download experiment from remote storage.
@@ -689,14 +704,15 @@ class RemoteStorageController(BaseRemoteStorageController):
         Args:
             workspace_id: Workspace identifier
             unique_id: Experiment identifier
-            sync_mode: 'all' (full sync), 'visualization' (json/tiff only),
-                       or 'essential_only' (yaml/json only)
+            sync_mode: RemoteExperimentSyncMode.ALL (full sync),
+                       RemoteExperimentSyncMode.VISUALIZATION (json/tiff only),
+                       or RemoteExperimentSyncMode.ESSENTIAL_ONLY (yaml/json only)
 
-        Note: Only sync_mode='all' updates the sync status file and downloads
+        Note: Only sync_mode=ALL updates the sync status file and downloads
         input data. Partial syncs (visualization, essential_only) leave the
         status unchanged so that a full sync can still be triggered later.
         """
-        is_full_sync = sync_mode == "all"
+        is_full_sync = sync_mode == RemoteExperimentSyncMode.ALL
 
         sync_status_params = {
             "remote_bucket_name": self.bucket_name,

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -92,9 +92,9 @@ class RemoteStorageBucketNotFoundError(Exception):
 @dataclass
 class RemoteSyncStatusData:
     remote_bucket_name: str
-    remote_storage_type: str
-    sync_action: str
-    sync_status: str
+    remote_storage_type: str  # RemoteStorageType
+    sync_action: str  # RemoteSyncAction
+    sync_status: str  # RemoteSyncStatus
     timestamp: str
 
     @classmethod
@@ -135,32 +135,35 @@ class RemoteSyncStatusFileUtil:
             workspace_id, unique_id
         )
 
-        remote_sync_status = None
+        sync_status = None
         if os.path.isfile(remote_sync_status_file_path):
             with open(remote_sync_status_file_path) as f:
                 sync_status_data = RemoteSyncStatusData.from_dict(json.load(f))
-                status_str = sync_status_data.sync_status.upper()
-                if status_str in RemoteSyncStatus.__members__:
-                    remote_sync_status = RemoteSyncStatus[status_str]
+                sync_status_str = sync_status_data.sync_status.upper()
+                if sync_status_str in RemoteSyncStatus.__members__:
+                    sync_status = RemoteSyncStatus[sync_status_str]
 
-        return remote_sync_status
+        return sync_status
 
     @classmethod
     def check_sync_status_success(cls, workspace_id: str, unique_id: str) -> bool:
         """
         check remote storage sync status file. (is success)
         """
-        return (
-            cls.check_sync_status_file(workspace_id, unique_id)
-            == RemoteSyncStatus.SUCCESS
-        )
+        sync_status = cls.check_sync_status_file(workspace_id, unique_id)
+        return sync_status == RemoteSyncStatus.SUCCESS
 
     @classmethod
     def check_sync_status_unsynced(cls, workspace_id: str, unique_id: str) -> bool:
         """
         check remote storage sync status file. (is unsynced)
         """
-        return cls.check_sync_status_file(workspace_id, unique_id) not in [
+        sync_status = cls.check_sync_status_file(workspace_id, unique_id)
+
+        return sync_status not in [
+            # Note: 'PROCESSING' is actually not yet synced (sync in progress),
+            #   but it is not clearly in an unsynced state (such as Error),
+            #   so it is treated as a synced state here.
             RemoteSyncStatus.PROCESSING,
             RemoteSyncStatus.SUCCESS,
         ]
@@ -172,7 +175,7 @@ class RemoteSyncStatusFileUtil:
         workspace_id: str,
         unique_id: str,
         sync_action: RemoteSyncAction,
-        status: RemoteSyncStatus,
+        sync_status: RemoteSyncStatus,
     ) -> None:
         """
         create remote storage sync status file.
@@ -190,7 +193,7 @@ class RemoteSyncStatusFileUtil:
                 remote_bucket_name=remote_bucket_name,
                 remote_storage_type=RemoteStorageType.get_activated_type().value,
                 sync_action=sync_action.value,
-                sync_status=status.value,
+                sync_status=sync_status.value,
                 timestamp=str(get_current_datetime()),
             )
             json.dump(asdict(sync_status_data), f, indent=2)
@@ -894,6 +897,9 @@ class RemoteStorageController(BaseRemoteStorageController):
 class BaseRemoteStorageSimpleReaderWriter(metaclass=ABCMeta):
     """
     Simplified Reader/Writer wrapper for RemoteStorageController
+    - This Reader class does not implement exclusive control of experiment data.
+      - It is used to access remote data (such as input data or a single file)
+        without specifying the experiment data key (workspace_id, unique_id).
     - params: Specify only bucket_name
     """
 
@@ -943,11 +949,13 @@ class BaseRemoteStorageReaderWriter(metaclass=ABCMeta):
         workspace_id: str,
         unique_id: str,
         sync_action: RemoteSyncAction,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
     ):
         self.bucket_name = bucket_name
         self.workspace_id = workspace_id
         self.unique_id = unique_id
         self.sync_action = sync_action
+        self.sync_mode = sync_mode
 
         is_locked = RemoteSyncLockFileUtil.check_sync_lock_file(workspace_id, unique_id)
         if is_locked:
@@ -958,12 +966,14 @@ class BaseRemoteStorageReaderWriter(metaclass=ABCMeta):
         RemoteSyncLockFileUtil.create_sync_lock_file(workspace_id, unique_id)
 
         # generate remote-sync-status-file (for pendding)
-        RemoteSyncStatusFileUtil.create_sync_status_file_for_processing(
-            bucket_name,
-            workspace_id,
-            unique_id,
-            self.sync_action,
-        )
+        # *updates are only made when self.sync_mode==ALL (full sync)
+        if self.sync_mode == RemoteExperimentSyncMode.ALL:
+            RemoteSyncStatusFileUtil.create_sync_status_file_for_processing(
+                bucket_name,
+                workspace_id,
+                unique_id,
+                self.sync_action,
+            )
 
         self.__controller = RemoteStorageController(bucket_name)
 
@@ -972,20 +982,22 @@ class BaseRemoteStorageReaderWriter(metaclass=ABCMeta):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # update remote-sync-status-file
-        if not exc_type:  # Processing success
-            RemoteSyncStatusFileUtil.create_sync_status_file_for_success(
-                self.bucket_name,
-                self.workspace_id,
-                self.unique_id,
-                self.sync_action,
-            )
-        else:  # Processing error
-            RemoteSyncStatusFileUtil.create_sync_status_file_for_error(
-                self.bucket_name,
-                self.workspace_id,
-                self.unique_id,
-                self.sync_action,
-            )
+        # *updates are only made when self.sync_mode==ALL (full sync)
+        if self.sync_mode == RemoteExperimentSyncMode.ALL:
+            if not exc_type:  # Processing success
+                RemoteSyncStatusFileUtil.create_sync_status_file_for_success(
+                    self.bucket_name,
+                    self.workspace_id,
+                    self.unique_id,
+                    self.sync_action,
+                )
+            else:  # Processing error
+                RemoteSyncStatusFileUtil.create_sync_status_file_for_error(
+                    self.bucket_name,
+                    self.workspace_id,
+                    self.unique_id,
+                    self.sync_action,
+                )
 
         # delete lock file
         RemoteSyncLockFileUtil.delete_sync_lock_file(self.workspace_id, self.unique_id)
@@ -996,9 +1008,15 @@ class RemoteStorageReader(BaseRemoteStorageReaderWriter):
     Reader wrapper for RemoteStorageController
     """
 
-    def __init__(self, bucket_name: str, workspace_id: str, unique_id: str):
+    def __init__(
+        self,
+        bucket_name: str,
+        workspace_id: str,
+        unique_id: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
+    ):
         super().__init__(
-            bucket_name, workspace_id, unique_id, RemoteSyncAction.DOWNLOAD
+            bucket_name, workspace_id, unique_id, RemoteSyncAction.DOWNLOAD, sync_mode
         )
 
 

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -89,6 +89,16 @@ class RemoteStorageBucketNotFoundError(Exception):
         super().__init__(message)
 
 
+class RemoteExperimentNotFoundError(Exception):
+    """Raised when specified experiment data does not exist."""
+
+    def __init__(self, workspace_id: str, unique_id: str):
+        self.workspace_id = workspace_id
+        self.unique_id = unique_id
+        message = f"Remote experiment data does not exist: ({workspace_id}/{unique_id})"
+        super().__init__(message)
+
+
 @dataclass
 class RemoteSyncStatusData:
     remote_bucket_name: str

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import time
 from abc import ABCMeta, abstractmethod
+from dataclasses import asdict, dataclass
 from datetime import timedelta
 from enum import Enum
 from typing import Dict, List
@@ -88,6 +89,25 @@ class RemoteStorageBucketNotFoundError(Exception):
         super().__init__(message)
 
 
+@dataclass
+class RemoteSyncStatusData:
+    remote_bucket_name: str
+    remote_storage_type: str
+    sync_action: str
+    sync_status: str
+    timestamp: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RemoteSyncStatusData":
+        return cls(
+            remote_bucket_name=data.get("remote_bucket_name", ""),
+            remote_storage_type=data.get("remote_storage_type", ""),
+            sync_action=data.get("sync_action", ""),
+            sync_status=data.get("sync_status", ""),
+            timestamp=data.get("timestamp", ""),
+        )
+
+
 class RemoteSyncStatusFileUtil:
     REMOTE_SYNC_STATUS_FILE = "remote_sync_stat.json"
 
@@ -118,8 +138,8 @@ class RemoteSyncStatusFileUtil:
         remote_sync_status = None
         if os.path.isfile(remote_sync_status_file_path):
             with open(remote_sync_status_file_path) as f:
-                sync_status_data = json.load(f)
-                status_str = str(sync_status_data.get("status")).upper()
+                sync_status_data = RemoteSyncStatusData.from_dict(json.load(f))
+                status_str = sync_status_data.sync_status.upper()
                 if status_str in RemoteSyncStatus.__members__:
                     remote_sync_status = RemoteSyncStatus[status_str]
 
@@ -151,7 +171,7 @@ class RemoteSyncStatusFileUtil:
         remote_bucket_name: str,
         workspace_id: str,
         unique_id: str,
-        remote_sync_action: RemoteSyncAction,
+        sync_action: RemoteSyncAction,
         status: RemoteSyncStatus,
     ) -> None:
         """
@@ -166,14 +186,14 @@ class RemoteSyncStatusFileUtil:
             exist_ok=True,
         )
         with open(remote_sync_status_file_path, "w") as f:
-            sync_status_data = {
-                "remote_bucket_name": remote_bucket_name,
-                "remote_storage_type": RemoteStorageType.get_activated_type().value,
-                "action": remote_sync_action.value,
-                "status": status.value,
-                "timestamp": get_current_datetime(),
-            }
-            json.dump(sync_status_data, f, default=str, indent=2)
+            sync_status_data = RemoteSyncStatusData(
+                remote_bucket_name=remote_bucket_name,
+                remote_storage_type=RemoteStorageType.get_activated_type().value,
+                sync_action=sync_action.value,
+                sync_status=status.value,
+                timestamp=str(get_current_datetime()),
+            )
+            json.dump(asdict(sync_status_data), f, indent=2)
 
     @classmethod
     def create_sync_status_file_for_success(
@@ -181,13 +201,13 @@ class RemoteSyncStatusFileUtil:
         remote_bucket_name: str,
         workspace_id: str,
         unique_id: str,
-        remote_sync_action: RemoteSyncAction,
+        sync_action: RemoteSyncAction,
     ) -> None:
         cls.create_sync_status_file(
             remote_bucket_name,
             workspace_id,
             unique_id,
-            remote_sync_action,
+            sync_action,
             RemoteSyncStatus.SUCCESS,
         )
 
@@ -197,13 +217,13 @@ class RemoteSyncStatusFileUtil:
         remote_bucket_name: str,
         workspace_id: str,
         unique_id: str,
-        remote_sync_action: RemoteSyncAction,
+        sync_action: RemoteSyncAction,
     ) -> None:
         cls.create_sync_status_file(
             remote_bucket_name,
             workspace_id,
             unique_id,
-            remote_sync_action,
+            sync_action,
             RemoteSyncStatus.PROCESSING,
         )
 
@@ -213,13 +233,13 @@ class RemoteSyncStatusFileUtil:
         remote_bucket_name: str,
         workspace_id: str,
         unique_id: str,
-        remote_sync_action: RemoteSyncAction,
+        sync_action: RemoteSyncAction,
     ) -> None:
         cls.create_sync_status_file(
             remote_bucket_name,
             workspace_id,
             unique_id,
-            remote_sync_action,
+            sync_action,
             RemoteSyncStatus.ERROR,
         )
 
@@ -247,8 +267,8 @@ class RemoteSyncStatusFileUtil:
         remote_bucket_name = None
         if os.path.isfile(remote_sync_status_file_path):
             with open(remote_sync_status_file_path) as f:
-                sync_status_data = json.load(f)
-                remote_bucket_name = sync_status_data.get("remote_bucket_name")
+                sync_status_data = RemoteSyncStatusData.from_dict(json.load(f))
+                remote_bucket_name = sync_status_data.remote_bucket_name
         else:
             logger.warning(
                 f"remote_sync_status_file not found. [{remote_sync_status_file_path}]"
@@ -718,7 +738,7 @@ class RemoteStorageController(BaseRemoteStorageController):
             "remote_bucket_name": self.bucket_name,
             "workspace_id": workspace_id,
             "unique_id": unique_id,
-            "remote_sync_action": RemoteSyncAction.DOWNLOAD,
+            "sync_action": RemoteSyncAction.DOWNLOAD,
         }
         result = False
 
@@ -764,7 +784,7 @@ class RemoteStorageController(BaseRemoteStorageController):
             "remote_bucket_name": self.bucket_name,
             "workspace_id": workspace_id,
             "unique_id": unique_id,
-            "remote_sync_action": RemoteSyncAction.UPLOAD,
+            "sync_action": RemoteSyncAction.UPLOAD,
         }
         result = False
 
@@ -800,7 +820,7 @@ class RemoteStorageController(BaseRemoteStorageController):
             "remote_bucket_name": self.bucket_name,
             "workspace_id": workspace_id,
             "unique_id": unique_id,
-            "remote_sync_action": RemoteSyncAction.DELETE,
+            "sync_action": RemoteSyncAction.DELETE,
         }
         result = False
 

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -22,6 +22,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.file_filter import FileSyncFilter
 from studio.app.common.core.storage.remote_storage_controller import (
     BaseRemoteStorageController,
+    RemoteExperimentNotFoundError,
     RemoteExperimentSyncMode,
     RemoteStorageBucketNotFoundError,
     RemoteSyncLockFileUtil,
@@ -912,11 +913,11 @@ class S3StorageController(BaseRemoteStorageController):
 
             if not all_s3_objects:
                 logger.warning(
-                    "remote data is not exists. [%s] [%s]",
+                    "Remote data is not exists. [%s] [%s]",
                     self.bucket_name,
                     experiment_remote_path,
                 )
-                return False
+                raise RemoteExperimentNotFoundError(workspace_id, unique_id)
 
             # Sort by directory depth (shallower files first)
             all_s3_objects.sort(key=lambda obj: obj["Key"].count("/"))

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -576,6 +576,13 @@ class S3StorageController(BaseRemoteStorageController):
                                     os.path.dirname(flie_local_path), exist_ok=True
                                 )
 
+                                # Check for the existence of the remote file
+                                #   before executing download_file
+                                #   (to avoid creating an empty file locally)
+                                await __s3_client.head_object(
+                                    Bucket=self.bucket_name, Key=file_remote_path
+                                )
+
                                 # download file
                                 await __s3_client.download_file(
                                     self.bucket_name,
@@ -636,6 +643,13 @@ class S3StorageController(BaseRemoteStorageController):
                     # Create local directory if needed
                     os.makedirs(os.path.dirname(file_local_path), exist_ok=True)
 
+                    # Check for the existence of the remote file
+                    #   before executing download_file
+                    #   (to avoid creating an empty file locally)
+                    await __s3_client.head_object(
+                        Bucket=self.bucket_name, Key=file_remote_path
+                    )
+
                     # Download file from S3
                     await __s3_client.download_file(
                         self.bucket_name,
@@ -646,7 +660,7 @@ class S3StorageController(BaseRemoteStorageController):
                     logger.debug(f"Downloaded: {file_remote_path}")
                 except Exception as e:
                     # File may not exist in S3 - this is OK for optional files
-                    logger.debug(
+                    logger.warning(
                         f"Could not download [{self.bucket_name}]"
                         f"[{file_remote_path}]: {e}"
                     )

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -22,6 +22,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.file_filter import FileSyncFilter
 from studio.app.common.core.storage.remote_storage_controller import (
     BaseRemoteStorageController,
+    RemoteExperimentSyncMode,
     RemoteStorageBucketNotFoundError,
     RemoteSyncLockFileUtil,
     RemoteSyncStatusFileUtil,
@@ -865,7 +866,10 @@ class S3StorageController(BaseRemoteStorageController):
         return True
 
     async def download_experiment(
-        self, workspace_id: str, unique_id: str, sync_mode: str = "all"
+        self,
+        workspace_id: str,
+        unique_id: str,
+        sync_mode: RemoteExperimentSyncMode = RemoteExperimentSyncMode.ALL,
     ) -> bool:
         """
         Download experiment from S3 to local storage.
@@ -873,10 +877,10 @@ class S3StorageController(BaseRemoteStorageController):
         Args:
             workspace_id: Workspace identifier
             unique_id: Unique experiment identifier
-            sync_mode:
-                - 'all': sync everything (default)
-                - 'essential_only': skip large files, sync yaml/json (for dataview)
-                - 'visualization': sync only json and tiff (for viewing results)
+            sync_mode: RemoteExperimentSyncMode enum value
+                - ALL: sync everything (default)
+                - ESSENTIAL_ONLY: skip large files, sync yaml/json (for dataview)
+                - VISUALIZATION: sync only json and tiff (for viewing results)
 
         Returns:
             True if download successful, False otherwise
@@ -925,7 +929,9 @@ class S3StorageController(BaseRemoteStorageController):
             # cleaning data from local path (only for full sync, not partial syncs)
             # Partial syncs (visualization, essential_only) should preserve existing
             # files to avoid redundant downloads
-            if sync_mode == "all" and os.path.isdir(experiment_local_path):
+            if sync_mode == RemoteExperimentSyncMode.ALL and os.path.isdir(
+                experiment_local_path
+            ):
                 await self._clear_local_experiment_data(experiment_local_path)
 
             target_files_count = len(all_s3_objects)
@@ -1252,7 +1258,9 @@ class S3StorageController(BaseRemoteStorageController):
                 await self.download_input_data(workspace_id, filename)
             else:
                 await self.download_experiment(
-                    workspace_id, unique_id, sync_mode="visualization"
+                    workspace_id,
+                    unique_id,
+                    sync_mode=RemoteExperimentSyncMode.VISUALIZATION,
                 )
             return True
         except Exception as e:

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -15,6 +15,7 @@ from studio.app.common.core.dataview.dataview_services import (
 )
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentNotFoundError,
     RemoteStorageController,
     RemoteStorageLockError,
     RemoteStorageReader,
@@ -219,7 +220,7 @@ async def public_reproduce_experiment(
     )
 
     if not record:
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
     # Ensure experiment is available on local EBS (download from S3 if needed)
     # Also try to sync if status is pending/error - the local data might be incomplete
@@ -267,13 +268,16 @@ async def public_reproduce_experiment(
                         f"from remote bucket {remote_bucket_name}"
                     )
                     return JSONResponse(
-                        status_code=503,
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                         content={
                             "status": "download_error",
                             "message": "Failed to load experiment data, "
                             "please try again later",
                         },
                     )
+        except RemoteExperimentNotFoundError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
         except RemoteStorageLockError as e:
             logger.warning(e)
             raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -294,7 +298,7 @@ async def public_reproduce_experiment(
                     f"and not yet available locally"
                 )
                 return JSONResponse(
-                    status_code=202,
+                    status_code=status.HTTP_202_ACCEPTED,
                     content={
                         "status": "pending_sync",
                         "message": (
@@ -311,7 +315,7 @@ async def public_reproduce_experiment(
             f"{display_validation.reason}"
         )
         return JSONResponse(
-            status_code=503,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content={
                 "status": "data_error",
                 "message": display_validation.reason
@@ -390,7 +394,7 @@ async def publish_dataview_records(
             )
 
             if not record:
-                raise HTTPException(status_code=404)
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
             # Validate publish eligibility when publishing
             if flag == PublishFlags.on:
@@ -402,7 +406,7 @@ async def publish_dataview_records(
                 )
                 if not validation.can_publish:
                     raise HTTPException(
-                        status_code=400,
+                        status_code=status.HTTP_400_BAD_REQUEST,
                         detail=validation.reason,
                     )
 
@@ -435,7 +439,7 @@ async def publish_dataview_records(
                         )
                         if not exists:
                             raise HTTPException(
-                                status_code=400,
+                                status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Cannot publish: {error_msg}",
                             )
                 else:
@@ -499,12 +503,14 @@ async def publish_dataview_records(
                 continue
             else:
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to publish experiment: {str(e)}"
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to publish experiment: {str(e)}",
                 )
 
     # Should never reach here
     raise HTTPException(
-        status_code=500, detail="Failed to publish experiment after multiple retries"
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Failed to publish experiment after multiple retries",
     )
 
 
@@ -527,7 +533,7 @@ def multiple_publish_dataview_records(
         # First check S3 bucket (applies to all)
         if not current_user.remote_bucket_name:
             raise HTTPException(
-                status_code=400,
+                status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot publish data: No cloud storage bucket configured "
                 "for your account. Please contact support to enable publishing.",
             )
@@ -563,7 +569,7 @@ def multiple_publish_dataview_records(
                 detail += f"- {rec['name']}: {rec['reason']}\n"
             if len(failed_records) > 5:
                 detail += f"... and {len(failed_records) - 5} more"
-            raise HTTPException(status_code=400, detail=detail)
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
 
     DataviewService.multiple_publish_dataview_records(db, current_user.id, ids, flag)
 

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -223,15 +223,18 @@ async def public_reproduce_experiment(
 
     # Ensure experiment is available on local EBS (download from S3 if needed)
     # Also try to sync if status is pending/error - the local data might be incomplete
-    needs_sync = RemoteSyncStatusFileUtil.check_sync_status_unsynced(
+    is_unsynced = RemoteSyncStatusFileUtil.check_sync_status_unsynced(
         workspace_id, unique_id
     )
-    if not needs_sync and hasattr(record, "local_sync_status"):
+
+    if not is_unsynced and hasattr(record, "local_sync_status"):
         # Also sync if status indicates data might be incomplete
         needs_sync = record.local_sync_status in [
             LocalSyncStatus.pending.value,
             LocalSyncStatus.error.value,
         ]
+    else:
+        needs_sync = is_unsynced
 
     if needs_sync:
         # Get owner's bucket from workspace

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -1,7 +1,7 @@
 import os
 from typing import List, Optional, Sequence, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 from fastapi_pagination.ext.sqlmodel import paginate
 from sqlalchemy.sql import Select
@@ -16,8 +16,10 @@ from studio.app.common.core.dataview.dataview_services import (
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
-    RemoteStorageSimpleReader,
+    RemoteStorageLockError,
+    RemoteStorageReader,
     RemoteStorageType,
+    RemoteSyncStatusFileUtil,
 )
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 from studio.app.common.db.database import get_db
@@ -34,7 +36,6 @@ from studio.app.common.schemas.dataview import (
 )
 from studio.app.common.schemas.users import User
 from studio.app.common.schemas.workflow import WorkflowWithResults
-from studio.app.dir_path import DIRPATH
 
 router = APIRouter(tags=["Dataview"], prefix="/api/dataview")
 public_router = APIRouter(tags=["Dataview"], prefix="/api/public/dataview")
@@ -222,8 +223,9 @@ async def public_reproduce_experiment(
 
     # Ensure experiment is available on local EBS (download from S3 if needed)
     # Also try to sync if status is pending/error - the local data might be incomplete
-    experiment_path = os.path.join(DIRPATH.OUTPUT_DIR, workspace_id, unique_id)
-    needs_sync = not os.path.exists(experiment_path)
+    needs_sync = RemoteSyncStatusFileUtil.check_sync_status_unsynced(
+        workspace_id, unique_id
+    )
     if not needs_sync and hasattr(record, "local_sync_status"):
         # Also sync if status indicates data might be incomplete
         needs_sync = record.local_sync_status in [
@@ -243,31 +245,35 @@ async def public_reproduce_experiment(
             owner_bucket = getattr(workspace.user, "remote_bucket_name", None)
         remote_bucket_name = owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
 
-        async with RemoteStorageSimpleReader(
-            remote_bucket_name
-        ) as remote_storage_controller:
-            logger.info(
-                f"Downloading published experiment {workspace_id}/{unique_id} "
-                f"from remote bucket {remote_bucket_name}"
-            )
-            available = await remote_storage_controller.download_experiment(
-                workspace_id,
-                unique_id,
-            )
-
-            if not available:
-                logger.error(
-                    f"Failed to download experiment {workspace_id}/{unique_id} "
+        try:
+            async with RemoteStorageReader(
+                remote_bucket_name, workspace_id, unique_id
+            ) as remote_storage_controller:
+                logger.info(
+                    f"Downloading published experiment {workspace_id}/{unique_id} "
                     f"from remote bucket {remote_bucket_name}"
                 )
-                return JSONResponse(
-                    status_code=503,
-                    content={
-                        "status": "download_error",
-                        "message": "Failed to load experiment data, "
-                        "please try again later",
-                    },
+                available = await remote_storage_controller.download_experiment(
+                    workspace_id,
+                    unique_id,
                 )
+
+                if not available:
+                    logger.error(
+                        f"Failed to download experiment {workspace_id}/{unique_id} "
+                        f"from remote bucket {remote_bucket_name}"
+                    )
+                    return JSONResponse(
+                        status_code=503,
+                        content={
+                            "status": "download_error",
+                            "message": "Failed to load experiment data, "
+                            "please try again later",
+                        },
+                    )
+        except RemoteStorageLockError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
 
     # Validate experiment is displayable (checks if required files exist locally)
     # This should be done BEFORE checking sync status, because on-demand download
@@ -467,7 +473,7 @@ async def publish_dataview_records(
                     continue
                 else:
                     raise HTTPException(
-                        status_code=409,
+                        status_code=status.HTTP_409_CONFLICT,
                         detail="Concurrent modification detected. Please try again.",
                     )
 

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -292,21 +292,23 @@ async def sync_remote_experiment(
     remote_bucket_name: str = Depends(get_user_remote_bucket_name),
 ):
     try:
+        result = False
+
         async with RemoteStorageReader(
             remote_bucket_name, workspace_id, unique_id
         ) as remote_storage_controller:
             result = await remote_storage_controller.download_experiment(
                 workspace_id, unique_id
             )
+            if not result:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail="record not found"
+                )
 
-        if not result:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="record not found"
-            )
         return result
 
     except HTTPException as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise e
     except RemoteStorageLockError as e:
         logger.error(e)

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -15,6 +15,7 @@ from studio.app.common.core.experiment.experiment_writer import ExptDataWriter
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentNotFoundError,
     RemoteStorageController,
     RemoteStorageLockError,
     RemoteStorageReader,
@@ -125,6 +126,9 @@ async def rename_experiment(
 
         return config
 
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.error(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -166,6 +170,9 @@ async def delete_experiment(
 
         return result
 
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.error(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -221,6 +228,9 @@ async def delete_experiment_list(
 
         return True
 
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.error(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -310,6 +320,9 @@ async def sync_remote_experiment(
     except HTTPException as e:
         logger.error(e, exc_info=True)
         raise e
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.error(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))

--- a/studio/app/common/routers/internal.py
+++ b/studio/app/common/routers/internal.py
@@ -225,7 +225,10 @@ async def _download_single_experiment(
 
     try:
         async with RemoteStorageReader(
-            bucket_name, workspace_id, unique_id
+            bucket_name,
+            workspace_id,
+            unique_id,
+            RemoteExperimentSyncMode.THUMBNAILS_ONLY,
         ) as controller:
             if has_thumbnails:
                 await controller.download_experiment(

--- a/studio/app/common/routers/internal.py
+++ b/studio/app/common/routers/internal.py
@@ -26,6 +26,7 @@ from sqlmodel import Session, select
 from studio.app.common.core.auth.auth_dependencies import _get_user_remote_bucket_name
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
     RemoteStorageController,
     RemoteStorageReader,
     RemoteStorageSimpleReader,
@@ -230,12 +231,12 @@ async def _download_single_experiment(
                 await controller.download_experiment(
                     workspace_id,
                     unique_id,
-                    sync_mode="thumbnails_only",
+                    sync_mode=RemoteExperimentSyncMode.THUMBNAILS_ONLY,
                 )
             await controller.download_experiment(
                 workspace_id,
                 unique_id,
-                sync_mode="essential_only",
+                sync_mode=RemoteExperimentSyncMode.ESSENTIAL_ONLY,
             )
         logger.info("Proactive sync completed for" f" {workspace_id}/{unique_id}")
     except Exception as e:

--- a/studio/app/common/routers/internal.py
+++ b/studio/app/common/routers/internal.py
@@ -27,6 +27,7 @@ from studio.app.common.core.auth.auth_dependencies import _get_user_remote_bucke
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
+    RemoteStorageReader,
     RemoteStorageSimpleReader,
 )
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -222,7 +223,9 @@ async def _download_single_experiment(
         return
 
     try:
-        async with RemoteStorageSimpleReader(bucket_name) as controller:
+        async with RemoteStorageReader(
+            bucket_name, workspace_id, unique_id
+        ) as controller:
             if has_thumbnails:
                 await controller.download_experiment(
                     workspace_id,

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional
 
 import pandas as pd
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 
 from studio.app.common.core.auth.auth_dependencies import get_outputs_remote_bucket_name
@@ -11,6 +11,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk_utils import SmkUtils
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
+    RemoteStorageLockError,
     RemoteStorageReader,
     RemoteStorageSimpleReader,
     RemoteStorageSimpleWriter,
@@ -117,8 +118,8 @@ async def get_or_generate_thumbnail(
 
     # Download from remote storage if needed
     if not os.path.exists(abs_original_path) and RemoteStorageController.is_available():
-        async with RemoteStorageSimpleReader(
-            remote_bucket_name
+        async with RemoteStorageReader(
+            remote_bucket_name, workspace_id, unique_id
         ) as remote_storage_controller:
             await remote_storage_controller.download_thumbnail_source(
                 workspace_id, unique_id, original_path, thumb_type
@@ -239,27 +240,29 @@ async def sync_visualization_files(
         "from remote storage"
     )
 
-    # Use SimpleReader to avoid updating sync status - partial syncs should NOT
-    # mark as synced, so background full sync can still run
-    async with RemoteStorageSimpleReader(
-        remote_bucket_name
-    ) as remote_storage_controller:
-        result = await remote_storage_controller.download_experiment(
-            workspace_id, unique_id, sync_mode="visualization"
-        )
-
-        # Also download input files needed for viewing images
-        try:
-            input_filenames = SmkUtils.get_datatypes_inputs(
-                workspace_id, unique_id, apply_basename=True
+    try:
+        async with RemoteStorageReader(
+            remote_bucket_name, workspace_id, unique_id
+        ) as remote_storage_controller:
+            result = await remote_storage_controller.download_experiment(
+                workspace_id, unique_id, sync_mode="visualization"
             )
-            for input_filename in input_filenames:
-                await remote_storage_controller.download_input_data(
-                    workspace_id, input_filename
+
+            # Also download input files needed for viewing images
+            try:
+                input_filenames = SmkUtils.get_datatypes_inputs(
+                    workspace_id, unique_id, apply_basename=True
                 )
-        except (AssertionError, KeyError):
-            # snakemake.yaml may be empty or missing required keys
-            pass
+                for input_filename in input_filenames:
+                    await remote_storage_controller.download_input_data(
+                        workspace_id, input_filename
+                    )
+            except (AssertionError, KeyError):
+                # snakemake.yaml may be empty or missing required keys
+                pass
+    except RemoteStorageLockError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
 
     # Trigger background task to download remaining files (PKL/NWB)
     # This prepares Edit ROI while user is viewing results
@@ -307,14 +310,18 @@ async def get_thumbnail(
     # Try to sync thumbnail from remote storage if not available locally
     if not os.path.exists(thumb_path) and RemoteStorageController.is_available():
         try:
-            async with RemoteStorageSimpleReader(
-                remote_bucket_name
+            async with RemoteStorageReader(
+                remote_bucket_name, workspace_id, unique_id
             ) as remote_storage_controller:
                 await remote_storage_controller.download_experiment(
                     workspace_id, unique_id, sync_mode="thumbnails_only"
                 )
+        except RemoteStorageLockError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
         except Exception as e:
             logger.warning(f"Failed to sync thumbnail from remote storage: {e}")
+            pass  # Continue processing
 
     # If thumbnail still doesn't exist, try to generate it
     if not os.path.exists(thumb_path):
@@ -323,14 +330,18 @@ async def get_thumbnail(
         # find the source TIFF/JSON files for generation
         if RemoteStorageController.is_available():
             try:
-                async with RemoteStorageSimpleReader(
-                    remote_bucket_name
+                async with RemoteStorageReader(
+                    remote_bucket_name, workspace_id, unique_id
                 ) as remote_storage_controller:
                     await remote_storage_controller.download_experiment(
                         workspace_id, unique_id, sync_mode="essential_only"
                     )
+            except RemoteStorageLockError as e:
+                logger.warning(e)
+                raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
             except Exception as e:
                 logger.warning(f"Failed to sync config files from remote storage: {e}")
+                pass  # Continue processing
 
         # Get the original file path for generation
         if thumb_type == ThumbnailType.INPUT:
@@ -430,26 +441,28 @@ async def _ensure_visualization_synced(dirpath: str, remote_bucket_name: str) ->
 
     logger.info(f"On-demand sync for visualization: {workspace_id}/{unique_id}")
 
-    # Use SimpleReader to avoid updating sync status - partial syncs should NOT
-    # mark as synced, so that Edit ROI can still trigger a full sync later
-    async with RemoteStorageSimpleReader(
-        remote_bucket_name
-    ) as remote_storage_controller:
-        await remote_storage_controller.download_experiment(
-            workspace_id, unique_id, sync_mode="visualization"
-        )
-        # Also download input files (if snakemake config is available)
-        try:
-            input_filenames = SmkUtils.get_datatypes_inputs(
-                workspace_id, unique_id, apply_basename=True
+    try:
+        async with RemoteStorageReader(
+            remote_bucket_name, workspace_id, unique_id
+        ) as remote_storage_controller:
+            await remote_storage_controller.download_experiment(
+                workspace_id, unique_id, sync_mode="visualization"
             )
-            for input_filename in input_filenames:
-                await remote_storage_controller.download_input_data(
-                    workspace_id, input_filename
+            # Also download input files (if snakemake config is available)
+            try:
+                input_filenames = SmkUtils.get_datatypes_inputs(
+                    workspace_id, unique_id, apply_basename=True
                 )
-        except (AssertionError, KeyError):
-            # snakemake.yaml may be empty or missing required keys
-            pass
+                for input_filename in input_filenames:
+                    await remote_storage_controller.download_input_data(
+                        workspace_id, input_filename
+                    )
+            except (AssertionError, KeyError):
+                # snakemake.yaml may be empty or missing required keys
+                pass
+    except RemoteStorageLockError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
 
 
 def get_initial_timeseries_data(dirpath) -> JsonTimeSeriesData:

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -120,7 +120,10 @@ async def get_or_generate_thumbnail(
     # Download from remote storage if needed
     if not os.path.exists(abs_original_path) and RemoteStorageController.is_available():
         async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
+            remote_bucket_name,
+            workspace_id,
+            unique_id,
+            RemoteExperimentSyncMode.THUMBNAILS_ONLY,
         ) as remote_storage_controller:
             await remote_storage_controller.download_thumbnail_source(
                 workspace_id, unique_id, original_path, thumb_type
@@ -186,11 +189,12 @@ async def _background_full_sync(
 
         logger.info(f"Background full sync starting for {workspace_id}/{unique_id}")
 
+        sync_mode = RemoteExperimentSyncMode.ALL
         async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
+            remote_bucket_name, workspace_id, unique_id, sync_mode
         ) as remote_storage_controller:
             await remote_storage_controller.download_experiment(
-                workspace_id, unique_id, sync_mode=RemoteExperimentSyncMode.ALL
+                workspace_id, unique_id, sync_mode=sync_mode
             )
 
         logger.info(f"Background full sync completed for {workspace_id}/{unique_id}")
@@ -242,13 +246,14 @@ async def sync_visualization_files(
     )
 
     try:
+        sync_mode = RemoteExperimentSyncMode.VISUALIZATION
         async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
+            remote_bucket_name, workspace_id, unique_id, sync_mode
         ) as remote_storage_controller:
             result = await remote_storage_controller.download_experiment(
                 workspace_id,
                 unique_id,
-                sync_mode=RemoteExperimentSyncMode.VISUALIZATION,
+                sync_mode=sync_mode,
             )
 
             # Also download input files needed for viewing images
@@ -313,13 +318,14 @@ async def get_thumbnail(
     # Try to sync thumbnail from remote storage if not available locally
     if not os.path.exists(thumb_path) and RemoteStorageController.is_available():
         try:
+            sync_mode = RemoteExperimentSyncMode.THUMBNAILS_ONLY
             async with RemoteStorageReader(
-                remote_bucket_name, workspace_id, unique_id
+                remote_bucket_name, workspace_id, unique_id, sync_mode
             ) as remote_storage_controller:
                 await remote_storage_controller.download_experiment(
                     workspace_id,
                     unique_id,
-                    sync_mode=RemoteExperimentSyncMode.THUMBNAILS_ONLY,
+                    sync_mode=sync_mode,
                 )
         except RemoteStorageLockError as e:
             logger.warning(e)
@@ -335,13 +341,14 @@ async def get_thumbnail(
         # find the source TIFF/JSON files for generation
         if RemoteStorageController.is_available():
             try:
+                sync_mode = RemoteExperimentSyncMode.ESSENTIAL_ONLY
                 async with RemoteStorageReader(
-                    remote_bucket_name, workspace_id, unique_id
+                    remote_bucket_name, workspace_id, unique_id, sync_mode
                 ) as remote_storage_controller:
                     await remote_storage_controller.download_experiment(
                         workspace_id,
                         unique_id,
-                        sync_mode=RemoteExperimentSyncMode.ESSENTIAL_ONLY,
+                        sync_mode=sync_mode,
                     )
             except RemoteStorageLockError as e:
                 logger.warning(e)
@@ -449,13 +456,14 @@ async def _ensure_visualization_synced(dirpath: str, remote_bucket_name: str) ->
     logger.info(f"On-demand sync for visualization: {workspace_id}/{unique_id}")
 
     try:
+        sync_mode = RemoteExperimentSyncMode.VISUALIZATION
         async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
+            remote_bucket_name, workspace_id, unique_id, sync_mode
         ) as remote_storage_controller:
             await remote_storage_controller.download_experiment(
                 workspace_id,
                 unique_id,
-                sync_mode=RemoteExperimentSyncMode.VISUALIZATION,
+                sync_mode=sync_mode,
             )
             # Also download input files (if snakemake config is available)
             try:

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -10,6 +10,7 @@ from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk_utils import SmkUtils
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
     RemoteStorageController,
     RemoteStorageLockError,
     RemoteStorageReader,
@@ -189,7 +190,7 @@ async def _background_full_sync(
             remote_bucket_name, workspace_id, unique_id
         ) as remote_storage_controller:
             await remote_storage_controller.download_experiment(
-                workspace_id, unique_id, sync_mode="all"
+                workspace_id, unique_id, sync_mode=RemoteExperimentSyncMode.ALL
             )
 
         logger.info(f"Background full sync completed for {workspace_id}/{unique_id}")
@@ -245,7 +246,9 @@ async def sync_visualization_files(
             remote_bucket_name, workspace_id, unique_id
         ) as remote_storage_controller:
             result = await remote_storage_controller.download_experiment(
-                workspace_id, unique_id, sync_mode="visualization"
+                workspace_id,
+                unique_id,
+                sync_mode=RemoteExperimentSyncMode.VISUALIZATION,
             )
 
             # Also download input files needed for viewing images
@@ -314,7 +317,9 @@ async def get_thumbnail(
                 remote_bucket_name, workspace_id, unique_id
             ) as remote_storage_controller:
                 await remote_storage_controller.download_experiment(
-                    workspace_id, unique_id, sync_mode="thumbnails_only"
+                    workspace_id,
+                    unique_id,
+                    sync_mode=RemoteExperimentSyncMode.THUMBNAILS_ONLY,
                 )
         except RemoteStorageLockError as e:
             logger.warning(e)
@@ -334,7 +339,9 @@ async def get_thumbnail(
                     remote_bucket_name, workspace_id, unique_id
                 ) as remote_storage_controller:
                     await remote_storage_controller.download_experiment(
-                        workspace_id, unique_id, sync_mode="essential_only"
+                        workspace_id,
+                        unique_id,
+                        sync_mode=RemoteExperimentSyncMode.ESSENTIAL_ONLY,
                     )
             except RemoteStorageLockError as e:
                 logger.warning(e)
@@ -446,7 +453,9 @@ async def _ensure_visualization_synced(dirpath: str, remote_bucket_name: str) ->
             remote_bucket_name, workspace_id, unique_id
         ) as remote_storage_controller:
             await remote_storage_controller.download_experiment(
-                workspace_id, unique_id, sync_mode="visualization"
+                workspace_id,
+                unique_id,
+                sync_mode=RemoteExperimentSyncMode.VISUALIZATION,
             )
             # Also download input files (if snakemake config is available)
             try:

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -10,6 +10,7 @@ from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk_utils import SmkUtils
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentNotFoundError,
     RemoteExperimentSyncMode,
     RemoteStorageController,
     RemoteStorageLockError,
@@ -268,6 +269,9 @@ async def sync_visualization_files(
             except (AssertionError, KeyError):
                 # snakemake.yaml may be empty or missing required keys
                 pass
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.warning(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -327,6 +331,9 @@ async def get_thumbnail(
                     unique_id,
                     sync_mode=sync_mode,
                 )
+        except RemoteExperimentNotFoundError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
         except RemoteStorageLockError as e:
             logger.warning(e)
             raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -350,6 +357,11 @@ async def get_thumbnail(
                         unique_id,
                         sync_mode=sync_mode,
                     )
+            except RemoteExperimentNotFoundError as e:
+                logger.warning(e)
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+                )
             except RemoteStorageLockError as e:
                 logger.warning(e)
                 raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
@@ -477,6 +489,9 @@ async def _ensure_visualization_synced(dirpath: str, remote_bucket_name: str) ->
             except (AssertionError, KeyError):
                 # snakemake.yaml may be empty or missing required keys
                 pass
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except RemoteStorageLockError as e:
         logger.warning(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -360,17 +360,21 @@ async def force_sync_unsynced_experiment(
     )
 
     if is_remote_unsynced:
-        async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
-        ) as remote_storage_controller:
-            result = await remote_storage_controller.download_experiment(
-                workspace_id, unique_id
-            )
-
-            if not result:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="sync remote experiment failed",
+        try:
+            async with RemoteStorageReader(
+                remote_bucket_name, workspace_id, unique_id
+            ) as remote_storage_controller:
+                result = await remote_storage_controller.download_experiment(
+                    workspace_id, unique_id
                 )
+
+                if not result:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="sync remote experiment failed",
+                    )
+        except RemoteStorageLockError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
 
     return True

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -101,7 +101,7 @@ async def fetch_last_experiment(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
     except HTTPException as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise e
     except RemoteStorageLockError as e:
         logger.error(e)
@@ -161,7 +161,7 @@ async def reproduce_experiment(
             )
 
     except HTTPException as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise e
     except RemoteStorageLockError as e:
         logger.error(e)

--- a/studio/app/optinist/routers/roi.py
+++ b/studio/app/optinist/routers/roi.py
@@ -45,17 +45,22 @@ async def ensure_experiment_synced_for_edit(
         logger.info(
             f"Edit ROI: Lazy loading experiment {workspace_id}/{unique_id} from S3"
         )
-        async with RemoteStorageReader(
-            remote_bucket_name, workspace_id, unique_id
-        ) as remote_storage_controller:
-            result = await remote_storage_controller.download_experiment(
-                workspace_id, unique_id
-            )
-            if not result:
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Failed to sync experiment data for Edit ROI",
+
+        try:
+            async with RemoteStorageReader(
+                remote_bucket_name, workspace_id, unique_id
+            ) as remote_storage_controller:
+                result = await remote_storage_controller.download_experiment(
+                    workspace_id, unique_id
                 )
+                if not result:
+                    raise HTTPException(
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        detail="Failed to sync experiment data for Edit ROI",
+                    )
+        except RemoteStorageLockError as e:
+            logger.warning(e)
+            raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
 
 
 @router.post(

--- a/studio/tests/app/common/core/storage/test_file_filter.py
+++ b/studio/tests/app/common/core/storage/test_file_filter.py
@@ -5,10 +5,13 @@ Tests file filtering logic for selective S3 sync operations.
 """
 
 from studio.app.common.core.storage.file_filter import FileSyncFilter
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+)
 
 
 class TestFileSyncFilterAllMode:
-    """Tests for sync_mode='all'"""
+    """Tests for sync_mode=ALL"""
 
     def setup_method(self):
         self.filter = FileSyncFilter()
@@ -24,13 +27,15 @@ class TestFileSyncFilterAllMode:
         ]
 
         for file_path in test_files:
-            should_sync, reason = self.filter.should_sync_file(file_path, "all")
+            should_sync, reason = self.filter.should_sync_file(
+                file_path, RemoteExperimentSyncMode.ALL
+            )
             assert should_sync is True
             assert reason == "sync_mode=all"
 
 
 class TestFileSyncFilterThumbnailsOnlyMode:
-    """Tests for sync_mode='thumbnails_only'"""
+    """Tests for sync_mode=THUMBNAILS_ONLY"""
 
     def setup_method(self):
         self.filter = FileSyncFilter()
@@ -45,7 +50,7 @@ class TestFileSyncFilterThumbnailsOnlyMode:
 
         for file_path in thumb_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "thumbnails_only"
+                file_path, RemoteExperimentSyncMode.THUMBNAILS_ONLY
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "thumbnail file"
@@ -63,14 +68,14 @@ class TestFileSyncFilterThumbnailsOnlyMode:
 
         for file_path in non_thumb_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "thumbnails_only"
+                file_path, RemoteExperimentSyncMode.THUMBNAILS_ONLY
             )
             assert should_sync is False, f"Expected {file_path} to be skipped"
             assert reason == "not needed for thumbnails"
 
 
 class TestFileSyncFilterVisualizationMode:
-    """Tests for sync_mode='visualization'"""
+    """Tests for sync_mode=VISUALIZATION"""
 
     def setup_method(self):
         self.filter = FileSyncFilter()
@@ -85,7 +90,7 @@ class TestFileSyncFilterVisualizationMode:
 
         for file_path in json_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "visualization"
+                file_path, RemoteExperimentSyncMode.VISUALIZATION
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "visualization file"
@@ -101,7 +106,7 @@ class TestFileSyncFilterVisualizationMode:
 
         for file_path in tiff_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "visualization"
+                file_path, RemoteExperimentSyncMode.VISUALIZATION
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "visualization file"
@@ -116,7 +121,7 @@ class TestFileSyncFilterVisualizationMode:
 
         for file_path in yaml_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "visualization"
+                file_path, RemoteExperimentSyncMode.VISUALIZATION
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "visualization file"
@@ -132,14 +137,14 @@ class TestFileSyncFilterVisualizationMode:
 
         for file_path in large_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "visualization"
+                file_path, RemoteExperimentSyncMode.VISUALIZATION
             )
             assert should_sync is False, f"Expected {file_path} to be skipped"
             assert reason == "not needed for visualization"
 
 
 class TestFileSyncFilterEssentialOnlyMode:
-    """Tests for sync_mode='essential_only'"""
+    """Tests for sync_mode=ESSENTIAL_ONLY"""
 
     def setup_method(self):
         self.filter = FileSyncFilter()
@@ -154,7 +159,7 @@ class TestFileSyncFilterEssentialOnlyMode:
 
         for file_path in yaml_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "essential_only"
+                file_path, RemoteExperimentSyncMode.ESSENTIAL_ONLY
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "essential file"
@@ -169,7 +174,7 @@ class TestFileSyncFilterEssentialOnlyMode:
 
         for file_path in json_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "essential_only"
+                file_path, RemoteExperimentSyncMode.ESSENTIAL_ONLY
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "essential file"
@@ -189,7 +194,7 @@ class TestFileSyncFilterEssentialOnlyMode:
 
         for file_path in large_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "essential_only"
+                file_path, RemoteExperimentSyncMode.ESSENTIAL_ONLY
             )
             assert should_sync is False, f"Expected {file_path} to be skipped"
             assert reason == "large file - skipped"
@@ -204,7 +209,7 @@ class TestFileSyncFilterEssentialOnlyMode:
 
         for file_path in unknown_files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "essential_only"
+                file_path, RemoteExperimentSyncMode.ESSENTIAL_ONLY
             )
             assert should_sync is True, f"Expected {file_path} to sync"
             assert reason == "unknown type - synced for safety"
@@ -226,20 +231,20 @@ class TestFileSyncFilterCaseInsensitivity:
 
         for file_path in files:
             should_sync, reason = self.filter.should_sync_file(
-                file_path, "thumbnails_only"
+                file_path, RemoteExperimentSyncMode.THUMBNAILS_ONLY
             )
             assert should_sync is True, f"Expected {file_path} to match"
 
     def test_case_insensitive_extensions(self):
         """Extension matching is case-insensitive"""
         files_by_mode = {
-            "visualization": [
+            RemoteExperimentSyncMode.VISUALIZATION: [
                 ("file.JSON", True),
                 ("file.Json", True),
                 ("file.TIFF", True),
                 ("file.Yaml", True),
             ],
-            "essential_only": [
+            RemoteExperimentSyncMode.ESSENTIAL_ONLY: [
                 ("config.YAML", True),
                 ("data.JSON", True),
                 ("config.YML", True),
@@ -267,9 +272,9 @@ class TestFileSyncFilterPathHandling:
         ]
 
         expected = [
-            ("thumbnails_only", True),
-            ("visualization", True),
-            ("essential_only", True),
+            (RemoteExperimentSyncMode.THUMBNAILS_ONLY, True),
+            (RemoteExperimentSyncMode.VISUALIZATION, True),
+            (RemoteExperimentSyncMode.ESSENTIAL_ONLY, True),
         ]
 
         for path, (mode, should_sync_expected) in zip(s3_paths, expected):
@@ -284,6 +289,8 @@ class TestFileSyncFilterPathHandling:
         ]
 
         for path in nested_paths:
-            should_sync, reason = self.filter.should_sync_file(path, "visualization")
+            should_sync, reason = self.filter.should_sync_file(
+                path, RemoteExperimentSyncMode.VISUALIZATION
+            )
             assert should_sync is True
             assert reason == "visualization file"

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentNotFoundError,
     RemoteExperimentSyncMode,
 )
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
@@ -75,8 +76,8 @@ class TestS3StorageControllerDownloadExperiment:
         self.controller = S3StorageController("test-bucket")
 
     @pytest.mark.asyncio
-    async def test_download_experiment_empty_s3_returns_false(self):
-        """Returns False when S3 prefix has no objects"""
+    async def test_download_experiment_empty_s3_raises_not_found(self):
+        """Raises RemoteExperimentNotFoundError when S3 prefix has no objects"""
         mock_client = AsyncMock()
         mock_client.list_objects_v2.return_value = {"KeyCount": 0}
         mock_client.__aenter__.return_value = mock_client
@@ -87,9 +88,8 @@ class TestS3StorageControllerDownloadExperiment:
             "_S3StorageController__get_s3_client",
             return_value=mock_client,
         ):
-            result = await self.controller.download_experiment("1", "exp123")
-
-        assert result is False
+            with pytest.raises(RemoteExperimentNotFoundError):
+                await self.controller.download_experiment("1", "exp123")
 
     @pytest.mark.asyncio
     async def test_download_experiment_all_mode(self):

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -8,6 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+)
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 
 
@@ -126,7 +129,7 @@ class TestS3StorageControllerDownloadExperiment:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
 
             result = await self.controller.download_experiment(
-                "1", "exp123", sync_mode="all"
+                "1", "exp123", sync_mode=RemoteExperimentSyncMode.ALL
             )
 
         assert result is True
@@ -170,7 +173,7 @@ class TestS3StorageControllerDownloadExperiment:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
 
             result = await self.controller.download_experiment(
-                "1", "exp123", sync_mode="essential_only"
+                "1", "exp123", sync_mode=RemoteExperimentSyncMode.ESSENTIAL_ONLY
             )
 
         assert result is True
@@ -225,7 +228,7 @@ class TestS3StorageControllerDownloadExperiment:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
 
             result = await self.controller.download_experiment(
-                "1", "exp123", sync_mode="thumbnails_only"
+                "1", "exp123", sync_mode=RemoteExperimentSyncMode.THUMBNAILS_ONLY
             )
 
         assert result is True
@@ -273,7 +276,7 @@ class TestS3StorageControllerDownloadExperiment:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
 
             result = await self.controller.download_experiment(
-                "1", "exp123", sync_mode="visualization"
+                "1", "exp123", sync_mode=RemoteExperimentSyncMode.VISUALIZATION
             )
 
         assert result is True

--- a/studio/tests/app/common/routers/test_data_sync.py
+++ b/studio/tests/app/common/routers/test_data_sync.py
@@ -430,8 +430,8 @@ class TestLazySync:
             "studio.app.common.core.storage.remote_storage_controller."
             "RemoteStorageController"
         ) as mock_controller_class, patch(
-            "studio.app.common.core.storage.remote_storage_controller."
-            "RemoteStorageSimpleReader"
+            "studio.app.common.core.experiment.experiment_reader."
+            "RemoteStorageReader"
         ) as mock_reader_class:
             mock_controller_class.is_available.return_value = True
 
@@ -486,8 +486,8 @@ class TestLazySync:
             "studio.app.common.core.storage.remote_storage_controller."
             "RemoteStorageController"
         ) as mock_controller_class, patch(
-            "studio.app.common.core.storage.remote_storage_controller."
-            "RemoteStorageSimpleReader"
+            "studio.app.common.core.experiment.experiment_reader."
+            "RemoteStorageReader"
         ) as mock_reader_class:
             mock_controller_class.is_available.return_value = True
 
@@ -1112,7 +1112,7 @@ class TestDownloadSingleExperiment:
         with patch(
             "studio.app.common.routers.internal." "RemoteStorageController"
         ) as mock_ctrl, patch(
-            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            "studio.app.common.routers.internal." "RemoteStorageReader",
             return_value=mock_reader,
         ), patch(
             "os.path.exists", return_value=False
@@ -1149,7 +1149,7 @@ class TestDownloadSingleExperiment:
         with patch(
             "studio.app.common.routers.internal." "RemoteStorageController"
         ) as mock_ctrl, patch(
-            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            "studio.app.common.routers.internal." "RemoteStorageReader",
             return_value=mock_reader,
         ), patch(
             "os.path.exists", return_value=False
@@ -1182,7 +1182,7 @@ class TestDownloadSingleExperiment:
         with patch(
             "studio.app.common.routers.internal." "RemoteStorageController"
         ) as mock_ctrl, patch(
-            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            "studio.app.common.routers.internal." "RemoteStorageReader",
             return_value=mock_reader,
         ), patch(
             "os.path.exists", return_value=True
@@ -1206,7 +1206,7 @@ class TestDownloadSingleExperiment:
         with patch(
             "studio.app.common.routers.internal." "RemoteStorageController"
         ) as mock_ctrl, patch(
-            "studio.app.common.routers.internal." "RemoteStorageSimpleReader",
+            "studio.app.common.routers.internal." "RemoteStorageReader",
             return_value=mock_reader,
         ), patch(
             "os.path.exists", return_value=False

--- a/studio/tests/app/common/routers/test_data_sync.py
+++ b/studio/tests/app/common/routers/test_data_sync.py
@@ -22,6 +22,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from studio.app.common.core.storage.remote_storage_controller import (
+    RemoteExperimentSyncMode,
+)
+
 # ---------------------------------------------------------------------------
 # Mock aws_constants for Lambda tests (aws_constants is only available in Lambda)
 # Only install if not already loaded (e.g., by infrastructure test conftest)
@@ -430,8 +434,7 @@ class TestLazySync:
             "studio.app.common.core.storage.remote_storage_controller."
             "RemoteStorageController"
         ) as mock_controller_class, patch(
-            "studio.app.common.core.experiment.experiment_reader."
-            "RemoteStorageReader"
+            "studio.app.common.core.experiment.experiment_reader." "RemoteStorageReader"
         ) as mock_reader_class:
             mock_controller_class.is_available.return_value = True
 
@@ -486,8 +489,7 @@ class TestLazySync:
             "studio.app.common.core.storage.remote_storage_controller."
             "RemoteStorageController"
         ) as mock_controller_class, patch(
-            "studio.app.common.core.experiment.experiment_reader."
-            "RemoteStorageReader"
+            "studio.app.common.core.experiment.experiment_reader." "RemoteStorageReader"
         ) as mock_reader_class:
             mock_controller_class.is_available.return_value = True
 
@@ -1132,11 +1134,11 @@ class TestDownloadSingleExperiment:
         calls = mock_reader.download_experiment.call_args_list
         assert calls[0] == (
             ("ws1", "uid1"),
-            {"sync_mode": "thumbnails_only"},
+            {"sync_mode": RemoteExperimentSyncMode.THUMBNAILS_ONLY},
         )
         assert calls[1] == (
             ("ws1", "uid1"),
-            {"sync_mode": "essential_only"},
+            {"sync_mode": RemoteExperimentSyncMode.ESSENTIAL_ONLY},
         )
 
     @pytest.mark.asyncio
@@ -1169,7 +1171,7 @@ class TestDownloadSingleExperiment:
         calls = mock_reader.download_experiment.call_args_list
         assert calls[0] == (
             ("ws1", "uid1"),
-            {"sync_mode": "essential_only"},
+            {"sync_mode": RemoteExperimentSyncMode.ESSENTIAL_ONLY},
         )
 
     @pytest.mark.asyncio

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -283,10 +283,14 @@ class TestPublicDataviewReproduceWorkflow:
             "find_published_dataview_record",
             return_value=mock_record,
         ):
-            with patch("os.path.exists", return_value=True):
+            with patch(
+                "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+                "check_sync_status_unsynced",
+                return_value=False,
+            ):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        "studio.app.common.routers.dataview.RemoteStorageReader",
                         return_value=mock_remote_reader,
                     ):
                         with patch(
@@ -327,10 +331,14 @@ class TestPublicDataviewReproduceWorkflow:
             "find_published_dataview_record",
             return_value=mock_record,
         ):
-            with patch("os.path.exists", return_value=True):
+            with patch(
+                "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+                "check_sync_status_unsynced",
+                return_value=False,
+            ):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        "studio.app.common.routers.dataview.RemoteStorageReader",
                         return_value=mock_remote_reader,
                     ):
                         with patch(
@@ -371,10 +379,14 @@ class TestPublicDataviewReproduceWorkflow:
             "find_published_dataview_record",
             return_value=mock_record,
         ):
-            with patch("os.path.exists", return_value=False):
+            with patch(
+                "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+                "check_sync_status_unsynced",
+                return_value=True,
+            ):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        "studio.app.common.routers.dataview.RemoteStorageReader",
                         return_value=mock_remote_reader,
                     ):
                         with patch(
@@ -419,10 +431,14 @@ class TestPublicDataviewReproduceWorkflow:
             "find_published_dataview_record",
             return_value=mock_record,
         ):
-            with patch("os.path.exists", return_value=True):
+            with patch(
+                "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+                "check_sync_status_unsynced",
+                return_value=False,
+            ):
                 with patch("os.environ.get", return_value="test-bucket"):
                     with patch(
-                        "studio.app.common.routers.dataview.RemoteStorageSimpleReader",
+                        "studio.app.common.routers.dataview.RemoteStorageReader",
                         return_value=mock_remote_reader,
                     ):
                         with patch(


### PR DESCRIPTION
## Content

このPRでは、以下で起案されている問題への対処を行っている
（remote storage (S3) からの experiment data の download で、不要な重複downloadが発生している問題）
- #358
- #361

### 対応内容

#### 1. 適切な Remote data reader module が適切に利用されていなかった構成を改善

- remote expriment の dwonload (download_experiment()) に、RemoteStorageSimpleReader が利用されていたが、以下の問題があった
  - RemoteStorageSimpleReader では、 同一 expriment の download に対する排他処理の機構がなく、同一 expriment の重複downloadが許容されていた（負荷面やデータの整合性面で課題）
- 上記に対して、適切な Reader module の利用に置き換える（RemoteStorageReader）
- また、単に RemoteStorageSimpleReader→RemoteStorageReader へ置き換えるだけでは、ロジックやUIの面で不整合が生じていたため、必要な調整を適用
  - RemoteStorageReader 内に、処理ステータスファイル（REMOTE_SYNC_STATUS_FILE）の更新判定ロジックを追加
  - 重複downloadをblockした際の状態を、UIへ適切に反映（エラー表示や自動Retry処理など）

#### 2. 現行コードに対する各種のRefactoring

- download_experiment の mode指定（sync_mode）が、文字列型であり、コードの可読性・メンテナンス性に課題があった
  - 専用の Status class （RemoteExperimentSyncMode(Enum)）を用意し対処

- 処理ステータスファイル（REMOTE_SYNC_STATUS_FILE）の構造化（dict型→dataclass化）

#### 3. 現行コードのその他不具合の改善

- remote に存在しない experiment の dowload 要求（404 error）を行った場合、ローカルに不要な空ファイル（experiment.yaml等）が生成されていた動作を改善
- remote に存在しない experiment の dowload 要求（404 error）を行った場合、frontend へ適切なエラーレスポンス（HTTP_404_NOT_FOUND）を応答する様にエラー処理を整理

## Testcase

### remote expriment の 重複dwonload発生の改善を確認

- [x] ログから重複dwonloadの発生の解消を確認
  - 手順:
    1. local container から experiment data を削除し、remote expriment の downloadが発生する状態を用意
    2. Dataview page (pubic, private) にて、remote expriment の download request を同時発生させる（複数ブラウザからのoutput dialog の同時表示など）
  - 期待結果:
    - 修正前には記録されていた、以下のような重複 dwonload のログが記録されていないこと
      ```
      2026-02-18 17:36:30,985 INFO:     [optinist] (pid:67) (client:default) download_experiment():829 - Download data from S3 [optinist-user-48-bc1d0b98d4] (15/43) app/studio_data/output/113/36aed3fc/caiman_cnmf_t28ssmgpcz/images.json (334,303 bytes)
      2026-02-18 17:36:31,059 INFO:     [optinist] (pid:66) (client:default) download_experiment():829 - Download data from S3 [optinist-user-48-bc1d0b98d4] (15/43) app/studio_data/output/113/36aed3fc/caiman_cnmf_t28ssmgpcz/images.json (334,303 bytes)
      2026-02-18 17:36:31,073 INFO:     [optinist] (pid:67) (client:default) download_experiment():829 - Download data from S3 [optinist-user-48-bc1d0b98d4] (16/43) app/studio_data/output/113/36aed3fc/caiman_cnmf_t28ssmgpcz/non_cell_roi.json (365,680 bytes)
      2026-02-18 17:36:31,130 INFO:     [optinist] (pid:65) (client:default) download_experiment():829 - Download data from S3 [optinist-user-48-bc1d0b98d4] (16/43) app/studio_data/output/113/36aed3fc/caiman_cnmf_t28ssmgpcz/non_cell_roi.json (365,680 bytes)
      ```
    - ※もし重複dwonloadがリクエストされた場合は、423 error が記録される仕様となっている

- [x] UIの確認
  - [x] 重複dwonloadをリクエストした場合（HTTP_423_LOCKEDが応答された場合）は、UI上以下の表示となること
    - Dataview > List thumbnail
      - <img width="300" height="177" alt="screen-thumbnail" src="https://github.com/user-attachments/assets/248ec513-24b8-4054-8309-9ec812dc2364" />
    - Dataview > Input view
      - <img width="877" height="326" alt="screen-output-view" src="https://github.com/user-attachments/assets/4eec8225-6353-4baf-a946-d2bf3a161b24" />
    - Dataview > Output view
      - <img width="877" height="327" alt="screen-input-view" src="https://github.com/user-attachments/assets/2320c6fd-4d9d-4c31-8137-5e91c16277b9" />
    - Dataview > Detail view
      - <img width="857" height="358" alt="screen-detail-view" src="https://github.com/user-attachments/assets/b67b72a2-e852-4929-b6ce-58233a3c6b38" />

- [x] Retry UIの動作
  - RetryのUI表示時、一定期間（10秒間隔 x 30回）でRetryが実行され、他リクエストのdownloadが終了後、データが自動表示されること
    - Dataview > Input view
    - Dataview > Output view
    - Dataview > Detail view

- [x] その他 現行機能の正常動作を確認
  - [x] Workflow実行
  - [x] Record画面操作（表示/変更/削除）
  - [x] Visualize画面操作
  - [x] Dataview > publish/unpublish
