### PR TITLE
Refactoring feature/hdf5-mat-thumbnail

### DIFF
--- a/studio/app/common/core/dataview/dataview.py
+++ b/studio/app/common/core/dataview/dataview.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DatasetPaths:
+    """Internal dataset paths for structured data formats (HDF5, MAT, etc.).
+
+    When a new structured data type is added, add a field here.
+    All functions in the thumbnail chain accept a single DatasetPaths parameter,
+    so no other function signatures need to change.
+    """
+
+    hdf5_path: Optional[str] = None
+    mat_path: Optional[str] = None

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -8,6 +8,7 @@ from fastapi import Request
 from sqlalchemy import func
 from sqlmodel import Session, delete
 
+from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptOutputPathIds
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_record_services import (
@@ -19,7 +20,6 @@ from studio.app.common.core.utils.filepath_creater import (
     join_filepath,
     normalize_output_path,
 )
-from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.common.core.workflow.workflow import NodeType
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.db.database import session_scope

--- a/studio/app/common/core/dataview/dataview_services.py
+++ b/studio/app/common/core/dataview/dataview_services.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Request
 from sqlalchemy import func
@@ -19,6 +19,7 @@ from studio.app.common.core.utils.filepath_creater import (
     join_filepath,
     normalize_output_path,
 )
+from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.common.core.workflow.workflow import NodeType
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.db.database import session_scope
@@ -419,34 +420,22 @@ class DataviewService:
         )
         return success_count, error_count
 
-    @classmethod
-    def make_dataview_thumnail_paths(
-        cls,
-        workspace_id: str,
-        unique_id: str,
-        experiment_config_: ExptConfig = None,
-        workflow_config_: WorkflowConfig = None,
-    ) -> tuple:
-        """
-        Create values to set in DataviewThumbnails
-        *Constructed from ExptConfig and WorkflowConfig
+    @staticmethod
+    def select_best_thumbnail_input(
+        workflow_config: WorkflowConfig,
+    ) -> Tuple[Optional[str], DatasetPaths]:
+        """Select the input node best suited for thumbnail generation.
+
+        Priority: IMAGE (TIFF=3) > HDF5 with dataset path (2)
+        > MAT with dataset path (1) > any other input node (0).
+
+        This ensures that in multi-input workflows (e.g. tutorial4: HDF5
+        imaging + MAT behavior) we always pick the most visually informative
+        source regardless of dict order.
 
         Returns:
-            Tuple of (DataviewThumbnails, hdf5_path, mat_path)
+            (normalized_image_path, DatasetPaths)
         """
-
-        # Make input data (image) thumbnails path (from WorkflowConfig)
-        # Select the input node that will produce the best thumbnail.
-        # Priority: IMAGE (TIFF) > HDF5 with dataset path > MAT with dataset
-        # path > any other input node.  This ensures that in multi-input
-        # workflows (e.g. tutorial4: HDF5 imaging + MAT behavior) we always
-        # pick the most visually informative source regardless of dict order.
-        image_url = None
-        workflow_config = (
-            workflow_config_
-            if workflow_config_
-            else WorkflowConfigReader.read(workspace_id, unique_id)
-        )
         input_node_types = [
             NodeType.IMAGE,
             NodeType.HDF5,
@@ -456,13 +445,13 @@ class DataviewService:
             NodeType.FLUO,
             NodeType.BEHAVIOR,
         ]
-        hdf5_path = None
-        mat_path = None
         best_priority = -1
+        image_url = None
+        dataset_paths = DatasetPaths()
+
         for _, node in workflow_config.nodeDict.items():
             if node.type not in input_node_types or not node.data.path:
                 continue
-            # Assign priority: renderable image data first
             if node.type == NodeType.IMAGE:
                 priority = 3
             elif node.type == NodeType.HDF5 and node.data.hdf5Path:
@@ -474,8 +463,36 @@ class DataviewService:
             if priority > best_priority:
                 best_priority = priority
                 image_url = normalize_output_path(node.data.path[0])
-                hdf5_path = node.data.hdf5Path
-                mat_path = node.data.matPath
+                dataset_paths = DatasetPaths(
+                    hdf5_path=node.data.hdf5Path,
+                    mat_path=node.data.matPath,
+                )
+
+        return image_url, dataset_paths
+
+    @classmethod
+    def make_dataview_thumnail_paths(
+        cls,
+        workspace_id: str,
+        unique_id: str,
+        experiment_config_: ExptConfig = None,
+        workflow_config_: WorkflowConfig = None,
+    ) -> Tuple[DataviewThumbnails, DatasetPaths]:
+        """
+        Create values to set in DataviewThumbnails
+        *Constructed from ExptConfig and WorkflowConfig
+
+        Returns:
+            Tuple of (DataviewThumbnails, DatasetPaths)
+        """
+
+        # Make input data (image) thumbnails path (from WorkflowConfig)
+        workflow_config = (
+            workflow_config_
+            if workflow_config_
+            else WorkflowConfigReader.read(workspace_id, unique_id)
+        )
+        image_url, dataset_paths = cls.select_best_thumbnail_input(workflow_config)
 
         # Make output data (roi) thumbnails path (from ExptConfig)
         roi_url = None
@@ -493,7 +510,7 @@ class DataviewService:
             image_url=image_url,
             roi_url=roi_url,
         )
-        return thumbnails, hdf5_path, mat_path
+        return thumbnails, dataset_paths
 
     @classmethod
     def generate_thumbnail_images(
@@ -502,8 +519,7 @@ class DataviewService:
         unique_id: str,
         image_path: Optional[str] = None,
         roi_path: Optional[str] = None,
-        hdf5_path: Optional[str] = None,
-        mat_path: Optional[str] = None,
+        dataset_paths: Optional[DatasetPaths] = None,
     ) -> DataviewThumbnails:
         """
         Generate PNG thumbnails for DataView.
@@ -512,7 +528,7 @@ class DataviewService:
         in DataView. These are ~50-100KB vs full data files which can be 100MB+.
 
         For TIFF files: renders first frame as grayscale image
-        For HDF5/MAT files: renders dataset preview if hdf5_path/mat_path provided
+        For HDF5/MAT files: renders dataset preview if dataset_paths provided
         For other formats (microscope, etc.): generates placeholder with file type label
 
         Stores in: {output_dir}/{workspace_id}/{unique_id}/thumbnails/
@@ -524,8 +540,7 @@ class DataviewService:
             unique_id: Experiment unique identifier
             image_path: Path to input file (TIFF, HDF5, MAT, etc.) (optional)
             roi_path: Path to cell_roi.json file (optional)
-            hdf5_path: Internal HDF5 dataset path (optional)
-            mat_path: Internal MAT dataset path (optional)
+            dataset_paths: Internal dataset paths for structured data (optional)
 
         Returns:
             DataviewThumbnails with paths to generated PNG thumbnails
@@ -551,8 +566,7 @@ class DataviewService:
                     source_path=image_path,
                     output_path=input_thumb_path,
                     abs_source_path=abs_image_path,
-                    hdf5_path=hdf5_path,
-                    mat_path=mat_path,
+                    dataset_paths=dataset_paths,
                 )
                 logger.debug(f"Generated input thumbnail: {input_thumb_path}")
             except Exception as e:

--- a/studio/app/common/core/dataview/thumbnail_generator.py
+++ b/studio/app/common/core/dataview/thumbnail_generator.py
@@ -9,9 +9,9 @@ import imageio.v3 as imageio
 import numpy as np
 import tifffile
 
+from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.const import EXTENSION_LABELS, ThumbnailConst, ThumbnailType
 from studio.app.dir_path import DIRPATH
 

--- a/studio/app/common/core/dataview/thumbnail_generator.py
+++ b/studio/app/common/core/dataview/thumbnail_generator.py
@@ -11,6 +11,7 @@ import tifffile
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.const import EXTENSION_LABELS, ThumbnailConst, ThumbnailType
 from studio.app.dir_path import DIRPATH
 
@@ -471,15 +472,14 @@ class ThumbnailGenerator:
         source_path: str,
         output_path: str,
         abs_source_path: str = None,
-        hdf5_path: str = None,
-        mat_path: str = None,
+        dataset_paths: DatasetPaths = None,
     ) -> None:
         """
         Generate an input thumbnail, choosing the right strategy automatically.
 
         - TIFF file exists locally → render first frame as grayscale
-        - HDF5 file + hdf5_path → render dataset preview
-        - MAT file + mat_path → render dataset preview
+        - HDF5 file + dataset_paths.hdf5_path → render dataset preview
+        - MAT file + dataset_paths.mat_path → render dataset preview
         - Otherwise → placeholder with file type label
 
         Args:
@@ -487,10 +487,11 @@ class ThumbnailGenerator:
             output_path: Path to save the PNG thumbnail
             abs_source_path: Absolute path to the source file for reading.
                 If None, uses source_path directly.
-            hdf5_path: Internal HDF5 dataset path (e.g. "/data/images")
-            mat_path: Internal MAT dataset path (e.g. "data/images")
+            dataset_paths: Internal dataset paths for structured data formats
         """
         resolved = abs_source_path or source_path
+        hdf5_path = dataset_paths.hdf5_path if dataset_paths else None
+        mat_path = dataset_paths.mat_path if dataset_paths else None
 
         if cls.can_generate_tiff_thumbnail(source_path):
             if resolved and os.path.exists(resolved):

--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -46,8 +46,7 @@ class ExperimentRecordService:
         # Get original thumbnail paths (TIFF/JSON references)
         (
             original_thumbnails,
-            hdf5_path,
-            mat_path,
+            dataset_paths,
         ) = DataviewService.make_dataview_thumnail_paths(
             workspace_id,
             unique_id,
@@ -63,8 +62,7 @@ class ExperimentRecordService:
                 unique_id,
                 image_path=original_thumbnails.image_url,
                 roi_path=original_thumbnails.roi_url,
-                hdf5_path=hdf5_path,
-                mat_path=mat_path,
+                dataset_paths=dataset_paths,
             )
             # Use generated PNG paths if available, fall back to originals
             thumbnails = DataviewThumbnails(

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 
 from studio.app.common.core.auth.auth_dependencies import get_outputs_remote_bucket_name
+from studio.app.common.core.dataview.dataview import DatasetPaths
 from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
@@ -50,8 +51,7 @@ async def get_or_generate_thumbnail(
     original_path: str,
     remote_bucket_name: str,
     thumb_type: ThumbnailType,
-    hdf5_path: str = None,
-    mat_path: str = None,
+    dataset_paths: DatasetPaths = None,
 ) -> str:
     """
     Get thumbnail path, generating if needed (lazy migration).
@@ -71,8 +71,8 @@ async def get_or_generate_thumbnail(
         remote_bucket_name: remote storage bucket name for remote storage
         thumb_type: ThumbnailType.INPUT (for TIFF) or ThumbnailType.ROI
             (for cell_roi.json)
-        hdf5_path: Internal HDF5 dataset path (optional)
-        mat_path: Internal MAT dataset path (optional)
+        dataset_paths: Internal dataset paths for structured data
+            (optional)
 
     Returns:
         Path to the thumbnail PNG file (may be newly generated)
@@ -124,8 +124,7 @@ async def get_or_generate_thumbnail(
                     source_path=original_path,
                     output_path=thumb_path,
                     abs_source_path=abs_original_path,
-                    hdf5_path=hdf5_path,
-                    mat_path=mat_path,
+                    dataset_paths=dataset_paths,
                 )
             else:
                 ThumbnailGenerator.generate_roi_thumbnail(abs_original_path, thumb_path)
@@ -359,8 +358,7 @@ async def get_thumbnail(
                 pass  # Continue processing
 
         # Get the original file path for generation
-        hdf5_path = None
-        mat_path = None
+        dataset_paths = None
         if thumb_type == ThumbnailType.INPUT:
             # Need to find the input file and dataset paths
             try:
@@ -371,67 +369,61 @@ async def get_thumbnail(
                     original_path = input_filenames[0]
                 else:
                     raise HTTPException(
-                        status_code=404, detail="No input files found for thumbnail"
+                        status_code=404,
+                        detail="No input files found for thumbnail",
                     )
             except (AssertionError, KeyError):
                 raise HTTPException(
-                    status_code=404, detail="Could not determine input file"
+                    status_code=404,
+                    detail="Could not determine input file",
                 )
 
-            # Extract hdf5Path/matPath from workflow config, preferring the
-            # node that will produce the best thumbnail (HDF5 > MAT).
+            # Extract dataset paths from workflow config
             try:
-                from studio.app.common.core.workflow.workflow import NodeType
+                from studio.app.common.core.dataview.dataview_services import (
+                    DataviewService,
+                )
 
                 wf_config = WorkflowConfigReader.read(workspace_id, unique_id)
-                best_priority = -1
-                for _, node in wf_config.nodeDict.items():
-                    if not node.data.path:
-                        continue
-                    if node.type == NodeType.HDF5 and node.data.hdf5Path:
-                        priority = 2
-                    elif node.type == NodeType.MATLAB and node.data.matPath:
-                        priority = 1
-                    else:
-                        continue
-                    if priority > best_priority:
-                        best_priority = priority
-                        hdf5_path = node.data.hdf5Path
-                        mat_path = node.data.matPath
+                _, dataset_paths = DataviewService.select_best_thumbnail_input(
+                    wf_config
+                )
             except Exception:
                 pass  # Dataset paths are optional enhancement
         else:
-            # ROI thumbnail uses cell_roi.json - need to find actual path from config
+            # ROI thumbnail uses cell_roi.json
             from studio.app.common.core.dataview.dataview_services import (
                 DataviewService,
             )
 
             try:
-                thumbnails, _, _ = DataviewService.make_dataview_thumnail_paths(
+                thumbnails, _ = DataviewService.make_dataview_thumnail_paths(
                     workspace_id, unique_id
                 )
                 if thumbnails.roi_url:
                     original_path = thumbnails.roi_url
                 else:
                     raise HTTPException(
-                        status_code=404, detail="No ROI data found for thumbnail"
+                        status_code=404,
+                        detail="No ROI data found for thumbnail",
                     )
             except Exception as e:
                 logger.warning(f"Could not determine ROI path: {e}")
                 raise HTTPException(
-                    status_code=404, detail="Could not determine ROI file path"
+                    status_code=404,
+                    detail="Could not determine ROI file path",
                 )
 
-        # Generate thumbnail (may download source from remote storage if needed)
-        # Note: get_or_generate_thumbnail returns a normalized (relative) path
+        # Generate thumbnail (may download source from remote
+        # storage if needed). get_or_generate_thumbnail returns
+        # a normalized (relative) path.
         await get_or_generate_thumbnail(
             workspace_id,
             unique_id,
             original_path,
             remote_bucket_name,
             thumb_type,
-            hdf5_path=hdf5_path,
-            mat_path=mat_path,
+            dataset_paths=dataset_paths,
         )
         # Re-get the absolute path since generation should have created the file
         thumb_path = ThumbnailGenerator.get_thumbnail_path(

--- a/studio/tests/app/common/core/dataview/test_thumbnail_generator.py
+++ b/studio/tests/app/common/core/dataview/test_thumbnail_generator.py
@@ -9,6 +9,7 @@ import pytest
 from scipy.io import savemat
 
 from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
+from studio.app.common.core.dataview.dataview import DatasetPaths
 
 
 @pytest.fixture
@@ -137,7 +138,7 @@ class TestGenerateInputThumbnailDispatch:
             source_path=h5_path,
             output_path=output_path,
             abs_source_path=h5_path,
-            hdf5_path="/images",
+            dataset_paths=DatasetPaths(hdf5_path="/images"),
         )
         assert os.path.exists(output_path)
         img = imageio.imread(output_path)
@@ -152,7 +153,7 @@ class TestGenerateInputThumbnailDispatch:
             source_path=h5_path,
             output_path=output_path,
             abs_source_path=h5_path,
-            hdf5_path="/nonexistent",
+            dataset_paths=DatasetPaths(hdf5_path="/nonexistent"),
         )
         assert os.path.exists(output_path)
         img = imageio.imread(output_path)
@@ -165,7 +166,7 @@ class TestGenerateInputThumbnailDispatch:
             source_path=mat_file,
             output_path=output_path,
             abs_source_path=mat_file,
-            mat_path="matrix",
+            dataset_paths=DatasetPaths(mat_path="matrix"),
         )
         assert os.path.exists(output_path)
         img = imageio.imread(output_path)
@@ -180,8 +181,9 @@ class TestGenerateInputThumbnailDispatch:
             source_path=h5_path,
             output_path=output_path,
             abs_source_path=h5_path,
-            hdf5_path="/images",
-            mat_path="ignored",
+            dataset_paths=DatasetPaths(
+                hdf5_path="/images", mat_path="ignored"
+            ),
         )
         assert os.path.exists(output_path)
         img = imageio.imread(output_path)
@@ -209,7 +211,7 @@ class TestEdgeCases:
             source_path=mat_file,
             output_path=output,
             abs_source_path=mat_file,
-            mat_path="nonexistent",
+            dataset_paths=DatasetPaths(mat_path="nonexistent"),
         )
         assert os.path.exists(output)
         img = imageio.imread(output)

--- a/studio/tests/app/common/core/dataview/test_thumbnail_generator.py
+++ b/studio/tests/app/common/core/dataview/test_thumbnail_generator.py
@@ -8,8 +8,8 @@ import numpy as np
 import pytest
 from scipy.io import savemat
 
-from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
 from studio.app.common.core.dataview.dataview import DatasetPaths
+from studio.app.common.core.dataview.thumbnail_generator import ThumbnailGenerator
 
 
 @pytest.fixture
@@ -181,9 +181,7 @@ class TestGenerateInputThumbnailDispatch:
             source_path=h5_path,
             output_path=output_path,
             abs_source_path=h5_path,
-            dataset_paths=DatasetPaths(
-                hdf5_path="/images", mat_path="ignored"
-            ),
+            dataset_paths=DatasetPaths(hdf5_path="/images", mat_path="ignored"),
         )
         assert os.path.exists(output_path)
         img = imageio.imread(output_path)


### PR DESCRIPTION
# Refactoring Plan: Structured Data Paths & Priority Selection Logic

## Background

Commit `03163481` of #405  ("Create thumbnails for hdf5 and mat data") added HDF5/MAT thumbnail support.
The implementation has the following maintainability issues.

---

## Problems

### Problem 1: `hdf5_path` / `mat_path` threaded as separate parameters through every function signature

If a 3rd data type (e.g. Zarr, NWB) is added, **all** of the following function signatures must be modified:

| File | Function |
|---|---|
| `studio/app/common/core/dataview/dataview_services.py` | `make_dataview_thumnail_paths()` |
| `studio/app/common/core/dataview/dataview_services.py` | `generate_thumbnail_images()` |
| `studio/app/common/core/dataview/thumbnail_generator.py` | `generate_input_thumbnail()` |
| `studio/app/common/routers/outputs.py` | `get_or_generate_thumbnail()` |
| `studio/app/common/routers/outputs.py` | `get_thumbnail()` |
| `studio/app/common/core/experiment/experiment_record_services.py` | `create_experiment_record()` |

Additionally, the return type of `make_dataview_thumnail_paths` was `-> tuple`, losing type information.

### Problem 2: Duplicated `best_priority` selection logic

Nearly identical priority-based node selection logic was copied in **2 locations**:

1. **`dataview_services.py` L461-L478** -- inside `make_dataview_thumnail_paths()`
2. **`outputs.py` L387-L401** -- inside `get_thumbnail()`

```python
# Pattern duplicated in both locations:
best_priority = -1
for _, node in workflow_config.nodeDict.items():
    if node.type == NodeType.HDF5 and node.data.hdf5Path:
        priority = 2
    elif node.type == NodeType.MATLAB and node.data.matPath:
        priority = 1
    else:
        ...
    if priority > best_priority:
        best_priority = priority
        hdf5_path = node.data.hdf5Path
        mat_path = node.data.matPath
```

---

## Solutions

### Solution 1: Introduce `DatasetPaths` dataclass

Bundle the individual `hdf5_path` and `mat_path` parameters into a single dataclass.

**Defined in:** `studio/app/common/core/dataview/dataview.py`

```python
from dataclasses import dataclass
from typing import Optional

@dataclass
class DatasetPaths:
    """Internal dataset paths for structured data formats (HDF5, MAT, etc.).

    When a new structured data type is added, simply add a field here.
    No changes to function signatures are required.
    """
    hdf5_path: Optional[str] = None
    mat_path: Optional[str] = None
```

**Benefits:**
- Adding a 3rd data type only requires adding one field to `DatasetPaths`
- Every function in the chain takes a single `dataset_paths: DatasetPaths = None` parameter
- Return type of `make_dataview_thumnail_paths`: `tuple` -> `Tuple[DataviewThumbnails, DatasetPaths]`

### Solution 2: Extract priority selection logic into a shared function

Extract the duplicated `best_priority` loop into a single shared function.

**Defined in:** `studio/app/common/core/dataview/dataview_services.py` (as `DataviewService.select_best_thumbnail_input()`)

```python
@staticmethod
def select_best_thumbnail_input(
    workflow_config: WorkflowConfig,
) -> Tuple[Optional[str], DatasetPaths]:
    """Select the input node best suited for thumbnail generation.

    Priority: IMAGE (TIFF=3) > HDF5 with dataset path (2)
    > MAT with dataset path (1) > any other input (0).

    Returns:
        (normalized_image_path, DatasetPaths)
    """
    input_node_types = [
        NodeType.IMAGE, NodeType.HDF5, NodeType.MATLAB,
        NodeType.MICROSCOPE, NodeType.CSV, NodeType.FLUO, NodeType.BEHAVIOR,
    ]
    best_priority = -1
    image_url = None
    dataset_paths = DatasetPaths()

    for _, node in workflow_config.nodeDict.items():
        if node.type not in input_node_types or not node.data.path:
            continue
        if node.type == NodeType.IMAGE:
            priority = 3
        elif node.type == NodeType.HDF5 and node.data.hdf5Path:
            priority = 2
        elif node.type == NodeType.MATLAB and node.data.matPath:
            priority = 1
        else:
            priority = 0
        if priority > best_priority:
            best_priority = priority
            image_url = normalize_output_path(node.data.path[0])
            dataset_paths = DatasetPaths(
                hdf5_path=node.data.hdf5Path,
                mat_path=node.data.matPath,
            )

    return image_url, dataset_paths
```

---

## Files modified

| # | File | Changes |
|---|---|---|
| 1 | `studio/app/common/core/dataview/dataview.py` | Add `DatasetPaths` dataclass |
| 2 | `studio/app/common/core/dataview/dataview_services.py` | Add `select_best_thumbnail_input()`. Update `make_dataview_thumnail_paths` return type to `Tuple[DataviewThumbnails, DatasetPaths]`. Replace `hdf5_path`/`mat_path` params with `dataset_paths: DatasetPaths` in `generate_thumbnail_images` |
| 3 | `studio/app/common/core/dataview/thumbnail_generator.py` | Replace `hdf5_path`/`mat_path` params with `dataset_paths: DatasetPaths` in `generate_input_thumbnail` |
| 4 | `studio/app/common/core/experiment/experiment_record_services.py` | Update calls to match new API |
| 5 | `studio/app/common/routers/outputs.py` | Use shared `select_best_thumbnail_input()` + `DatasetPaths`. Remove duplicated priority logic |
| 6 | `studio/tests/app/common/core/dataview/test_thumbnail_generator.py` | Update `generate_input_thumbnail` calls to use `DatasetPaths` |

---

## Verification

1. Run existing tests:
   ```bash
   pytest studio/tests/app/common/core/dataview/test_thumbnail_generator.py -v
   ```
2. Run linter to detect type/import errors
3. Confirm no individual `hdf5_path` / `mat_path` pass-through parameters remain via grep:
   ```bash
   grep -rn 'hdf5_path.*mat_path' studio/app/ --include="*.py"
   ```
