### PR TITLE
Make cost-tracking labelling consistent

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -232,7 +232,7 @@ resource "aws_autoscaling_group" "main" {
 
   tag {
     key                 = "Environment"
-    value               = var.environment
+    value               = local.environment_label
     propagate_at_launch = true
   }
 

--- a/infrastructure/terraform/infrastructure.tf
+++ b/infrastructure/terraform/infrastructure.tf
@@ -365,8 +365,7 @@ resource "aws_s3_bucket" "app_storage" {
   force_destroy = true
 
   tags = {
-    Name            = "${local.env_prefix} Application Storage"
-    EnvironmentType = var.environment == "subscr" ? "Production" : "Development"
+    Name = "${local.env_prefix} Application Storage"
   }
 }
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      Environment = var.environment
+      Environment = local.environment_label
       ManagedBy   = "terraform"
       Project     = "optinist-cloud"
     }
@@ -268,7 +268,8 @@ data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}
 
 locals {
-  env_prefix = "${var.environment}-optinist"
+  env_prefix        = "${var.environment}-optinist"
+  environment_label = var.environment == "subscr" ? "Production" : "Development"
 
   # Resolve frontend host/port from ALB DNS when no custom domain is configured
   # - Production: uses custom domain on port 443


### PR DESCRIPTION
### Content

Cost tracking labelling method was inconsistent. Only some resources were labelled. 

  1. Added environment_label local in main.tf — maps subscr → "Production", everything else → "Development"
  2. Updated default_tags to use Environment = local.environment_label instead of var.environment — so all AWS resources get "Production" or "Development" instead of "subscr" or "development"
  3. Updated ASG tag in compute.tf — same fix, needed separately because ASGs don't inherit default_tags
  4. Removed EnvironmentType from the S3 bucket in infrastructure.tf — redundant now that Environment itself is human-readable