### PR TITLE
fix: resolve dev environment login/registration failures and Inject infrastructure values to terraform

### DIFF
--- a/infrastructure/scripts/app_setup.sh
+++ b/infrastructure/scripts/app_setup.sh
@@ -42,7 +42,6 @@ ECS_AGENT_RETRY_DELAY=30
 
 # Default IDs
 DEFAULT_ORG_ID=1
-DEFAULT_USER_ID=1
 ADMIN_ROLE_ID=1
 
 # Role Definitions
@@ -180,36 +179,44 @@ OPTINIST_ADMIN_UID=$(get_json_value "$APP_CONFIG_JSON" "admin_uid")
 
 echo "$(date): Discovering AWS infrastructure..."
 
-# Find RDS Proxy endpoint
-echo "$(date): Finding RDS Proxy..."
-RDS_PROXY_ENDPOINT=$(aws rds describe-db-proxies \
-    --region "$AWS_REGION" \
-    --query "DBProxies[?contains(DBProxyName, '${ENV_PREFIX}-optinist')].Endpoint" \
-    --output text 2>/dev/null | head -1)
-
-if [ -z "$RDS_PROXY_ENDPOINT" ]; then
-    echo "$(date): WARNING: RDS Proxy not found, trying direct RDS endpoint..."
-    RDS_PROXY_ENDPOINT=$(aws rds describe-db-instances \
+# Find RDS Proxy endpoint (use RDS_PROXY_ENDPOINT if passed from Terraform, otherwise discover)
+if [ -n "$RDS_PROXY_ENDPOINT" ]; then
+    echo "$(date): Using RDS Proxy endpoint from environment: $RDS_PROXY_ENDPOINT"
+else
+    echo "$(date): Finding RDS Proxy..."
+    RDS_PROXY_ENDPOINT=$(aws rds describe-db-proxies \
         --region "$AWS_REGION" \
-        --query "DBInstances[?contains(DBInstanceIdentifier, '${ENV_PREFIX}-optinist')].Endpoint.Address" \
+        --query "DBProxies[?contains(DBProxyName, '${ENV_PREFIX}-optinist')].Endpoint" \
         --output text 2>/dev/null | head -1)
+
+    if [ -z "$RDS_PROXY_ENDPOINT" ]; then
+        echo "$(date): WARNING: RDS Proxy not found, trying direct RDS endpoint..."
+        RDS_PROXY_ENDPOINT=$(aws rds describe-db-instances \
+            --region "$AWS_REGION" \
+            --query "DBInstances[?contains(DBInstanceIdentifier, '${ENV_PREFIX}-optinist')].Endpoint.Address" \
+            --output text 2>/dev/null | head -1)
+    fi
 fi
 
-# Find S3 bucket
-echo "$(date): Finding S3 bucket..."
-S3_BUCKET=$(aws s3api list-buckets \
-    --query "Buckets[?contains(Name, '${ENV_PREFIX}-optinist-app-storage')].Name" \
-    --output text 2>/dev/null | head -1)
+# Find S3 bucket (use S3_BUCKET_NAME if passed from Terraform, otherwise discover)
+if [ -n "$S3_BUCKET_NAME" ]; then
+    echo "$(date): Using S3 bucket from environment: $S3_BUCKET_NAME"
+    S3_BUCKET="$S3_BUCKET_NAME"
+else
+    echo "$(date): Finding S3 bucket..."
+    S3_BUCKET=$(aws s3api list-buckets \
+        --query "Buckets[?contains(Name, '${ENV_PREFIX}-optinist-app-storage')].Name" \
+        --output text 2>/dev/null | head -1)
 
-if [ -z "$S3_BUCKET" ]; then
-    echo "$(date): WARNING: Could not find S3 bucket with expected naming pattern"
-    # Try to find any bucket with optinist tag
-    S3_BUCKET=$(aws resourcegroupstaggingapi get-resources \
-        --resource-type-filters s3:bucket \
-        --tag-filters "Key=Name,Values=*optinist*" \
-        --region "$AWS_REGION" \
-        --query "ResourceTagMappingList[0].ResourceARN" \
-        --output text 2>/dev/null | cut -d':' -f6)
+    if [ -z "$S3_BUCKET" ]; then
+        echo "$(date): WARNING: Could not find S3 bucket with expected naming pattern"
+        S3_BUCKET=$(aws resourcegroupstaggingapi get-resources \
+            --resource-type-filters s3:bucket \
+            --tag-filters "Key=Name,Values=*optinist*" \
+            --region "$AWS_REGION" \
+            --query "ResourceTagMappingList[0].ResourceARN" \
+            --output text 2>/dev/null | cut -d':' -f6)
+    fi
 fi
 
 echo "$(date): RDS Proxy Endpoint: $RDS_PROXY_ENDPOINT"
@@ -248,8 +255,15 @@ echo "$(date): Starting database initialization"
 
 # Install MySQL client for database initialization
 echo "$(date): Installing MySQL client"
-apt-get update
-apt-get install -y mysql-client-core-8.0 python3-pip
+if command -v yum &>/dev/null; then
+    yum install -y mysql python3-pip
+elif command -v apt-get &>/dev/null; then
+    apt-get update
+    apt-get install -y mysql-client-core-8.0 python3-pip
+else
+    echo "$(date): ERROR: No supported package manager found"
+    exit 1
+fi
 
 # Extract hostname from RDS endpoint (remove port if present)
 RDS_HOST=$(echo "$RDS_PROXY_ENDPOINT" | cut -d':' -f1)
@@ -271,30 +285,32 @@ USE ${MYSQL_DATABASE};
 -- Insert initial data
 INSERT IGNORE INTO organization (name) VALUES ('${OPTINIST_ORG_NAME}');
 INSERT IGNORE INTO roles (id, role) VALUES
-  ($ROLE_ADMIN_ID, '$ROLE_ADMIN_NAME'),
-  ($ROLE_DATA_MANAGER_ID, '$ROLE_DATA_MANAGER_NAME'),
-  ($ROLE_OPERATOR_ID, '$ROLE_OPERATOR_NAME'),
-  ($ROLE_GUEST_OPERATOR_ID, '$ROLE_GUEST_OPERATOR_NAME');
+  (${ROLE_ADMIN_ID}, '${ROLE_ADMIN_NAME}'),
+  (${ROLE_DATA_MANAGER_ID}, '${ROLE_DATA_MANAGER_NAME}'),
+  (${ROLE_OPERATOR_ID}, '${ROLE_OPERATOR_NAME}'),
+  (${ROLE_GUEST_OPERATOR_ID}, '${ROLE_GUEST_OPERATOR_NAME}');
 
 -- Default admin user with S3 bucket info
 INSERT IGNORE INTO users (uid, organization_id, name, email, active, attributes)
-VALUES ('${OPTINIST_ADMIN_UID}', $DEFAULT_ORG_ID, '${OPTINIST_ADMIN_NAME}', '${OPTINIST_ADMIN_EMAIL}', true, '{"remote_bucket_name": "${S3_BUCKET}"}');
+VALUES ('${OPTINIST_ADMIN_UID}', ${DEFAULT_ORG_ID}, '${OPTINIST_ADMIN_NAME}', '${OPTINIST_ADMIN_EMAIL}', true, '{"remote_bucket_name": "${S3_BUCKET}"}');
 
-INSERT IGNORE INTO user_roles (user_id, role_id) VALUES ($DEFAULT_USER_ID, $ADMIN_ROLE_ID);
+INSERT IGNORE INTO user_roles (user_id, role_id)
+SELECT id, ${ADMIN_ROLE_ID} FROM users WHERE uid = '${OPTINIST_ADMIN_UID}';
 
-UPDATE users SET attributes = JSON_MERGE_PATCH(IFNULL(attributes,'{}'), '{"remote_bucket_name": "${S3_BUCKET}"}') WHERE id = $DEFAULT_USER_ID;
+UPDATE users SET attributes = JSON_MERGE_PATCH(IFNULL(attributes,'{}'), '{"remote_bucket_name": "${S3_BUCKET}"}') WHERE uid = '${OPTINIST_ADMIN_UID}';
 
 -- Tax rates initialization
 INSERT IGNORE INTO taxes (tax_type, tax_name, tax_rate, is_active, effective_date)
-VALUES ('$TAX_TYPE', '$TAX_NAME', $TAX_RATE, $TAX_IS_ACTIVE, CURDATE());
+VALUES ('${TAX_TYPE}', '${TAX_NAME}', ${TAX_RATE}, ${TAX_IS_ACTIVE}, CURDATE());
 
 -- Admin user storage quota initialization
 INSERT IGNORE INTO user_storage_usage (user_id, storage_usage_bytes, storage_quota_bytes)
-VALUES ($DEFAULT_USER_ID, $ADMIN_STORAGE_USAGE_BYTES, $ADMIN_STORAGE_QUOTA_BYTES);
+SELECT id, ${ADMIN_STORAGE_USAGE_BYTES}, ${ADMIN_STORAGE_QUOTA_BYTES} FROM users WHERE uid = '${OPTINIST_ADMIN_UID}'
+ON DUPLICATE KEY UPDATE storage_quota_bytes = ${ADMIN_STORAGE_QUOTA_BYTES};
 
 -- Admin user premium subscription
 INSERT IGNORE INTO subscription_users (plan_id, user_id, expiration)
-VALUES ($PREMIUM_PLAN_ID, $DEFAULT_USER_ID, DATE_ADD(NOW(), INTERVAL $ADMIN_SUBSCRIPTION_DAYS DAY));
+SELECT ${PREMIUM_PLAN_ID}, id, DATE_ADD(NOW(), INTERVAL ${ADMIN_SUBSCRIPTION_DAYS} DAY) FROM users WHERE uid = '${OPTINIST_ADMIN_UID}';
 
 INIT_SQL
 
@@ -304,6 +320,12 @@ INIT_SQL
 export MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE
 export OPTINIST_ORG_NAME OPTINIST_ADMIN_UID OPTINIST_ADMIN_NAME OPTINIST_ADMIN_EMAIL
 export S3_BUCKET DB_INIT_SQL_FILE
+export ROLE_ADMIN_ID ROLE_ADMIN_NAME ROLE_DATA_MANAGER_ID ROLE_DATA_MANAGER_NAME
+export ROLE_OPERATOR_ID ROLE_OPERATOR_NAME ROLE_GUEST_OPERATOR_ID ROLE_GUEST_OPERATOR_NAME
+export DEFAULT_ORG_ID ADMIN_ROLE_ID
+export TAX_TYPE TAX_NAME TAX_RATE TAX_IS_ACTIVE
+export ADMIN_STORAGE_USAGE_BYTES ADMIN_STORAGE_QUOTA_BYTES
+export PREMIUM_PLAN_ID ADMIN_SUBSCRIPTION_DAYS
 
 python3 << 'PYSUBST'
 import os
@@ -327,7 +349,25 @@ var_names = [
     'OPTINIST_ADMIN_UID',
     'OPTINIST_ADMIN_NAME',
     'OPTINIST_ADMIN_EMAIL',
-    'S3_BUCKET'
+    'S3_BUCKET',
+    'ROLE_ADMIN_ID',
+    'ROLE_ADMIN_NAME',
+    'ROLE_DATA_MANAGER_ID',
+    'ROLE_DATA_MANAGER_NAME',
+    'ROLE_OPERATOR_ID',
+    'ROLE_OPERATOR_NAME',
+    'ROLE_GUEST_OPERATOR_ID',
+    'ROLE_GUEST_OPERATOR_NAME',
+    'DEFAULT_ORG_ID',
+    'ADMIN_ROLE_ID',
+    'TAX_TYPE',
+    'TAX_NAME',
+    'TAX_RATE',
+    'TAX_IS_ACTIVE',
+    'ADMIN_STORAGE_USAGE_BYTES',
+    'ADMIN_STORAGE_QUOTA_BYTES',
+    'PREMIUM_PLAN_ID',
+    'ADMIN_SUBSCRIPTION_DAYS',
 ]
 
 # Perform substitutions with proper SQL escaping
@@ -353,7 +393,7 @@ max_attempts=$DB_INIT_MAX_ATTEMPTS
 attempt=1
 while [ $attempt -le $max_attempts ]; do
   echo "$(date): Attempting to initialize database (attempt $attempt/$max_attempts)"
-  if mysql -h "$RDS_HOST" -P $MYSQL_PORT -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$DB_INIT_SQL_FILE"; then
+  if mysql -h "$RDS_HOST" -P $MYSQL_PORT -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" --ssl "$MYSQL_DATABASE" < "$DB_INIT_SQL_FILE"; then
     echo "$(date): Database initialization successful"
     break
   else
@@ -375,7 +415,11 @@ echo "$(date): Verifying admin email in Firebase"
 
 # Install dependencies for Firebase Admin SDK
 echo "$(date): Installing firebase-admin..."
-python3 -m pip install firebase-admin
+python3 -m pip install firebase-admin || {
+    echo "$(date): WARNING: Failed to install firebase-admin. Skipping email verification."
+    echo "$(date): Application setup completed successfully (without Firebase verification)"
+    exit 0
+}
 
 # Run verification script
 echo "$(date): Running Firebase verification script..."

--- a/infrastructure/terraform/deployment.tf
+++ b/infrastructure/terraform/deployment.tf
@@ -23,7 +23,7 @@ resource "null_resource" "build_and_deploy" {
       # Build and push image
       echo "Building and pushing Docker image..."
       chmod +x ../scripts/ecr_build_push.sh
-      ../scripts/ecr_build_push.sh
+      ../scripts/ecr_build_push.sh --yes
 
       echo "Waiting for ECR image to be available..."
       sleep 60
@@ -106,7 +106,7 @@ resource "aws_ssm_document" "app_setup" {
           timeoutSeconds = "3600"
           runCommand = [
             "chmod +x /tmp/app_setup.sh",
-            "ENV_PREFIX=${var.environment} /tmp/app_setup.sh"
+            "ENV_PREFIX=${var.environment} S3_BUCKET_NAME=${aws_s3_bucket.app_storage.id} RDS_PROXY_ENDPOINT=${aws_db_proxy.main.endpoint} /tmp/app_setup.sh"
           ]
         }
       }

--- a/studio/app/common/core/middleware/constants.py
+++ b/studio/app/common/core/middleware/constants.py
@@ -1,0 +1,3 @@
+# Paths that should skip authentication-related middleware processing.
+# These endpoints are either public (login, refresh) or internal (health check).
+SKIP_AUTH_PATHS = ["/health", "/auth/login", "/auth/refresh"]

--- a/studio/app/common/core/middleware/secure_routing_middleware.py
+++ b/studio/app/common/core/middleware/secure_routing_middleware.py
@@ -30,6 +30,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.middleware.constants import SKIP_AUTH_PATHS
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 
@@ -160,8 +161,6 @@ class SecureRoutingMiddleware:
     - Immediate cache invalidation on subscription changes
     """
 
-    SKIP_AUTH_PATHS = ["/health", "/api/auth/login", "/api/auth/refresh"]
-
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
@@ -180,7 +179,7 @@ class SecureRoutingMiddleware:
 
         # Skip health check, auth endpoints, and system-internal API endpoints
         # System-internal endpoints use their own auth (shared secret, not JWT)
-        if path in self.SKIP_AUTH_PATHS or path.startswith("/system-internal/"):
+        if path in SKIP_AUTH_PATHS or path.startswith("/system-internal/"):
             await self.app(scope, receive, send)
             return
 

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -34,6 +34,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.middleware.constants import SKIP_AUTH_PATHS
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
@@ -44,7 +45,6 @@ from studio.app.common.models.instance_usage import InstanceUsageLog
 # Constants
 BEARER_PREFIX = "Bearer "
 BEARER_PREFIX_LENGTH = len(BEARER_PREFIX)
-SKIP_AUTH_PATHS = ["/health", "/api/auth/login", "/api/auth/refresh"]
 TIER_FREE = "free"
 TIER_PREMIUM = "premium"
 


### PR DESCRIPTION
 ## Summary                                                                                                
                                                                                                            
  - Fix `app_setup.sh` database seeding failures that prevented login (404) and registration (500) on the   
  development environment                                                                                   
  - Remove broad IAM permissions (`s3:ListAllMyBuckets`, `rds:DescribeDBProxies`) by passing infrastructure 
  values directly from Terraform                                                                            
  - Fix incorrect `SKIP_AUTH_PATHS` in middleware that referenced non-existent `/api/auth/*` routes
                                                                                                            
  ## Problem                                                                                                
                                                                                                            
  The development environment was completely unusable — users could not register or login.                  
                  
  **Root cause**: The `app_setup.sh` script (which seeds the database with initial data like organizations, 
  roles, and the admin user) was failing on every SSM execution due to 3 cascading issues:
                                                                                                            
  1. **`apt-get: command not found` (exit code 127)** — The EC2 instances run Amazon Linux (which uses      
  `yum`), but the script only supported `apt-get`. This caused the script to exit immediately before any
  database work.                                                                                            
                  
  2. **SQL variable substitution failure** — The SQL template uses a single-quoted heredoc (`<< 'INIT_SQL'`)
   to prevent shell expansion (protecting passwords with special characters). A Python script then
  substitutes `${VAR_NAME}` placeholders. However, constants like role IDs used bare `$VAR` syntax (no      
  braces), so they were never substituted — producing `Unknown column '$ROLE_ADMIN_ID'` MySQL errors.

  3. **`firebase-admin` pip install crash** — The Firebase email verification step at the end of the script 
  installs `firebase-admin`, but v6.9.0 requires `httpx==0.28.1` which isn't available on Amazon Linux's
  Python 3.7. Because the script has `set -e`, this pip failure caused the entire script to exit with an    
  error, even though database seeding had already completed.

  **Impact on users**:                                                                                      
  - **Registration → 500**: `INSERT INTO users` failed because `organization_id=1` referenced an empty
  `organization` table (foreign key constraint)                                                             
  - **Login → 404**: `authenticate_user()` couldn't find any users in the empty database
  - **Admin had no role**: The script used hardcoded `user_id=1` for role assignment, but auto-increment    
  assigned a different id                                                                                   
                                                                                                            
  **Separate middleware bug**: Both `SecureRoutingMiddleware` and `UserActivityMiddleware` had              
  `SKIP_AUTH_PATHS` referencing `/api/auth/login` and `/api/auth/refresh`, but the actual routes are
  `/auth/login` and `/auth/refresh` (no `/api` prefix). This meant the middlewares unnecessarily processed  
  login/refresh requests instead of skipping them.

  ## Solution                                                                                               
   
  ### `infrastructure/scripts/app_setup.sh`                                                                 
  - **Package manager detection**: Detect `yum` vs `apt-get` using `command -v` (POSIX-compliant) instead of
   hardcoding `apt-get`                                                                                     
  - **Consistent variable substitution**: Changed all SQL template variables from `$VAR` to `${VAR}` syntax,
   added them to the `export` list and Python `var_names` substitution list                                 
  - **UID-based admin queries**: Changed admin role assignment, storage quota, and subscription SQL from
  hardcoded `user_id=1` to `SELECT id FROM users WHERE uid = '${OPTINIST_ADMIN_UID}'` — works regardless of 
  auto-increment state
  - **Non-fatal Firebase pip install**: Wrapped in `|| { exit 0; }` so the script reports success when      
  database seeding completes, even if `firebase-admin` can't be installed                                   
  - **SSL for MySQL**: Added `--ssl` flag for RDS Proxy connections requiring TLS
  - **Terraform-injected infrastructure values**: Accept `RDS_PROXY_ENDPOINT` and `S3_BUCKET_NAME` as       
  environment variables when passed from Terraform, falling back to API discovery only when not provided    
                                                                                                            
  ### `infrastructure/terraform/deployment.tf`                                                              
  - Pass `S3_BUCKET_NAME` and `RDS_PROXY_ENDPOINT` directly to the setup script via the SSM document,
  eliminating the need for broad IAM discovery permissions                                                  
  - Add `--yes` flag to `ecr_build_push.sh` for non-interactive builds
                                                                                                            
  ### `studio/app/common/core/middleware/`                                                                  
  - Extract `SKIP_AUTH_PATHS` to a shared `constants.py` to prevent the two middleware definitions from     
  drifting                                                                                                  
  - Fix paths from `/api/auth/login` → `/auth/login` and `/api/auth/refresh` → `/auth/refresh` to match
  actual router prefixes                                                                                    
                  
  ### IAM (net zero in diff, applied via Terraform)                                                         
  - The `ecs_instance_infra_discovery` IAM policy (`rds:DescribeDBProxies`, `rds:DescribeDBInstances`,
  `s3:ListAllMyBuckets` with `Resource: *`) was created then removed during this work. Infrastructure values
   are now injected by Terraform directly, so no broad-scope discovery permissions are needed. Development
  instances cannot see production RDS or S3 metadata.                                                       
                  
  ## Why `/api/auth/*` was wrong                                                                            
   
  The middleware `SKIP_AUTH_PATHS` referenced `/api/auth/login` and `/api/auth/refresh`, but these paths    
  don't exist anywhere in the application:
                                                                                                            
  **Backend router** (`studio/app/common/routers/auth.py:18`):                                              
```
  router = APIRouter(prefix="/auth", tags=["auth"])  # No /api prefix                                       
                                                                                                            
  Router registration (studio/__main_unit__.py:204):                                                        
  app.include_router(auth.router)  # No additional prefix                                         
                                                                                                            
  Resulting endpoints:                                                                                      
  POST /auth/login        ← auth.py:23                                                                      
  POST /auth/refresh      ← auth.py:76                                                                      
                                                                                                            
  Frontend calls (frontend/src/api/auth/Auth.ts:20,25):                                                     
  axios.post("/auth/login", data)                                                                           
  axios.post("/auth/refresh", { refresh_token })                                                            
                                                                                                            
  Middleware skip paths (before fix):                                                                       
  # secure_routing_middleware.py:163, user_activity_middleware.py:47                                        
  SKIP_AUTH_PATHS = ["/health", "/api/auth/login", "/api/auth/refresh"]                                     
  #                             ^^^^ never matches — these routes don't exist                               
```
                                                                                                            
  Since /api/auth/login never matched the actual path /auth/login, the middlewares never skipped            
  login/refresh requests. On every login, SecureRoutingMiddleware attempted Firebase JWT validation (which  
  fails since no token exists yet) and UserActivityMiddleware tried to extract a UID — both falling through 
  gracefully but doing unnecessary work.                                                                    
                  
  Test plan                                                                                                 
   
  - SSM execution succeeds (exit code 0) with database seeding, RDS and S3 values from Terraform            
  - Admin user has correct role (admin) assigned by UID lookup
  - Login works for admin user                                                                              
  - Registration endpoint returns non-500 responses                                                         
  - IAM policy ecs-instance-infra-discovery is removed from AWS                                             
  - Test users created successfully (13 users) after ECS redeployment                                       
  - Verify middleware correctly skips /auth/login and /auth/refresh (requires Docker image rebuild and      
  deploy with new code) 