### PR TITLE
Fix MockStorageController.upload_experiment

### DIFF
--- a/studio/app/common/core/storage/mock_storage_controller.py
+++ b/studio/app/common/core/storage/mock_storage_controller.py
@@ -349,10 +349,12 @@ class MockStorageController(BaseRemoteStorageController):
 
             create_directory(experiment_remote_path)
 
-            # copy target files
+            # copy target files (preserving subdirectory structure)
             for target_file in target_files:
-                target_file = f"{experiment_local_path}/{target_file}"
-                shutil.copy(target_file, experiment_remote_path)
+                source_path = f"{experiment_local_path}/{target_file}"
+                dest_path = f"{experiment_remote_path}/{target_file}"
+                os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                shutil.copy(source_path, dest_path)
 
         else:  # Target all files.
             logger.debug(


### PR DESCRIPTION
### Content

Fixed issue with properly maintaining directory hierarchy when copying to mock storage.

### Testcase

- Run `MockStorageController.upload_experiment` (Automatically executed when workflow is executed) and verify that the file storage configuration is maintained in the local directory and remote directory. 
  - [x] Tutorial 1 results
  - [x] Tutorial 2 results
