### PR TITLE
Centralize instance type configuration into variables

### DIFF
--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -17,7 +17,7 @@
 resource "aws_launch_template" "background" {
   name_prefix   = "${local.env_prefix}-background-"
   image_id      = data.aws_ami.ecs_optimized.id
-  instance_type = "t3.micro" # Minimal instance for background jobs
+  instance_type = var.background_instance_type
 
   vpc_security_group_ids = [aws_security_group.ecs.id]
 
@@ -76,7 +76,7 @@ resource "aws_instance" "background" {
     version = "$Latest"
   }
 
-  instance_type = "t3.micro"
+  instance_type = var.background_instance_type
   subnet_id     = aws_subnet.private1.id
 
   tags = {

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -122,7 +122,7 @@ data "aws_ami" "ecs_optimized" {
 resource "aws_launch_template" "ecs" {
   name_prefix   = "${local.env_prefix}-ecs-"
   image_id      = data.aws_ami.ecs_optimized.id
-  instance_type = "t3.large"
+  instance_type = var.free_instance_type
   key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
 
   vpc_security_group_ids = [aws_security_group.ecs.id]
@@ -333,7 +333,7 @@ resource "aws_ecs_service" "premium" {
 resource "aws_launch_template" "premium" {
   name_prefix   = "${local.env_prefix}-premium-"
   image_id      = data.aws_ami.ecs_optimized.id
-  instance_type = "t3.large"
+  instance_type = var.premium_instance_type
   key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
 
   vpc_security_group_ids = [aws_security_group.ecs.id]
@@ -475,7 +475,7 @@ resource "aws_instance" "premium" {
     version = "$Latest"
   }
 
-  instance_type = "t3.large"
+  instance_type = var.premium_instance_type
   subnet_id     = aws_subnet.private1.id
 
   # On shutdown, stop instance instead of terminating

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -207,6 +207,25 @@ variable "asg_desired_capacity" {
   default     = 1
 }
 
+# Instance type configuration
+variable "free_instance_type" {
+  description = "Instance type for free tier instances"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "premium_instance_type" {
+  description = "Instance type for premium tier instances"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "background_instance_type" {
+  description = "Instance type for background service instance"
+  type        = string
+  default     = "t3.micro"
+}
+
 # Frontend domain configuration
 variable "frontend_domain" {
   description = "Custom domain name for the frontend application"

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "premium_manager" {
       AUTOSCALING_TARGET_GROUP_ARN = aws_lb_target_group.autoscaling.arn
       PREMIUM_INSTANCE_IDS         = join(",", aws_instance.premium[*].id)
       PREMIUM_LAUNCH_TEMPLATE_ID   = aws_launch_template.premium.id
+      PREMIUM_INSTANCE_TYPE        = var.premium_instance_type
       CLUSTER_NAME                 = aws_ecs_cluster.main.name
       PREMIUM_SERVICE_NAME         = aws_ecs_service.premium.name
       RDS_HOST                     = aws_db_proxy.main.endpoint
@@ -579,14 +580,14 @@ resource "aws_lambda_function" "cost_tracker" {
 
   environment {
     variables = {
-      ASG_NAME               = aws_autoscaling_group.main.name
-      REGION                 = var.aws_region
-      RDS_HOST               = aws_db_proxy.main.endpoint
-      RDS_USER               = var.mysql_user
-      RDS_PASSWORD           = var.mysql_password
-      RDS_DATABASE           = var.mysql_database
-      PREMIUM_HOURLY_RATE    = "0.1088"
-      FREE_HOURLY_RATE       = "0.1088"
+      ASG_NAME            = aws_autoscaling_group.main.name
+      REGION              = var.aws_region
+      RDS_HOST            = aws_db_proxy.main.endpoint
+      RDS_USER            = var.mysql_user
+      RDS_PASSWORD        = var.mysql_password
+      RDS_DATABASE        = var.mysql_database
+      PREMIUM_HOURLY_RATE = "0.1088"
+      FREE_HOURLY_RATE    = "0.1088"
     }
   }
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1066,8 +1066,9 @@ def create_running_instance():
     ec2: "EC2Client" = boto3.client("ec2")
 
     try:
-        # Get launch template ID from environment
+        # Get launch template ID and instance type from environment
         launch_template_id = get_required_env_var("PREMIUM_LAUNCH_TEMPLATE_ID")
+        instance_type = get_required_env_var("PREMIUM_INSTANCE_TYPE")
 
         # Get subnet IDs from environment
         subnet_ids = get_required_env_var("SUBNET_IDS").split(",")
@@ -1086,7 +1087,7 @@ def create_running_instance():
                         "LaunchTemplateId": launch_template_id,
                         "Version": "$Latest",
                     },
-                    InstanceType="t3.large",
+                    InstanceType=instance_type,
                     SubnetId=subnet_id,
                     MinCount=1,
                     MaxCount=1,
@@ -1312,6 +1313,7 @@ def create_and_stop_standby_instance():
             )
 
             launch_template_id = get_required_env_var("PREMIUM_LAUNCH_TEMPLATE_ID")
+            instance_type = get_required_env_var("PREMIUM_INSTANCE_TYPE")
             subnet_ids = get_required_env_var("SUBNET_IDS").split(",")
 
             instance_id = None
@@ -1329,7 +1331,7 @@ def create_and_stop_standby_instance():
                             "LaunchTemplateId": (launch_template_id),
                             "Version": "$Latest",
                         },
-                        InstanceType="t3.large",
+                        InstanceType=instance_type,
                         SubnetId=subnet_id,
                         MinCount=1,
                         MaxCount=1,


### PR DESCRIPTION
## Summary

- Centralize all EC2 instance type definitions into `main.tf` variables, replacing hardcoded values scattered across multiple files
- Pass `PREMIUM_INSTANCE_TYPE` to Premium Manager Lambda via environment variable, eliminating the duplicated `"t3.large"` hardcode in `premium_manager.py`

## Motivation

Instance types were hardcoded in 5 locations across 3 files:

| Tier | Location | Before |
|------|----------|--------|
| Free | `compute.tf` Launch Template | `"t3.large"` hardcoded |
| Premium | `compute.tf` Launch Template + Instance | `"t3.large"` hardcoded |
| Premium | `premium_manager.py` (2 call sites) | `"t3.large"` hardcoded |
| Background | `background_service.tf` Launch Template + Instance | `"t3.micro"` hardcoded |

Changing an instance type required updating multiple files, with risk of inconsistency — particularly between Terraform and the Lambda Python code.

## Changes

| File | Change |
|------|--------|
| `main.tf` | Add `free_instance_type`, `premium_instance_type`, `background_instance_type` variables |
| `compute.tf` | Replace hardcoded values with `var.free_instance_type` / `var.premium_instance_type` |
| `background_service.tf` | Replace hardcoded values with `var.background_instance_type` |
| `premium_manager.tf` | Add `PREMIUM_INSTANCE_TYPE` Lambda environment variable |
| `premium_manager.py` | Read instance type from `PREMIUM_INSTANCE_TYPE` env var instead of hardcoding |

## Test plan

- [ ] `terraform plan` shows no infrastructure changes (default values match previous hardcoded values)
- [ ] Verify Premium Manager Lambda receives `PREMIUM_INSTANCE_TYPE` environment variable
- [ ] Verify dynamically created premium instances use the correct instance type
