### PR TITLE
Assign effective_frontend_domain to domain_url output

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -450,13 +450,13 @@ output "test_users" {
 
 # Route53 and SSL outputs
 output "domain_name" {
-  description = "Custom domain name for the application"
-  value       = var.frontend_domain
+  description = "Effective domain name for the application (ALB DNS in dev, custom domain in prod)"
+  value       = local.effective_frontend_domain
 }
 
 output "domain_url" {
   description = "Full URL for the application"
-  value       = "${var.frontend_protocol}://${var.frontend_domain}"
+  value       = "${var.frontend_protocol}://${local.effective_frontend_domain}"
 }
 
 output "domain_protocol" {
@@ -465,8 +465,8 @@ output "domain_protocol" {
 }
 
 output "domain_port" {
-  description = "Port for the application"
-  value       = var.frontend_port
+  description = "Effective port for the application (8080 in dev, frontend_port in prod)"
+  value       = local.effective_frontend_port
 }
 
 output "acm_certificate_arn" {

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -791,6 +791,15 @@ resource "aws_security_group" "alb" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
+  # Port 8080 used as main listener when custom domain is disabled (dev)
+  ingress {
+    from_port        = 8080
+    to_port          = 8080
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
### Content

effective_frontend_domain was added to various tf scripts, but the variable was never successfully assigned. The results in premium user assignment failure as frontend - backend mismatch
