### PR TITLE
Mitigate snakemake yaml sync error

### DIFF
--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -766,11 +766,16 @@ class RemoteStorageController(BaseRemoteStorageController):
             # Only download input data and mark success for full syncs
             if is_full_sync:
                 # Download the input data related to the experiment data as well.
-                input_filenames = SmkUtils.get_datatypes_inputs(
-                    workspace_id, unique_id, apply_basename=True
-                )
-                for input_filename in input_filenames:
-                    await self.download_input_data(workspace_id, input_filename)
+                try:
+                    input_filenames = SmkUtils.get_datatypes_inputs(
+                        workspace_id, unique_id, apply_basename=True
+                    )
+                    for input_filename in input_filenames:
+                        await self.download_input_data(workspace_id, input_filename)
+                except (AssertionError, KeyError) as e:
+                    # snakemake.yaml may be empty or missing required keys
+                    logger.warning(f"snakemake yaml read error: {e}")
+                    pass
 
                 # update sync status file
                 RemoteSyncStatusFileUtil.create_sync_status_file_for_success(


### PR DESCRIPTION
### Content

RemoteStorageController.download_experiment required a specific file (smakemake.yaml) to exist on the remote host.
If that file did not exist on the remote host (this only occurs in abnormal situations or with limited workflows(batch workflow)), download_experiment would throw an exception.

I've made adjustments to address this issue so that processing continues even if smakemake.yaml does not exist on the remote host.

### References

- #372

### Testcase

- [x] Synchronizing experiment data without snakemake.yaml
  - Action: Downloading and syncing experiment data from a remote machine that doesn't have snakemake.yaml
    - *Data can be downloaded from the sync button on the Record screen
  - Expected: A warning log message is recorded, but the download completes successfully.
