### PR TITLE
update code subscription checkout bug

### DIFF
--- a/frontend/src/pages/Subscription/index.tsx
+++ b/frontend/src/pages/Subscription/index.tsx
@@ -155,7 +155,16 @@ const SubscriptionPlans = () => {
             setRecoveryMessage(errorMessage)
             // Refresh subscription data to reflect the recovered subscription
             dispatch(getUserSubscription())
+          } else {
+            // Non-recovery rejection — Redux error state handles the UI display
+            // eslint-disable-next-line no-console
+            console.error("Checkout session failed:", errorMessage)
           }
+        } else {
+          // Defensive guard: createAsyncThunk should only produce
+          // fulfilled or rejected, but log if an unexpected state occurs.
+          // eslint-disable-next-line no-console
+          console.warn("Unexpected checkout result action:", resultAction)
         }
       } catch (error) {
         // eslint-disable-next-line no-console

--- a/frontend/src/pages/Subscription/index.tsx
+++ b/frontend/src/pages/Subscription/index.tsx
@@ -66,6 +66,7 @@ const SubscriptionPlans = () => {
 
   // State for data storage info dialog
   const [showDataStorageDialog, setShowDataStorageDialog] = useState(false)
+  const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null)
 
   // Fetch data on component mount
   useEffect(() => {
@@ -146,14 +147,15 @@ const SubscriptionPlans = () => {
 
           // Redirect to Stripe checkout
           window.location.href = checkout_url
-        } else {
-          // Handle error case
-          // eslint-disable-next-line no-console
-          console.error(
-            "Failed to create checkout session:",
-            resultAction.error,
-          )
-          // You might want to show an error message to the user here
+        } else if (createCheckoutSession.rejected.match(resultAction)) {
+          const errorMessage = resultAction.payload || ""
+          // Check if this is a subscription recovery case (409)
+          if (errorMessage.includes("already a premium user")) {
+            dispatch(clearError())
+            setRecoveryMessage(errorMessage)
+            // Refresh subscription data to reflect the recovered subscription
+            dispatch(getUserSubscription())
+          }
         }
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -286,6 +288,13 @@ const SubscriptionPlans = () => {
             <strong>{getExpirationDate()}</strong>. You can renew your
             subscription after this date.
           </Typography>
+        </Alert>
+      )}
+
+      {/* Subscription recovery notification */}
+      {recoveryMessage && (
+        <Alert severity="success" sx={{ mb: 3, maxWidth: "600px" }}>
+          <Typography variant="body2">{recoveryMessage}</Typography>
         </Alert>
       )}
 

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -549,6 +549,53 @@ class CheckoutService:
 
                     db.commit()
 
+                    # Set default payment method from the recovered subscription
+                    try:
+                        payment_method_id = None
+
+                        # Try getting payment method from the subscription
+                        if stripe_sub.default_payment_method:
+                            payment_method_id = stripe_sub.default_payment_method
+                        else:
+                            # Fallback: get the most recent payment method
+                            # attached to the customer
+                            for pm_type in [
+                                PAYMENT_METHOD_TYPE_CARD,
+                                PAYMENT_METHOD_TYPE_LINK,
+                            ]:
+                                payment_methods = stripe.PaymentMethod.list(
+                                    customer=customer_id, type=pm_type, limit=1
+                                )
+                                if payment_methods.data:
+                                    payment_method_id = (
+                                        payment_methods.data[0].id
+                                    )
+                                    break
+
+                        if payment_method_id:
+                            stripe.Customer.modify(
+                                customer_id,
+                                invoice_settings={
+                                    "default_payment_method": payment_method_id
+                                },
+                            )
+                            logger.info(
+                                f"Recovery: Set payment method "
+                                f"{payment_method_id} as default "
+                                f"for customer {customer_id}"
+                            )
+                        else:
+                            logger.warning(
+                                f"Recovery: No payment method found for "
+                                f"customer {customer_id}"
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Recovery: Failed to set default payment "
+                            f"method for customer {customer_id}: {str(e)}"
+                        )
+                        # Non-critical, continue with recovery
+
                     # Invalidate cache
                     try:
                         from studio.app.common.core.middleware.secure_routing_middleware import (  # noqa: E501
@@ -659,8 +706,10 @@ class CheckoutService:
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                "You already have an active subscription. "
-                                "It has been synced to your account."
+                                "You are already a premium user. "
+                                "Due to a temporary system issue, your "
+                                "subscription was not reflected in your "
+                                "account. It has now been restored."
                             ),
                         )
 
@@ -738,10 +787,7 @@ class CheckoutService:
                 )
 
         except HTTPException:
-            raise HTTPException(
-                status_code=500,
-                detail=("Error processing handle chekckout session request"),
-            )
+            raise
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Internal server error: {str(e)}"

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -785,6 +785,9 @@ class CheckoutService:
                 )
 
         except HTTPException:
+            # Re-raise HTTPExceptions as-is (e.g., 404 plan not found, 400
+            # missing Stripe price, 409 subscription recovery) so they are not
+            # caught by the generic Exception handler below and wrapped in a 500.
             raise
         except Exception as e:
             raise HTTPException(

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
+from sqlalchemy import update
 from sqlmodel import Session
 
 from studio.app.common.core.logger import AppLogger
@@ -11,16 +12,20 @@ from studio.app.common.core.subscription.constants import (
     PAYMENT_METHOD_TYPE_CARD,
     PAYMENT_METHOD_TYPE_LINK,
     STRIPE_PROVIDER_NAME,
+    StorageQuota,
+    StripeSubscriptionStatus,
     SubscriptionActiveStatus,
     SubscriptionPeriods,
     SyncStatus,
 )
+from studio.app.common.core.utils.datetime_utils import datetime_from_timestamp
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.models.subscription import (
     SubscriptionPlans,
     SubscriptionProvider,
     SubscriptionUserAccount,
     SubscriptionUserPurchase,
+    UserStorageUsage,
     UserSubscription,
 )
 from studio.app.common.models.user import User
@@ -445,6 +450,154 @@ class CheckoutService:
         return purchase
 
     @staticmethod
+    def recover_existing_stripe_subscription(
+        db: Session, user_id: int, customer_id: str, plan_id: int
+    ) -> bool:
+        """
+        Check if the user already has an active/trialing subscription in Stripe
+        that was not synced to the database (e.g., server was down when webhook
+        was sent). If found, sync it to the database to prevent duplicate
+        subscriptions.
+
+        Args:
+            db: Database session
+            user_id: Internal user ID
+            customer_id: Stripe customer ID
+            plan_id: Subscription plan ID being requested
+
+        Returns:
+            True if an existing subscription was recovered, False otherwise
+        """
+        try:
+            # Check for active or trialing subscriptions in Stripe
+            for status in [
+                StripeSubscriptionStatus.ACTIVE,
+                StripeSubscriptionStatus.TRIAL,
+            ]:
+                stripe_subscriptions = stripe.Subscription.list(
+                    customer=customer_id, status=status, limit=1
+                )
+                if stripe_subscriptions.data:
+                    stripe_sub = stripe_subscriptions.data[0]
+                    logger.info(
+                        f"Found existing Stripe subscription {stripe_sub.id} "
+                        f"(status={status}) for user {user_id}. "
+                        f"Recovering missed webhook."
+                    )
+
+                    # Determine expiration from Stripe subscription
+                    trial_end = getattr(stripe_sub, "trial_end", None)
+                    current_period_end = getattr(
+                        stripe_sub, "current_period_end", None
+                    )
+
+                    if trial_end:
+                        expiration_date = datetime_from_timestamp(trial_end)
+                    elif current_period_end:
+                        expiration_date = datetime_from_timestamp(
+                            current_period_end
+                        )
+                    else:
+                        logger.warning(
+                            f"No expiration data in Stripe subscription "
+                            f"{stripe_sub.id}, skipping recovery"
+                        )
+                        return False
+
+                    # Determine the plan from stripe subscription metadata
+                    sub_metadata = getattr(stripe_sub, "metadata", {}) or {}
+                    recovered_plan_id = sub_metadata.get("plan_id")
+                    if recovered_plan_id:
+                        recovered_plan_id = int(recovered_plan_id)
+                    else:
+                        recovered_plan_id = plan_id
+
+                    # Sync to database: create/update subscription
+                    CheckoutService.create_or_update_subscription(
+                        db, user_id, recovered_plan_id, expiration_date
+                    )
+
+                    # Ensure provider and account are linked
+                    provider_id = CheckoutService.get_or_create_stripe_provider(
+                        db
+                    )
+                    CheckoutService.create_or_update_user_account(
+                        db, user_id, provider_id, customer_id
+                    )
+
+                    # Record purchase if not already recorded
+                    existing_purchase = (
+                        db.query(SubscriptionUserPurchase)
+                        .filter(
+                            SubscriptionUserPurchase.user_id == user_id,
+                            SubscriptionUserPurchase.plan_id
+                            == recovered_plan_id,
+                        )
+                        .first()
+                    )
+                    if not existing_purchase:
+                        CheckoutService.record_purchase(
+                            db, recovered_plan_id, user_id
+                        )
+
+                    # Update storage quota
+                    storage_quota_bytes = StorageQuota.bytes_for_plan(
+                        recovered_plan_id
+                    )
+                    rows_updated = db.execute(
+                        update(UserStorageUsage)
+                        .where(UserStorageUsage.user_id == user_id)
+                        .values(storage_quota_bytes=storage_quota_bytes)
+                    ).rowcount
+                    if not rows_updated:
+                        db.add(
+                            UserStorageUsage(
+                                user_id=user_id,
+                                storage_usage_bytes=0,
+                                storage_quota_bytes=storage_quota_bytes,
+                            )
+                        )
+
+                    db.commit()
+
+                    # Invalidate cache
+                    try:
+                        from studio.app.common.core.middleware.secure_routing_middleware import (  # noqa: E501
+                            invalidate_user_tier_cache,
+                        )
+
+                        user_record = (
+                            db.query(User).filter(User.id == user_id).first()
+                        )
+                        if user_record:
+                            invalidate_user_tier_cache(user_record.uid)
+                    except Exception:
+                        pass  # Cache invalidation is best-effort
+
+                    logger.info(
+                        f"Successfully recovered Stripe subscription "
+                        f"{stripe_sub.id} for user {user_id}. "
+                        f"Expiration: {expiration_date}"
+                    )
+                    return True
+
+            return False
+
+        except stripe.error.StripeError as e:
+            logger.error(
+                f"Stripe API error during subscription recovery for "
+                f"user {user_id}: {str(e)}"
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                f"Error during subscription recovery for "
+                f"user {user_id}: {str(e)}"
+            )
+            db.rollback()
+            return False
+
+    @staticmethod
     async def handle_checkout_session(
         db: Session, request: CreateCheckoutSessionRequest, user: User
     ) -> CreateCheckoutSessionResponse:
@@ -501,6 +654,31 @@ class CheckoutService:
                         f"Created and saved new Stripe customer {customer_id} "
                         f"for user {user.id}"
                     )
+
+                # Check if user already has an active subscription in Stripe
+                # that wasn't synced to DB (e.g., server was down during
+                # webhook). If found, recover it to prevent duplicate
+                # subscriptions.
+                existing_db_subscription = (
+                    CheckoutService.get_existing_subscription(db, user.id)
+                )
+                if not existing_db_subscription:
+                    recovered = (
+                        CheckoutService.recover_existing_stripe_subscription(
+                            db,
+                            user.id,
+                            customer_id,
+                            int(request.plan_id),
+                        )
+                    )
+                    if recovered:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "You already have an active subscription. "
+                                "It has been synced to your account."
+                            ),
+                        )
 
                 # Check if user has any previous purchase history
                 # Check both database and Stripe to ensure we don't miss any purchases

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -18,8 +18,8 @@ from studio.app.common.core.subscription.constants import (
     SubscriptionPeriods,
     SyncStatus,
 )
-from studio.app.common.core.utils.datetime_utils import datetime_from_timestamp
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
+from studio.app.common.core.utils.datetime_utils import datetime_from_timestamp
 from studio.app.common.models.subscription import (
     SubscriptionPlans,
     SubscriptionProvider,
@@ -487,16 +487,12 @@ class CheckoutService:
 
                     # Determine expiration from Stripe subscription
                     trial_end = getattr(stripe_sub, "trial_end", None)
-                    current_period_end = getattr(
-                        stripe_sub, "current_period_end", None
-                    )
+                    current_period_end = getattr(stripe_sub, "current_period_end", None)
 
                     if trial_end:
                         expiration_date = datetime_from_timestamp(trial_end)
                     elif current_period_end:
-                        expiration_date = datetime_from_timestamp(
-                            current_period_end
-                        )
+                        expiration_date = datetime_from_timestamp(current_period_end)
                     else:
                         logger.warning(
                             f"No expiration data in Stripe subscription "
@@ -518,9 +514,7 @@ class CheckoutService:
                     )
 
                     # Ensure provider and account are linked
-                    provider_id = CheckoutService.get_or_create_stripe_provider(
-                        db
-                    )
+                    provider_id = CheckoutService.get_or_create_stripe_provider(db)
                     CheckoutService.create_or_update_user_account(
                         db, user_id, provider_id, customer_id
                     )
@@ -530,20 +524,15 @@ class CheckoutService:
                         db.query(SubscriptionUserPurchase)
                         .filter(
                             SubscriptionUserPurchase.user_id == user_id,
-                            SubscriptionUserPurchase.plan_id
-                            == recovered_plan_id,
+                            SubscriptionUserPurchase.plan_id == recovered_plan_id,
                         )
                         .first()
                     )
                     if not existing_purchase:
-                        CheckoutService.record_purchase(
-                            db, recovered_plan_id, user_id
-                        )
+                        CheckoutService.record_purchase(db, recovered_plan_id, user_id)
 
                     # Update storage quota
-                    storage_quota_bytes = StorageQuota.bytes_for_plan(
-                        recovered_plan_id
-                    )
+                    storage_quota_bytes = StorageQuota.bytes_for_plan(recovered_plan_id)
                     rows_updated = db.execute(
                         update(UserStorageUsage)
                         .where(UserStorageUsage.user_id == user_id)
@@ -566,9 +555,7 @@ class CheckoutService:
                             invalidate_user_tier_cache,
                         )
 
-                        user_record = (
-                            db.query(User).filter(User.id == user_id).first()
-                        )
+                        user_record = db.query(User).filter(User.id == user_id).first()
                         if user_record:
                             invalidate_user_tier_cache(user_record.uid)
                     except Exception:
@@ -591,8 +578,7 @@ class CheckoutService:
             return False
         except Exception as e:
             logger.error(
-                f"Error during subscription recovery for "
-                f"user {user_id}: {str(e)}"
+                f"Error during subscription recovery for " f"user {user_id}: {str(e)}"
             )
             db.rollback()
             return False
@@ -659,17 +645,15 @@ class CheckoutService:
                 # that wasn't synced to DB (e.g., server was down during
                 # webhook). If found, recover it to prevent duplicate
                 # subscriptions.
-                existing_db_subscription = (
-                    CheckoutService.get_existing_subscription(db, user.id)
+                existing_db_subscription = CheckoutService.get_existing_subscription(
+                    db, user.id
                 )
                 if not existing_db_subscription:
-                    recovered = (
-                        CheckoutService.recover_existing_stripe_subscription(
-                            db,
-                            user.id,
-                            customer_id,
-                            int(request.plan_id),
-                        )
+                    recovered = CheckoutService.recover_existing_stripe_subscription(
+                        db,
+                        user.id,
+                        customer_id,
+                        int(request.plan_id),
                     )
                     if recovered:
                         raise HTTPException(

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -567,9 +567,7 @@ class CheckoutService:
                                     customer=customer_id, type=pm_type, limit=1
                                 )
                                 if payment_methods.data:
-                                    payment_method_id = (
-                                        payment_methods.data[0].id
-                                    )
+                                    payment_method_id = payment_methods.data[0].id
                                     break
 
                         if payment_method_id:

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -497,12 +497,47 @@ async def validate_checkout_session(
         # Verify database was updated by webhook - check if user has
         # active premium subscription
         subscription = SubscriptionService.get_user_subscription(db, user.id)
-        if not subscription:
+        if not subscription or (
+            subscription and subscription[1].id == SubscriptionPlanIds.FREE
+        ):
+            # Webhook may have failed (server was down). Attempt recovery
+            # by checking Stripe for an active subscription and syncing it.
             logger.warning(
                 f"Checkout session {request.session_id} is complete but no "
-                f"subscription found in database for user {user.id}. "
-                f"Webhook may have failed."
+                f"premium subscription found in database for user {user.id}. "
+                f"Attempting subscription recovery."
             )
+
+            # Get customer ID for recovery
+            subscription_account = CheckoutService.get_subscription_account(
+                db, user.id
+            )
+            if subscription_account:
+                # Get plan_id from session metadata
+                metadata = session.metadata or {}
+                plan_id = metadata.get("plan_id")
+                if plan_id:
+                    recovered = (
+                        CheckoutService.recover_existing_stripe_subscription(
+                            db,
+                            user.id,
+                            subscription_account.provider_customer_id,
+                            int(plan_id),
+                        )
+                    )
+                    if recovered:
+                        logger.info(
+                            f"Successfully recovered subscription for user "
+                            f"{user.id} during checkout validation."
+                        )
+                        return CheckoutValidationResponse(
+                            status=CheckoutValidationStatus.SUCCESS,
+                            message=(
+                                "Payment successful! Your premium "
+                                "subscription is now active."
+                            ),
+                        )
+
             return CheckoutValidationResponse(
                 status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message=(
@@ -511,22 +546,7 @@ async def validate_checkout_session(
                 ),
             )
 
-        # Verify it's a premium subscription (not free)
         sub_data, plan_data = subscription
-        if plan_data.id == SubscriptionPlanIds.FREE:
-            logger.warning(
-                f"Checkout session {request.session_id} is complete but user "
-                f"{user.id} only has free subscription (plan_id={plan_data.id}). "
-                f"Webhook may have failed."
-            )
-            return CheckoutValidationResponse(
-                status=CheckoutValidationStatus.WEBHOOK_FAILED,
-                message=(
-                    "Payment was successful, but subscription activation "
-                    "is pending. Please contact support if this persists."
-                ),
-            )
-
         logger.info(
             f"Checkout session {request.session_id} is valid and database is updated "
             f"with premium subscription (plan_id={plan_data.id}) for user {user.id}"

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -509,21 +509,17 @@ async def validate_checkout_session(
             )
 
             # Get customer ID for recovery
-            subscription_account = CheckoutService.get_subscription_account(
-                db, user.id
-            )
+            subscription_account = CheckoutService.get_subscription_account(db, user.id)
             if subscription_account:
                 # Get plan_id from session metadata
                 metadata = session.metadata or {}
                 plan_id = metadata.get("plan_id")
                 if plan_id:
-                    recovered = (
-                        CheckoutService.recover_existing_stripe_subscription(
-                            db,
-                            user.id,
-                            subscription_account.provider_customer_id,
-                            int(plan_id),
-                        )
+                    recovered = CheckoutService.recover_existing_stripe_subscription(
+                        db,
+                        user.id,
+                        subscription_account.provider_customer_id,
+                        int(plan_id),
                     )
                     if recovered:
                         logger.info(


### PR DESCRIPTION
# Fix: Prevent duplicate Stripe subscriptions when server is down during checkout

## Problem

When the server goes down while a user is completing checkout on Stripe, the `checkout.session.completed` webhook fails to process. This creates a state where:

1. The subscription exists in Stripe (payment was successful)
2. The subscription does **not** exist in the app's database (webhook never processed)
3. The user sees no active subscription and can click "Subscribe" again
4. A **duplicate subscription** is created in Stripe
5. The user loses their trial period (Stripe already has payment history from the first subscription)

### Root Cause

There was no check for existing active Stripe subscriptions before creating a new checkout session. The system relied entirely on the webhook to sync state, with no recovery mechanism when the webhook failed.

---

## Specification

### Solution

Added a `recover_existing_stripe_subscription()` method that checks Stripe for active/trialing subscriptions that are not reflected in the database, and syncs them. This recovery is triggered at **two points**:

#### 1. Checkout session creation (`checkout_service.py`)

Before creating a new checkout session, the system now:
- Checks if the user has an active subscription in the database
- If not, queries Stripe for any `active` or `trialing` subscriptions for the customer
- If found, syncs the subscription to the database (subscription record, purchase record, storage quota, cache)
- Returns HTTP 409 with message "You already have an active subscription. It has been synced to your account."
- This **prevents the duplicate subscription** from being created

#### 2. Checkout validation endpoint (`subscriptions.py`)

When the client polls `validate-checkout-session` after payment and detects `webhook_failed`:
- Previously: returned an error asking the user to contact support
- Now: attempts recovery by calling `recover_existing_stripe_subscription()`
- If recovery succeeds, returns `SUCCESS` instead of `WEBHOOK_FAILED`
- This provides a **seamless recovery** for the user without needing support

### Recovery method details

`recover_existing_stripe_subscription()` performs the following when it finds an unsynced Stripe subscription:

- Reads expiration from `trial_end` or `current_period_end`
- Reads `plan_id` from subscription metadata (falls back to requested plan)
- Creates/updates `UserSubscription` record
- Links Stripe customer to user via `SubscriptionUserAccount`
- Records purchase in `SubscriptionUserPurchase` (if not already recorded)
- Updates `UserStorageUsage` quota for the plan
- Sets default payment method on the Stripe Customer
- Invalidates tier cache for immediate routing update
- All changes are committed atomically

### Flow Diagram

#### Normal Flow (no error)

```mermaid
sequenceDiagram
    participant U as User (Browser)
    participant F as Frontend (React)
    participant B as Backend (FastAPI)
    participant S as Stripe API
    participant DB as Database (MySQL)

    U->>F: Click "Upgrade to Premium"
    F->>B: POST /checkout/session {plan_id}
    B->>DB: Get subscription plan
    B->>DB: Get/create Stripe customer account
    B->>S: checkout.Session.create()
    S-->>B: {checkout_url, session_id}
    B-->>F: 200 {checkout_url}
    F->>S: Redirect to checkout_url
    U->>S: Complete payment
    S->>B: Webhook: checkout.session.completed
    B->>DB: Create subscription, purchase, storage quota
    B->>S: Set default payment method
    S-->>U: Redirect to /subscription/thanks?session_id=...
    F->>B: POST /checkout/validate-checkout-session {session_id}
    B->>S: Session.retrieve(session_id)
    B->>DB: Check subscription exists
    B-->>F: {status: "success"}
    F->>U: Show "Payment successful!"
```

#### Error Scenario: Server down during webhook

```mermaid
sequenceDiagram
    participant U as User (Browser)
    participant F as Frontend (React)
    participant B as Backend (FastAPI)
    participant S as Stripe API
    participant DB as Database (MySQL)

    Note over B: Server is DOWN

    U->>S: Complete payment on Stripe Checkout
    S--xB: Webhook: checkout.session.completed (FAILED — server down)
    Note over S,DB: Subscription exists in Stripe<br/>but NOT in database

    Note over B: Server comes back UP
    S-->>U: Redirect to /subscription/thanks?session_id=...
```

After the server comes back up, there are **two possible recovery paths**:

#### Recovery Path 1: /subscription/thanks page (automatic — happens first)

The thanks page validates the checkout session. If payment succeeded but the DB
was not updated (webhook missed), it triggers recovery automatically.

```mermaid
sequenceDiagram
    participant U as User (Browser)
    participant F as Frontend (React)
    participant B as Backend (FastAPI)
    participant S as Stripe API
    participant DB as Database (MySQL)

    Note over U,F: User lands on /subscription/thanks

    F->>B: POST /checkout/validate-checkout-session {session_id}
    B->>S: Session.retrieve(session_id)
    S-->>B: {payment_status: "paid", status: "complete"}

    B->>DB: get_user_subscription(user_id)
    DB-->>B: No premium subscription (or Free plan)

    rect rgb(255, 240, 230)
        Note over B: Recovery triggered in validate endpoint
        B->>DB: get_subscription_account(user_id)
        DB-->>B: {provider_customer_id: "cus_..."}
        B->>B: recover_existing_stripe_subscription()
        B->>S: Subscription.list(customer, status="active")
        S-->>B: [active subscription found!]

        Note over B: Sync Stripe → Database
        B->>DB: create_or_update_subscription(plan_id, expiration)
        B->>DB: create_or_update_user_account(provider_id, customer_id)
        B->>DB: record_purchase(plan_id, user_id)
        B->>DB: UPDATE user_storage_usage SET quota = premium_quota
        B->>DB: COMMIT

        Note over B: Restore Payment Method
        B->>S: Get default_payment_method from subscription
        B->>S: Customer.modify(invoice_settings.default_payment_method)
        B->>B: invalidate_user_tier_cache(uid)
    end

    B-->>F: {status: "success", message: "Payment successful!"}
    F->>U: Show "Payment successful!"

    Note over F: If recovery fails on first attempt,<br/>frontend retries up to 3 times<br/>with exponential backoff<br/>(3s, 6s, 9s delays)
```

**Key detail**: The frontend (`ValidateCheckoutSession.ts`) retries the validation up to **3 times**
with increasing delays (3s, 6s, 9s) if it gets `WEBHOOK_FAILED` status. This gives time for either
the webhook to arrive or the recovery to succeed.

If all retries fail, the user sees a `WEBHOOK_FAILED` message:
> "Payment was successful, but subscription activation is pending. Please contact support if this persists."

#### Recovery Path 2: User clicks "Upgrade to Premium" again (manual fallback)

If the user navigates away from the thanks page without recovery succeeding,
and later returns to `/subscription` and tries to upgrade again:

```mermaid
sequenceDiagram
    participant U as User (Browser)
    participant F as Frontend (React)
    participant B as Backend (FastAPI)
    participant S as Stripe API
    participant DB as Database (MySQL)

    U->>F: Visit /subscription page
    F->>B: GET /subscription (getUserSubscription)
    B->>DB: Query subscription_users
    DB-->>B: No active subscription found
    B-->>F: {plan: "free", status: "free"}
    Note over F: UI shows user as Free plan

    U->>F: Click "Upgrade to Premium" again
    F->>B: POST /checkout/session {plan_id: 2}

    rect rgb(255, 240, 230)
        Note over B: Recovery triggered in handle_checkout_session
        B->>DB: get_existing_subscription(user_id)
        DB-->>B: None (no subscription in DB)

        B->>B: recover_existing_stripe_subscription()
        B->>S: Subscription.list(customer, status="active")
        S-->>B: [active subscription found!]

        Note over B: Sync Stripe → Database
        B->>DB: create_or_update_subscription(plan_id, expiration)
        B->>DB: create_or_update_user_account(provider_id, customer_id)
        B->>DB: record_purchase(plan_id, user_id)
        B->>DB: UPDATE user_storage_usage SET quota = premium_quota
        B->>DB: COMMIT

        Note over B: Restore Payment Method
        B->>S: Get default_payment_method from subscription
        B->>S: Customer.modify(invoice_settings.default_payment_method)
        B->>B: invalidate_user_tier_cache(uid)
    end

    B-->>F: 409 "You are already a premium user..."

    rect rgb(230, 245, 255)
        Note over F: Frontend Recovery Handling
        F->>F: Check: errorMessage.includes("already a premium user")
        F->>F: clearError() — suppress error banner
        F->>F: setRecoveryMessage(errorMessage)
        F->>B: GET /subscription (refresh data)
        B->>DB: Query subscription_users
        DB-->>B: Active premium subscription found
        B-->>F: {plan: "premium", status: "premium"}
        F->>U: Show success alert:<br/>"Your subscription has been restored"
    end
```

#### Recovery Path Comparison

| | Path 1: /subscription/thanks | Path 2: Click "Upgrade" again |
|---|---|---|
| **Trigger** | Automatic (page load) | Manual (user clicks button) |
| **When** | Immediately after payment | Anytime later |
| **Endpoint** | `POST /checkout/validate-checkout-session` | `POST /checkout/session` |
| **Retries** | 3 times with backoff (3s, 6s, 9s) | No retry (single attempt) |
| **Response on success** | `{status: "success"}` | `409` with recovery message |
| **User experience** | Seamless — user sees "Payment successful!" | Shows recovery alert message |
| **Requires session_id** | Yes (from URL query param) | No (checks Stripe by customer_id) |

#### Database State Changes During Recovery

```
BEFORE recovery (webhook was missed):
┌──────────────────────┬──────────────────────────────┐
│ subscription_users    │ No record for user           │
│ subscription_purchases│ No record for user           │
│ user_storage_usage    │ quota = free tier (5GB)      │
│ Stripe                │ Active subscription exists   │
└──────────────────────┴──────────────────────────────┘

AFTER recovery:
┌──────────────────────┬──────────────────────────────┐
│ subscription_users    │ plan_id=2, status=synced     │
│ subscription_purchases│ plan_id=2, recorded          │
│ user_storage_usage    │ quota = premium (200GB)      │
│ Stripe Customer       │ default_payment_method set   │
│ Tier cache            │ invalidated                  │
└──────────────────────┴──────────────────────────────┘
```

#### Error Handling Summary

| Layer | Error Type | Handling |
|-------|-----------|----------|
| Backend | `HTTPException` (404, 400, 409) | Re-raised as-is via `except HTTPException: raise` |
| Backend | `stripe.error.StripeError` | Wrapped as 400 |
| Backend | `Exception` (unexpected) | Wrapped as 500 |
| Frontend (thanks) | `WEBHOOK_FAILED` | Retry up to 3 times, then show pending message |
| Frontend (subscription) | 409 with "already a premium user" | Recovery UI — show success alert, refresh subscription |
| Frontend (subscription) | Other rejection | `console.error`, Redux error state handles UI |
| Frontend (subscription) | Unexpected action state | `console.warn` (defensive guard) |

### Files changed

| File | Change |
|------|--------|
| `studio/app/common/core/subscription/checkout_service.py` | Added `recover_existing_stripe_subscription()` method; added recovery guard in `handle_checkout_session()`; added `except HTTPException: raise` with comment |
| `studio/app/common/routers/subscriptions.py` | Updated `validate_checkout_session` to attempt recovery before returning `webhook_failed` |
| `frontend/src/pages/Subscription/index.tsx` | Added recovery message handling for 409 response; added defensive `else` guards |

---

## Test

### How to test

1. Prepare a Free User
2. Go to subscription plans page and click upgrade
3. Once you are on checkout page from Stripe, stop the backend container and complete the checkout with test card
4. After clicking Subscribe/Pay you should be redirected to the app but the page is not loading since the server is down
5. Start the backend container
6. Access subscriptions page and click upgrade again to recover the premium plan from Stripe

### Test plan

- [x] Simulate server downtime during checkout: complete payment on Stripe, then try to subscribe again — should recover existing subscription (HTTP 409) instead of creating a duplicate
- [x] Verify `validate-checkout-session` polling recovers the subscription when webhook was missed
- [x] Verify normal checkout flow still works when no existing Stripe subscription exists
- [x] Verify trial period is preserved on recovered subscriptions (uses `trial_end` from Stripe)
- [x] Verify duplicate Stripe subscriptions are no longer created
- [x] Verify storage quota is correctly updated on recovery

### Evidence

**Recovery message shown to user:**

<img width="1917" height="114" alt="Screenshot 2026-03-11 at 10 58 17" src="https://github.com/user-attachments/assets/d018f1f0-95c2-478e-a2a2-2099d77318a9" />

**Subscription page after recovery:**

<img width="1333" height="1143" alt="Screenshot 2026-03-11 at 10 57 41" src="https://github.com/user-attachments/assets/3641155a-69a6-472f-9107-7e70ace83a4c" />

**Backend recovery logs:**

<img width="1801" height="539" alt="Screenshot 2026-03-12 at 9 12 46" src="https://github.com/user-attachments/assets/647d33e3-7d06-47e1-bbdb-ac62c0bef290" />

**Payment method restored after recovery:**

<img width="755" height="286" alt="Screenshot 2026-03-12 at 9 16 59" src="https://github.com/user-attachments/assets/d932eba5-c022-46cc-8fe2-b5c096314c34" />

**RDS Before & After recovery:**

<img width="2013" height="410" alt="Screenshot 2026-03-12 at 15 25 17" src="https://github.com/user-attachments/assets/b36997fd-1105-49ba-bfec-9f7faea5a885" />

**Video Evidence:**

https://drive.google.com/drive/folders/1xBdJvBnIhT3EjCog0BCqdggslU_Et1hs