### PR TITLE
Fix cost tracker, add to monthly-maintenance

### DIFF
--- a/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
+++ b/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
@@ -1,0 +1,423 @@
+# Cost Tracking: Usage-Based Cost Metrics and Budget Monitoring
+
+## Executive Summary
+
+- **Cost Tracker Lambda** publishes hourly cost and utilization metrics to the `Optinist/CostTracking` CloudWatch namespace
+- **Usage-based cost reporting** uses the `instance_usage_log` table to compute per-user costs from actual session hours rather than assuming 24/7 usage
+- **Actual AWS spend** queried from Cost Explorer and compared against projected budget to trigger cost alarms
+- **Session lifecycle** tracked across all user flows (login, logout, cleanup, assignment, release) to ensure accurate hour accounting
+- **CloudWatch dashboard** shows spend vs. budget on the left axis and instance/user counts on the right axis
+
+---
+
+## Key Architectural Principles
+
+1. **Measure Actual Usage, Not Theoretical Maximums**
+   - Per-user cost is derived from real session hours recorded in `instance_usage_log`
+   - Cost Explorer provides ground-truth month-to-date spend
+
+2. **Session Lifecycle Completeness**
+   - Every code path that creates or destroys a user session also creates or closes a usage log entry
+   - `ended_at IS NULL` means an active session; `COALESCE(ended_at, NOW())` handles open sessions in queries
+   - Crash safety: usage logs are closed BEFORE assignment records are deleted
+
+3. **Least-Privilege Lambda**
+   - Cost Tracker has its own IAM role (`subscr-cost-tracker-lambda-role`) separate from the premium manager
+   - Only permissions granted: CloudWatch metrics, EC2 Describe, ASG Describe, Cost Explorer
+
+4. **Hourly Cadence with Daily Alarm Evaluation**
+   - Lambda runs hourly to keep metrics fresh
+   - Cost alarm evaluates on a 24-hour period to avoid noisy alerts from hourly fluctuations
+
+---
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "Data Sources"
+        A[EC2 DescribeInstances] --> F
+        B[ASG DescribeAutoScalingGroups] --> F
+        C[RDS: instance_usage_log] --> F
+        D[RDS: user assignments] --> F
+        E[Cost Explorer: GetCostAndUsage] --> F
+    end
+
+    subgraph "Cost Tracker Lambda (Hourly)"
+        F[handler] --> G[track_premium_instances]
+        F --> H[track_free_instances]
+        F --> I[query_user_counts]
+        F --> J[query_actual_spend]
+        F --> K[query_usage_hours]
+        G --> L[calculate_metrics]
+        H --> L
+        I --> L
+        J --> L
+        K --> L
+        L --> M[publish_metrics]
+    end
+
+    subgraph "Outputs"
+        M --> N[CloudWatch: Optinist/CostTracking]
+        N --> O[CloudWatch Dashboard]
+        N --> P[Cost High Alarm -> SNS]
+    end
+
+    style F fill:#87CEEB
+    style L fill:#FFD700
+    style P fill:#FFB6C1
+```
+
+### Responsibility Matrix
+
+| Responsibility                     | Cost Tracker       | Premium Manager    | Premium Cleanup    | Middleware         |
+|------------------------------------|--------------------|--------------------|--------------------|--------------------|
+| Publish cost/budget metrics        | Yes - Exclusive    | No                 | No                 | No                 |
+| Query Cost Explorer                | Yes - Exclusive    | No                 | No                 | No                 |
+| Create usage log (premium)         | No                 | Yes                | No                 | No                 |
+| Create usage log (free)            | No                 | No                 | No                 | Yes                |
+| Close usage log (premium release)  | No                 | Yes                | Yes (stale)        | No                 |
+| Close usage log (free logout)      | No                 | No                 | No                 | No (router does)   |
+| Close usage log (free cleanup)     | No                 | No                 | No                 | No (cleanup job)   |
+| Query usage hours                  | Yes                | No                 | No                 | No                 |
+
+---
+
+## Implementation Details
+
+### Cost Tracker Lambda
+
+**File:** `infrastructure/terraform/cost_tracker_package/cost_tracker.py`
+
+#### Handler: `handler()`
+
+Orchestrates 6 steps sequentially on each hourly invocation:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ 1. Collect premium instance counts (EC2 DescribeInstances)│
+│    → Filter: tag Service=premium-tier                     │
+└───────────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────────┐
+│ 2. Collect free instance counts (ASG)                     │
+│    → InService instances from auto scaling group          │
+└───────────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────────┐
+│ 3. Query active user counts from RDS                      │
+│    → free_user_assignments + premium_user_assignments     │
+└───────────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────────┐
+│ 4. Query actual month-to-date spend (Cost Explorer)       │
+│    → UnblendedCost for current month                      │
+└───────────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────────┐
+│ 5. Query session hours from instance_usage_log            │
+│    → SUM(TIMESTAMPDIFF) grouped by tier                   │
+└───────────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────────┐
+│ 6. Calculate derived metrics and publish to CloudWatch    │
+│    → Per-user costs, utilization, budget projections      │
+└───────────────────────────────────────────────────────────┘
+```
+
+#### calculate_metrics()
+
+**File:** `infrastructure/terraform/cost_tracker_package/cost_tracker.py`
+**Purpose:** Derive per-user costs, utilization rates, and budget projections from raw data
+**Input:** Instance counts, user counts, actual spend, usage hours
+**Output:** Dict with all derived metric values
+
+Key formulas:
+
+- **Cost per premium user:** `(premium_session_hours * PREMIUM_HOURLY_RATE) / premium_user_count`
+- **Cost per free user:** `(free_session_hours * FREE_HOURLY_RATE) / free_user_count`
+- **Projected monthly spend:** `(actual_spend / days_elapsed) * days_in_month`
+
+### Usage Log Lifecycle
+
+**Table:** `instance_usage_log`
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Middleware
+    participant Router
+    participant Manager
+    participant Cleanup
+    participant CostTracker
+
+    Note over User,CostTracker: Free Tier Flow
+    User->>Middleware: First API request
+    Middleware->>Middleware: INSERT usage log (tier=free)
+    User->>Router: POST /users/me/free/logout
+    Router->>Router: UPDATE ended_at = NOW()
+
+    Note over User,CostTracker: Premium Tier Flow
+    User->>Manager: POST /users/me/premium/assign
+    Manager->>Manager: INSERT usage log (tier=premium)
+    User->>Manager: DELETE /users/me/premium/assign
+    Manager->>Manager: UPDATE ended_at = NOW()
+
+    Note over User,CostTracker: Safety Net
+    Cleanup-->>Cleanup: Close stale logs (hourly)
+
+    Note over User,CostTracker: Reporting
+    CostTracker->>CostTracker: SUM hours WHERE ended_at IS NULL -> COALESCE(ended_at, NOW())
+```
+
+#### Where Usage Logs Are Created
+
+| Trigger | File | Tier | Condition |
+|---------|------|------|-----------|
+| First free user activity | `studio/app/common/core/middleware/user_activity_middleware.py` | free | New assignment (rowcount == 0) |
+| Premium assignment | `infrastructure/terraform/premium_manager_package/premium_manager.py` | premium | Non-standby assignment |
+
+#### Where Usage Logs Are Closed
+
+| Trigger | File | Tier |
+|---------|------|------|
+| Free user logout | `studio/app/common/routers/users_me.py` | free |
+| Free cleanup (mark cleaned) | `studio/app/common/core/background/cleanup_job.py` | free |
+| Free cleanup (orphaned) | `studio/app/common/core/background/cleanup_job.py` | free |
+| Free-to-premium migration | `infrastructure/terraform/premium_manager_package/premium_manager.py` | free |
+| Premium user release | `infrastructure/terraform/premium_manager_package/premium_manager.py` | premium |
+| Premium stale cleanup | `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` | premium |
+| Premium test cleanup | `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` | premium |
+
+---
+
+## Edge Case Handling
+
+### 1. Application Crash Before Session Close
+
+**Problem:** If the application crashes, `ended_at` remains NULL and session hours keep accumulating.
+
+**Solution:** Multiple safety nets:
+- Cost tracker query uses `COALESCE(ended_at, NOW())` so open sessions are counted accurately up to query time
+- Premium Cleanup runs hourly and closes stale premium sessions
+- Data Cleanup Job closes orphaned free sessions
+
+### 2. First Day of Month (No Cost Explorer Data)
+
+**Problem:** Cost Explorer's end date is exclusive; on the 1st, `Start == End` is invalid.
+
+**Solution:** `query_actual_spend()` returns `0.0` when `first_of_month == today`, avoiding an API error.
+
+### 3. Division by Zero in Metric Calculations
+
+**Problem:** Zero users or zero instances would cause division errors.
+
+**Solution:** All division operations are guarded:
+- `days_elapsed = max(..., 0.01)` prevents zero denominator for daily rate
+- Per-user costs return `0.0` when user count is zero
+- Utilization returns `0.0` when capacity is zero
+
+### 4. Duplicate Active Sessions
+
+**Problem:** Concurrent middleware requests could create duplicate usage log entries for the same user.
+
+**Solution:** The `FreeUserAssignment` INSERT uses a transaction; if the assignment INSERT fails with `IntegrityError`, the entire transaction (including the usage log INSERT) rolls back. Premium assignments are single-threaded per user through the Lambda.
+
+### 5. Cost Explorer API Costs
+
+**Problem:** Cost Explorer charges $0.01 per API request (~$7.30/month at hourly cadence).
+
+**Solution:** This is an accepted operational cost. The metric provides ground-truth spend data that cannot be derived from other sources.
+
+---
+
+## Constants
+
+| Constant | Value | Source | Purpose |
+|----------|-------|--------|---------|
+| `PREMIUM_HOURLY_RATE` | `0.1088` | Env var (default) | t3.large on-demand rate in ap-northeast-1 (as of March 2026) |
+| `FREE_HOURLY_RATE` | `0.1088` | Env var (default) | Same instance type for free tier (as of March 2026) |
+
+These rates are used to convert session hours into estimated cost:
+
+```
+cost_per_premium_user = (premium_session_hours * PREMIUM_HOURLY_RATE) / premium_user_count
+cost_per_free_user    = (free_session_hours * FREE_HOURLY_RATE) / free_user_count
+```
+
+---
+
+## Formulas
+
+### Projected Monthly Spend
+
+```
+days_elapsed    = (current_day - 1) + (current_hour / 24)   # min 0.01
+daily_rate      = actual_spend / days_elapsed
+projected_monthly = daily_rate * days_in_month
+```
+
+- `actual_spend` comes from Cost Explorer (`UnblendedCost`, month-to-date)
+- Published as the `ExpectedMonthlyBudget` metric
+
+### Per-User Cost
+
+```
+premium_total_cost    = premium_session_hours_mtd * PREMIUM_HOURLY_RATE
+cost_per_premium_user = premium_total_cost / premium_user_count   (0 if no users)
+
+free_total_cost       = free_session_hours_mtd * FREE_HOURLY_RATE
+cost_per_free_user    = free_total_cost / free_user_count          (0 if no users)
+```
+
+- Session hours are aggregated from `instance_usage_log` using `COALESCE(ended_at, NOW())`
+
+### Utilization
+
+```
+premium_utilization = (active_premium_users / running_premium_instances) * 100
+free_utilization    = (active_free_users / (running_free_instances * 5)) * 100
+```
+
+- Free tier assumes 5 users per instance
+
+---
+
+## Monitoring and Metrics
+
+### CloudWatch Metrics Published
+
+**Namespace:** `Optinist/CostTracking`
+**Frequency:** Hourly (via EventBridge `rate(1 hour)`)
+
+| Metric Name | Formula / Source | Unit |
+|-------------|-----------------|------|
+| `PremiumInstanceCount` | EC2 DescribeInstances (tag `Service=premium-tier`, state `running`) | Count |
+| `FreeInstanceCount` | ASG InService instance count | Count |
+| `ActivePremiumUsers` | `SELECT COUNT(*) FROM premium_user_assignments WHERE status='active' AND is_standby=0` | Count |
+| `ActiveFreeUsers` | `SELECT COUNT(*) FROM free_user_assignments` | Count |
+| `ActualMonthToDateSpend` | Cost Explorer `UnblendedCost` for current month | USD |
+| `ExpectedMonthlyBudget` | `(actual_spend / days_elapsed) * days_in_month` | USD |
+| `CostPerPremiumUser` | `(premium_hours * PREMIUM_HOURLY_RATE) / premium_users` | USD |
+| `CostPerFreeUser` | `(free_hours * FREE_HOURLY_RATE) / free_users` | USD |
+| `PremiumUtilization` | `premium_users / premium_instances * 100` | Percent |
+| `FreeUtilization` | `free_users / (free_instances * 5) * 100` | Percent |
+| `PremiumSessionHoursMTD` | `SUM(TIMESTAMPDIFF(...)) FROM instance_usage_log WHERE tier='premium'` | Count |
+
+### CloudWatch Alarms
+
+#### Cost Alarm: `subscr-monthly-cost-high`
+
+| Property | Value |
+|----------|-------|
+| **Metric** | `ExpectedMonthlyBudget` (daily max) |
+| **Threshold** | `var.monthly_budget_usd` (set in `terraform.tfvars`, not in repo) |
+| **Condition** | Projected monthly spend > budget |
+| **Evaluation** | 1 × 24h period |
+| **Action (ALARM)** | SNS `subscr-optinist-critical-alerts` → email `support@araya-optinist.com` |
+| **Action (OK)** | Same SNS topic (sends recovery notification) |
+| **Defined in** | `premium_manager.tf` → `aws_cloudwatch_metric_alarm.monthly_cost_high` |
+
+### CloudWatch Dashboard
+
+**Dashboard:** `subscr-optinist-monitoring`
+
+The "Cost Tracking & Instance Counts" widget (Row 2, right) displays:
+- **Left axis (USD):** Actual MTD Spend, Expected Budget
+- **Right axis (Count):** Premium Instances, Free Instances, Active Premium Users, Active Free Users
+
+---
+
+## Monthly Maintenance Report
+
+**Script:** `infrastructure/scripts/monthly-maintenance.sh`
+**Output:** `monthly-maintenance-YYYY-MM.md`
+
+The report queries and includes:
+
+| Section | Contents |
+|---------|----------|
+| **1. AWS Cost Review** | 3-month cost trend by service (from Cost Explorer), filtered to tagged resources. Flags services with >20% month-over-month increase. |
+| **1b. Cost Tracker Metrics** | Latest value for all 11 `Optinist/CostTracking` metrics (spend, budget, per-user costs, utilization, session hours, instance/user counts). |
+| **2. RDS Health Check** | Backup status, free storage (GB), slow query count (30 days), RDS error log count. |
+| **3. Lambda Log Review** | Error counts per Lambda function over past 30 days (days with errors + total). |
+| **4. Alarm Summary** | Count of ALARM transitions in past 30 days, list of unique alarms that fired. |
+| **5. Storage Overview** | S3 bucket size + 3-month trend, EFS filesystem sizes + 3-month trend, CloudWatch log group storage + retention settings. |
+| **6. Rotation Summary** | Manual section for support emails, recurring issues, handoff notes, action items. |
+| **Appendix A** | Raw RDS slow query and error log samples. |
+| **Appendix B** | Raw alarm state transition history. |
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ASG_NAME` | Auto Scaling Group name for free tier instance count | *(required)* |
+| `REGION` | AWS region for EC2/ASG/CloudWatch clients | `ap-northeast-1` |
+| `RDS_HOST` | Database endpoint (via RDS Proxy) | *(required)* |
+| `RDS_USER` | Database username | *(required)* |
+| `RDS_PASSWORD` | Database password | *(required)* |
+| `RDS_DATABASE` | Database name | *(required)* |
+| `PREMIUM_HOURLY_RATE` | Hourly EC2 rate for premium instances (t3.large ap-northeast-1, as of March 2026) | `0.1088` |
+| `FREE_HOURLY_RATE` | Hourly EC2 rate for free instances (t3.large ap-northeast-1, as of March 2026) | `0.1088` |
+
+### Database Tables
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `instance_usage_log` | Per-user session tracking | `user_id`, `tier`, `started_at`, `ended_at` |
+| `free_user_assignments` | Active free tier assignments | `user_id`, `instance_id` |
+| `premium_user_assignments` | Active premium assignments | `user_id`, `instance_id`, `status` |
+
+### Indices on `instance_usage_log`
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_usage_log_user_tier` | `(user_id, tier)` | Close logs by user and tier |
+| `idx_usage_log_active` | `(ended_at)` | Find active sessions |
+| `idx_usage_log_tier_started` | `(tier, started_at)` | Cost tracker monthly aggregation queries |
+
+---
+
+## AWS Resources
+
+| Resource | Name | Details |
+|----------|------|---------|
+| Lambda Function | `subscr-cost-tracker` | Timeout: 300s, Runtime: python3.11 |
+| IAM Role | `subscr-cost-tracker-lambda-role` | Least-privilege: CloudWatch, EC2, ASG, CE |
+| EventBridge Rule | `subscr-cost-tracker-schedule` | `rate(1 hour)` |
+| CloudWatch Log Group | `/aws/lambda/subscr-cost-tracker` | Retention: 30 days |
+| CloudWatch Alarm | `subscr-monthly-cost-high` | Metric math: spend - budget > 0 |
+| Lambda Layer | `aws_constants` | Shared constants (DatabaseConfig) |
+
+---
+
+## Key Functions Reference
+
+**In Cost Tracker Lambda:**
+
+| Function | Purpose |
+|----------|---------|
+| `handler()` | Orchestrates all 6 tracking steps |
+| `track_premium_instances()` | Count running/stopped premium EC2 instances by tag |
+| `track_free_instances()` | Count free tier instances from ASG |
+| `query_user_counts()` | Count active free and premium users from RDS |
+| `query_actual_spend()` | Query Cost Explorer for month-to-date UnblendedCost |
+| `query_usage_hours()` | Aggregate session hours from `instance_usage_log` by tier |
+| `calculate_metrics()` | Derive per-user costs, utilization, and budget projections |
+| `publish_metrics()` | Publish 12 metrics to CloudWatch `Optinist/CostTracking` |
+| `get_db_connection()` | Context manager for pymysql connection via RDS Proxy |
+
+**In Usage Log Writers (other components):**
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `_update_free_user_activity_sync()` | `studio/app/common/core/middleware/user_activity_middleware.py` | Create free usage log on first activity |
+| `_store_user_assignment_transaction()` | `infrastructure/terraform/premium_manager_package/premium_manager.py` | Create premium usage log on assignment |
+| `_remove_user_assignment_transaction()` | `infrastructure/terraform/premium_manager_package/premium_manager.py` | Close premium usage log on release |
+| `logout_free_user()` | `studio/app/common/routers/users_me.py` | Close free usage log on explicit logout |
+| `_mark_cleaned()` | `studio/app/common/core/background/cleanup_job.py` | Close free usage log on data cleanup |
+| `cleanup_stale_assignments()` | `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` | Close premium usage log on stale cleanup |

--- a/infrastructure/documentation/LOGGING_ARCHITECTURE.md
+++ b/infrastructure/documentation/LOGGING_ARCHITECTURE.md
@@ -687,7 +687,7 @@ The free manager also triggers on ASG lifecycle events (instance launch/terminat
 | `subscr-background-task-stopped`   | RunningTaskCount          | < 1          | ECS/ContainerInsights  |
 | `subscr-background-cpu-high`       | CpuUtilized               | > 400 units  | ECS/ContainerInsights  |
 | `subscr-background-memory-high`    | MemoryUtilized            | > 600 MB     | ECS/ContainerInsights  |
-| `subscr-premium-monthly-cost-high` | TotalMonthlyCost          | > $500/day   | OptiNiSt/Cost          |
+| `subscr-monthly-cost-high` | TotalMonthlyCost          | > $500/day   | OptiNiSt/Cost          |
 | `subscr-premium-cpu-high`          | CPUUtilization            | > 80%        | AWS/ECS                |
 | `subscr-premium-memory-high`       | MemoryUtilization         | > 85%        | AWS/ECS                |
 

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -454,11 +454,16 @@ When an alarm fires, follow the procedure for that alarm category.
 | `subscr-background-cpu-high` | CPU > 400 units (3 periods) | Background jobs are overloaded. Check for stuck or excessively large jobs. |
 | `subscr-background-memory-high` | Memory > 600 MB (3 periods) | Check for memory leaks in background job code. |
 
+### Account Cost Alarm
+
+| Alarm | Threshold | Action |
+|---|---|---|
+| `subscr-monthly-cost-high` | Projected monthly spend > `var.monthly_budget_usd` | Review cost trend. Check for orphaned or idle resources. |
+
 ### Premium Alarms
 
 | Alarm | Threshold | Action |
 |---|---|---|
-| `subscr-premium-monthly-cost-high` | Monthly cost > $500 | Review premium instance utilization. Check for orphaned instances. |
 | `subscr-premium-cpu-high` | CPU > 80% (2 periods) | Check premium user workload. May need larger instance type. |
 | `subscr-premium-memory-high` | Memory > 85% (3 periods) | Check for memory-intensive workflows. Review premium task definition limits. |
 
@@ -483,7 +488,7 @@ Critical CloudWatch alarms send email notifications to `support@araya-optinist.c
 | `subscr-optinist-alb-5xx-errors` | `monitoring.tf` | Users are seeing server errors |
 | `subscr-optinist-alb-response-time-high` | `monitoring.tf` | Users experiencing >5s response times |
 | `subscr-optinist-load-average-high` | `monitoring.tf` | EC2 hosts saturated, all services degrade |
-| `subscr-premium-monthly-cost-high` | `premium_manager.tf` | Unexpected cost spike |
+| `subscr-monthly-cost-high` | `monitoring.tf` | Unexpected cost spike |
 
 **High — degraded service:**
 
@@ -527,7 +532,7 @@ Critical CloudWatch alarms send email notifications to `support@araya-optinist.c
 | ACM | SSL/TLS certificate | Free |
 | Secrets Manager | 5 secrets | ~$2 |
 
-**Cost alerts:** The `subscr-premium-monthly-cost-high` alarm triggers at $500/month.
+**Cost alerts:** The `subscr-monthly-cost-high` alarm triggers when projected monthly spend exceeds `var.monthly_budget_usd` (set in `terraform.tfvars`).
 
 ---
 

--- a/infrastructure/scripts/monthly-maintenance.sh
+++ b/infrastructure/scripts/monthly-maintenance.sh
@@ -293,6 +293,60 @@ cat >> "$REPORT" <<'EOF'
 
 EOF
 
+# 1b. Cost Tracker Custom Metrics (from Optinist/CostTracking namespace)
+echo "  Querying cost tracker metrics..."
+COST_METRICS=(
+  "ActualMonthToDateSpend"
+  "ExpectedMonthlyBudget"
+  "CostPerPremiumUser"
+  "CostPerFreeUser"
+  "PremiumUtilization"
+  "FreeUtilization"
+  "PremiumSessionHoursMTD"
+  "ActivePremiumUsers"
+  "ActiveFreeUsers"
+  "PremiumInstanceCount"
+  "FreeInstanceCount"
+)
+
+cost_tracker_table="| Metric | Latest Value |
+|---|---|"
+
+for metric in "${COST_METRICS[@]}"; do
+  val=$(aws cloudwatch get-metric-statistics \
+    --namespace "Optinist/CostTracking" \
+    --metric-name "$metric" \
+    --start-time "$(iso_days_ago 2)" \
+    --end-time "$NOW_ISO" \
+    --period 3600 \
+    --statistics Maximum \
+    --region "$REGION" \
+    --query 'Datapoints | sort_by(@, &Timestamp) | [-1].Maximum' \
+    --output text 2>/dev/null || echo "N/A")
+  if [ "$val" = "None" ] || [ -z "$val" ]; then
+    val="N/A"
+  elif echo "$metric" | grep -qi "cost\|spend\|budget"; then
+    val=$(python3 -c "print(f'\${float($val):.2f}')" 2>/dev/null || echo "$val")
+  elif echo "$metric" | grep -qi "utilization"; then
+    val=$(python3 -c "print(f'{float($val):.1f}%')" 2>/dev/null || echo "$val")
+  elif echo "$metric" | grep -qi "hours"; then
+    val=$(python3 -c "print(f'{float($val):.1f}h')" 2>/dev/null || echo "$val")
+  else
+    val=$(python3 -c "v=float($val); print(f'{v:.0f}' if v==int(v) else f'{v:.2f}')" 2>/dev/null || echo "$val")
+  fi
+  cost_tracker_table="$cost_tracker_table
+| \`$metric\` | $val |"
+done
+
+cat >> "$REPORT" <<EOF
+### Cost Tracker Metrics (Latest)
+
+$cost_tracker_table
+
+> Source: \`Optinist/CostTracking\` CloudWatch namespace (published hourly by \`subscr-cost-tracker\` Lambda).
+
+EOF
+
 # ---------------------------------------------------------------------------
 # 2. RDS Health Check
 # ---------------------------------------------------------------------------

--- a/infrastructure/scripts/monthly-maintenance.sh
+++ b/infrastructure/scripts/monthly-maintenance.sh
@@ -347,6 +347,92 @@ $cost_tracker_table
 
 EOF
 
+# 1c. Per-User Usage Breakdown (via cost-tracker Lambda)
+echo "  Querying per-user usage breakdown..."
+USAGE_REPORT_TMP=$(mktemp)
+usage_invoke_ok=true
+aws lambda invoke \
+  --function-name "subscr-cost-tracker" \
+  --payload '{"mode":"usage_report"}' \
+  --region "$REGION" \
+  "$USAGE_REPORT_TMP" >/dev/null 2>&1 || usage_invoke_ok=false
+
+usage_summary=""
+usage_detail_table=""
+
+if [ "$usage_invoke_ok" = true ] && [ -f "$USAGE_REPORT_TMP" ]; then
+  # Lambda response wraps data in {"statusCode":200,"body":"..."}
+  usage_body=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    resp = json.load(f)
+body = resp.get('body', '{}')
+if isinstance(body, str):
+    body = json.loads(body)
+print(json.dumps(body))
+" "$USAGE_REPORT_TMP" 2>/dev/null || echo "{}")
+
+  usage_summary=$(echo "$usage_body" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+s = data.get('summary', {})
+if not s:
+    print('*(No usage data available — instance_usage_log may be empty)*')
+    sys.exit(0)
+
+month = s.get('month', 'N/A')
+p = s.get('premium', {})
+f = s.get('free', {})
+
+print(f'**Month: {month}**')
+print()
+print('| Tier | Users | Total Hours | Total Cost | Avg Hours/User | Avg Cost/User |')
+print('|---|---|---|---|---|---|')
+if p.get('users', 0) > 0:
+    print(f'| Premium | {p[\"users\"]} | {p[\"total_hours\"]:.1f}h | \${p[\"total_cost\"]:.2f} | {p[\"avg_hours\"]:.1f}h | \${p[\"avg_cost\"]:.2f} |')
+else:
+    print('| Premium | 0 | — | — | — | — |')
+if f.get('users', 0) > 0:
+    print(f'| Free | {f[\"users\"]} | {f[\"total_hours\"]:.1f}h | \${f[\"total_cost\"]:.2f} | {f[\"avg_hours\"]:.1f}h | \${f[\"avg_cost\"]:.2f} |')
+else:
+    print('| Free | 0 | — | — | — | — |')
+grand_hours = p.get('total_hours', 0) + f.get('total_hours', 0)
+grand_cost = p.get('total_cost', 0) + f.get('total_cost', 0)
+grand_users = p.get('users', 0) + f.get('users', 0)
+print(f'| **Total** | **{grand_users}** | **{grand_hours:.1f}h** | **\${grand_cost:.2f}** | | |')
+" 2>/dev/null || echo "*(Failed to parse usage summary)*")
+
+  usage_detail_table=$(echo "$usage_body" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+users = data.get('users', [])
+if not users:
+    print('*(No per-user data available)*')
+    sys.exit(0)
+
+print('| User | Tier | Sessions | Hours | Cost |')
+print('|---|---|---|---|---|')
+for u in users:
+    print(f'| \`{u[\"user_id\"]}\` | {u[\"tier\"]} | {u[\"sessions\"]} | {u[\"hours\"]:.1f}h | \${u[\"cost\"]:.2f} |')
+" 2>/dev/null || echo "*(Failed to parse per-user data)*")
+else
+  usage_summary="*(Failed to invoke cost-tracker Lambda — is it deployed?)*"
+  usage_detail_table="*(No data)*"
+fi
+
+# Store detail table for appendix
+echo "$usage_detail_table" > "$APPENDIX_TMP/usage_detail.txt"
+rm -f "$USAGE_REPORT_TMP"
+
+cat >> "$REPORT" <<EOF
+### Per-User Usage Summary
+
+$usage_summary
+
+> Per-user detail in [Appendix C](#appendix-c-per-user-usage-breakdown). Source: \`instance_usage_log\` table via \`subscr-cost-tracker\` Lambda.
+
+EOF
+
 # ---------------------------------------------------------------------------
 # 2. RDS Health Check
 # ---------------------------------------------------------------------------
@@ -790,6 +876,17 @@ echo "  Writing appendices..."
   echo '```'
   cat "$APPENDIX_TMP/alarm_history.txt" 2>/dev/null || echo "(no data)"
   echo '```'
+  echo ""
+} >> "$REPORT"
+
+# ---------------------------------------------------------------------------
+# Appendix C: Per-User Usage Breakdown
+# ---------------------------------------------------------------------------
+{
+  echo "## Appendix C: Per-User Usage Breakdown"
+  echo ""
+  cat "$APPENDIX_TMP/usage_detail.txt" 2>/dev/null || echo "*(No data)*"
+  echo ""
 } >> "$REPORT"
 
 echo ""

--- a/infrastructure/terraform/cost_tracker_package/cost_tracker.py
+++ b/infrastructure/terraform/cost_tracker_package/cost_tracker.py
@@ -1,74 +1,475 @@
 """
 Cost Tracker Lambda Function
 
-Tracks resource usage and costs for premium and free tier instances.
-Triggered by CloudWatch Events on a schedule.
+Tracks resource usage, actual AWS spend, and per-user cost metrics.
+Publishes to CloudWatch namespace Optinist/CostTracking on an hourly schedule.
+
+Uses instance_usage_log table for accurate per-user cost reporting
+based on actual session hours rather than assuming 24/7 usage.
 """
 
+import calendar
 import json
 import logging
 import os
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Dict
 
 import boto3
+import pymysql
+from aws_constants import DatabaseConfig
 
-if TYPE_CHECKING:
-    from mypy_boto3_autoscaling import AutoScalingClient
-    from mypy_boto3_cloudwatch import CloudWatchClient
-    from mypy_boto3_ec2 import EC2Client
-
-# Set up logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Hourly rates for usage-based cost (t3.large ap-northeast-1, as of March 2026)
+PREMIUM_HOURLY_RATE = float(os.environ.get("PREMIUM_HOURLY_RATE", "0.1088"))
+FREE_HOURLY_RATE = float(os.environ.get("FREE_HOURLY_RATE", "0.1088"))
 
-def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """
-    Cost tracking Lambda function handler
+NAMESPACE = "Optinist/CostTracking"
 
-    Args:
-        event: CloudWatch event data
-        context: Lambda context
+SSL_ARGS = {"check_hostname": False}
 
-    Returns:
-        Response with tracking results
-    """
-    logger.info("Cost tracking Lambda invoked")
-    logger.info(f"Event: {json.dumps(event)}")
 
+# ============================================================
+# Database helpers (same pattern as common_user_manager.py)
+# ============================================================
+
+
+def get_required_env_var(var_name: str, default_value: str = None) -> str:
+    value = os.environ.get(var_name, default_value)
+    if value is None or value == "":
+        raise ValueError(f"Missing required environment variable: {var_name}")
+    return value
+
+
+def _get_db_params():
+    """Parse RDS connection params from environment."""
+    rds_host = get_required_env_var("RDS_HOST")
+    if ":" in rds_host:
+        host, port_str = rds_host.split(":", 1)
+        port = int(port_str)
+    else:
+        host = rds_host
+        port = DatabaseConfig.DEFAULT_PORT
+    return {
+        "host": host,
+        "port": port,
+        "user": get_required_env_var("RDS_USER"),
+        "password": get_required_env_var("RDS_PASSWORD"),
+        "database": get_required_env_var("RDS_DATABASE"),
+    }
+
+
+def _create_ssl_connection(params):
+    """Create a pymysql connection with SSL enforcement."""
+    return pymysql.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        database=params["database"],
+        charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+        ssl=SSL_ARGS,
+    )
+
+
+def get_db_connection():
+    """Get pymysql connection for direct SQL queries."""
+
+    @contextmanager
+    def connection_context():
+        conn = None
+        try:
+            conn = _create_ssl_connection(_get_db_params())
+            yield conn
+        finally:
+            if conn:
+                conn.close()
+
+    return connection_context()
+
+
+# ============================================================
+# Data collection functions
+# ============================================================
+
+
+def track_premium_instances(ec2_client) -> Dict[str, Any]:
+    """Track premium instance counts using EC2 DescribeInstances with tag filter."""
     try:
-        # Get environment variables
-        spot_fleet_id = os.environ.get("SPOT_FLEET_ID")
-        asg_name = os.environ.get("ASG_NAME")
-        region = os.environ.get("REGION", "ap-northeast-1")
+        response = ec2_client.describe_instances(
+            Filters=[
+                {"Name": "tag:Service", "Values": ["premium-tier"]},
+                {
+                    "Name": "instance-state-name",
+                    "Values": ["running", "stopped", "pending"],
+                },
+            ]
+        )
+
+        running = 0
+        stopped = 0
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                state = instance.get("State", {}).get("Name")
+                if state == "running":
+                    running += 1
+                elif state == "stopped":
+                    stopped += 1
+
+        logger.info(f"Premium instances — running: {running}, stopped: {stopped}")
+        return {"running_instances": running, "stopped_instances": stopped}
+
+    except Exception as e:
+        logger.warning(f"Error tracking premium instances: {e}")
+        return {"running_instances": 0, "stopped_instances": 0}
+
+
+def track_free_instances(asg_client, asg_name: str | None) -> Dict[str, Any]:
+    """Track free tier instance metrics from ASG."""
+    try:
+        if not asg_name:
+            logger.warning("No ASG name provided")
+            return {"instance_count": 0, "running_instances": 0}
+
+        response = asg_client.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[asg_name]
+        )
+
+        if not response["AutoScalingGroups"]:
+            logger.warning(f"ASG {asg_name} not found")
+            return {"instance_count": 0, "running_instances": 0}
+
+        asg = response["AutoScalingGroups"][0]
+        instances = asg.get("Instances", [])
+        running_instances = len(
+            [i for i in instances if i.get("LifecycleState") == "InService"]
+        )
 
         logger.info(
-            f"Tracking costs for: Spot Fleet {spot_fleet_id}, "
-            f"ASG {asg_name}, Region {region}"
+            f"Free tier instances — total: {len(instances)}, "
+            f"running: {running_instances}"
         )
+        return {
+            "instance_count": len(instances),
+            "running_instances": running_instances,
+        }
+
+    except Exception as e:
+        logger.warning(f"Error tracking free instances: {e}")
+        return {"instance_count": 0, "running_instances": 0}
+
+
+def query_user_counts() -> Dict[str, int]:
+    """Query active user counts from RDS."""
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT COUNT(*) as count FROM free_user_assignments")
+                free_count = cursor.fetchone()["count"]
+
+                cursor.execute(
+                    "SELECT COUNT(*) as count FROM premium_user_assignments "
+                    "WHERE status = 'active' AND is_standby = 0"
+                )
+                premium_count = cursor.fetchone()["count"]
+
+        logger.info(f"User counts — free: {free_count}, premium: {premium_count}")
+        return {"free": free_count, "premium": premium_count}
+
+    except Exception as e:
+        logger.warning(f"Error querying user counts: {e}")
+        return {"free": 0, "premium": 0}
+
+
+def query_actual_spend(ce_client) -> float:
+    """Query Cost Explorer for month-to-date actual spend."""
+    try:
+        now = datetime.now(timezone.utc)
+        first_of_month = now.strftime("%Y-%m-01")
+        today = now.strftime("%Y-%m-%d")
+
+        # CE end date is exclusive; if today is the 1st, no data yet
+        if first_of_month == today:
+            logger.info("First day of month — no Cost Explorer data yet")
+            return 0.0
+
+        response = ce_client.get_cost_and_usage(
+            TimePeriod={"Start": first_of_month, "End": today},
+            Granularity="MONTHLY",
+            Metrics=["UnblendedCost"],
+        )
+
+        results = response.get("ResultsByTime", [])
+        if results:
+            amount = float(
+                results[0].get("Total", {}).get("UnblendedCost", {}).get("Amount", "0")
+            )
+            logger.info(f"Month-to-date spend: ${amount:.2f}")
+            return amount
+
+        return 0.0
+
+    except Exception as e:
+        logger.warning(f"Error querying Cost Explorer: {e}")
+        return 0.0
+
+
+def query_usage_hours() -> Dict[str, Any]:
+    """Query instance_usage_log for session hours this month."""
+    try:
+        now = datetime.now(timezone.utc)
+        month_start = now.strftime("%Y-%m-01 00:00:00")
+
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                # Premium: per-user hours this month
+                cursor.execute(
+                    """SELECT COUNT(DISTINCT user_id) AS user_count,
+                              SUM(TIMESTAMPDIFF(SECOND, started_at,
+                                  COALESCE(ended_at, NOW())) / 3600.0) AS total_hours
+                       FROM instance_usage_log
+                       WHERE tier = 'premium' AND started_at >= %s""",
+                    (month_start,),
+                )
+                premium_row = cursor.fetchone()
+
+                # Free: total session hours
+                cursor.execute(
+                    """SELECT COUNT(DISTINCT user_id) AS user_count,
+                              SUM(TIMESTAMPDIFF(SECOND, started_at,
+                                  COALESCE(ended_at, NOW())) / 3600.0) AS total_hours
+                       FROM instance_usage_log
+                       WHERE tier = 'free' AND started_at >= %s""",
+                    (month_start,),
+                )
+                free_row = cursor.fetchone()
+
+        result = {
+            "premium_user_count": int(premium_row["user_count"] or 0),
+            "premium_total_hours": float(premium_row["total_hours"] or 0.0),
+            "free_user_count": int(free_row["user_count"] or 0),
+            "free_total_hours": float(free_row["total_hours"] or 0.0),
+        }
+
+        logger.info(
+            f"Usage hours — premium: {result['premium_total_hours']:.1f}h "
+            f"({result['premium_user_count']} users), "
+            f"free: {result['free_total_hours']:.1f}h "
+            f"({result['free_user_count']} users)"
+        )
+        return result
+
+    except Exception as e:
+        logger.warning(f"Error querying usage hours: {e}")
+        return {
+            "premium_user_count": 0,
+            "premium_total_hours": 0.0,
+            "free_user_count": 0,
+            "free_total_hours": 0.0,
+        }
+
+
+def calculate_metrics(
+    premium_instances: Dict[str, Any],
+    free_instances: Dict[str, Any],
+    user_counts: Dict[str, int],
+    actual_spend: float,
+    usage_hours: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Derive per-user costs, utilization, and budget thresholds."""
+    premium_count = user_counts["premium"]
+    free_count = user_counts["free"]
+    premium_running = premium_instances["running_instances"]
+    free_running = free_instances.get("running_instances", 0)
+
+    now = datetime.now(timezone.utc)
+    days_in_month = calendar.monthrange(now.year, now.month)[1]
+    days_elapsed = max(now.day - 1 + now.hour / 24.0, 1)
+
+    # Projected budget from actual spend trend
+    daily_rate = actual_spend / days_elapsed
+    projected_monthly = daily_rate * days_in_month
+
+    # Usage-based per-user costs
+    # Premium: actual session hours * hourly rate / active users
+    premium_total_cost = usage_hours["premium_total_hours"] * PREMIUM_HOURLY_RATE
+    cost_per_premium = (
+        (premium_total_cost / usage_hours["premium_user_count"])
+        if usage_hours["premium_user_count"] > 0
+        else 0.0
+    )
+
+    # Free: actual session hours * hourly rate / unique free users this month
+    free_total_cost = usage_hours["free_total_hours"] * FREE_HOURLY_RATE
+    cost_per_free = (
+        (free_total_cost / usage_hours["free_user_count"])
+        if usage_hours["free_user_count"] > 0
+        else 0.0
+    )
+
+    # Utilization: users per available capacity
+    premium_utilization = (
+        (premium_count / premium_running * 100) if premium_running > 0 else 0.0
+    )
+    # Free tier: each instance serves ~5 users
+    free_capacity = free_running * 5
+    free_utilization = (free_count / free_capacity * 100) if free_capacity > 0 else 0.0
+
+    return {
+        "projected_monthly": projected_monthly,
+        "cost_per_premium": cost_per_premium,
+        "cost_per_free": cost_per_free,
+        "premium_utilization": premium_utilization,
+        "free_utilization": free_utilization,
+        "premium_session_hours_mtd": usage_hours["premium_total_hours"],
+    }
+
+
+def publish_metrics(
+    cloudwatch_client,
+    premium_instances: Dict[str, Any],
+    free_instances: Dict[str, Any],
+    user_counts: Dict[str, int],
+    actual_spend: float,
+    calculated: Dict[str, Any],
+) -> None:
+    """Publish all metrics to CloudWatch."""
+    try:
+        now = datetime.now(timezone.utc)
+
+        metric_data = [
+            {
+                "MetricName": "PremiumInstanceCount",
+                "Value": premium_instances["running_instances"],
+                "Unit": "Count",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "FreeInstanceCount",
+                "Value": free_instances.get("running_instances", 0),
+                "Unit": "Count",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "ActivePremiumUsers",
+                "Value": user_counts["premium"],
+                "Unit": "Count",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "ActiveFreeUsers",
+                "Value": user_counts["free"],
+                "Unit": "Count",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "ActualMonthToDateSpend",
+                "Value": actual_spend,
+                "Unit": "None",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "ExpectedMonthlyBudget",
+                "Value": calculated["projected_monthly"],
+                "Unit": "None",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "CostPerPremiumUser",
+                "Value": calculated["cost_per_premium"],
+                "Unit": "None",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "CostPerFreeUser",
+                "Value": calculated["cost_per_free"],
+                "Unit": "None",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "PremiumUtilization",
+                "Value": calculated["premium_utilization"],
+                "Unit": "Percent",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "FreeUtilization",
+                "Value": calculated["free_utilization"],
+                "Unit": "Percent",
+                "Timestamp": now,
+            },
+            {
+                "MetricName": "PremiumSessionHoursMTD",
+                "Value": calculated["premium_session_hours_mtd"],
+                "Unit": "Count",
+                "Timestamp": now,
+            },
+        ]
+
+        # CloudWatch accepts max 1000 metric data points per call,
+        # but best practice is batches of 20
+        cloudwatch_client.put_metric_data(Namespace=NAMESPACE, MetricData=metric_data)
+
+        logger.info(f"Published {len(metric_data)} metrics to {NAMESPACE}")
+
+    except Exception as e:
+        logger.error(f"Error publishing metrics: {e}")
+
+
+# ============================================================
+# Handler
+# ============================================================
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Cost tracking Lambda handler — orchestrates all tracking steps."""
+    logger.info("Cost tracking Lambda invoked")
+
+    try:
+        region = os.environ.get("REGION", "ap-northeast-1")
+        asg_name = os.environ.get("ASG_NAME")
 
         # Initialize AWS clients
-        ec2_client: "EC2Client" = boto3.client("ec2", region_name=region)
-        cloudwatch_client: "CloudWatchClient" = boto3.client(
-            "cloudwatch", region_name=region
+        ec2_client = boto3.client("ec2", region_name=region)
+        cloudwatch_client = boto3.client("cloudwatch", region_name=region)
+        asg_client = boto3.client("autoscaling", region_name=region)
+        # Cost Explorer endpoint is always us-east-1
+        ce_client = boto3.client("ce", region_name="us-east-1")
+
+        # 1. Collect instance counts
+        premium_instances = track_premium_instances(ec2_client)
+        free_instances = track_free_instances(asg_client, asg_name)
+
+        # 2. Query active user counts from RDS
+        user_counts = query_user_counts()
+
+        # 3. Query actual month-to-date spend from Cost Explorer
+        actual_spend = query_actual_spend(ce_client)
+
+        # 4. Query usage hours from instance_usage_log
+        usage_hours = query_usage_hours()
+
+        # 5. Calculate derived metrics
+        calculated = calculate_metrics(
+            premium_instances,
+            free_instances,
+            user_counts,
+            actual_spend,
+            usage_hours,
         )
-        asg_client: "AutoScalingClient" = boto3.client(
-            "autoscaling", region_name=region
-        )
 
-        # Track premium instances (spot fleet)
-        premium_metrics = track_premium_instances(ec2_client, spot_fleet_id)
-
-        # Track free tier instances (auto scaling group)
-        free_metrics = track_free_instances(asg_client, asg_name)
-
-        # Calculate utilization metrics
-        utilization = calculate_premium_utilization(premium_metrics, free_metrics)
-
-        # Publish metrics to CloudWatch
-        publish_cost_metrics(
-            cloudwatch_client, premium_metrics, free_metrics, utilization
+        # 6. Publish all metrics to CloudWatch
+        publish_metrics(
+            cloudwatch_client,
+            premium_instances,
+            free_instances,
+            user_counts,
+            actual_spend,
+            calculated,
         )
 
         logger.info("Cost tracking completed successfully")
@@ -78,9 +479,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             "body": json.dumps(
                 {
                     "message": "Cost tracking completed",
-                    "premium_metrics": premium_metrics,
-                    "free_metrics": free_metrics,
-                    "utilization": utilization,
+                    "premium_instances": premium_instances,
+                    "free_instances": free_instances,
+                    "user_counts": user_counts,
+                    "actual_spend": actual_spend,
+                    "usage_hours": usage_hours,
+                    "calculated": calculated,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             ),
@@ -97,145 +501,3 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 }
             ),
         }
-
-
-def track_premium_instances(
-    ec2_client: "EC2Client", spot_fleet_id: str | None
-) -> Dict[str, Any]:
-    """Track premium instance metrics"""
-    try:
-        if not spot_fleet_id:
-            logger.warning("No spot fleet ID provided")
-            return {"instance_count": 0, "running_instances": 0}
-
-        # Get spot fleet instances
-        response = ec2_client.describe_spot_fleet_instances(
-            SpotFleetRequestId=spot_fleet_id
-        )
-        instances = response.get("ActiveInstances", [])
-
-        running_instances = len(
-            [i for i in instances if i.get("InstanceHealth") == "healthy"]
-        )
-
-        logger.info(
-            f"Premium instances - Total: {len(instances)}, Running: {running_instances}"
-        )
-
-        return {
-            "instance_count": len(instances),
-            "running_instances": running_instances,
-            "spot_fleet_id": spot_fleet_id,
-        }
-
-    except Exception as e:
-        logger.warning(f"Error tracking premium instances: {e}")
-        return {"instance_count": 0, "running_instances": 0}
-
-
-def track_free_instances(
-    asg_client: "AutoScalingClient", asg_name: str | None
-) -> Dict[str, Any]:
-    """Track free tier instance metrics"""
-    try:
-        if not asg_name:
-            logger.warning("No ASG name provided")
-            return {"instance_count": 0, "running_instances": 0}
-
-        # Get ASG instances
-        response = asg_client.describe_auto_scaling_groups(
-            AutoScalingGroupNames=[asg_name]
-        )
-
-        if not response["AutoScalingGroups"]:
-            logger.warning(f"ASG {asg_name} not found")
-            return {"instance_count": 0, "running_instances": 0}
-
-        asg = response["AutoScalingGroups"][0]
-        instances = asg.get("Instances", [])
-        running_instances = len(
-            [i for i in instances if i.get("LifecycleState") == "InService"]
-        )
-
-        logger.info(
-            f"Free tier instances - Total: {len(instances)}, "
-            f"Running: {running_instances}"
-        )
-
-        return {
-            "instance_count": len(instances),
-            "running_instances": running_instances,
-            "asg_name": asg_name,
-        }
-
-    except Exception as e:
-        logger.warning(f"Error tracking free instances: {e}")
-        return {"instance_count": 0, "running_instances": 0}
-
-
-def calculate_premium_utilization(
-    premium_metrics: Dict[str, Any], free_metrics: Dict[str, Any]
-) -> int:
-    """Calculate premium utilization percentage"""
-    try:
-        total_instances = premium_metrics.get(
-            "running_instances", 0
-        ) + free_metrics.get("running_instances", 0)
-
-        if total_instances == 0:
-            return 0
-
-        # For now, return a simple calculation based on active instances
-        # In a real implementation, you'd check actual user assignments
-        return min(100, (total_instances * 80))  # Assume 80% utilization per instance
-
-    except Exception as e:
-        logger.warning(f"Error calculating premium utilization: {e}")
-        return 0
-
-
-def publish_cost_metrics(
-    cloudwatch_client: "CloudWatchClient",
-    premium_metrics: Dict[str, Any],
-    free_metrics: Dict[str, Any],
-    utilization: int,
-) -> None:
-    """Publish metrics to CloudWatch"""
-    try:
-        namespace = "Optinist/CostTracking"
-
-        metrics = [
-            {
-                "MetricName": "PremiumInstanceCount",
-                "Value": premium_metrics.get("running_instances", 0),
-                "Unit": "Count",
-            },
-            {
-                "MetricName": "FreeInstanceCount",
-                "Value": free_metrics.get("running_instances", 0),
-                "Unit": "Count",
-            },
-            {
-                "MetricName": "PremiumUtilization",
-                "Value": utilization,
-                "Unit": "Percent",
-            },
-        ]
-
-        for metric in metrics:
-            cloudwatch_client.put_metric_data(
-                Namespace=namespace,
-                MetricData=[
-                    {
-                        "MetricName": metric["MetricName"],
-                        "Value": metric["Value"],
-                        "Unit": metric["Unit"],
-                        "Timestamp": datetime.now(timezone.utc),
-                    }
-                ],
-            )
-
-        logger.info(f"Published {len(metrics)} metrics to CloudWatch")
-
-    except Exception as e:
-        logger.error(f"Error publishing metrics: {e}")

--- a/infrastructure/terraform/cost_tracker_package/cost_tracker.py
+++ b/infrastructure/terraform/cost_tracker_package/cost_tracker.py
@@ -273,6 +273,103 @@ def query_usage_hours() -> Dict[str, Any]:
         }
 
 
+def generate_usage_report() -> Dict[str, Any]:
+    """Generate per-user usage breakdown for the current month.
+
+    Returns a dict with per-user rows and tier-level averages, suitable for
+    the monthly maintenance report.
+    """
+    try:
+        now = datetime.now(timezone.utc)
+        month_start = now.strftime("%Y-%m-01 00:00:00")
+        month_label = now.strftime("%Y-%m")
+
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """SELECT user_id, tier,
+                              COUNT(*) AS sessions,
+                              SUM(TIMESTAMPDIFF(SECOND, started_at,
+                                  COALESCE(ended_at, NOW())) / 3600.0) AS hours
+                       FROM instance_usage_log
+                       WHERE started_at >= %s
+                       GROUP BY user_id, tier
+                       ORDER BY hours DESC""",
+                    (month_start,),
+                )
+                rows = cursor.fetchall()
+
+        users = []
+        premium_hours_total = 0.0
+        free_hours_total = 0.0
+        premium_user_count = 0
+        free_user_count = 0
+
+        for row in rows:
+            hours = float(row["hours"] or 0.0)
+            tier = row["tier"]
+            rate = PREMIUM_HOURLY_RATE if tier == "premium" else FREE_HOURLY_RATE
+            cost = hours * rate
+
+            users.append(
+                {
+                    "user_id": row["user_id"],
+                    "tier": tier,
+                    "sessions": int(row["sessions"]),
+                    "hours": round(hours, 2),
+                    "cost": round(cost, 2),
+                }
+            )
+
+            if tier == "premium":
+                premium_hours_total += hours
+                premium_user_count += 1
+            else:
+                free_hours_total += hours
+                free_user_count += 1
+
+        premium_cost_total = premium_hours_total * PREMIUM_HOURLY_RATE
+        free_cost_total = free_hours_total * FREE_HOURLY_RATE
+
+        summary = {
+            "month": month_label,
+            "premium": {
+                "users": premium_user_count,
+                "total_hours": round(premium_hours_total, 2),
+                "total_cost": round(premium_cost_total, 2),
+                "avg_hours": round(premium_hours_total / premium_user_count, 2)
+                if premium_user_count > 0
+                else 0.0,
+                "avg_cost": round(premium_cost_total / premium_user_count, 2)
+                if premium_user_count > 0
+                else 0.0,
+            },
+            "free": {
+                "users": free_user_count,
+                "total_hours": round(free_hours_total, 2),
+                "total_cost": round(free_cost_total, 2),
+                "avg_hours": round(free_hours_total / free_user_count, 2)
+                if free_user_count > 0
+                else 0.0,
+                "avg_cost": round(free_cost_total / free_user_count, 2)
+                if free_user_count > 0
+                else 0.0,
+            },
+        }
+
+        logger.info(
+            f"Usage report — {len(users)} users, "
+            f"premium: {premium_user_count} ({premium_hours_total:.1f}h), "
+            f"free: {free_user_count} ({free_hours_total:.1f}h)"
+        )
+
+        return {"summary": summary, "users": users}
+
+    except Exception as e:
+        logger.error(f"Error generating usage report: {e}")
+        return {"summary": {}, "users": [], "error": str(e)}
+
+
 def calculate_metrics(
     premium_instances: Dict[str, Any],
     free_instances: Dict[str, Any],
@@ -426,8 +523,29 @@ def publish_metrics(
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """Cost tracking Lambda handler — orchestrates all tracking steps."""
+    """Cost tracking Lambda handler — orchestrates all tracking steps.
+
+    Supports two modes via event["mode"]:
+      - (default): hourly metrics collection and CloudWatch publish
+      - "usage_report": on-demand per-user usage breakdown for reports
+    """
     logger.info("Cost tracking Lambda invoked")
+
+    mode = event.get("mode", "metrics")
+
+    if mode == "usage_report":
+        try:
+            report = generate_usage_report()
+            return {
+                "statusCode": 200,
+                "body": json.dumps(report, default=str),
+            }
+        except Exception as e:
+            logger.error(f"Error generating usage report: {e}")
+            return {
+                "statusCode": 500,
+                "body": json.dumps({"error": str(e)}),
+            }
 
     try:
         region = os.environ.get("REGION", "ap-northeast-1")

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -205,6 +205,11 @@ variable "admin_storage_quota_bytes" {
   default     = 214748364800 # 200 GB
 }
 
+variable "monthly_budget_usd" {
+  description = "Monthly cost budget in USD. Alert fires when projected spend exceeds this."
+  type        = number
+}
+
 # Data sources
 data "aws_caller_identity" "current" {}
 

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -390,12 +390,12 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 6
         properties = {
           metrics = [
-            ["AWS/Billing", "EstimatedCharges", "Currency", "USD", "ServiceName", "AmazonEC2", { "label" : "EC2 Costs" }],
-            ["AWS/Billing", "EstimatedCharges", "Currency", "USD", "ServiceName", "AmazonECS", { "label" : "ECS Costs" }],
-            ["AWS/Billing", "EstimatedCharges", "Currency", "USD", "ServiceName", "AmazonElasticLoadBalancing", { "label" : "ALB Costs" }],
+            ["Optinist/CostTracking", "ActualMonthToDateSpend", { "label" : "Actual MTD Spend ($)", "yAxis" : "left" }],
+            ["Optinist/CostTracking", "ExpectedMonthlyBudget", { "label" : "Expected Budget ($)", "yAxis" : "left" }],
             ["Optinist/CostTracking", "PremiumInstanceCount", { "label" : "Premium Instances", "yAxis" : "right" }],
             ["Optinist/CostTracking", "FreeInstanceCount", { "label" : "Free Tier Instances", "yAxis" : "right" }],
-            ["Optinist/CostTracking", "PremiumUtilization", { "label" : "Premium Utilization %", "yAxis" : "right" }]
+            ["Optinist/CostTracking", "ActivePremiumUsers", { "label" : "Active Premium Users", "yAxis" : "right" }],
+            ["Optinist/CostTracking", "ActiveFreeUsers", { "label" : "Active Free Users", "yAxis" : "right" }]
           ]
           view    = "timeSeries"
           stacked = false
@@ -403,6 +403,16 @@ resource "aws_cloudwatch_dashboard" "main" {
           title   = "Cost Tracking & Instance Counts"
           period  = 3600
           stat    = "Maximum"
+          yAxis = {
+            left = {
+              label = "USD"
+              min   = 0
+            }
+            right = {
+              label = "Count"
+              min   = 0
+            }
+          }
         }
       },
       # Row 3: Load Balancer Performance
@@ -694,7 +704,7 @@ resource "aws_cloudwatch_dashboard" "main" {
             aws_cloudwatch_metric_alarm.background_cpu_high.arn,
             aws_cloudwatch_metric_alarm.background_memory_high.arn,
             # Premium Tier Alarms
-            aws_cloudwatch_metric_alarm.premium_cost_high.arn,
+            aws_cloudwatch_metric_alarm.monthly_cost_high.arn,
             aws_cloudwatch_metric_alarm.premium_cpu_high.arn,
             aws_cloudwatch_metric_alarm.premium_memory_high.arn,
             # Autoscaling Alarms

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -286,6 +286,14 @@ def cleanup_stale_assignments(connection) -> Dict[str, Any]:
                             f"target group: {target_group_arn}"
                         )
 
+                    # Close usage log before deleting assignment
+                    cursor.execute(
+                        """UPDATE instance_usage_log SET ended_at = NOW()
+                           WHERE user_id = %s AND tier = 'premium'
+                           AND ended_at IS NULL""",
+                        (user_id,),
+                    )
+
                     # Remove from database
                     cursor.execute(
                         "DELETE FROM premium_user_assignments WHERE user_id = %s",
@@ -723,25 +731,68 @@ def get_standby_pool_status() -> Dict[str, Any]:
 
 
 def ensure_standby_pool_capacity() -> Dict[str, Any]:
-    """Ensure standby pool maintains required capacity and handle failed instances"""
+    """Ensure standby pool maintains required capacity and handle failed instances.
+
+    When more instances are flagged as standby than the target pool size,
+    clears excess is_standby flags so those instances become eligible for
+    normal idle cleanup/termination in subsequent runs.
+    """
     try:
         status = get_standby_pool_status()
 
         if "error" in status:
             return {"success": False, "error": status["error"]}
 
-        target_stopped = 1
+        target_stopped = int(os.environ.get("PREMIUM_STANDBY_POOL_SIZE", "1"))
         actions_taken = []
 
         # Log current status
         print(
             f"Standby pool status: {status['running']} running, "
-            f"{status['stopped']} stopped, {status['failed']} failed"
+            f"{status['stopped']} stopped, {status['failed']} failed "
+            f"(target standby: {target_stopped})"
         )
 
         # Check for capacity issues
         if status["stopped"] < target_stopped and status["idle_running"] == 0:
             actions_taken.append("Low standby capacity detected")
+
+        # Enforce pool size: clear excess standby flags
+        if status["stopped"] > target_stopped:
+            excess = status["stopped"] - target_stopped
+            print(
+                f"Excess standby instances: {excess} "
+                f"(have {status['stopped']}, target {target_stopped}). "
+                f"Clearing excess is_standby flags."
+            )
+            try:
+                with get_db_connection() as conn:
+                    with conn.cursor() as cursor:
+                        # Keep the newest target_stopped standby instances,
+                        # clear is_standby on the rest (oldest first)
+                        cursor.execute(
+                            """UPDATE premium_user_assignments
+                               SET is_standby = 0
+                               WHERE is_standby = 1
+                               AND id NOT IN (
+                                   SELECT id FROM (
+                                       SELECT id FROM premium_user_assignments
+                                       WHERE is_standby = 1
+                                       ORDER BY last_activity DESC
+                                       LIMIT %s
+                                   ) AS keep_rows
+                               )""",
+                            (target_stopped,),
+                        )
+                        cleared = cursor.rowcount
+                    conn.commit()
+                actions_taken.append(
+                    f"Cleared is_standby flag on {cleared} excess instances"
+                )
+                print(f"Cleared is_standby flag on {cleared} excess instances")
+            except Exception as e:
+                actions_taken.append(f"Failed to clear excess standby flags: {e}")
+                print(f"Error clearing excess standby flags: {e}")
 
         if status["failed"] > 0:
             actions_taken.append(f"Found {status['failed']} failed instances")
@@ -1024,6 +1075,14 @@ def cleanup_test_user_assignments(connection, user_emails: List[str]) -> Dict[st
                             print(f"Deleted target group for user {user_id}")
                         except Exception as e:
                             print(f"Warning: Failed to delete target group: {e}")
+
+                    # Close usage log before deleting assignment
+                    cursor.execute(
+                        """UPDATE instance_usage_log SET ended_at = NOW()
+                           WHERE user_id = %s AND tier = 'premium'
+                           AND ended_at IS NULL""",
+                        (user_id,),
+                    )
 
                     # Remove from database
                     cursor.execute(
@@ -1378,7 +1437,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         print("Step 4: Reconciling instance states...")
         results["reconciliation_stats"] = reconcile_instance_states()
 
-        # 5. Monitor standby pool capacity (read-only check)
+        # 5. Monitor and enforce standby pool capacity
         print("Step 5: Checking standby pool capacity...")
         results["capacity_check"] = ensure_standby_pool_capacity()
 

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -537,29 +537,60 @@ resource "aws_cloudwatch_log_metric_filter" "premium_assignments" {
 # Cost tracker
 # ======================
 
+# Install dependencies for cost tracker Lambda
+resource "null_resource" "install_cost_tracker_dependencies" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      mkdir -p ${path.module}/cost_tracker_package
+      /usr/bin/python3 -m pip install pymysql -t ${path.module}/cost_tracker_package/ --no-cache-dir
+      cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py
+    EOT
+  }
+
+  triggers = {
+    code_changes = md5(join("", [
+      filesha256("${path.module}/cost_tracker_package/cost_tracker.py"),
+      filesha256("${path.module}/../aws_constants.py")
+    ]))
+  }
+}
+
 # Create ZIP using archive_file for cost tracker Lambda
 data "archive_file" "cost_tracker_zip" {
   type        = "zip"
   source_dir  = "${path.module}/cost_tracker_package"
   output_path = "${path.module}/cost_tracker.py.zip"
+
+  depends_on = [null_resource.install_cost_tracker_dependencies]
 }
 
 # Cost Tracking Lambda Function
 resource "aws_lambda_function" "cost_tracker" {
   filename         = "${path.module}/cost_tracker.py.zip"
   function_name    = "subscr-cost-tracker"
-  role             = aws_iam_role.premium_manager_lambda.arn
+  role             = aws_iam_role.cost_controller_lambda.arn
   handler          = "cost_tracker.handler"
   runtime          = "python3.11"
   timeout          = 300
+  layers           = [aws_lambda_layer_version.aws_constants.arn]
   source_code_hash = data.archive_file.cost_tracker_zip.output_base64sha256
 
   environment {
     variables = {
-      ASG_NAME      = aws_autoscaling_group.main.name
-      REGION        = var.aws_region
-      INSTANCE_TYPE = "t3.large"
+      ASG_NAME               = aws_autoscaling_group.main.name
+      REGION                 = var.aws_region
+      RDS_HOST               = aws_db_proxy.main.endpoint
+      RDS_USER               = var.mysql_user
+      RDS_PASSWORD           = var.mysql_password
+      RDS_DATABASE           = var.mysql_database
+      PREMIUM_HOURLY_RATE    = "0.1088"
+      FREE_HOURLY_RATE       = "0.1088"
     }
+  }
+
+  vpc_config {
+    subnet_ids         = [aws_subnet.private1.id, aws_subnet.private2.id]
+    security_group_ids = [aws_security_group.ecs.id]
   }
 
   tags = {
@@ -568,7 +599,9 @@ resource "aws_lambda_function" "cost_tracker" {
   }
 
   depends_on = [
-    aws_iam_role_policy_attachment.premium_manager_lambda_basic
+    aws_iam_role_policy_attachment.cost_controller_lambda_vpc,
+    aws_cloudwatch_log_group.cost_tracker_logs,
+    data.archive_file.cost_tracker_zip
   ]
 }
 
@@ -583,9 +616,9 @@ resource "aws_cloudwatch_log_group" "cost_tracker_logs" {
   }
 }
 
-# Cost Controller Lambda Role
+# Cost Tracker Lambda Role (dedicated least-privilege role)
 resource "aws_iam_role" "cost_controller_lambda" {
-  name = "subscr-cost-controller-lambda-role"
+  name = "subscr-cost-tracker-lambda-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -601,9 +634,46 @@ resource "aws_iam_role" "cost_controller_lambda" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "cost_controller_lambda_basic" {
+resource "aws_iam_role_policy_attachment" "cost_controller_lambda_vpc" {
   role       = aws_iam_role.cost_controller_lambda.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy" "cost_tracker_permissions" {
+  name = "subscr-cost-tracker-permissions"
+  role = aws_iam_role.cost_controller_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData",
+          "cloudwatch:GetMetricData"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "autoscaling:DescribeAutoScalingGroups"
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ce:GetCostAndUsage"
+        Resource = "*"
+      }
+    ]
+  })
 }
 
 # EventBridge rule to trigger cost tracker Lambda hourly
@@ -632,22 +702,23 @@ resource "aws_lambda_permission" "allow_eventbridge_cost_tracker" {
   source_arn    = aws_cloudwatch_event_rule.cost_tracker_schedule.arn
 }
 
-# Essential CloudWatch Alarms for Premium Monitoring
-resource "aws_cloudwatch_metric_alarm" "premium_cost_high" {
-  alarm_name          = "subscr-premium-monthly-cost-high"
+# Account-level cost alarm
+# Fires when projected monthly spend exceeds the budget set in tfvars
+resource "aws_cloudwatch_metric_alarm" "monthly_cost_high" {
+  alarm_name          = "subscr-monthly-cost-high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = "TotalMonthlyCost"
-  namespace           = "OptiNiSt/Cost"
-  period              = "86400" # Daily
+  metric_name         = "ExpectedMonthlyBudget"
+  namespace           = "Optinist/CostTracking"
+  period              = "86400"
   statistic           = "Maximum"
-  threshold           = "500"
-  alarm_description   = "Monthly cost estimate is high"
+  threshold           = var.monthly_budget_usd
+  alarm_description   = "Projected monthly spend exceeds budget ($${var.monthly_budget_usd})"
   alarm_actions       = [aws_sns_topic.critical_alerts.arn]
   ok_actions          = [aws_sns_topic.critical_alerts.arn]
 
   tags = {
-    Name    = "High Monthly Cost Alarm"
+    Name    = "Monthly Cost Budget Alarm"
     Service = "cost-monitoring"
   }
 }

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -439,6 +439,15 @@ def _store_user_assignment_transaction(
                         f"workflows - will preserve count in premium assignment"
                     )
 
+            # Close free-tier usage log before deleting assignment
+            if user_id is not None:
+                cursor.execute(
+                    """UPDATE instance_usage_log SET ended_at = NOW()
+                       WHERE user_id = %s AND tier = 'free'
+                       AND ended_at IS NULL""",
+                    (user_id,),
+                )
+
             cursor.execute(
                 """DELETE FROM free_user_assignments WHERE user_id = %s""",
                 (user_id,),
@@ -477,6 +486,15 @@ def _store_user_assignment_transaction(
                 preserved_workflow_count,  # Preserve workflow count from free tier
             ),
         )
+
+        # Log premium usage session (skip standby — no real user)
+        if user_id is not None and not is_standby:
+            cursor.execute(
+                """INSERT INTO instance_usage_log
+                   (user_id, instance_id, tier, started_at)
+                   VALUES (%s, %s, 'premium', NOW())""",
+                (user_id, instance_id),
+            )
 
     print(
         f"Stored assignment in RDS: user {user_id} -> instance {instance_id} "
@@ -520,6 +538,15 @@ def _remove_user_assignment_transaction(connection, user_id: int):
 
         if not assignment:
             raise Exception(f"No assignment found for user {user_id}")
+
+        # Close usage log BEFORE delete (crash-safe: orphan assignment
+        # is recoverable, missing ended_at is not)
+        cursor.execute(
+            """UPDATE instance_usage_log SET ended_at = NOW()
+               WHERE user_id = %s AND tier = 'premium'
+               AND ended_at IS NULL""",
+            (user_id,),
+        )
 
         # Delete assignment
         cursor.execute(

--- a/studio/alembic/versions/k901k9300025_add_instance_usage_log.py
+++ b/studio/alembic/versions/k901k9300025_add_instance_usage_log.py
@@ -1,0 +1,69 @@
+"""add_instance_usage_log
+
+Track per-user session hours for usage-based cost reporting.
+
+Table created:
+- instance_usage_log: Records user sessions with start/end timestamps
+
+Revision ID: k901k9300025
+Revises: j901j9290024
+Create Date: 2026-03-06 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+revision = "k901k9300025"
+down_revision = "j901j9290024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "instance_usage_log",
+        sa.Column(
+            "id",
+            mysql.BIGINT(unsigned=True),
+            primary_key=True,
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            mysql.BIGINT(unsigned=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "instance_id",
+            sa.VARCHAR(20),
+            nullable=False,
+        ),
+        sa.Column(
+            "tier",
+            sa.Enum("free", "premium", name="usage_tier_enum"),
+            nullable=False,
+        ),
+        sa.Column(
+            "started_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "ended_at",
+            sa.TIMESTAMP(),
+            nullable=True,
+            comment="NULL means session is still active",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.Index("idx_usage_log_user_tier", "user_id", "tier"),
+        sa.Index("idx_usage_log_active", "ended_at"),
+        sa.Index("idx_usage_log_tier_started", "tier", "started_at"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("instance_usage_log")

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -35,6 +35,7 @@ from studio.app.common.models import (
     User,
     Workspace,
 )
+from studio.app.common.models.instance_usage import UsageTier
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -422,7 +423,7 @@ class DataCleanupJob:
                     update(InstanceUsageLog)
                     .where(
                         InstanceUsageLog.user_id == user_id,
-                        InstanceUsageLog.tier == "free",
+                        InstanceUsageLog.tier == UsageTier.FREE,
                         InstanceUsageLog.ended_at.is_(None),
                     )
                     .values(ended_at=get_current_datetime())

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -477,7 +477,7 @@ class DataCleanupJob:
                 update(InstanceUsageLog)
                 .where(
                     InstanceUsageLog.user_id == assignment.user_id,
-                    InstanceUsageLog.tier == "free",
+                    InstanceUsageLog.tier == UsageTier.FREE,
                     InstanceUsageLog.ended_at.is_(None),
                 )
                 .values(ended_at=get_current_datetime())

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -20,7 +20,7 @@ import shutil
 from datetime import timedelta
 from typing import List, Tuple
 
-from sqlalchemy import func
+from sqlalchemy import func, update
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
@@ -29,7 +29,12 @@ from studio.app.common.core.subscription.constants import SyncStatusConstants
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.db.database import session_scope
-from studio.app.common.models import FreeUserAssignment, User, Workspace
+from studio.app.common.models import (
+    FreeUserAssignment,
+    InstanceUsageLog,
+    User,
+    Workspace,
+)
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -412,6 +417,16 @@ class DataCleanupJob:
             assignment = result_row[0] if result_row else None
 
             if assignment:
+                # Close usage log before deleting assignment
+                db.execute(
+                    update(InstanceUsageLog)
+                    .where(
+                        InstanceUsageLog.user_id == user_id,
+                        InstanceUsageLog.tier == "free",
+                        InstanceUsageLog.ended_at.is_(None),
+                    )
+                    .values(ended_at=get_current_datetime())
+                )
                 db.delete(assignment)
                 db.commit()
 
@@ -455,6 +470,17 @@ class DataCleanupJob:
 
             workspace_ids = [str(row[0].id) for row in workspaces_result]
             cls._cleanup_user_data(assignment.user_id, workspace_ids)
+
+            # Close usage log before deleting assignment
+            db.execute(
+                update(InstanceUsageLog)
+                .where(
+                    InstanceUsageLog.user_id == assignment.user_id,
+                    InstanceUsageLog.tier == "free",
+                    InstanceUsageLog.ended_at.is_(None),
+                )
+                .values(ended_at=get_current_datetime())
+            )
 
             # Remove assignment
             db.delete(assignment)

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -442,7 +442,7 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
                 usage_entry = InstanceUsageLog(
                     user_id=user_id,
                     instance_id=instance_id,
-                    tier="free",
+                    tier=TIER_FREE,
                     started_at=now,
                 )
                 session.add(usage_entry)

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -39,6 +39,7 @@ from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.db.database import session_scope
 from studio.app.common.models import FreeUserAssignment
+from studio.app.common.models.instance_usage import InstanceUsageLog
 
 # Constants
 BEARER_PREFIX = "Bearer "
@@ -436,6 +437,15 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
                     last_activity=now,
                 )
                 session.add(assignment)
+
+                # Log usage session for cost tracking
+                usage_entry = InstanceUsageLog(
+                    user_id=user_id,
+                    instance_id=instance_id,
+                    tier="free",
+                    started_at=now,
+                )
+                session.add(usage_entry)
 
             session.commit()
             return True

--- a/studio/app/common/models/__init__.py
+++ b/studio/app/common/models/__init__.py
@@ -1,5 +1,6 @@
 from studio.app.common.models.experiment import ExperimentRecord
 from studio.app.common.models.free_user import FreeUserAssignment
+from studio.app.common.models.instance_usage import InstanceUsageLog
 from studio.app.common.models.premium_user import PremiumUserAssignment
 from studio.app.common.models.subscription import (
     SubscriptionPlans,
@@ -12,6 +13,7 @@ from studio.app.common.models.workspace import Workspace, WorkspacesShareUser
 __all__ = [
     "ExperimentRecord",
     "FreeUserAssignment",
+    "InstanceUsageLog",
     "PremiumUserAssignment",
     "Organization",
     "Role",

--- a/studio/app/common/models/instance_usage.py
+++ b/studio/app/common/models/instance_usage.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import TIMESTAMP
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.dialects.mysql import BIGINT, VARCHAR
+from sqlalchemy.sql.functions import current_timestamp
+from sqlmodel import Column, Field, SQLModel
+
+
+class UsageTier(str, Enum):
+    FREE = "free"
+    PREMIUM = "premium"
+
+
+class InstanceUsageLog(SQLModel, table=True):
+    __tablename__ = "instance_usage_log"
+
+    id: Optional[int] = Field(
+        sa_column=Column(
+            BIGINT(unsigned=True),
+            primary_key=True,
+            nullable=False,
+            autoincrement=True,
+        ),
+        default=None,
+    )
+    user_id: int = Field(
+        sa_column=Column(BIGINT(unsigned=True), nullable=False),
+    )
+    instance_id: str = Field(sa_column=Column(VARCHAR(20), nullable=False))
+    tier: UsageTier = Field(
+        sa_column=Column(
+            SQLEnum("free", "premium", name="usage_tier_enum"),
+            nullable=False,
+        ),
+    )
+    started_at: Optional[datetime] = Field(
+        sa_column=Column(TIMESTAMP, nullable=False, server_default=current_timestamp()),
+    )
+    ended_at: Optional[datetime] = Field(
+        sa_column=Column(
+            TIMESTAMP,
+            nullable=True,
+            comment="NULL means session is still active",
+        ),
+        default=None,
+    )

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -27,7 +27,7 @@ from studio.app.common.core.users import crud_users
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.db.database import get_db
 from studio.app.common.models import FreeUserAssignment
-from studio.app.common.models.instance_usage import InstanceUsageLog
+from studio.app.common.models.instance_usage import InstanceUsageLog, UsageTier
 from studio.app.common.schemas.users import SelfUserUpdate, User, UserPasswordUpdate
 
 router = APIRouter(prefix="/users/me", tags=["users/me"])
@@ -270,7 +270,7 @@ async def logout_free_user(
             update(InstanceUsageLog)
             .where(
                 InstanceUsageLog.user_id == current_user.id,
-                InstanceUsageLog.tier == "free",
+                InstanceUsageLog.tier == UsageTier.FREE,
                 InstanceUsageLog.ended_at.is_(None),
             )
             .values(ended_at=now)

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -27,6 +27,7 @@ from studio.app.common.core.users import crud_users
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.db.database import get_db
 from studio.app.common.models import FreeUserAssignment
+from studio.app.common.models.instance_usage import InstanceUsageLog
 from studio.app.common.schemas.users import SelfUserUpdate, User, UserPasswordUpdate
 
 router = APIRouter(prefix="/users/me", tags=["users/me"])
@@ -255,12 +256,27 @@ async def logout_free_user(
         # Update logged_out_at timestamp via direct SQL
         from sqlalchemy import update
 
+        now = get_current_datetime()
+
         stmt = (
             update(FreeUserAssignment)
             .where(FreeUserAssignment.user_id == current_user.id)
-            .values(logged_out_at=get_current_datetime())
+            .values(logged_out_at=now)
         )
         result = db.execute(stmt)
+
+        # Close usage log session
+        usage_stmt = (
+            update(InstanceUsageLog)
+            .where(
+                InstanceUsageLog.user_id == current_user.id,
+                InstanceUsageLog.tier == "free",
+                InstanceUsageLog.ended_at.is_(None),
+            )
+            .values(ended_at=now)
+        )
+        db.execute(usage_stmt)
+
         db.commit()
 
         if result.rowcount > 0:


### PR DESCRIPTION
### Content

#### Summary
- Adds `instance_usage_log` table to track per-user session hours across free and premium tiers, enabling usage-based cost reporting instead of assuming 24/7 usage.
- Rewrites Cost Tracker Lambda to query Cost Explorer for actual spend, compute per-user costs from session hours, and publish 11 metrics to CloudWatch `Optinist/CostTracking` namespace. Adds on-demand `usage_report` mode returning per-user breakdown (user, tier, sessions, hours, cost).
- Integrates usage log lifecycle into all user session flows: middleware (free login), router (free logout), premium manager (assign/release), and cleanup jobs (stale/orphaned sessions).
- Replaces the hardcoded $500 cost alarm with a configurable `var.monthly_budget_usd` threshold based on projected spend.

#### Design Decisions
- **Usage logs closed BEFORE assignments deleted** — if the Lambda crashes between the two operations, an orphan assignment is recoverable but a missing `ended_at` would permanently inflate session hours. Ordering the operations this way is crash-safe.
- **Dedicated IAM role for Cost Tracker** — `subscr-cost-tracker-lambda-role` has only CloudWatch, EC2 Describe, ASG Describe, and Cost Explorer permissions rather than inheriting the premium manager's broader role. Follows least-privilege.
- **Cost Explorer `UnblendedCost` over `AmortizedCost`** — unblended reflects actual invoice amounts and is simpler to reason about. No reserved instances or savings plans are in use.
- **Hourly cadence, daily alarm evaluation** — metrics refresh hourly for dashboard freshness, but the cost alarm evaluates on a 24-hour period to avoid alert noise from hourly fluctuations.
- **Per-user cost uses unique session users, not currently-active users** — dividing total MTD session cost by `COUNT(DISTINCT user_id)` from usage logs gives an accurate per-user cost even when users log in/out throughout the month.
- **Per-user breakdown via Lambda invoke, not direct RDS** — the maintenance script invokes the cost-tracker Lambda in `usage_report` mode rather than connecting to RDS directly. This reuses the Lambda's existing VPC/RDS credentials and avoids exposing database access to the script runner.
- **Standby pool size from env var** — `PREMIUM_STANDBY_POOL_SIZE` replaces the hardcoded `1`, allowing ops to tune without redeployment.

### Evidence
- N/A (infrastructure change, requires deployment to verify metrics in CloudWatch)

### References
- Builds on prior commits: cost tracker Lambda skeleton, monitoring dashboard, maintenance scripts
- Architecture doc: `infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md` (included in this PR)

#### Files changed

##### Infrastructure — Lambda Code
- `infrastructure/terraform/cost_tracker_package/cost_tracker.py` -- Rewrite: add RDS queries for user counts and session hours, Cost Explorer integration, usage-based metric calculations, batch CloudWatch publish. Add `generate_usage_report()` and `usage_report` handler mode for on-demand per-user breakdown
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` -- Close usage logs before deleting stale/test premium assignments; enforce standby pool size by clearing excess `is_standby` flags
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Create premium usage log on assignment; close free usage log on free-to-premium migration; close premium usage log on release

##### Infrastructure — Terraform
- `infrastructure/terraform/main.tf` -- Add `monthly_budget_usd` variable for configurable cost alarm threshold
- `infrastructure/terraform/monitoring.tf` -- Update dashboard widget to show Actual MTD Spend and Expected Budget on left axis; update alarm reference from `premium_cost_high` to `monthly_cost_high`
- `infrastructure/terraform/premium_manager.tf` -- Add dedicated IAM role/policy for cost tracker; add VPC config, Lambda layer, RDS env vars; replace hardcoded $500 alarm with `var.monthly_budget_usd`; add dependency install step for pymysql

##### Backend — Models & Migrations
- `studio/alembic/versions/k901k9300025_add_instance_usage_log.py` -- New: Alembic migration creating `instance_usage_log` table with indices for user/tier lookups and monthly aggregation
- `studio/app/common/models/instance_usage.py` -- New: SQLModel for `instance_usage_log` with `UsageTier` enum
- `studio/app/common/models/__init__.py` -- Export `InstanceUsageLog`

##### Backend — Session Lifecycle
- `studio/app/common/core/middleware/user_activity_middleware.py` -- Create free-tier usage log entry when a new free assignment is created
- `studio/app/common/routers/users_me.py` -- Close free-tier usage log on explicit logout
- `studio/app/common/core/background/cleanup_job.py` -- Close free-tier usage logs in both cleanup paths (mark_cleaned and orphaned assignments)

##### Documentation
- `infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md` -- New: comprehensive architecture doc covering data flows, formulas, edge cases, metrics reference, and maintenance report integration
- `infrastructure/documentation/LOGGING_ARCHITECTURE.md` -- Update alarm name from `subscr-premium-monthly-cost-high` to `subscr-monthly-cost-high`
- `infrastructure/documentation/MAINTENANCE_PROCEDURES.md` -- Add cost alarm section, update alarm references and cost alert description
- `infrastructure/scripts/monthly-maintenance.sh` -- Add section 1b querying all 11 `Optinist/CostTracking` metrics with formatted output. Add section 1c invoking cost-tracker Lambda in `usage_report` mode: per-tier averages in main report, per-user breakdown in Appendix C

### Manual Testcases
- Deploy to staging environment
- Verify `instance_usage_log` table is created by running the Alembic migration
- Login as a free user → verify `instance_usage_log` row created with `tier=free`, `ended_at=NULL`
- Logout free user → verify `ended_at` is populated on the usage log row
- Assign a premium user → verify usage log row with `tier=premium`
- Release premium user → verify `ended_at` is populated
- Wait for Cost Tracker Lambda hourly trigger (or invoke manually)
- Check CloudWatch namespace `Optinist/CostTracking` for all 11 metrics
- Verify dashboard widget "Cost Tracking & Instance Counts" shows spend on left axis, counts on right axis
- Set `monthly_budget_usd` below current projected spend → verify alarm transitions to ALARM state
- Run `./infrastructure/scripts/monthly-maintenance.sh` → verify "Cost Tracker Metrics" section appears in report
- Verify "Per-User Usage Summary" section appears in main report with tier averages
- Verify "Appendix C: Per-User Usage Breakdown" contains per-user table (user_id, tier, sessions, hours, cost)
- Invoke Lambda manually with `{"mode":"usage_report"}` → verify JSON response contains `summary` and `users` arrays

### Unit, Integration, Contract Test Coverage
- No automated tests added for Lambda or usage log lifecycle (Lambda runs in AWS, not in local test suite)
- Model `InstanceUsageLog` follows the same pattern as existing `FreeUserAssignment` which has integration coverage

### Others

#### Difficulties
- Cost Explorer API has a quirk where the end date is exclusive, so querying on the 1st of the month with `Start == End` is invalid. Added an early return for this edge case.
- MySQL `UPDATE ... WHERE id NOT IN (SELECT id FROM ...)` requires a subquery wrapper to avoid "You can't specify target table for update in FROM clause" error.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `instance_usage_log` table creation | Low | New table, no existing data affected. Migration has downgrade path. |
| Usage log lifecycle (create/close) | Medium | Touches 6 code paths across 4 components. If any path misses closing a log, session hours inflate. Safety net: premium cleanup and data cleanup close orphans hourly. |
| Cost Tracker Lambda rewrite | Medium | Complete rewrite with new RDS and Cost Explorer dependencies. Failure is non-destructive (metrics stop updating, no user impact). `usage_report` mode is read-only; errors return 500 without side effects. |
| Cost alarm threshold change | Low | Moving from hardcoded $500 to `var.monthly_budget_usd`. Value set in `terraform.tfvars` (not in repo). |
| Standby pool enforcement | Medium | New logic clears excess `is_standby` flags. Incorrect clearing could cause premature instance termination. Mitigated by keeping newest instances and only clearing oldest. |
