### PR TITLE
Fix/thumbnail placeholder type image

### DIFF
--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -32,7 +32,7 @@ from studio.app.common.schemas.dataview import (
     PublishValidationResult,
 )
 from studio.app.common.schemas.workflow import WorkflowConfig
-from studio.app.const import ThumbnailConst, ThumbnailType
+from studio.app.const import ThumbnailType
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -506,22 +506,19 @@ class DataviewService:
             ThumbnailGenerator,
         )
 
-        thumb_dir = join_filepath(
-            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, ThumbnailConst.DIRNAME]
-        )
-
         input_thumb_path = None
         roi_thumb_path = None
 
         # Generate input thumbnail
         if image_path:
-            abs_image_path = cls._resolve_image_path(workspace_id, image_path)
+            abs_image_path = ThumbnailGenerator.resolve_source_path(
+                workspace_id, image_path
+            )
+            input_thumb_path = ThumbnailGenerator.get_thumbnail_path(
+                workspace_id, unique_id, ThumbnailType.INPUT
+            )
             try:
-                create_directory(thumb_dir)
-                input_thumb_path = join_filepath(
-                    [thumb_dir, ThumbnailType.INPUT.filename]
-                )
-
+                create_directory(os.path.dirname(input_thumb_path))
                 ThumbnailGenerator.generate_input_thumbnail(
                     source_path=image_path,
                     output_path=input_thumb_path,
@@ -534,15 +531,15 @@ class DataviewService:
 
         # Generate ROI thumbnail from cell_roi.json
         if roi_path:
-            abs_roi_path = roi_path
-            if not os.path.isabs(roi_path):
-                abs_roi_path = join_filepath([DIRPATH.OUTPUT_DIR, roi_path])
-            if os.path.exists(abs_roi_path):
+            abs_roi_path = ThumbnailGenerator.resolve_source_path(
+                workspace_id, roi_path
+            )
+            if abs_roi_path:
+                roi_thumb_path = ThumbnailGenerator.get_thumbnail_path(
+                    workspace_id, unique_id, ThumbnailType.ROI
+                )
                 try:
-                    create_directory(thumb_dir)
-                    roi_thumb_path = join_filepath(
-                        [thumb_dir, ThumbnailType.ROI.filename]
-                    )
+                    create_directory(os.path.dirname(roi_thumb_path))
                     ThumbnailGenerator.generate_roi_thumbnail(
                         abs_roi_path, roi_thumb_path
                     )
@@ -557,25 +554,3 @@ class DataviewService:
             ),
             roi_url=normalize_output_path(roi_thumb_path) if roi_thumb_path else None,
         )
-
-    @classmethod
-    def _resolve_image_path(cls, workspace_id: str, image_path: str) -> Optional[str]:
-        """
-        Resolve image path to absolute path.
-        Input images can be in the input directory (just filename) or output directory.
-        """
-        if os.path.isabs(image_path) and os.path.exists(image_path):
-            return image_path
-
-        # Try as relative path from output dir
-        abs_path = join_filepath([DIRPATH.OUTPUT_DIR, image_path])
-        if os.path.exists(abs_path):
-            return abs_path
-
-        # Try as input file (just filename)
-        filename = os.path.basename(image_path)
-        input_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filename])
-        if os.path.exists(input_path):
-            return input_path
-
-        return None

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -522,28 +522,12 @@ class DataviewService:
                     [thumb_dir, ThumbnailType.INPUT.filename]
                 )
 
-                # Check if it's a TIFF file that we can render
-                if ThumbnailGenerator.can_generate_tiff_thumbnail(image_path):
-                    if abs_image_path and os.path.exists(abs_image_path):
-                        ThumbnailGenerator.generate_tiff_thumbnail(
-                            abs_image_path, input_thumb_path
-                        )
-                        logger.debug(f"Generated TIFF thumbnail: {input_thumb_path}")
-                    else:
-                        # TIFF file not found locally, generate placeholder
-                        ThumbnailGenerator.generate_placeholder_thumbnail(
-                            input_thumb_path, file_path=image_path
-                        )
-                        logger.debug(
-                            f"Generated placeholder thumbnail (TIFF not found): "
-                            f"{input_thumb_path}"
-                        )
-                else:
-                    # Non-TIFF file (HDF5, MAT, microscope, etc.) - generate placeholder
-                    ThumbnailGenerator.generate_placeholder_thumbnail(
-                        input_thumb_path, file_path=image_path
-                    )
-                    logger.debug(f"Generated placeholder thumbnail: {input_thumb_path}")
+                ThumbnailGenerator.generate_input_thumbnail(
+                    source_path=image_path,
+                    output_path=input_thumb_path,
+                    abs_source_path=abs_image_path,
+                )
+                logger.debug(f"Generated input thumbnail: {input_thumb_path}")
             except Exception as e:
                 logger.warning(f"Failed to generate input thumbnail: {e}")
                 input_thumb_path = None

--- a/studio/app/common/core/dataview/thumbnail_generator.py
+++ b/studio/app/common/core/dataview/thumbnail_generator.py
@@ -2,16 +2,78 @@
 
 import json
 import os
+from typing import Optional
 
 import imageio.v3 as imageio
 import numpy as np
 import tifffile
 
-from studio.app.const import EXTENSION_LABELS
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.const import EXTENSION_LABELS, ThumbnailConst, ThumbnailType
+from studio.app.dir_path import DIRPATH
 
 
 class ThumbnailGenerator:
     """Utility class for generating PNG thumbnails from various sources."""
+
+    @classmethod
+    def get_thumbnail_path(
+        cls, workspace_id: str, unique_id: str, thumb_type: ThumbnailType
+    ) -> str:
+        """
+        Get the absolute path for a thumbnail PNG.
+
+        Args:
+            workspace_id: Workspace identifier
+            unique_id: Experiment unique identifier
+            thumb_type: ThumbnailType.INPUT or ThumbnailType.ROI
+
+        Returns:
+            Absolute path to the thumbnail PNG file
+        """
+        return join_filepath(
+            [
+                DIRPATH.OUTPUT_DIR,
+                workspace_id,
+                unique_id,
+                ThumbnailConst.DIRNAME,
+                thumb_type.filename,
+            ]
+        )
+
+    @classmethod
+    def resolve_source_path(cls, workspace_id: str, file_path: str) -> Optional[str]:
+        """
+        Resolve a source file path to an absolute path.
+
+        Tries in order:
+        1. Already absolute and exists → return as-is
+        2. Relative from OUTPUT_DIR → return if exists
+        3. Basename in INPUT_DIR/workspace_id → return if exists
+        4. None if not found
+
+        Args:
+            workspace_id: Workspace identifier
+            file_path: File path (absolute, relative, or just filename)
+
+        Returns:
+            Absolute path if found, None otherwise
+        """
+        if os.path.isabs(file_path) and os.path.exists(file_path):
+            return file_path
+
+        # Try as relative path from output dir
+        abs_path = join_filepath([DIRPATH.OUTPUT_DIR, file_path])
+        if os.path.exists(abs_path):
+            return abs_path
+
+        # Try as input file (just filename)
+        filename = os.path.basename(file_path)
+        input_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filename])
+        if os.path.exists(input_path):
+            return input_path
+
+        return None
 
     @classmethod
     def generate_tiff_thumbnail(

--- a/studio/app/common/core/dataview/thumbnail_generator.py
+++ b/studio/app/common/core/dataview/thumbnail_generator.py
@@ -182,7 +182,7 @@ class ThumbnailGenerator:
         output_path: str,
         file_path: str = None,
         label: str = None,
-        size: int = 512,
+        size: int = 256,
     ) -> None:
         """
         Generate a placeholder PNG thumbnail with text label.
@@ -195,7 +195,7 @@ class ThumbnailGenerator:
             output_path: Path to save PNG thumbnail
             file_path: Optional source file path (used to detect type from extension)
             label: Optional explicit label text (overrides file_path detection)
-            size: Thumbnail size in pixels (default 512px)
+            size: Thumbnail size in pixels (default 256px)
         """
         # Determine label from file extension if not provided
         if label is None and file_path:
@@ -300,6 +300,33 @@ class ThumbnailGenerator:
                             for dx in range(scale):
                                 if 0 <= py + dy < h and 0 <= px + dx < w:
                                     img[py + dy, px + dx] = text_color
+
+    @classmethod
+    def generate_input_thumbnail(
+        cls, source_path: str, output_path: str, abs_source_path: str = None
+    ) -> None:
+        """
+        Generate an input thumbnail, choosing the right strategy automatically.
+
+        - TIFF file exists locally → render first frame as grayscale
+        - TIFF file not found locally → placeholder with file type label
+        - Non-TIFF file (HDF5, MAT, etc.) → placeholder with file type label
+
+        Args:
+            source_path: Original file path (used for extension detection and label)
+            output_path: Path to save the PNG thumbnail
+            abs_source_path: Absolute path to the source file for reading.
+                If None, uses source_path directly.
+        """
+        resolved = abs_source_path or source_path
+
+        if cls.can_generate_tiff_thumbnail(source_path):
+            if resolved and os.path.exists(resolved):
+                cls.generate_tiff_thumbnail(resolved, output_path)
+            else:
+                cls.generate_placeholder_thumbnail(output_path, file_path=source_path)
+        else:
+            cls.generate_placeholder_thumbnail(output_path, file_path=source_path)
 
     @classmethod
     def can_generate_tiff_thumbnail(cls, file_path: str) -> bool:

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -130,15 +130,27 @@ async def get_or_generate_thumbnail(
                 workspace_id, unique_id, original_path, thumb_type
             )
 
-    # Generate thumbnail if original file now exists
-    if os.path.exists(abs_original_path):
+    # Generate thumbnail
+    # - INPUT: always generates (TIFF render if file exists, placeholder if not)
+    # - ROI: requires the source file to exist
+    can_generate = False
+    if thumb_type == ThumbnailType.INPUT:
+        can_generate = True  # generate_input_thumbnail handles missing files
+    elif os.path.exists(abs_original_path):
+        can_generate = True
+
+    if can_generate:
         try:
             thumb_dir = os.path.dirname(thumb_path)
             create_directory(thumb_dir)
 
             if thumb_type == ThumbnailType.INPUT:
-                ThumbnailGenerator.generate_tiff_thumbnail(
-                    abs_original_path, thumb_path
+                ThumbnailGenerator.generate_input_thumbnail(
+                    source_path=original_path,
+                    output_path=thumb_path,
+                    abs_source_path=(
+                        abs_original_path if os.path.exists(abs_original_path) else None
+                    ),
                 )
             else:
                 ThumbnailGenerator.generate_roi_thumbnail(abs_original_path, thumb_path)

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 
 from studio.app.common.core.auth.auth_dependencies import get_outputs_remote_bucket_name
+from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk_utils import SmkUtils
@@ -31,42 +32,12 @@ from studio.app.common.core.workspace.workspace_dependencies import (
 )
 from studio.app.common.dataclass.timeseries_chunk_handler import TimeSeriesChunkHandler
 from studio.app.common.schemas.outputs import JsonTimeSeriesData, OutputData
-from studio.app.const import (
-    ACCEPT_FILE_EXT,
-    ORIGINAL_DATA_EXT,
-    ThumbnailConst,
-    ThumbnailType,
-)
+from studio.app.const import ACCEPT_FILE_EXT, ORIGINAL_DATA_EXT, ThumbnailType
 from studio.app.dir_path import DIRPATH
 
 router = APIRouter(prefix="/outputs", tags=["outputs"])
 
 logger = AppLogger.get_logger()
-
-
-def _get_thumbnail_png_path(
-    workspace_id: str, unique_id: str, thumb_type: ThumbnailType
-) -> str:
-    """
-    Get the expected path for a thumbnail PNG.
-
-    Args:
-        workspace_id: Workspace identifier
-        unique_id: Experiment unique identifier
-        thumb_type: ThumbnailType.INPUT or ThumbnailType.ROI
-
-    Returns:
-        Absolute path to the thumbnail PNG file
-    """
-    return join_filepath(
-        [
-            DIRPATH.OUTPUT_DIR,
-            workspace_id,
-            unique_id,
-            ThumbnailConst.DIRNAME,
-            thumb_type.filename,
-        ]
-    )
 
 
 async def get_or_generate_thumbnail(
@@ -98,28 +69,21 @@ async def get_or_generate_thumbnail(
     Returns:
         Path to the thumbnail PNG file (may be newly generated)
     """
-    from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
-    from studio.app.common.core.utils.filepath_creater import create_directory
-
-    thumb_path = _get_thumbnail_png_path(workspace_id, unique_id, thumb_type)
+    thumb_path = ThumbnailGenerator.get_thumbnail_path(
+        workspace_id, unique_id, thumb_type
+    )
 
     # Check if PNG thumbnail already exists
     if os.path.exists(thumb_path):
         return normalize_output_path(thumb_path)
 
     # Resolve the original file path
-    abs_original_path = original_path
-    if not os.path.isabs(original_path):
-        # Try output directory first
-        abs_original_path = join_filepath([DIRPATH.OUTPUT_DIR, original_path])
-
-    # For input files (TIFFs), the path might be just a filename
-    if thumb_type == ThumbnailType.INPUT and not os.path.exists(abs_original_path):
-        filename = os.path.basename(original_path)
-        abs_original_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filename])
+    abs_original_path = ThumbnailGenerator.resolve_source_path(
+        workspace_id, original_path
+    )
 
     # Download from remote storage if needed
-    if not os.path.exists(abs_original_path) and RemoteStorageController.is_available():
+    if abs_original_path is None and RemoteStorageController.is_available():
         async with RemoteStorageReader(
             remote_bucket_name,
             workspace_id,
@@ -129,6 +93,10 @@ async def get_or_generate_thumbnail(
             await remote_storage_controller.download_thumbnail_source(
                 workspace_id, unique_id, original_path, thumb_type
             )
+        # Re-resolve after download
+        abs_original_path = ThumbnailGenerator.resolve_source_path(
+            workspace_id, original_path
+        )
 
     # Generate thumbnail
     # - INPUT: always generates (TIFF render if file exists, placeholder if not)
@@ -136,21 +104,18 @@ async def get_or_generate_thumbnail(
     can_generate = False
     if thumb_type == ThumbnailType.INPUT:
         can_generate = True  # generate_input_thumbnail handles missing files
-    elif os.path.exists(abs_original_path):
+    elif abs_original_path is not None:
         can_generate = True
 
     if can_generate:
         try:
-            thumb_dir = os.path.dirname(thumb_path)
-            create_directory(thumb_dir)
+            create_directory(os.path.dirname(thumb_path))
 
             if thumb_type == ThumbnailType.INPUT:
                 ThumbnailGenerator.generate_input_thumbnail(
                     source_path=original_path,
                     output_path=thumb_path,
-                    abs_source_path=(
-                        abs_original_path if os.path.exists(abs_original_path) else None
-                    ),
+                    abs_source_path=abs_original_path,
                 )
             else:
                 ThumbnailGenerator.generate_roi_thumbnail(abs_original_path, thumb_path)
@@ -329,7 +294,9 @@ async def get_thumbnail(
     """
 
     # Get the expected thumbnail path
-    thumb_path = _get_thumbnail_png_path(workspace_id, unique_id, thumb_type)
+    thumb_path = ThumbnailGenerator.get_thumbnail_path(
+        workspace_id, unique_id, thumb_type
+    )
 
     # Try to sync thumbnail from remote storage if not available locally
     if not os.path.exists(thumb_path) and RemoteStorageController.is_available():
@@ -426,7 +393,9 @@ async def get_thumbnail(
             workspace_id, unique_id, original_path, remote_bucket_name, thumb_type
         )
         # Re-get the absolute path since generation should have created the file
-        thumb_path = _get_thumbnail_png_path(workspace_id, unique_id, thumb_type)
+        thumb_path = ThumbnailGenerator.get_thumbnail_path(
+            workspace_id, unique_id, thumb_type
+        )
 
     # Check if thumbnail exists after all attempts
     if not os.path.exists(thumb_path):

--- a/studio/app/const.py
+++ b/studio/app/const.py
@@ -39,7 +39,7 @@ FRONTEND_URL = get_env_var("FRONTEND_URL", default="http://localhost:3000")
 
 # File sync patterns for selective sync
 ESSENTIAL_SYNC_PATTERNS = (".yaml", ".yml", ".json")
-LARGE_FILE_PATTERNS = tuple(ACCEPT_FILE_EXT.ALL_EXT.value + [".pkl"])
+LARGE_FILE_PATTERNS = tuple(ACCEPT_FILE_EXT.ALL_EXT.value + [".pkl", ".bin", ".npy"])
 # Visualization mode: JSON for timeseries data, TIFF for images,
 # YAML for snakemake config
 VISUALIZATION_SYNC_PATTERNS = (".json", ".tif", ".tiff", ".yaml")


### PR DESCRIPTION
## Content

### 不具合

Workflow の Input が 非Image data (HDF5、 MAT) の場合、簡素な thumbnail が作成されるが、
この thumbnail が、remote storage からの experiment data同期（download）のタイミングでは、生成されていなかった。
そのため、container local に 対象の experiment (workflow) を 初回downloadした際、thumbnail 表示が必ずリンク切れとなっ
ていた。
- thumbnailリンク切れ
  <img width="172" height="207" alt="image" src="https://github.com/user-attachments/assets/9a6af4a6-1096-426f-bc0b-d31ac8fffb3f" />

### 対策

- experiment data同期（download）時にも、適切な thumbnail 生成処理を追加
- また同時に thumbnail モジュールのコードへrefactoringを適用（コード共通化など）

### Testcase

- [x] Workflow実行後のthumbnail生成
  - Tutorial 1 … dataview で image thumbnail, roi thumbnail, が表示される
  - Tutorial 4 … dataview で "Data" thumbnail, roi thumbnail, が表示される

- [x] experiment data同期（download）実行後のthubmnail生成
  - Tutorial 1 … dataview で image thumbnail, roi thumbnail, が表示される
  - Tutorial 4 … dataview で "Data" thumbnail, roi thumbnail, が表示される
