### PR TITLE
Fix/premium popup 2

### DIFF
--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -13,7 +13,13 @@ import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
 const PremiumNotificationManager: FC = () => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
-  const { isPremiumUser, assignmentResult, error } = usePremiumAssignment()
+  const {
+    isPremiumUser,
+    assignmentResult,
+    error,
+    isAssigning,
+    isRetryableError,
+  } = usePremiumAssignment()
 
   const [hasShownAssignmentSuccess, setHasShownAssignmentSuccess] =
     useState(false)
@@ -63,8 +69,12 @@ const PremiumNotificationManager: FC = () => {
   ])
 
   // Show waiting snackbar when premium user does not have a dedicated instance.
+  // Two triggers: isAssigning (assignment API in flight) or assignmentResult
+  // shows a shared instance. Gate prevents flash on refresh before status check.
   useEffect(() => {
-    if (isPremiumUser && assignmentResult && !hasDedicatedInstance) {
+    const needsWaiting =
+      isAssigning || (assignmentResult && !hasDedicatedInstance)
+    if (isPremiumUser && needsWaiting) {
       if (!waitingKeyRef.current) {
         const key = enqueueSnackbar(
           "Please wait while your dedicated premium " +
@@ -76,6 +86,7 @@ const PremiumNotificationManager: FC = () => {
         )
         waitingKeyRef.current = key
         logPremiumUiEvent("waiting_popup_shown", {
+          is_assigning: isAssigning,
           has_assignment: !!assignmentResult,
           is_shared: assignmentResult?.is_shared ?? null,
           instance_id: assignmentResult?.instance_id ?? null,
@@ -83,15 +94,21 @@ const PremiumNotificationManager: FC = () => {
       }
     }
 
-    if (hasDedicatedInstance && waitingKeyRef.current) {
+    // Dismiss when: dedicated instance ready, OR assignment released/cleared
+    if (
+      waitingKeyRef.current &&
+      (hasDedicatedInstance || (!isAssigning && !assignmentResult))
+    ) {
       logPremiumUiEvent("waiting_popup_dismissed", {
         instance_id: assignmentResult?.instance_id ?? null,
+        reason: hasDedicatedInstance ? "dedicated_ready" : "assignment_cleared",
       })
       closeSnackbar(waitingKeyRef.current)
       waitingKeyRef.current = null
     }
   }, [
     isPremiumUser,
+    isAssigning,
     hasDedicatedInstance,
     assignmentResult,
     enqueueSnackbar,
@@ -101,7 +118,17 @@ const PremiumNotificationManager: FC = () => {
   // Show error notification for assignment failures
   useEffect(() => {
     if (isPremiumUser && error && !hasShownError) {
-      if (!error.includes("scaling") && !error.includes("retry")) {
+      if (!isRetryableError) {
+        // Dismiss waiting popup before showing error so they don't overlap
+        if (waitingKeyRef.current) {
+          logPremiumUiEvent("waiting_popup_dismissed", {
+            instance_id: assignmentResult?.instance_id ?? null,
+            reason: "error_shown",
+          })
+          closeSnackbar(waitingKeyRef.current)
+          waitingKeyRef.current = null
+        }
+
         enqueueSnackbar(
           "Premium assignment issue: " +
             `${error}. Falling back to shared resources.`,
@@ -114,7 +141,15 @@ const PremiumNotificationManager: FC = () => {
         setHasShownError(true)
       }
     }
-  }, [isPremiumUser, error, hasShownError, enqueueSnackbar])
+  }, [
+    isPremiumUser,
+    error,
+    isRetryableError,
+    hasShownError,
+    assignmentResult,
+    enqueueSnackbar,
+    closeSnackbar,
+  ])
 
   // Reset notification flags when user changes or errors clear
   useEffect(() => {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -63,6 +63,7 @@ interface PremiumAssignmentState {
   statusResult: PremiumStatusResult | null
   routingInfo: RoutingInfo | null
   error: string | null
+  isRetryableError: boolean
   isPremiumUser: boolean
   showInactivityWarning: boolean
   lastActivityTime: number
@@ -106,6 +107,7 @@ export const PremiumAssignmentProvider: React.FC<{
     statusResult: null,
     routingInfo: null,
     error: null,
+    isRetryableError: false,
     isPremiumUser: false,
     showInactivityWarning: false,
     lastActivityTime: Date.now(),
@@ -156,6 +158,7 @@ export const PremiumAssignmentProvider: React.FC<{
         statusResult: null,
         routingInfo: null,
         error: null,
+        isRetryableError: false,
         isPremiumUser: false,
         showInactivityWarning: false,
         lastActivityTime: Date.now(),
@@ -278,16 +281,25 @@ export const PremiumAssignmentProvider: React.FC<{
         return null
       }
 
-      setState((prev) => ({ ...prev, isAssigning: true, error: null }))
+      setState((prev) => ({
+        ...prev,
+        isAssigning: true,
+        error: null,
+        isRetryableError: false,
+      }))
 
       try {
         const result = await assignPremiumInstance()
+        const isRetryable =
+          !result.assigned &&
+          (result.scaling_in_progress || result.retry_after != null)
 
         setState((prev) => ({
           ...prev,
           isAssigning: false,
           assignmentResult: result,
           error: result.assigned ? null : result.message,
+          isRetryableError: isRetryable,
         }))
 
         if (result.assigned) {
@@ -321,6 +333,7 @@ export const PremiumAssignmentProvider: React.FC<{
           ...prev,
           isAssigning: false,
           error: errorMessage,
+          isRetryableError: false,
         }))
         return null
       }
@@ -417,6 +430,7 @@ export const PremiumAssignmentProvider: React.FC<{
           ...prev,
           assignmentResult,
           error: null,
+          isRetryableError: false,
         }))
         routingService.setPremiumAssigned(true)
         try {
@@ -427,6 +441,7 @@ export const PremiumAssignmentProvider: React.FC<{
         }
         return
       }
+      setState((prev) => ({ ...prev, isAssigning: true }))
 
       // Attempt assignment directly (inline to avoid dependency issues)
       const assignmentResponse = await assignPremiumInstance()
@@ -434,6 +449,7 @@ export const PremiumAssignmentProvider: React.FC<{
         // Update state to reflect the assignment
         setState((prev) => ({
           ...prev,
+          isAssigning: false,
           assignmentResult: assignmentResponse,
           error: null,
         }))
@@ -444,10 +460,34 @@ export const PremiumAssignmentProvider: React.FC<{
         } catch {
           // Non-critical; beacon will fail gracefully
         }
+      } else {
+        // Only store assignmentResult for transient errors (scaling/retry)
+        // so the waiting popup stays visible and polling retries.
+        // For non-retryable errors, leave assignmentResult null to prevent
+        // contradictory polling + "Falling back to shared" notification.
+        const isRetryable =
+          assignmentResponse.scaling_in_progress ||
+          assignmentResponse.retry_after != null
+        setState((prev) => ({
+          ...prev,
+          isAssigning: false,
+          assignmentResult: isRetryable ? assignmentResponse : null,
+          error: assignmentResponse.message || null,
+          isRetryableError: isRetryable,
+        }))
       }
     } catch (error) {
+      // Set error state so the error notification fires
+      const errorMessage =
+        error instanceof Error ? error.message : "Assignment failed"
       // eslint-disable-next-line no-console
       console.warn("Auto-assignment failed:", error)
+      setState((prev) => ({
+        ...prev,
+        isAssigning: false,
+        error: errorMessage,
+        isRetryableError: false,
+      }))
       routingService.clearRoutingInfo()
     }
   }, [isPremiumUser, hasAttemptedAutoAssignment])
@@ -597,11 +637,13 @@ export const PremiumAssignmentProvider: React.FC<{
   // Poll for premium instance when user is on temporary shared instance
   // Only the leader tab polls to prevent duplicate API calls
   useEffect(() => {
+    const hasDedicated =
+      state.assignmentResult?.assigned && !state.assignmentResult?.is_shared
     const shouldPoll =
       isPremiumUser &&
       isTabLeader &&
-      state.assignmentResult?.assigned &&
-      state.assignmentResult?.is_shared
+      state.assignmentResult != null &&
+      !hasDedicated
 
     if (!shouldPoll) {
       return
@@ -618,6 +660,7 @@ export const PremiumAssignmentProvider: React.FC<{
         error:
           "No premium instance available after extended wait. " +
           "Please try again later or contact support.",
+        isRetryableError: false,
       }))
       return
     }
@@ -639,6 +682,7 @@ export const PremiumAssignmentProvider: React.FC<{
             ...prev,
             assignmentResult: result,
             error: null,
+            isRetryableError: false,
           }))
           // Reset polling state on success
           setPollInterval(INITIAL_POLL_INTERVAL_MS)


### PR DESCRIPTION
### Content

#### Summary
- The premium "Please wait" popup previously did not appear until the assignment API responded, leaving a gap after login with no user feedback. It now shows immediately when the assignment call begins via a new `isAssigning` trigger.
- The popup dismiss logic was incomplete -- it only dismissed on dedicated instance ready. It now also dismisses when the assignment is cleared (non-retryable error or release) and explicitly before showing an error notification to prevent overlap.
- Error classification in the notification manager used fragile `error.includes("scaling"/"retry")` string matching. Replaced with a structured `isRetryableError` boolean set at the source in the context provider.
- The `autoAssignOnLogin` catch block previously swallowed errors silently. It now sets `error` state so the notification manager can display them. The else branch (assignment not granted) now distinguishes retryable vs non-retryable responses -- retryable ones keep `assignmentResult` for polling, non-retryable ones clear it.
- Polling condition broadened from `assigned && is_shared` to `assignmentResult != null && !hasDedicated` so polling also covers retryable failure responses (e.g. scaling in progress).

#### Design Decisions
- **`isAssigning` triggers the waiting popup** -- Shows feedback immediately on login rather than waiting for the first API round-trip. Prevents a confusing blank period where nothing appears to happen.
- **Dismiss on `!isAssigning && !assignmentResult`** -- Covers the case where assignment fails entirely (no result stored). Without this, the persistent waiting popup would never dismiss on non-retryable errors.
- **Dismiss waiting popup before showing error** -- Prevents two overlapping snackbars (waiting + error) from confusing the user.
- **`isRetryableError` in context state, not derived in notification manager** -- The context already computes retryability to decide whether to store `assignmentResult` for polling. Keeping the flag at the source prevents the notification manager from needing to know about API response shape (`scaling_in_progress`, `retry_after`).
- **Retryable vs non-retryable split in `autoAssignOnLogin` else branch** -- Non-retryable errors clear `assignmentResult` to prevent contradictory behavior (polling + "Falling back to shared" notification simultaneously). Retryable errors keep it so polling continues.

### Evidence
- `npx tsc --noEmit` passes with no errors in either modified file.

### References
- Related commits on `develop-subscription`: `6586ad59` (assignmentResult refresh fix), `97cfb2be` (remove isAssigning from popup)

#### Files changed
- `frontend/src/contexts/PremiumAssignmentContext.tsx` -- Add `isRetryableError` to state interface/init/reset; set `isAssigning` flag in `autoAssignOnLogin`; add retryable vs non-retryable else branch; propagate error in catch block; broaden polling condition to cover non-dedicated results; set `isRetryableError` at every error path
- `frontend/src/components/Premium/PremiumNotificationManager.tsx` -- Consume `isAssigning` and `isRetryableError` from context; trigger waiting popup on `isAssigning`; add dismiss conditions for assignment-cleared and error-shown; replace `error.includes()` with `!isRetryableError`; add `reason` and `is_assigning` to log events; fix exhaustive deps

### Manual Testcases
- **Immediate feedback on login:** Log in as a premium user with no existing assignment. Verify the "Please wait" popup appears immediately (during the API call), not after the response.
- **Dedicated instance ready:** Wait for dedicated instance assignment. Verify the waiting popup dismisses and the success notification appears.
- **Retryable error (scaling):** Simulate a backend response with `scaling_in_progress: true`. Verify the waiting popup stays visible, no "Falling back to shared" warning appears, and polling retries.
- **Non-retryable error:** Simulate a backend response with `assigned: false` and no scaling/retry fields. Verify the waiting popup dismisses and the "Falling back to shared" warning appears (no overlap).
- **Network error:** Disconnect network during auto-assign. Verify the waiting popup dismisses and the error notification fires.
- **Page refresh while on shared instance:** Refresh while assigned to a shared instance. Verify no popup flash -- the waiting popup appears only after the status check confirms a shared assignment.
- **Backend message wording independence:** Change the backend error message text. Verify notification behavior is unchanged (proves no string-matching dependency).
- `npx tsc --noEmit` -- no new type errors

### Unit, Integration, Contract Test Coverage
- No new tests added. Changes are UI notification timing and classification logic; existing behavior is preserved with a more robust mechanism.

### Others

#### Difficulties
- Needed to audit every `setState` call that touches `error` (eleven call sites) to ensure `isRetryableError` stays in sync. Explicit `false` at every non-retryable path prevents stale `true` values leaking across error transitions.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Waiting popup timing | Medium | New `isAssigning` trigger shows popup earlier; verify no flash on refresh before status check completes |
| Error notification overlap | Low | Explicit dismiss-before-error prevents stacking; second dismiss is a no-op via null check on ref |
| Error classification | Low | Strictly more correct than string matching; same two categories (retryable / not) |
| Polling condition broadening | Medium | Now polls on any non-dedicated `assignmentResult`; verify no unnecessary polling when `assigned: false` with non-retryable error (mitigated by clearing `assignmentResult` to null) |
| State shape change | Low | New `isRetryableError` field defaults `false`; only the notification manager reads it |
