### PR TITLE
Add flushSync to premium popup

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback,
   useRef,
 } from "react"
+import { flushSync } from "react-dom"
 import { useSelector } from "react-redux"
 
 import {
@@ -441,7 +442,10 @@ export const PremiumAssignmentProvider: React.FC<{
         }
         return
       }
-      setState((prev) => ({ ...prev, isAssigning: true }))
+
+      flushSync(() => {
+        setState((prev) => ({ ...prev, isAssigning: true }))
+      })
 
       // Attempt assignment directly (inline to avoid dependency issues)
       const assignmentResponse = await assignPremiumInstance()


### PR DESCRIPTION
### Content
Fix a race condition where React's batched rendering could skip showing the "assigning" popup if the async
  call resolved quickly, not a page-refresh issue.

In React 18, state updates inside event handlers and async functions are batched by default. Without flushSync, React might delay rendering isAssigning: true until after the await assignPremiumInstance() call starts (or even completes). This means the user could briefly see no popup at all during the assignment request.

With flushSync, React is forced to synchronously flush the state update and re-render before execution continues to the await line. This guarantees the waiting/assigning popup is visible to the user the instant the assignment process begins, with no visual gap.

### Changes
`frontend/src/contexts/PremiumAssignmentContext.tsx`
- Wrap the setState({ isAssigning: true }) call in flushSync() from react-dom.     