### PR TITLE
Premium popup fix and logging

### DIFF
--- a/frontend/src/api/premium/PremiumAssignmentApi.ts
+++ b/frontend/src/api/premium/PremiumAssignmentApi.ts
@@ -103,3 +103,21 @@ export const sendPremiumHeartbeat =
 
 export const getBeaconTokenApi = () =>
   axios.get<{ token: string }>("/users/me/premium/beacon-token")
+
+/**
+ * Log a premium UI event to the backend (CloudWatch) for timing correlation.
+ */
+export const logPremiumUiEvent = async (
+  eventType: string,
+  details?: Record<string, unknown>,
+): Promise<void> => {
+  try {
+    await axios.post("/users/me/premium/ui-event", {
+      event_type: eventType,
+      timestamp_ms: Date.now(),
+      details: details ?? {},
+    })
+  } catch {
+    // Non-critical logging; swallow errors silently
+  }
+}

--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -8,12 +8,12 @@ import { FC, useEffect, useRef, useState } from "react"
 
 import { useSnackbar } from "notistack"
 
+import { logPremiumUiEvent } from "api/premium/PremiumAssignmentApi"
 import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
 const PremiumNotificationManager: FC = () => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
-  const { isPremiumUser, assignmentResult, error, isAssigning } =
-    usePremiumAssignment()
+  const { isPremiumUser, assignmentResult, error } = usePremiumAssignment()
 
   const [hasShownAssignmentSuccess, setHasShownAssignmentSuccess] =
     useState(false)
@@ -45,6 +45,9 @@ const PremiumNotificationManager: FC = () => {
           autoHideDuration: 5000,
         },
       )
+      logPremiumUiEvent("dedicated_instance_ready", {
+        instance_id: assignmentResult.instance_id,
+      })
 
       setHasShownAssignmentSuccess(true)
       setLastAssignmentId(assignmentResult.instance_id)
@@ -58,10 +61,9 @@ const PremiumNotificationManager: FC = () => {
     enqueueSnackbar,
   ])
 
-  // Show waiting snackbar when premium user does not have
-  // a dedicated instance (covers shared, scaling, not-yet-assigned)
+  // Show waiting snackbar when premium user does not have a dedicated instance.
   useEffect(() => {
-    if (isPremiumUser && !hasDedicatedInstance && !isAssigning) {
+    if (isPremiumUser && !hasDedicatedInstance) {
       if (!waitingKeyRef.current) {
         const key = enqueueSnackbar(
           "Please wait while your dedicated premium " +
@@ -72,17 +74,25 @@ const PremiumNotificationManager: FC = () => {
           },
         )
         waitingKeyRef.current = key
+        logPremiumUiEvent("waiting_popup_shown", {
+          has_assignment: !!assignmentResult,
+          is_shared: assignmentResult?.is_shared ?? null,
+          instance_id: assignmentResult?.instance_id ?? null,
+        })
       }
     }
 
     if (hasDedicatedInstance && waitingKeyRef.current) {
+      logPremiumUiEvent("waiting_popup_dismissed", {
+        instance_id: assignmentResult?.instance_id ?? null,
+      })
       closeSnackbar(waitingKeyRef.current)
       waitingKeyRef.current = null
     }
   }, [
     isPremiumUser,
     hasDedicatedInstance,
-    isAssigning,
+    assignmentResult,
     enqueueSnackbar,
     closeSnackbar,
   ])

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -388,6 +388,31 @@ async def send_premium_heartbeat(current_user: User = Depends(get_current_user))
         }
 
 
+@router.post("/premium/ui-event")
+async def log_premium_ui_event(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Log a frontend premium UI event to backend logs (CloudWatch).
+    Lightweight endpoint for correlating UI timing with backend events.
+    """
+    body = await request.json()
+    event_type = body.get("event_type", "unknown")
+    timestamp_ms = body.get("timestamp_ms")
+    details = body.get("details", {})
+
+    logger.info(
+        "Premium UI event: user=%s (uid: %s) event=%s timestamp_ms=%s details=%s",
+        current_user.id,
+        current_user.uid,
+        event_type,
+        timestamp_ms,
+        details,
+    )
+    return {"logged": True}
+
+
 @router.put("", response_model=User)
 async def update_me(
     data: SelfUserUpdate,


### PR DESCRIPTION
### Content

#### Files changed

**Frontend**
- `frontend/src/components/Premium/PremiumNotificationManager.tsx` -- Remove `!isAssigning` guard that prevented the "Please wait" popup from appearing immediately on premium user login; add `logPremiumUiEvent` calls for popup shown, dismissed, and dedicated instance ready events
- `frontend/src/api/premium/PremiumAssignmentApi.ts` -- Add `logPremiumUiEvent()` fire-and-forget API function to send UI timing events to the backend

**Backend**
- `studio/app/common/routers/users_me.py` -- Add `POST /users/me/premium/ui-event` endpoint that logs frontend premium UI events via `logger.info` for CloudWatch visibility

#### Design Decisions
- **Removed `!isAssigning` instead of fixing it**: `autoAssignOnLogin()` never sets `isAssigning = true` (it calls APIs inline, bypassing the `assign()` wrapper), so the guard was effectively a race-condition trap — it could suppress the popup when `assign()` was called from other code paths. Removing it makes the condition simply `isPremiumUser && !hasDedicatedInstance`, which is the correct semantic.
- **Fire-and-forget logging**: `logPremiumUiEvent` swallows errors silently. These are diagnostic logs, not user-facing features — a failure to log must never affect the user experience.
- **Raw `Request.json()` on the backend**: Used `Request` instead of a Pydantic model to keep the endpoint minimal and flexible for arbitrary event details. This is a logging-only endpoint with no persistence or validation requirements.
- **Three events, not more**: Only `waiting_popup_shown`, `waiting_popup_dismissed`, and `dedicated_instance_ready` are logged. All other state transitions (assign calls, polling, migration) are already captured by existing backend logs. Adding more would be noise.

### References
- Observed during manual testing: premium user login showed no "Please wait" popup for several minutes, making it appear the system was unresponsive.
- CloudWatch log groups used for correlation: `/ecs/subscr-optinist-cloud-taskdef` (where UI events land, since the popup fires before ALB routes to the premium instance).

### Manual Testcases
1. **Premium user login — popup appears immediately**
   - Sign in as a premium user with no active dedicated instance
   - Expected: "Please wait while your dedicated premium resource is being prepared" popup appears within 1-2 seconds of page load
   - Check CloudWatch `/ecs/subscr-optinist-cloud-taskdef` for `"Premium UI event"` with `event=waiting_popup_shown`
2. **Dedicated instance becomes ready — popup dismissed**
   - Wait for the dedicated instance to be assigned (polling or migration completes)
   - Expected: waiting popup dismissed, success toast "Premium instance assigned successfully!" appears
   - Check CloudWatch for `event=waiting_popup_dismissed` followed by `event=dedicated_instance_ready`
3. **Non-premium user — no popup**
   - Sign in as a free-tier user
   - Expected: no premium popups shown, no `ui-event` requests in network tab

### Unit, Integration, Contract Test Coverage
- No new tests — logging-only change with a UI bug fix. The notification manager is a presentational component; the premium assignment context has existing test coverage.

### Others

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Premium notification popup | Low | Removed a guard condition; popup now shows in strictly more cases (`isPremiumUser && !hasDedicatedInstance`), which is the intended behavior |
| UI event logging endpoint | Low | Logging-only, no side effects, authenticated, errors swallowed on frontend |
| Existing premium assignment flow | Low | No changes to assignment logic, polling, or routing — only the notification layer is touched |
