### PR TITLE
ExperimentsSynced, SyncErrors, and SyncErrorRate CloudWatch metrics

### DIFF
--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -171,6 +171,7 @@ class PublishedExperimentSyncJob:
 
             if not pending:
                 logger.debug("No pending experiments to validate")
+                cls._publish_metrics(0, 0)
                 return
 
             logger.info(f"Found {len(pending)} experiments to validate")
@@ -663,7 +664,8 @@ class PublishedExperimentSyncJob:
             cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
 
             total = synced_count + error_count
-            error_rate = (error_count / total * 100) if total > 0 else 0
+            error_rate = float(error_count / total * 100) if total > 0 else 0.0
+            timestamp = get_current_datetime()
 
             cloudwatch.put_metric_data(
                 Namespace="OptiNiSt/BackgroundJobs",
@@ -672,19 +674,25 @@ class PublishedExperimentSyncJob:
                         "MetricName": "ExperimentsSynced",
                         "Value": synced_count,
                         "Unit": "Count",
-                        "Timestamp": get_current_datetime(),
+                        "Timestamp": timestamp,
                     },
                     {
                         "MetricName": "SyncErrors",
                         "Value": error_count,
                         "Unit": "Count",
-                        "Timestamp": get_current_datetime(),
+                        "Timestamp": timestamp,
                     },
+                ],
+            )
+
+            cloudwatch.put_metric_data(
+                Namespace="OptiNiSt/BackgroundJobs",
+                MetricData=[
                     {
                         "MetricName": "SyncErrorRate",
                         "Value": error_rate,
                         "Unit": "Percent",
-                        "Timestamp": get_current_datetime(),
+                        "Timestamp": timestamp,
                     },
                 ],
             )
@@ -703,4 +711,7 @@ class PublishedExperimentSyncJob:
                     " permissions."
                 )
         except Exception as e:
-            logger.warning(f"Failed to publish metrics: {e}")
+            logger.error(
+                f"Failed to publish metrics: {e}",
+                exc_info=True,
+            )

--- a/studio/tests/app/common/core/background/test_sync_job.py
+++ b/studio/tests/app/common/core/background/test_sync_job.py
@@ -566,3 +566,270 @@ class TestRetryCount:
             mock_boto.return_value = mock_cw
             cls._check_persistent_failure(42, "ws1", "uid1")
             mock_cw.put_metric_data.assert_called_once()
+
+
+class TestValidationLogicMetrics:
+    """Tests that _run_validation_logic always publishes metrics"""
+
+    @pytest.mark.asyncio
+    async def test_publishes_zero_metrics_when_no_pending(self):
+        """Metrics are published even when no experiments are pending"""
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_pending_experiments",
+            return_value=[],
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_publish_metrics",
+        ) as mock_publish:
+            await PublishedExperimentSyncJob._run_validation_logic()
+
+            mock_publish.assert_called_once_with(0, 0)
+
+    @pytest.mark.asyncio
+    async def test_publishes_correct_counts_after_validation(self):
+        """Metrics reflect actual sync/error counts from validation"""
+        pending = [
+            ("ws1", "uid1", 1, "bucket1"),
+            ("ws2", "uid2", 2, "bucket1"),
+            ("ws3", "uid3", 3, "bucket1"),
+        ]
+
+        mock_s3 = MagicMock()
+
+        async def mock_validate(s3, ws, uid, eid, bucket):
+            return eid != 2  # exp 2 fails, others succeed
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_pending_experiments",
+            return_value=pending,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_get_s3_controller",
+            return_value=mock_s3,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_validate_experiment",
+            side_effect=mock_validate,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_publish_metrics",
+        ) as mock_publish:
+            await PublishedExperimentSyncJob._run_validation_logic()
+
+            mock_publish.assert_called_once_with(2, 1)
+
+    @pytest.mark.asyncio
+    async def test_counts_gather_exceptions_as_errors(self):
+        """Bare exceptions from asyncio.gather are counted as errors"""
+        pending = [
+            ("ws1", "uid1", 1, "bucket1"),
+            ("ws2", "uid2", 2, "bucket1"),
+        ]
+
+        async def mock_validate(s3, ws, uid, eid, bucket):
+            if eid == 1:
+                return True
+            raise RuntimeError("unexpected")
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_pending_experiments",
+            return_value=pending,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_get_s3_controller",
+            return_value=MagicMock(),
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_validate_experiment",
+            side_effect=mock_validate,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_mark_sync_error",
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_publish_metrics",
+        ) as mock_publish:
+            await PublishedExperimentSyncJob._run_validation_logic()
+
+            mock_publish.assert_called_once_with(1, 1)
+
+    @pytest.mark.asyncio
+    async def test_publishes_metrics_when_all_fail(self):
+        """Metrics published correctly when every experiment fails"""
+        pending = [
+            ("ws1", "uid1", 1, "bucket1"),
+            ("ws2", "uid2", 2, "bucket1"),
+        ]
+
+        async def mock_validate(s3, ws, uid, eid, bucket):
+            return False
+
+        with patch.object(
+            PublishedExperimentSyncJob,
+            "_get_pending_experiments",
+            return_value=pending,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_get_s3_controller",
+            return_value=MagicMock(),
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_validate_experiment",
+            side_effect=mock_validate,
+        ), patch.object(
+            PublishedExperimentSyncJob,
+            "_publish_metrics",
+        ) as mock_publish:
+            await PublishedExperimentSyncJob._run_validation_logic()
+
+            mock_publish.assert_called_once_with(0, 2)
+
+
+class TestPublishMetrics:
+    """Tests for _publish_metrics CloudWatch publishing"""
+
+    def test_publishes_count_and_percent_metrics(self):
+        """Publishes ExperimentsSynced, SyncErrors, and SyncErrorRate"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(5, 2)
+
+            assert mock_cw.put_metric_data.call_count == 2
+
+            # First call: Count metrics
+            count_call = mock_cw.put_metric_data.call_args_list[0]
+            count_data = count_call[1]["MetricData"]
+            assert len(count_data) == 2
+            assert count_data[0]["MetricName"] == "ExperimentsSynced"
+            assert count_data[0]["Value"] == 5
+            assert count_data[0]["Unit"] == "Count"
+            assert count_data[1]["MetricName"] == "SyncErrors"
+            assert count_data[1]["Value"] == 2
+            assert count_data[1]["Unit"] == "Count"
+
+            # Second call: Percent metric
+            pct_call = mock_cw.put_metric_data.call_args_list[1]
+            pct_data = pct_call[1]["MetricData"]
+            assert len(pct_data) == 1
+            assert pct_data[0]["MetricName"] == "SyncErrorRate"
+            assert pct_data[0]["Unit"] == "Percent"
+            assert abs(pct_data[0]["Value"] - 28.571) < 0.1
+
+    def test_publishes_zero_counts(self):
+        """Zero counts publish 0 values and 0.0 error rate"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(0, 0)
+
+            assert mock_cw.put_metric_data.call_count == 2
+            pct_call = mock_cw.put_metric_data.call_args_list[1]
+            pct_data = pct_call[1]["MetricData"]
+            assert pct_data[0]["Value"] == 0.0
+
+    def test_error_rate_is_float(self):
+        """SyncErrorRate value is always a float"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(10, 0)
+
+            pct_call = mock_cw.put_metric_data.call_args_list[1]
+            pct_data = pct_call[1]["MetricData"]
+            assert isinstance(pct_data[0]["Value"], float)
+
+    def test_hundred_percent_error_rate(self):
+        """100% error rate when all experiments fail"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(0, 5)
+
+            pct_call = mock_cw.put_metric_data.call_args_list[1]
+            pct_data = pct_call[1]["MetricData"]
+            assert pct_data[0]["Value"] == 100.0
+            assert isinstance(pct_data[0]["Value"], float)
+
+    def test_cloudwatch_error_is_logged_with_traceback(self):
+        """CloudWatch errors are logged at error level with traceback"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_cw.put_metric_data.side_effect = Exception("CloudWatch error")
+            mock_boto.return_value = mock_cw
+
+            with patch(
+                "studio.app.common.core.background.sync_job.logger"
+            ) as mock_logger:
+                PublishedExperimentSyncJob._publish_metrics(1, 0)
+
+                mock_logger.error.assert_called_once()
+                call_kwargs = mock_logger.error.call_args[1]
+                assert call_kwargs.get("exc_info") is True
+
+    def test_does_not_raise_on_cloudwatch_error(self):
+        """_publish_metrics swallows exceptions, never propagates"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_cw.put_metric_data.side_effect = Exception("CloudWatch down")
+            mock_boto.return_value = mock_cw
+
+            # Should not raise
+            PublishedExperimentSyncJob._publish_metrics(1, 0)
+
+    def test_count_metrics_published_when_percent_fails(self):
+        """Count metrics succeed even if Percent call fails"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            # First call (Count) succeeds, second call (Percent) fails
+            mock_cw.put_metric_data.side_effect = [
+                None,
+                Exception("Invalid unit"),
+            ]
+            mock_boto.return_value = mock_cw
+
+            with patch("studio.app.common.core.background.sync_job.logger"):
+                PublishedExperimentSyncJob._publish_metrics(5, 1)
+
+            # First call completed successfully with Count metrics
+            first_call = mock_cw.put_metric_data.call_args_list[0]
+            count_data = first_call[1]["MetricData"]
+            assert count_data[0]["MetricName"] == "ExperimentsSynced"
+            assert count_data[0]["Value"] == 5
+            assert count_data[1]["MetricName"] == "SyncErrors"
+            assert count_data[1]["Value"] == 1
+
+    def test_uses_consistent_timestamp(self):
+        """All metrics in a call share the same timestamp"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(3, 1)
+
+            count_call = mock_cw.put_metric_data.call_args_list[0]
+            count_data = count_call[1]["MetricData"]
+            pct_call = mock_cw.put_metric_data.call_args_list[1]
+            pct_data = pct_call[1]["MetricData"]
+
+            ts = count_data[0]["Timestamp"]
+            assert count_data[1]["Timestamp"] == ts
+            assert pct_data[0]["Timestamp"] == ts
+
+    def test_uses_correct_namespace(self):
+        """All calls use the OptiNiSt/BackgroundJobs namespace"""
+        with patch("boto3.client") as mock_boto:
+            mock_cw = MagicMock()
+            mock_boto.return_value = mock_cw
+
+            PublishedExperimentSyncJob._publish_metrics(1, 0)
+
+            for call in mock_cw.put_metric_data.call_args_list:
+                assert call[1]["Namespace"] == "OptiNiSt/BackgroundJobs"


### PR DESCRIPTION
### Content

#### Summary
- The sync job's ExperimentsSynced, SyncErrors, and SyncErrorRate CloudWatch metrics were never published despite experiments being processed successfully.
- Root cause: the dataview endpoint marks experiments as `synced` when users view them, so by the time the sync job runs, `_get_pending_experiments()` returns empty and the method returns early — skipping `_publish_metrics()` entirely.
- Secondary issue: all three metrics were published in a single `put_metric_data` call, so a failure in the `Percent`-unit SyncErrorRate metric would silently block the two `Count` metrics. The exception handler used `logger.warning` without `exc_info`, hiding the actual error.

#### Design Decisions
- **Publish metrics on the empty-pending path** -- Added `_publish_metrics(0, 0)` before the early return at line 174. This ensures metrics appear in CloudWatch every run (every 5 minutes), even when the dataview endpoint has already handled all syncing. Publishing zeros is cheap and provides continuous proof-of-life for the sync job. The cleanup job's metrics work because `users_to_cleanup` is typically non-empty, so it never hits its equivalent early return.
- **Split `put_metric_data` into two calls (Count then Percent)** -- CloudWatch rejects the entire batch if any single `MetricDatum` is invalid. Isolating SyncErrorRate into its own call ensures ExperimentsSynced and SyncErrors are committed before the Percent metric is attempted. Trade-off: one extra API call per run (~$0.00 cost impact).
- **Single timestamp variable** -- The original code called `get_current_datetime()` three times (once per metric), producing slightly different timestamps. Now captures one timestamp and reuses it for consistency.
- **Explicit `float` for error_rate** -- Changed `0` to `0.0` and added `float()` cast to ensure the Percent value is always a float, avoiding any potential type-related CloudWatch rejection.
- **Upgraded `logger.warning` to `logger.error` with `exc_info=True`** -- The original handler silently swallowed exceptions with no traceback, making diagnosis impossible. Now captures the full stack trace.

### Evidence
- `pytest studio/tests/app/common/core/background/test_sync_job.py` -- 36 tests pass (13 new)
- `test_publishes_zero_metrics_when_no_pending` directly validates the root cause fix

### References
- CloudWatch `put_metric_data` batch semantics: entire call fails if any MetricDatum is invalid
- Dataview self-healing path: `studio/app/common/routers/dataview.py:293-298` sets `local_sync_status = synced` when data is locally available, bypassing the sync job

#### Files changed
- `studio/app/common/core/background/sync_job.py` -- Publish metrics on empty-pending early return; split put_metric_data into Count and Percent calls; use consistent timestamp; ensure error_rate is float; upgrade error logging from warning to error with traceback
- `studio/tests/app/common/core/background/test_sync_job.py` -- Add TestValidationLogicMetrics (4 tests: empty pending, correct counts, gather exceptions, all-fail) and TestPublishMetrics (9 tests: metric structure, zero counts, float type, 100% error rate, error logging, no-raise guarantee, Percent isolation, consistent timestamp, namespace)

### Manual Testcases
- Deploy to staging and publish an experiment (status becomes `pending`)
- View the experiment in the UI before the sync job runs (triggers dataview self-healing path)
- Wait for sync job to run (every 5 minutes)
- Query CloudWatch: `aws cloudwatch list-metrics --namespace "OptiNiSt/BackgroundJobs"`
- Verify ExperimentsSynced, SyncErrors, and SyncErrorRate now appear (with value 0 if dataview handled the sync)
- Confirm PersistentSyncFailure, DataCleanupCount, and CleanupErrors still publish correctly
- Run `pytest studio/tests/app/common/core/background/test_sync_job.py -v` -- all 36 tests pass

### Unit, Integration, Contract Test Coverage
- 13 new unit tests covering both `_run_validation_logic` metric publishing paths and `_publish_metrics` edge cases
- Tests verify behavior against the original bugs: early return without metrics, silent exception swallowing, batch failure propagation

### Others

#### Difficulties (if any)
The root cause was not in `_publish_metrics` itself but in the caller never reaching it. The dataview endpoint's self-healing behavior (`dataview.py:293-298`) creates a race where experiments are marked `synced` before the sync job runs, leaving `_get_pending_experiments()` empty on every invocation.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Metric publishing on empty pending | Low | Publishes zeros — no functional impact, adds observability |
| Split put_metric_data calls | Low | One extra CloudWatch API call per run; no behavioral change to metric data |
| Error logging upgrade | Low | Changes log level from warning to error for metric failures; no functional impact |
