### PR TITLE
Add sticky sessions to premium target groups

### DIFF
--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -417,6 +417,7 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           "elasticloadbalancing:CreateRule",
           "elasticloadbalancing:DeleteRule",
           "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
           "elasticloadbalancing:RegisterTargets",
           "elasticloadbalancing:DeregisterTargets",
           "elasticloadbalancing:AddTags",

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 # Constants
 DEFAULT_DEVELOPMENT_CAPACITY = 3  # Fallback capacity for dev/testing
 DEFAULT_IDLE_TIMEOUT_HOURS = 3  # Hours before idle instances become standby
+STICKY_SESSION_DURATION_SECONDS = 300  # Match ALB target group stickiness settings
 
 # MySQL GET_LOCK names for preventing concurrent instance creation
 CREATE_STANDBY_LOCK = "create_standby_lock"
@@ -1764,6 +1765,18 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
 
             # 10. Optimize shared instances (safety net)
             try:
+                try:
+                    fix_result = fix_incorrect_is_shared_flags()
+                    if fix_result.get("fixed_count", 0) > 0:
+                        print(
+                            f"Fixed {fix_result['fixed_count']} stale is_shared flags"
+                        )
+                except Exception:
+                    print("WARNING: fix_incorrect_is_shared_flags() failed")
+                    import traceback
+
+                    traceback.print_exc()
+
                 shared_result = process_shared_instance_optimization()
                 shared_migrations = shared_result.get("migrations_performed", 0)
                 shared_found = shared_result.get("shared_instances_found", 0)
@@ -2116,6 +2129,26 @@ def target_group_exists(target_group_arn: str) -> bool:
         raise
 
 
+def _enable_sticky_sessions(
+    elbv2: "ElasticLoadBalancingv2Client", target_group_arn: str
+) -> None:
+    """Enable ALB sticky sessions on a target group (matches compute.tf main TG)."""
+    try:
+        elbv2.modify_target_group_attributes(
+            TargetGroupArn=target_group_arn,
+            Attributes=[
+                {"Key": "stickiness.enabled", "Value": "true"},
+                {"Key": "stickiness.type", "Value": "lb_cookie"},
+                {
+                    "Key": "stickiness.lb_cookie.duration_seconds",
+                    "Value": str(STICKY_SESSION_DURATION_SECONDS),
+                },
+            ],
+        )
+    except Exception as e:
+        print(f"WARNING: Failed to enable sticky sessions on {target_group_arn}: {e}")
+
+
 def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
     """
     Create a new target group for a premium user, or return existing one if
@@ -2151,7 +2184,9 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
                 {"Key": "Service", "Value": "optinist-premium"},
             ],
         )
-        return response["TargetGroups"][0]["TargetGroupArn"]
+        tg_arn = response["TargetGroups"][0]["TargetGroupArn"]
+        _enable_sticky_sessions(elbv2, tg_arn)
+        return tg_arn
 
     except Exception as e:
         if "DuplicateTargetGroupName" in str(e):
@@ -2162,6 +2197,7 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
             try:
                 response = elbv2.describe_target_groups(Names=[target_group_name])
                 existing_arn = response["TargetGroups"][0]["TargetGroupArn"]
+                _enable_sticky_sessions(elbv2, existing_arn)
                 print(f"Found existing target group: {existing_arn}")
                 return existing_arn
             except Exception as describe_error:
@@ -2748,6 +2784,7 @@ def assign_premium_user(
             target_group_arn = target_group_response["TargetGroups"][0][
                 "TargetGroupArn"
             ]
+            _enable_sticky_sessions(elbv2, target_group_arn)
 
             # 8. Register instance to target group
             elbv2.register_targets(


### PR DESCRIPTION
### Content

#### Summary
- Premium target groups lack sticky session configuration, causing the ALB to round-robin requests across containers when a TG has multiple registered tasks — breaking in-memory state and log offsets mid-session.
- Enable ALB cookie-based sticky sessions (lb_cookie, 300s) on every premium target group at creation time, matching the main TG config in `compute.tf`. Retroactively apply stickiness to pre-existing TGs via the `DuplicateTargetGroupName` fallback and `assign_premium_user` inline creation.
- Call `fix_incorrect_is_shared_flags()` in scheduled monitoring before `process_shared_instance_optimization()` so stale flags are corrected before the optimizer attempts unnecessary migrations.
- Add the `ModifyTargetGroupAttributes` IAM permission required by the new `modify_target_group_attributes` API call.

#### Design Decisions
- **Helper function `_enable_sticky_sessions()` instead of inline calls.** Three call sites need the same `modify_target_group_attributes` invocation. A helper keeps them consistent and avoids duplicating the attribute list.
- **`try/except` in the helper, not at each call site.** A TG without stickiness is better than no TG at all. If the API call fails (throttling, transient error), TG creation still succeeds and stickiness is retried on the next assignment via the `DuplicateTargetGroupName` handler.
- **Stickiness applied in the `DuplicateTargetGroupName` handler.** Pre-existing TGs created before this change lack stickiness. The handler now applies it transparently — no manual migration needed.
- **`fix_incorrect_is_shared_flags()` called before `process_shared_instance_optimization()`.** Correcting stale flags first prevents the optimizer from attempting unnecessary migrations for users already alone on their instance.
- **Isolated `try/except` for `fix_incorrect_is_shared_flags()`.** Failure doesn't break the existing optimization step. Follows the file's convention of inline `import traceback`.
- **Module-level constant `STICKY_SESSION_DURATION_SECONDS = 300`.** Follows codebase convention of extracting magic numbers into named constants alongside `DEFAULT_IDLE_TIMEOUT_HOURS`, `LOCK_TIMEOUT_SECONDS`, etc.

### Evidence
- `compute.tf:85-89` defines the main TG stickiness config (lb_cookie, 300s) — this change mirrors it for premium TGs.
- `fix_incorrect_is_shared_flags()` (line ~4558) is already implemented with `@with_transaction` safety.

#### Files changed
- `infrastructure/terraform/premium_manager.tf` -- Add `ModifyTargetGroupAttributes` IAM permission to the Lambda's ELB policy; existing resource scoping (`targetgroup/premium-*`) already covers the target groups
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add `STICKY_SESSION_DURATION_SECONDS` constant; add typed `_enable_sticky_sessions()` helper; call it after TG creation in `create_or_get_target_group()`, in the `DuplicateTargetGroupName` handler, and in `assign_premium_user()` inline creation; call `fix_incorrect_is_shared_flags()` before `process_shared_instance_optimization()` in step 10 of `handle_scheduled_monitoring()`

### Manual Testcases
- Assign a premium user — verify the new TG has stickiness enabled (`aws elbv2 describe-target-group-attributes --target-group-arn <arn>`)
- Trigger assignment for a user whose TG already exists (DuplicateTargetGroupName path) — verify stickiness is applied to the pre-existing TG
- Simulate `modify_target_group_attributes` failure (temporarily remove IAM permission) — verify TG creation still succeeds and a WARNING is logged
- Manually set `is_shared=1` for a user who is alone on their instance — trigger scheduled monitoring and verify the flag is corrected to 0
- Verify `process_shared_instance_optimization()` still runs after `fix_incorrect_is_shared_flags()` succeeds or fails

### Unit, Integration, Contract Test Coverage
- No existing test suite for `premium_manager.py` Lambda code. No tests added or broken by this change.

### Others

#### Difficulties
- None.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Sticky sessions | Low | Additive-only. Single-target TGs (most premium users) are unaffected. Multi-target TGs get consistent routing. Helper failure is swallowed with a warning — no degradation from current behavior. |
| IAM permission | Low | `ModifyTargetGroupAttributes` is scoped to existing `targetgroup/premium-*` and `targetgroup/subscr-*` resource ARNs. Must be applied via `terraform apply` before deploying the Lambda code. |
| is_shared cleanup | Low | Reuses existing `fix_incorrect_is_shared_flags()` with `@with_transaction`. Isolated `try/except` — failure doesn't break step 10. Idempotent. |
| Deployment order | Medium | Terraform IAM change must be applied before the Lambda deployment, otherwise `modify_target_group_attributes` calls will fail with AccessDenied. The helper's `try/except` makes this a soft failure (logged warning), but stickiness won't take effect until IAM is in place. |
