### PR TITLE
Fix/private dataview reproduce

### DIFF
--- a/frontend/src/api/dataview/Dataview.ts
+++ b/frontend/src/api/dataview/Dataview.ts
@@ -20,6 +20,16 @@ export const getDataviewRecordsApi = async (
   return response.data
 }
 
+export async function privateDataviewReproduceWorkflowApi(
+  workspaceId: number,
+  uid: string,
+): Promise<WorkflowWithResultDTO> {
+  const response = await axios.get(
+    `/api/dataview/workflow/reproduce/${workspaceId}/${uid}`,
+  )
+  return response.data
+}
+
 export async function publicDataviewReproduceWorkflowApi(
   workspaceId: number,
   uid: string,

--- a/frontend/src/components/Dataview/BaseNodesView.tsx
+++ b/frontend/src/components/Dataview/BaseNodesView.tsx
@@ -26,7 +26,10 @@ import { SyncStatusView } from "components/Dataview/SyncStatusView"
 import { useSyncRetry } from "components/Dataview/useSyncRetry"
 import { DisplayDataItem } from "components/Workspace/Visualize/DisplayDataItem"
 import { WORKSPACE_TYPE } from "const/Workspace"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { DATA_TYPE } from "store/slice/DisplayData/DisplayDataType"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
 import { clearCurrentPipeline } from "store/slice/Pipeline/PipelineSlice"
@@ -152,7 +155,9 @@ const BaseNodesView = ({
   const dispatch = useDispatch<AppDispatch>()
 
   const fetchFn = useCallback(() => {
-    const api = is_public ? publicDataviewReproduceWorkflow : reproduceWorkflow
+    const api = is_public
+      ? publicDataviewReproduceWorkflow
+      : privateDataviewReproduceWorkflow
     return dispatch(api({ workspaceId: workspaceId!, uid: uid! })).unwrap()
   }, [dispatch, is_public, workspaceId, uid])
 

--- a/frontend/src/components/Dataview/WorkflowDetailsView.tsx
+++ b/frontend/src/components/Dataview/WorkflowDetailsView.tsx
@@ -24,7 +24,10 @@ import Loading from "components/common/Loading"
 import { SyncStatusView } from "components/Dataview/SyncStatusView"
 import { useSyncRetry } from "components/Dataview/useSyncRetry"
 import { WORKSPACE_TYPE } from "const/Workspace"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { DataviewType } from "store/slice/Dataview/DataviewType"
 import { selectFlowNodes } from "store/slice/FlowElement/FlowElementSelectors"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
@@ -75,7 +78,9 @@ export const WorkflowDetailsView = ({
   })
 
   const fetchFn = useCallback(() => {
-    const api = is_public ? publicDataviewReproduceWorkflow : reproduceWorkflow
+    const api = is_public
+      ? publicDataviewReproduceWorkflow
+      : privateDataviewReproduceWorkflow
     return dispatch(
       api({
         workspaceId: dataviewRecord!.workspace.id,

--- a/frontend/src/components/Dataview/useSyncRetry.ts
+++ b/frontend/src/components/Dataview/useSyncRetry.ts
@@ -43,7 +43,7 @@ export const useSyncRetry = ({
       .catch((error) => {
         setLoading(false)
 
-        if (is_public && error?.response) {
+        if (error?.response) {
           const status = error.response.status
           const data = error.response.data
 

--- a/frontend/src/store/slice/Dataview/DataviewActions.ts
+++ b/frontend/src/store/slice/Dataview/DataviewActions.ts
@@ -5,6 +5,7 @@ import {
   getPublicDataviewRecordsApi,
   postPublishAllApi,
   postPublishApi,
+  privateDataviewReproduceWorkflowApi,
   publicDataviewReproduceWorkflowApi,
   putAttributesApi,
 } from "api/dataview/Dataview"
@@ -40,6 +41,24 @@ export const getPublicDataviewRecords = createAsyncThunk<
       return response
     } catch (e) {
       return rejectWithValue(e)
+    }
+  },
+)
+
+export const privateDataviewReproduceWorkflow = createAsyncThunk<
+  WorkflowWithResultDTO,
+  { workspaceId: number; uid: string }
+>(
+  `${DATAVIEW_SLICE_NAME}/privateDataviewReproduceWorkflow`,
+  async ({ workspaceId, uid }, thunkAPI) => {
+    try {
+      const response = await privateDataviewReproduceWorkflowApi(
+        workspaceId,
+        uid,
+      )
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
     }
   },
 )

--- a/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
@@ -20,7 +20,10 @@ import {
   INITIAL_IMAGE_ELEMENT_NAME,
 } from "const/flowchart"
 import { WORKSPACE_TYPE } from "const/Workspace"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { uploadFile } from "store/slice/FileUploader/FileUploaderActions"
 import {
   addAlgorithmNode,
@@ -272,6 +275,7 @@ export const flowElementSlice = createSlice({
           importWorkflowConfig.fulfilled,
           fetchWorkflow.fulfilled,
           reproduceWorkflow.fulfilled,
+          privateDataviewReproduceWorkflow.fulfilled,
           publicDataviewReproduceWorkflow.fulfilled,
         ),
         (state, action) => {

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -4,7 +4,10 @@ import { isInputNodePostData } from "api/run/RunUtils"
 import { INITIAL_IMAGE_ELEMENT_ID } from "const/flowchart"
 import { WORKSPACE_TYPE } from "const/Workspace"
 import { FileNodeFactory } from "factories/FileNodeFactory"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { uploadFile } from "store/slice/FileUploader/FileUploaderActions"
 import { addInputNode } from "store/slice/FlowElement/FlowElementActions"
 import {
@@ -234,6 +237,7 @@ export const inputNodeSlice = createSlice({
         isAnyOf(
           fetchWorkflow.fulfilled,
           reproduceWorkflow.fulfilled,
+          privateDataviewReproduceWorkflow.fulfilled,
           publicDataviewReproduceWorkflow.fulfilled,
         ),
         (state, action) => {

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,7 +1,10 @@
 import { createSlice, isAnyOf, PayloadAction } from "@reduxjs/toolkit"
 
 import { COMPLETE_STATUS } from "api/run/Run"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { convertFunctionsToRunResultDTO } from "store/slice/Experiments/ExperimentsUtils"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
 import {
@@ -96,6 +99,7 @@ export const pipelineSlice = createSlice({
         isAnyOf(
           fetchWorkflow.fulfilled,
           reproduceWorkflow.fulfilled,
+          privateDataviewReproduceWorkflow.fulfilled,
           publicDataviewReproduceWorkflow.fulfilled,
         ),
         (state, action) => {
@@ -159,6 +163,7 @@ export const pipelineSlice = createSlice({
         isAnyOf(
           fetchWorkflow.rejected,
           reproduceWorkflow.rejected,
+          privateDataviewReproduceWorkflow.rejected,
           publicDataviewReproduceWorkflow.rejected,
           clearFlowElements,
         ),

--- a/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
@@ -1,7 +1,10 @@
 import { PayloadAction, createSlice, isAnyOf } from "@reduxjs/toolkit"
 
 import { StatusROI } from "components/Workspace/Visualize/Plot/ImagePlot"
-import { publicDataviewReproduceWorkflow } from "store/slice/Dataview/DataviewActions"
+import {
+  privateDataviewReproduceWorkflow,
+  publicDataviewReproduceWorkflow,
+} from "store/slice/Dataview/DataviewActions"
 import { reproduceWorkflow } from "store/slice/Workflow/WorkflowActions"
 import {
   delWorkspace,
@@ -65,6 +68,10 @@ export const workspaceSlice = createSlice({
   extraReducers(builder) {
     builder
       .addCase(reproduceWorkflow.fulfilled, (state, action) => {
+        state.currentWorkspace.workspaceId = action.meta.arg.workspaceId
+        state.currentWorkspace.selectedTab = 0
+      })
+      .addCase(privateDataviewReproduceWorkflow.fulfilled, (state, action) => {
         state.currentWorkspace.workspaceId = action.meta.arg.workspaceId
         state.currentWorkspace.selectedTab = 0
       })

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -179,6 +179,29 @@ class DataviewService:
     OUTPUTS_IMAGE_URL_PREFIX = r"^/outputs/image/"
 
     @classmethod
+    def find_dataview_record(
+        cls, db: Session, workspace_id: int, unique_id: str
+    ) -> ExperimentRecord:
+        """
+        Search for a experiment_record that matches the specified id
+        """
+        record: ExperimentRecord = (
+            db.query(ExperimentRecord)
+            .join(
+                Workspace,
+                Workspace.id == ExperimentRecord.workspace_id,
+            )
+            .filter(
+                Workspace.deleted.is_(False),
+                ExperimentRecord.workspace_id == int(workspace_id),
+                ExperimentRecord.uid == unique_id,
+            )
+            .first()
+        )
+
+        return record
+
+    @classmethod
     def find_published_dataview_record(
         cls, db: Session, workspace_id: int, unique_id: str
     ) -> ExperimentRecord:

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -180,12 +180,16 @@ class DataviewService:
 
     @classmethod
     def find_dataview_record(
-        cls, db: Session, workspace_id: int, unique_id: str
+        cls,
+        db: Session,
+        workspace_id: int,
+        unique_id: str,
+        published_only: bool = False,
     ) -> ExperimentRecord:
         """
         Search for a experiment_record that matches the specified id
         """
-        record: ExperimentRecord = (
+        query = (
             db.query(ExperimentRecord)
             .join(
                 Workspace,
@@ -196,34 +200,14 @@ class DataviewService:
                 ExperimentRecord.workspace_id == int(workspace_id),
                 ExperimentRecord.uid == unique_id,
             )
-            .first()
         )
 
-        return record
-
-    @classmethod
-    def find_published_dataview_record(
-        cls, db: Session, workspace_id: int, unique_id: str
-    ) -> ExperimentRecord:
-        """
-        Search for a published experiment_record that matches the specified id
-        """
-        record: ExperimentRecord = (
-            db.query(ExperimentRecord)
-            .join(
-                Workspace,
-                Workspace.id == ExperimentRecord.workspace_id,
-            )
-            .filter(
-                Workspace.deleted.is_(False),
-                ExperimentRecord.workspace_id == int(workspace_id),
-                ExperimentRecord.uid == unique_id,
+        if published_only:
+            query = query.filter(
                 ExperimentRecord.publish_status == PublishStatus.on.value,
             )
-            .first()
-        )
 
-        return record
+        return query.first()
 
     @classmethod
     def find_published_dataview_record_input(
@@ -324,8 +308,8 @@ class DataviewService:
         # Request case for output data
         if workspace_id and unique_id:
             # Check whether the data is in a public record
-            record = DataviewService.find_published_dataview_record(
-                db, int(workspace_id), unique_id
+            record = DataviewService.find_dataview_record(
+                db, int(workspace_id), unique_id, published_only=True
             )
             is_allowed_access = record is not None
 

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -215,8 +215,8 @@ async def public_reproduce_experiment(
     db: Session = Depends(get_db),
 ):
     # Check target record accessibility
-    record = DataviewService.find_published_dataview_record(
-        db, int(workspace_id), unique_id
+    record = DataviewService.find_dataview_record(
+        db, int(workspace_id), unique_id, published_only=True
     )
 
     if not record:

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -23,6 +23,9 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteSyncStatusFileUtil,
 )
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
+from studio.app.common.core.workspace.workspace_dependencies import (
+    is_workspace_available,
+)
 from studio.app.common.db.database import get_db
 from studio.app.common.routers.workflow import reproduce_experiment
 from studio.app.common.schemas.base import SortDirection, SortOptions
@@ -301,7 +304,7 @@ async def public_reproduce_experiment(
 
 async def _ensure_experiment_downloaded(
     db: Session, workspace_id: str, unique_id: str
-) -> None:
+) -> Optional[JSONResponse]:
     """
     Download experiment data from remote storage (S3) to local EBS if needed.
     Resolves the owner's bucket from the workspace record.
@@ -396,6 +399,7 @@ async def _validate_experiment_exists_in_s3(
 @router.get(
     "/workflow/reproduce/{workspace_id}/{unique_id}",
     response_model=WorkflowWithResults,
+    dependencies=[Depends(is_workspace_available)],
     description="""
 - Dataview access wrapper for `GET /workflow/reproduce`
 """,

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -205,7 +205,7 @@ async def search_dataview_records(
     "/workflow/reproduce/{workspace_id}/{unique_id}",
     response_model=WorkflowWithResults,
     description="""
-- Public access wrapper for `GET /workflow/reproduce`
+- Public Dataview access wrapper for `GET /workflow/reproduce`
 - Returns 202 if experiment is published but not yet synced
 """,
 )
@@ -238,49 +238,11 @@ async def public_reproduce_experiment(
         needs_sync = is_unsynced
 
     if needs_sync:
-        # Get owner's bucket from workspace
-        workspace = (
-            db.query(models.Workspace)
-            .filter(models.Workspace.id == int(workspace_id))
-            .first()
+        download_error = await _ensure_experiment_downloaded(
+            db, workspace_id, unique_id
         )
-        owner_bucket = None
-        if workspace and workspace.user:
-            owner_bucket = getattr(workspace.user, "remote_bucket_name", None)
-        remote_bucket_name = owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
-
-        try:
-            async with RemoteStorageReader(
-                remote_bucket_name, workspace_id, unique_id
-            ) as remote_storage_controller:
-                logger.info(
-                    f"Downloading published experiment {workspace_id}/{unique_id} "
-                    f"from remote bucket {remote_bucket_name}"
-                )
-                available = await remote_storage_controller.download_experiment(
-                    workspace_id,
-                    unique_id,
-                )
-
-                if not available:
-                    logger.error(
-                        f"Failed to download experiment {workspace_id}/{unique_id} "
-                        f"from remote bucket {remote_bucket_name}"
-                    )
-                    return JSONResponse(
-                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        content={
-                            "status": "download_error",
-                            "message": "Failed to load experiment data, "
-                            "please try again later",
-                        },
-                    )
-        except RemoteExperimentNotFoundError as e:
-            logger.warning(e)
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-        except RemoteStorageLockError as e:
-            logger.warning(e)
-            raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
+        if download_error is not None:
+            return download_error
 
     # Validate experiment is displayable (checks if required files exist locally)
     # This should be done BEFORE checking sync status, because on-demand download
@@ -337,6 +299,66 @@ async def public_reproduce_experiment(
     return await reproduce_experiment(workspace_id, unique_id)
 
 
+async def _ensure_experiment_downloaded(
+    db: Session, workspace_id: str, unique_id: str
+) -> None:
+    """
+    Download experiment data from remote storage (S3) to local EBS if needed.
+    Resolves the owner's bucket from the workspace record.
+
+    Raises:
+        HTTPException(404): If experiment not found in remote storage
+        HTTPException(423): If remote storage is locked
+
+    Returns JSONResponse(503) via raise-like return if download fails,
+    so callers must check the return value.
+    """
+    workspace = (
+        db.query(models.Workspace)
+        .filter(models.Workspace.id == int(workspace_id))
+        .first()
+    )
+    owner_bucket = None
+    if workspace and workspace.user:
+        owner_bucket = getattr(workspace.user, "remote_bucket_name", None)
+    remote_bucket_name = owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
+
+    try:
+        async with RemoteStorageReader(
+            remote_bucket_name, workspace_id, unique_id
+        ) as remote_storage_controller:
+            logger.info(
+                f"Downloading dataview experiment {workspace_id}/{unique_id} "
+                f"from remote bucket {remote_bucket_name}"
+            )
+            available = await remote_storage_controller.download_experiment(
+                workspace_id,
+                unique_id,
+            )
+
+            if not available:
+                logger.error(
+                    f"Failed to download experiment {workspace_id}/{unique_id} "
+                    f"from remote bucket {remote_bucket_name}"
+                )
+                return JSONResponse(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    content={
+                        "status": "download_error",
+                        "message": "Failed to load experiment data, "
+                        "please try again later",
+                    },
+                )
+    except RemoteExperimentNotFoundError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except RemoteStorageLockError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
+
+    return None
+
+
 async def _validate_experiment_exists_in_s3(
     workspace_id: str, unique_id: str, bucket_name: str
 ) -> Tuple[bool, Optional[str]]:
@@ -369,6 +391,41 @@ async def _validate_experiment_exists_in_s3(
         return False, f"Could not verify S3 data: {str(e)}"
 
     return True, None
+
+
+@router.get(
+    "/workflow/reproduce/{workspace_id}/{unique_id}",
+    response_model=WorkflowWithResults,
+    description="""
+- Dataview access wrapper for `GET /workflow/reproduce`
+""",
+)
+async def private_reproduce_experiment(
+    workspace_id: str,
+    unique_id: str,
+    db: Session = Depends(get_db),
+):
+    # Check target record accessibility
+    record = DataviewService.find_dataview_record(db, int(workspace_id), unique_id)
+
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    # Ensure experiment is available on local EBS (download from S3 if needed)
+    # Also try to sync if status is pending/error - the local data might be incomplete
+    is_unsynced = RemoteSyncStatusFileUtil.check_sync_status_unsynced(
+        workspace_id, unique_id
+    )
+    needs_sync = is_unsynced
+
+    if needs_sync:
+        download_error = await _ensure_experiment_downloaded(
+            db, workspace_id, unique_id
+        )
+        if download_error is not None:
+            return download_error
+
+    return await reproduce_experiment(workspace_id, unique_id)
 
 
 @router.post(

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -280,7 +280,7 @@ class TestPublicDataviewReproduceWorkflow:
 
         with patch(
             "studio.app.common.routers.dataview.DataviewService."
-            "find_published_dataview_record",
+            "find_dataview_record",
             return_value=mock_record,
         ):
             with patch(
@@ -328,7 +328,7 @@ class TestPublicDataviewReproduceWorkflow:
 
         with patch(
             "studio.app.common.routers.dataview.DataviewService."
-            "find_published_dataview_record",
+            "find_dataview_record",
             return_value=mock_record,
         ):
             with patch(
@@ -376,7 +376,7 @@ class TestPublicDataviewReproduceWorkflow:
 
         with patch(
             "studio.app.common.routers.dataview.DataviewService."
-            "find_published_dataview_record",
+            "find_dataview_record",
             return_value=mock_record,
         ):
             with patch(
@@ -428,7 +428,7 @@ class TestPublicDataviewReproduceWorkflow:
 
         with patch(
             "studio.app.common.routers.dataview.DataviewService."
-            "find_published_dataview_record",
+            "find_dataview_record",
             return_value=mock_record,
         ):
             with patch(


### PR DESCRIPTION
## Content

### 問題

- Private dataview page (管理UI内のdataview) において、以下の問題が生じていた。
  - ECS container の作成直後（まだexperiment dataのダウンロード完了前）に、dataview page の Output viewを表示すると、`Remote data is temporary locked` 等の複数のエラーが plot box に表示された。

### 要因・対策

- 要因
  - Private dataview page の reproduce 処理で、Public dataview page で適用されているような、データ同期を考慮した処理が不足していた。
- 対策
  - Private dataview page の reproduce 処理へ、Public dataview page と同様のデータ同期処理を追加した。

## Testcase

- 前提:
  - 2つのブラウザを利用
  - テスト用の experiment data の id は仮に "experiment_1" とする
  - テスト用の experiment は任意だが、Tutorial 1 を利用可能
  - container local に "experiment_1" が同期前の状態を用意（手動で local の "experiment_1" directory を事前削除しておくなど）
- テスト実施手順:
  1. browser 1 から、private dataview page で、experiment_1 の output view を表示 → 同期処理中(loading icon表示)となる 
  2. \1. の処理中に、browser 2 から、private dataview page で、同じ experiment_1 の output view を表示 → 同期処理中(Retry中表示)となる 
  3. その後 同期処理 完了後に以下を確認
      1. browser 1 に、 各 output の plot が全て正常に表示される
      2. browser 2 にも、 自動Retryにより、各 output の plot が全て正常に表示される
