### PR TITLE
Fix false assigning popup on refresh because hasAttemptedAutoAssignment

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -53,6 +53,35 @@ const MAX_POLL_ATTEMPTS = 40
 const BACKOFF_MULTIPLIER = 1.5
 const ERROR_BACKOFF_MULTIPLIER = 2
 
+// sessionStorage keys — per-tab persistence across page refreshes.
+// Clears automatically when the tab closes.
+const SS_HAS_ATTEMPTED = "premium_hasAttempted"
+const SS_POLL_ATTEMPTS = "premium_pollAttempts"
+
+function ssRead(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function ssWrite(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value)
+  } catch {
+    // sessionStorage unavailable (e.g., some private browsing modes)
+  }
+}
+
+function ssRemove(key: string): void {
+  try {
+    sessionStorage.removeItem(key)
+  } catch {
+    // sessionStorage unavailable
+  }
+}
+
 // Heartbeat retry configuration (Case 49)
 const HEARTBEAT_MAX_RETRIES = 3
 const HEARTBEAT_RETRY_DELAY_MS = 1000
@@ -115,13 +144,26 @@ export const PremiumAssignmentProvider: React.FC<{
     heartbeatFailing: false,
   })
 
-  // Flag to prevent multiple auto-assignment attempts per session
-  const [hasAttemptedAutoAssignment, setHasAttemptedAutoAssignment] =
-    useState(false)
+  // Ref guard to prevent multiple auto-assignment attempts per mount.
+  // useRef (not useState) so the flag is set synchronously and survives
+  // StrictMode double-invocations without triggering extra renders.
+  const hasAttemptedRef = useRef(ssRead(SS_HAS_ATTEMPTED) === "true")
 
   // Polling state with backoff
   const [pollInterval, setPollInterval] = useState(INITIAL_POLL_INTERVAL_MS)
-  const [pollAttempts, setPollAttempts] = useState(0)
+  const [pollAttempts, setPollAttempts] = useState(() => {
+    const stored = ssRead(SS_POLL_ATTEMPTS)
+    return stored ? parseInt(stored, 10) || 0 : 0
+  })
+
+  // Sync pollAttempts to sessionStorage so the cap survives page refreshes
+  useEffect(() => {
+    if (pollAttempts > 0) {
+      ssWrite(SS_POLL_ATTEMPTS, String(pollAttempts))
+    } else {
+      ssRemove(SS_POLL_ATTEMPTS)
+    }
+  }, [pollAttempts])
 
   // Cross-tab leader election for coordinating polling
   const [isTabLeader, setIsTabLeader] = useState(false)
@@ -145,7 +187,9 @@ export const PremiumAssignmentProvider: React.FC<{
 
   // Reset flag when user changes
   useEffect(() => {
-    setHasAttemptedAutoAssignment(false)
+    hasAttemptedRef.current = false
+    ssRemove(SS_HAS_ATTEMPTED)
+    ssRemove(SS_POLL_ATTEMPTS)
   }, [currentUser?.id])
 
   // Reset state when logout generation changes to prevent stale closures
@@ -165,7 +209,9 @@ export const PremiumAssignmentProvider: React.FC<{
         lastActivityTime: Date.now(),
         heartbeatFailing: false,
       })
-      setHasAttemptedAutoAssignment(false)
+      hasAttemptedRef.current = false
+      ssRemove(SS_HAS_ATTEMPTED)
+      ssRemove(SS_POLL_ATTEMPTS)
     }
     // Only run on logoutGeneration change, not initial mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -410,10 +456,10 @@ export const PremiumAssignmentProvider: React.FC<{
    * Auto-assign on premium user login (fully isolated to prevent loops)
    */
   const autoAssignOnLogin = useCallback(async () => {
-    if (!isPremiumUser || hasAttemptedAutoAssignment) return
+    if (!isPremiumUser || hasAttemptedRef.current) return
 
     // Set flag immediately to prevent duplicate calls
-    setHasAttemptedAutoAssignment(true)
+    hasAttemptedRef.current = true
 
     try {
       // Check current status first (inline to avoid dependency issues)
@@ -440,6 +486,7 @@ export const PremiumAssignmentProvider: React.FC<{
         } catch {
           // Non-critical; beacon will fail gracefully
         }
+        ssWrite(SS_HAS_ATTEMPTED, "true")
         return
       }
 
@@ -480,6 +527,9 @@ export const PremiumAssignmentProvider: React.FC<{
           isRetryableError: isRetryable,
         }))
       }
+      // Persist only after a successful status/assign round-trip.
+      // On network error (catch below), leave unpersisted so refresh retries.
+      ssWrite(SS_HAS_ATTEMPTED, "true")
     } catch (error) {
       // Set error state so the error notification fires
       const errorMessage =
@@ -494,7 +544,7 @@ export const PremiumAssignmentProvider: React.FC<{
       }))
       routingService.clearRoutingInfo()
     }
-  }, [isPremiumUser, hasAttemptedAutoAssignment])
+  }, [isPremiumUser])
 
   /**
    * Auto-release on logout via sendBeacon.
@@ -620,15 +670,9 @@ export const PremiumAssignmentProvider: React.FC<{
       console.log("Conditions not met for auto-assignment:", {
         isPremiumUser,
         hasCurrentUser: !!currentUser,
-        hasAttemptedAutoAssignment,
       })
     }
-  }, [
-    isPremiumUser,
-    currentUser,
-    hasAttemptedAutoAssignment,
-    autoAssignOnLogin,
-  ])
+  }, [isPremiumUser, currentUser, autoAssignOnLogin])
 
   // Reset polling state when user changes or gets a dedicated instance
   useEffect(() => {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -464,6 +464,11 @@ export const PremiumAssignmentProvider: React.FC<{
     try {
       // Check current status first (inline to avoid dependency issues)
       const statusResponse = await getPremiumStatus()
+      if (statusResponse?.error) {
+        // Lambda failed transiently — don't trigger assignment flow.
+        // Not persisted to sessionStorage, so page refresh retries.
+        return
+      }
       if (statusResponse?.assignment) {
         // User already has an assignment - update state immediately so notifications trigger
         // Convert PremiumAssignment to PremiumAssignmentResult format

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -153,14 +153,15 @@ export const PremiumAssignmentProvider: React.FC<{
   const [pollInterval, setPollInterval] = useState(INITIAL_POLL_INTERVAL_MS)
   const [pollAttempts, setPollAttempts] = useState(() => {
     const stored = ssRead(SS_POLL_ATTEMPTS)
-    return stored ? parseInt(stored, 10) || 0 : 0
+    const n = Number(stored)
+    return Number.isNaN(n) ? 0 : n
   })
 
   // Sync pollAttempts to sessionStorage so the cap survives page refreshes
   useEffect(() => {
     if (pollAttempts > 0) {
       ssWrite(SS_POLL_ATTEMPTS, String(pollAttempts))
-    } else {
+    } else if (ssRead(SS_POLL_ATTEMPTS) !== null) {
       ssRemove(SS_POLL_ATTEMPTS)
     }
   }, [pollAttempts])
@@ -491,7 +492,7 @@ export const PremiumAssignmentProvider: React.FC<{
         } catch {
           // Non-critical; beacon will fail gracefully
         }
-        ssWrite(SS_HAS_ATTEMPTED, "true")
+        ssWrite(SS_HAS_ATTEMPTED, "true") // duplicated in assign path below — both exits must persist
         return
       }
 
@@ -534,8 +535,10 @@ export const PremiumAssignmentProvider: React.FC<{
       }
       // Persist only after a successful status/assign round-trip.
       // On network error (catch below), leave unpersisted so refresh retries.
-      ssWrite(SS_HAS_ATTEMPTED, "true")
+      ssWrite(SS_HAS_ATTEMPTED, "true") // duplicated in already-assigned path above — both exits must persist
     } catch (error) {
+      // hasAttemptedRef stays true to prevent rapid-fire retries on this mount.
+      // sessionStorage is NOT written, so a page refresh will retry.
       // Set error state so the error notification fires
       const errorMessage =
         error instanceof Error ? error.message : "Assignment failed"
@@ -549,7 +552,7 @@ export const PremiumAssignmentProvider: React.FC<{
       }))
       routingService.clearRoutingInfo()
     }
-  }, [isPremiumUser])
+  }, [isPremiumUser]) // refs and setState are stable — no other deps needed
 
   /**
    * Auto-release on logout via sendBeacon.

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -26,6 +26,11 @@ logger = AppLogger.get_logger()
 _assignment_attempts = {}
 _RATE_LIMIT_SECONDS = 30
 
+
+class PremiumStatusCheckError(Exception):
+    pass
+
+
 # Timeout and retry configuration for Lambda calls
 LAMBDA_TIMEOUT_SECONDS = 60
 LAMBDA_MAX_RETRIES = 2
@@ -472,11 +477,17 @@ class PremiumAssignmentService:
                     f"Failed to get status for premium user"
                     f"{user_id}: {response_payload}"
                 )
-                return None
+                raise PremiumStatusCheckError(
+                    f"Lambda returned {status_code} for user {user_id}"
+                )
 
+        except PremiumStatusCheckError:
+            raise
         except Exception as e:
             logger.error(f"Error getting status for premium user {user_id}: {str(e)}")
-            return None
+            raise PremiumStatusCheckError(
+                f"Status check failed for user {user_id}: {e}"
+            ) from e
 
     async def update_user_activity(self, user_id: int, user_uid: str) -> Dict[str, any]:
         """


### PR DESCRIPTION
### Content

#### Summary
- Premium users see a false "assigning" popup on every page refresh because `hasAttemptedAutoAssignment` is React state that resets on mount. The `MAX_POLL_ATTEMPTS=40` cap is also defeated since `pollAttempts` resets to 0 on every refresh.
- Lambda 500 errors are masked as "not assigned" (`get_premium_user_status` returns `None` for both 404 and 500), triggering a false re-assignment popup even when the user IS assigned.
- Persist `hasAttemptedRef` and `pollAttempts` to `sessionStorage` so they survive page refreshes. Convert `hasAttemptedAutoAssignment` from `useState` to `useRef` for synchronous race prevention.
- Raise `PremiumStatusCheckError` on Lambda failures instead of returning `None`, so the frontend can distinguish errors from "not assigned" and skip the false re-assignment flow.

#### Design Decisions
- **`useRef` instead of `useState` for `hasAttemptedRef`.** The flag is a synchronous guard against duplicate `autoAssignOnLogin` calls. `useState` is batched — two rapid calls could both read `false` before either setter takes effect. `useRef.current = true` is immediate. Also avoids unnecessary re-renders and StrictMode double-invocation issues.
- **`sessionStorage` over `localStorage`.** Session storage is scoped per tab and auto-clears on tab close, matching the existing `isTabLeader` per-tab design. A new tab gets a fresh assignment attempt (correct behavior). No cross-tab leakage or stale state after closing the browser.
- **`hasAttemptedRef` persisted only on success, not eagerly.** The ref is set to `true` at the top of `autoAssignOnLogin` for in-memory race prevention, but the `sessionStorage` write happens only after the status/assign round-trip succeeds. If the API call throws (network error, Lambda timeout), the flag is not persisted — page refresh gets a fresh attempt. This prevents stranding genuinely unassigned users during transient failures.
- **`pollAttempts` synced via `useEffect`.** A single effect writes to `sessionStorage` whenever `pollAttempts` changes, and removes the key when reset to 0. One sync point instead of patching every `setPollAttempts` call site.
- **`pollInterval` not persisted.** The backoff recalculates from the attempt count on the next poll tick. Persisting a mid-backoff interval value adds scope for no benefit.
- **Raise exception instead of returning `None` on Lambda errors.** The `/premium/status` endpoint already has a `try/except` that catches exceptions and returns `{"assignment": None, "error": str(e)}`. Raising `PremiumStatusCheckError` reuses that existing error path without any endpoint changes. Returning a sentinel dict would require adding type checks in the caller.
- **Re-raise from generic `except` block.** The outer `except Exception` in `get_premium_user_status` previously swallowed all errors as `None`. Now it wraps them in `PremiumStatusCheckError` and re-raises, preserving the original exception via `from e`. The `PremiumStatusCheckError`-specific `except` block re-raises without wrapping.
- **Frontend silently returns on error, no UI message.** A transient Lambda failure does not change the user's actual assignment state. Showing an error would be misleading. The next successful status check (on refresh or next poll) will confirm the real state.
- **All sessionStorage helpers wrapped in `try/catch`.** Private browsing mode or storage quota errors fall back silently to in-memory state (current behavior).

### Evidence
- TypeScript project-wide `tsc --noEmit` reports no errors from the changed file.

### References
- `PREMIUM_INSTABILITY_PLAN.md` -- Fix 1 (Critical): "Persist frontend premium state across page refreshes"
- `PREMIUM_INSTABILITY_PLAN.md` -- Fix 2 (High): "Distinguish Lambda errors from 'not assigned'"
- `PREMIUM_INSTABILITY_REPORT.md` -- RC4 (false popup on refresh), RC1 (polling counter resets), RC2 (Lambda 500 errors masked as not-assigned)

#### Files changed
- `frontend/src/contexts/PremiumAssignmentContext.tsx` -- Add `ssRead`/`ssWrite`/`ssRemove` sessionStorage helpers; convert `hasAttemptedAutoAssignment` from `useState` to `useRef` initialized from sessionStorage; initialize `pollAttempts` from sessionStorage; add `useEffect` to sync `pollAttempts`; persist `hasAttemptedRef` on successful assignment only; clear storage keys on user change and logout; guard `autoAssignOnLogin` to return early when `statusResponse.error` is set
- `studio/app/common/core/premium/premium_assignment_service.py` -- Add `PremiumStatusCheckError` exception class; raise it on non-200/non-404 Lambda responses instead of returning `None`; re-raise wrapped errors from the generic `except` block

### Manual Testcases
- Login as a premium user — verify the "assigning" popup shows once and dismisses after assignment completes
- Refresh the page (F5) — verify no popup reappears
- Let polling run to several attempts, then refresh — open DevTools > Application > Session Storage and verify `premium_pollAttempts` preserves the pre-refresh count; polling resumes from that count, not 0
- Let polling reach 40 attempts — verify polling stops and does not restart on refresh
- Log out and log in as a different user — verify `premium_hasAttempted` and `premium_pollAttempts` are absent from session storage
- Close the tab and open a new one — verify session storage is clean and auto-assignment runs fresh
- Open a private/incognito window, log in as premium — verify behavior is identical to normal mode (helpers degrade gracefully)
- Simulate a Lambda 500 (e.g., temporarily break the Lambda URL or mock the response) — verify no "assigning" popup appears; the frontend silently skips the assignment flow
- After the Lambda recovers, refresh — verify normal assignment resumes

### Unit, Integration, Contract Test Coverage
- No existing tests for `PremiumAssignmentContext`. No tests added or broken by this change.

### Others

#### Difficulties
- None.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Session persistence | Low | All helpers wrapped in try/catch; private browsing falls back to in-memory (current behavior). No change to happy-path logic. |
| Polling cap enforcement | Low | Restored `pollAttempts` feeds into the same `useEffect` guard that checks `>= MAX_POLL_ATTEMPTS`. Over-counted attempts stop polling early (safe direction). |
| User switch / logout cleanup | Low | Two independent cleanup paths (user-change effect, logout-generation effect) both clear storage keys. |
| `useRef` race prevention | Low | Strictly safer than `useState` — synchronous flag set eliminates the batched-render race window. |
| Error propagation | Low | `PremiumStatusCheckError` is caught by the endpoint's existing `try/except`. The only behavioral change is the response includes `error` instead of `assigned: false`. Frontend already handles the `error` field. |
| Silent error swallowing | Low | Returning early on error preserves the user's current state. Worse case: a genuinely unassigned user must refresh once more after the Lambda recovers. |
