### PR TITLE
Add SEO metadata to public pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ from datetime import datetime
 
 
 # -- Project information -----------------------------------------------------
-project = "OptiNiSt"
-copyright = f"{datetime.now().year}, OIST"
-author = ""
+project = "Araya-OptiNiSt Cloud"
+copyright = f"{datetime.now().year}, Araya Inc., OIST"
+author = "Araya Inc."
 release = "2.4.0"
 
 # -- readthedocs -------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ from datetime import datetime
 project = "Araya-OptiNiSt Cloud"
 copyright = f"{datetime.now().year}, Araya Inc., OIST"
 author = "Araya Inc."
-release = "2.4.0"
+release = "1.0.0"
 
 # -- readthedocs -------------------------------------------------------------
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Araya-OptiNiSt Cloud – a no-code cloud platform for calcium imaging data analysis. Build visual pipelines, ensure reproducibility, and collaborate with NWB-compatible workflows.
+   :keywords: OptiNiSt, Araya, calcium imaging, neuroscience, data analysis, no-code, NWB, Neurodata Without Borders, visual workflow, pipeline builder, ROI analysis, cloud computing, reproducible science, OIST, microscopy, open science
 
 Araya-OptiNiSt Cloud
 ==========================================

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,25 +5,43 @@
     <link rel="icon" href="%PUBLIC_URL%/static/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+
+    <!-- SEO: Primary Meta Tags -->
+    <title>Araya OptiNiSt - No-Code Scientific Data Analysis Platform</title>
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Araya OptiNiSt (Optical Neuroimage Studio) is a no-code cloud platform for scientific data analysis. Build visual pipelines, analyze calcium imaging data, and collaborate with NWB-compatible workflows."
     />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+    <meta
+      name="keywords"
+      content="OptiNiSt, calcium imaging, neuroscience, data analysis, no-code, NWB, Neurodata Without Borders, visual workflow, pipeline builder, ROI analysis, microscopy, cloud computing, reproducible science, open science, Araya, OIST"
+    />
+    <meta name="author" content="Araya Inc." />
+    <meta name="robots" content="index, follow" />
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>OptiNiSt</title>
+    <!-- SEO: Open Graph / Social Sharing -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Araya OptiNiSt - No-Code Scientific Data Analysis Platform" />
+    <meta
+      property="og:description"
+      content="Build analysis pipelines visually, ensure reproducibility, and collaborate seamlessly. The no-code platform for calcium imaging and neuroscience data analysis."
+    />
+    <meta property="og:image" content="%PUBLIC_URL%/static/optinist_logo.png" />
+    <meta property="og:url" content="https://www.araya-optinist.com/" />
+    <meta property="og:site_name" content="Araya OptiNiSt" />
+
+    <!-- SEO: Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Araya OptiNiSt - No-Code Scientific Data Analysis Platform" />
+    <meta
+      name="twitter:description"
+      content="Build analysis pipelines visually, ensure reproducibility, and collaborate seamlessly. The no-code platform for calcium imaging and neuroscience data analysis."
+    />
+    <meta name="twitter:image" content="%PUBLIC_URL%/static/optinist_logo.png" />
+
+    <link rel="canonical" href="https://www.araya-optinist.com/" />
+    <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json" />
+
     <!-- Google Fonts for Landing Page -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -39,15 +57,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/public/no-built-pages.html
+++ b/frontend/public/no-built-pages.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <title>OptiNiSt</title>
+    <meta name="description" content="" />
+    <title>Araya OptiNiSt</title>
     <style>
       body {
         margin: 0;


### PR DESCRIPTION
### Content

- The metadata (description, etc.) for public pages was inappropriate, so it has been corrected.
- SEO-related information has also been added.
- Also corrected information for the readthedocs page (copyright)

Note:
Since information is centrally managed in index.html, the metadata on public pages and user-only pages is the same.

### Testcase

- [x] The updated HTML metadata is reflected on the public page (check the page title, etc.).
  - [x] Landing page
  - [x] Public repository page
- [x] The same HTML metadata is reflected on the user-only page.