### PR TITLE
Assigned to the autoscaling-pool fallback can get stuck

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -135,6 +135,11 @@ class PremiumAssignment:
     # (awaiting migration to dedicated instance)
     AUTOSCALING_POOL = "autoscaling-pool"
 
+    # Handler action values (API request body "action" field)
+    ACTION_ASSIGN = "assign"
+    ACTION_RELEASE = "release"
+    ACTION_UPDATE_ACTIVITY = "update_activity"
+
 
 class DatabaseConfig:
     """

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -119,7 +119,10 @@ class PremiumAssignment:
     # Status: Assignment is being terminated
     TERMINATING = "terminating"
     # Status: Soft-released via beacon (grace period before full teardown).
-    # Reused TERMINATING enum value to avoid DB migration.
+    # IMPORTANT: Shares the TERMINATING DB value to avoid a schema migration.
+    # Safe only because all status checks use enum constants, not raw strings.
+    # Adding code that matches TERMINATING will also match PENDING_RELEASE rows.
+    # If a distinct status is ever needed, migrate the column value first.
     PENDING_RELEASE = "terminating"
     # Grace period (seconds) before a pending_release is finalized.
     PENDING_RELEASE_GRACE_SECONDS = 120

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -118,6 +118,11 @@ class PremiumAssignment:
     MIGRATING = "migrating"
     # Status: Assignment is being terminated
     TERMINATING = "terminating"
+    # Status: Soft-released via beacon (grace period before full teardown).
+    # Reused TERMINATING enum value to avoid DB migration.
+    PENDING_RELEASE = "terminating"
+    # Grace period (seconds) before a pending_release is finalized.
+    PENDING_RELEASE_GRACE_SECONDS = 120
 
     # Marker: Standby pool entries (no real ALB rule/target group yet)
     STANDBY = "standby"

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -569,6 +569,129 @@ def remove_user_assignment(user_id: int):
 
 
 @with_transaction
+def _soft_release_user_assignment_transaction(connection, user_id: int):
+    """Mark assignment as pending_release instead of deleting it.
+
+    Keeps the ALB rule and target group intact so a page refresh can
+    restore the assignment instantly without recreating AWS resources.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT instance_id, target_group_arn, alb_rule_arn, status
+               FROM premium_user_assignments
+               WHERE user_id = %s AND status = %s AND is_standby = 0
+               FOR UPDATE""",
+            (user_id, PremiumAssignment.ACTIVE),
+        )
+        assignment = cursor.fetchone()
+
+        if not assignment:
+            print(f"No active assignment to soft-release for user {user_id}")
+            return None
+
+        cursor.execute(
+            """UPDATE premium_user_assignments
+               SET status = %s, last_activity = NOW()
+               WHERE user_id = %s AND status = %s""",
+            (PremiumAssignment.PENDING_RELEASE, user_id, PremiumAssignment.ACTIVE),
+        )
+        # Close usage log so idle time is tracked accurately
+        cursor.execute(
+            """UPDATE instance_usage_log SET ended_at = NOW()
+               WHERE user_id = %s AND tier = 'premium'
+               AND ended_at IS NULL""",
+            (user_id,),
+        )
+
+    print(
+        f"Soft-released assignment: user {user_id} -> "
+        f"instance {assignment['instance_id']} (pending_release)"
+    )
+    return assignment
+
+
+def soft_release_user_assignment(user_id: int):
+    """Soft-release: mark as pending_release, keep ALB/TG intact."""
+    return _soft_release_user_assignment_transaction(user_id)
+
+
+@with_transaction
+def _restore_pending_release_transaction(connection, user_id: int):
+    """Restore a pending_release assignment back to active.
+
+    Returns the restored assignment dict, or None if no pending_release exists.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT user_id, instance_id, target_group_arn, alb_rule_arn,
+                      status, instance_state, is_shared
+               FROM premium_user_assignments
+               WHERE user_id = %s AND status = %s AND is_standby = 0
+               FOR UPDATE""",
+            (user_id, PremiumAssignment.PENDING_RELEASE),
+        )
+        assignment = cursor.fetchone()
+
+        if not assignment:
+            return None
+
+        cursor.execute(
+            """UPDATE premium_user_assignments
+               SET status = %s, last_activity = NOW()
+               WHERE user_id = %s AND status = %s""",
+            (PremiumAssignment.ACTIVE, user_id, PremiumAssignment.PENDING_RELEASE),
+        )
+
+    print(
+        f"Restored pending_release -> active: user {user_id} -> "
+        f"instance {assignment['instance_id']}"
+    )
+    return assignment
+
+
+def restore_pending_release(user_id: int):
+    """Restore a pending_release assignment back to active."""
+    return _restore_pending_release_transaction(user_id)
+
+
+@with_transaction
+def _finalize_expired_pending_releases_transaction(connection):
+    """Find and delete pending_release assignments past the grace period.
+
+    Returns list of assignments to finalize (caller handles ALB/TG teardown).
+    """
+    grace_seconds = PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT user_id, instance_id, target_group_arn, alb_rule_arn
+               FROM premium_user_assignments
+               WHERE status = %s
+               AND last_activity < DATE_SUB(NOW(), INTERVAL %s SECOND)
+               FOR UPDATE""",
+            (PremiumAssignment.PENDING_RELEASE, grace_seconds),
+        )
+        expired = cursor.fetchall()
+
+        for assignment in expired:
+            uid = assignment["user_id"]
+            cursor.execute(
+                "DELETE FROM premium_user_assignments WHERE user_id = %s",
+                (uid,),
+            )
+            print(
+                f"Finalized pending_release: deleted user {uid} -> "
+                f"instance {assignment['instance_id']}"
+            )
+
+    return expired
+
+
+def finalize_expired_pending_releases():
+    """Delete expired pending_release rows and return them for AWS cleanup."""
+    return _finalize_expired_pending_releases_transaction()
+
+
+@with_transaction
 def _get_existing_user_assignment_transaction(
     connection, user_id: int
 ) -> Optional[Dict[str, Any]]:
@@ -617,12 +740,14 @@ def _get_assigned_users_for_instance_transaction(connection, instance_id: str):
             print(f"- User: {user_id}, Standby: {is_standby}, Status: {status}")
 
         # Now get only real user assignments (exclude standby entries) with lock
+        # Include pending_release so instance isn't treated as idle during grace
         cursor.execute(
             """SELECT user_id, is_shared, instance_state
                FROM premium_user_assignments
-               WHERE instance_id = %s AND status = 'active' AND is_standby = 0
+               WHERE instance_id = %s AND status IN ('active', %s)
+               AND is_standby = 0
                FOR UPDATE""",
-            (instance_id,),
+            (instance_id, PremiumAssignment.PENDING_RELEASE),
         )
         real_users = cursor.fetchall()
 
@@ -732,13 +857,18 @@ def get_all_premium_instances_with_states():
 
 @with_transaction
 def _count_active_premium_users_transaction(connection):
-    """Count users with active premium assignments with transaction safety"""
+    """Count users with active premium assignments with transaction safety.
+
+    Includes pending_release users because their instance and resources
+    are still allocated during the grace period.
+    """
     with connection.cursor() as cursor:
         # First count all assignments for debugging
         cursor.execute(
             "SELECT COUNT(*) as total_count, "
             "SUM(CASE WHEN is_standby = 1 THEN 1 ELSE 0 END) as standby_count "
-            "FROM premium_user_assignments WHERE status = 'active'"
+            "FROM premium_user_assignments WHERE status IN ('active', %s)",
+            (PremiumAssignment.PENDING_RELEASE,),
         )
         debug_result = cursor.fetchone()
         total_count = debug_result["total_count"] if debug_result else 0
@@ -747,7 +877,8 @@ def _count_active_premium_users_transaction(connection):
         # Count only real user assignments (exclude standby)
         cursor.execute(
             "SELECT COUNT(*) as count FROM premium_user_assignments "
-            "WHERE status = 'active' AND is_standby = 0"
+            "WHERE status IN ('active', %s) AND is_standby = 0",
+            (PremiumAssignment.PENDING_RELEASE,),
         )
         result = cursor.fetchone()
         real_user_count = result["count"] if result else 0
@@ -1565,6 +1696,22 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                         ),
                     }
 
+                # Restore pending_release on status check (user refreshed)
+                if assignment["status"] == PremiumAssignment.PENDING_RELEASE:
+                    try:
+                        restored = restore_pending_release(user_id)
+                        if restored:
+                            assignment = restored
+                            assignment["status"] = PremiumAssignment.ACTIVE
+                            print(
+                                f"Restored pending_release on status check "
+                                f"for user {user_id}"
+                            )
+                    except Exception as restore_err:
+                        print(
+                            f"Failed to restore pending_release: " f"{str(restore_err)}"
+                        )
+
                 print(
                     f"Found assignment - "
                     f"instance_id={assignment['instance_id']}, "
@@ -1807,7 +1954,36 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                 print(f"Standby pool has {excess} excess instances, trimming")
                 cleanup_excess_standby_instances(excess)
 
-            # 10. Cleanup ghost ECS container instance registrations
+            # 10a. Finalize expired pending_release assignments
+            try:
+                expired = finalize_expired_pending_releases()
+                if expired:
+                    print(
+                        f"Finalizing {len(expired)} expired "
+                        f"pending_release assignments"
+                    )
+                    for assignment in expired:
+                        rule_arn = (
+                            assignment.get("alb_rule_arn") or ""
+                        ).strip() or None
+                        tg_arn = (
+                            assignment.get("target_group_arn") or ""
+                        ).strip() or None
+                        teardown_errors = _teardown_alb_resources(
+                            assignment["user_id"], rule_arn, tg_arn
+                        )
+                        if teardown_errors:
+                            print(
+                                f"Teardown warnings for user "
+                                f"{assignment['user_id']}: {teardown_errors}"
+                            )
+            except Exception:
+                print("WARNING: finalize_expired_pending_releases() failed")
+                import traceback
+
+                traceback.print_exc()
+
+            # 10b. Cleanup ghost ECS container instance registrations
             # (deregister container instances where EC2 is stopped/terminated)
             cleanup_ghost_ecs_registrations()
 
@@ -2052,7 +2228,8 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             if action == "assign":
                 return assign_premium_user(user_id, body_data, user_uid)
             elif action == "release":
-                return release_premium_user(user_id)
+                hard = body_data.get("hard", False)
+                return release_premium_user(user_id, hard=hard)
             elif action == "update_activity":
                 return handle_activity_update(user_id)
             else:
@@ -2335,6 +2512,29 @@ def assign_premium_user(
             ),
         }
 
+    # Restore pending_release if user refreshed (beacon fired but user is back)
+    try:
+        restored = restore_pending_release(user_id)
+        if restored:
+            print(
+                f"Restored pending_release for user {user_id} -> "
+                f"instance {restored['instance_id']} (page refresh detected)"
+            )
+            return {
+                "statusCode": 200,
+                "body": json.dumps(
+                    {
+                        "message": "Premium assignment restored",
+                        "instance_id": restored["instance_id"],
+                        "assigned": True,
+                        "is_shared": bool(restored.get("is_shared", False)),
+                        "assignment_source": "restored_from_pending_release",
+                    }
+                ),
+            }
+    except Exception as restore_error:
+        print(f"Pending release restore check failed: {str(restore_error)}")
+
     # Return existing assignment if user is already assigned
     try:
         existing_assignment = get_existing_user_assignment(user_id)
@@ -2354,7 +2554,57 @@ def assign_premium_user(
                     f"User {user_id} needs migration "
                     f"(instance={existing_instance_id}, "
                     f"shared={existing_assignment.get('is_shared')})"
-                    f", triggering migration check..."
+                    f", attempting inline migration..."
+                )
+
+                # Try inline migration: find a ready dedicated instance now
+                all_instances = get_all_premium_instances_with_states()
+                running_instances = [
+                    i for i in all_instances if i["state"] == InstanceState.RUNNING
+                ]
+                for instance in running_instances:
+                    candidate_id = instance["instance_id"]
+                    if not check_instance_readiness_with_retry(
+                        candidate_id, max_wait_seconds=10, retry_interval=5
+                    ):
+                        continue
+                    assigned = get_assigned_users_for_instance(candidate_id)
+                    if len(assigned) > 0:
+                        continue
+                    # Found a ready, empty dedicated instance — migrate now
+                    print(
+                        f"Inline migration: migrating user {user_id} "
+                        f"from {existing_instance_id} to {candidate_id}"
+                    )
+                    if migrate_user_to_dedicated_instance(user_id, candidate_id):
+                        # Re-fetch updated assignment after migration
+                        migrated = get_existing_user_assignment(user_id)
+                        if migrated:
+                            print(
+                                f"Inline migration successful: user {user_id} "
+                                f"now on {migrated['instance_id']}"
+                            )
+                            return {
+                                "statusCode": 200,
+                                "body": json.dumps(
+                                    {
+                                        "message": f"User {user_id} migrated to "
+                                        f"instance {migrated['instance_id']}",
+                                        "instance_id": migrated["instance_id"],
+                                        "target_group_arn": migrated[
+                                            "target_group_arn"
+                                        ],
+                                        "rule_arn": migrated["alb_rule_arn"],
+                                        "is_shared": False,
+                                        "assignment_source": "inline_migration",
+                                    }
+                                ),
+                            }
+
+                # No inline migration possible — fall back to async
+                print(
+                    f"Inline migration not possible for user {user_id}, "
+                    f"falling back to async migration"
                 )
                 invoke_migration_async()
 
@@ -3779,92 +4029,120 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
         return False
 
 
-def release_premium_user(user_id: int) -> Dict[str, Any]:
-    """Release premium user from assigned instance
-    (always succeeds to prevent logout blocking)"""
-
-    _: "EC2Client" = boto3.client("ec2")
+def _teardown_alb_resources(user_id, rule_arn, target_group_arn):
+    """Delete ALB rule and target group for a released user."""
     elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+    errors = []
+
+    if rule_arn:
+        try:
+            elbv2.delete_rule(RuleArn=rule_arn)
+            print(f"Deleted ALB rule: {rule_arn}")
+        except Exception as rule_error:
+            error_msg = f"Error deleting ALB rule: {str(rule_error)}"
+            print(error_msg)
+            errors.append(error_msg)
+
+    autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
+    if (
+        target_group_arn
+        and target_group_arn != PremiumAssignment.STANDBY
+        and target_group_arn != autoscaling_tg_arn
+    ):
+        try:
+            elbv2.delete_target_group(TargetGroupArn=target_group_arn)
+            print(f"Deleted target group: {target_group_arn}")
+        except Exception as tg_error:
+            error_msg = f"Error deleting target group: {str(tg_error)}"
+            print(error_msg)
+            errors.append(error_msg)
+    elif target_group_arn == autoscaling_tg_arn:
+        print(
+            f"Skipping deletion of shared autoscaling "
+            f"target group: {target_group_arn}"
+        )
+
+    return errors
+
+
+def release_premium_user(user_id: int, hard: bool = False) -> Dict[str, Any]:
+    """Release premium user from assigned instance.
+
+    By default performs a soft-release (keeps ALB/TG intact for grace period).
+    Set hard=True to immediately delete everything (used by finalization and
+    explicit logout).
+
+    Always succeeds to prevent logout blocking.
+    """
 
     instance_id = None
     success = True
     errors = []
 
     try:
-        # 1. Get assignment from RDS (may fail if already removed)
-        try:
-            assignment = remove_user_assignment(user_id)
-            instance_id = assignment["instance_id"]
-            # Normalize empty/whitespace strings to None
-            target_group_arn = (assignment["target_group_arn"] or "").strip() or None
-            rule_arn = (assignment["alb_rule_arn"] or "").strip() or None
-            print(f"Found assignment for user {user_id} on instance {instance_id}")
-        except Exception as assignment_error:
-            print(f"No assignment found for user {user_id}: {str(assignment_error)}")
-            # User may not have been assigned or already released
-            target_group_arn = None
-            rule_arn = None
-
-        # 2. Delete ALB listener rule (if it exists)
-        if rule_arn:
+        if hard:
+            # Hard release: delete row + ALB resources immediately
             try:
-                elbv2.delete_rule(RuleArn=rule_arn)
-                print(f"Deleted ALB rule: {rule_arn}")
-            except Exception as rule_error:
-                error_msg = f"Error deleting ALB rule: {str(rule_error)}"
-                print(error_msg)
-                errors.append(error_msg)
-
-        # 3. Delete target group (if it exists)
-        # Skip deletion for special target groups
-        # (standby placeholder, autoscaling pool)
-        autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
-        if (
-            target_group_arn
-            and target_group_arn != PremiumAssignment.STANDBY
-            and target_group_arn != autoscaling_tg_arn
-        ):
-            try:
-                elbv2.delete_target_group(TargetGroupArn=target_group_arn)
-                print(f"Deleted target group: {target_group_arn}")
-            except Exception as tg_error:
-                error_msg = f"Error deleting target group: {str(tg_error)}"
-                print(error_msg)
-                errors.append(error_msg)
-        elif target_group_arn == autoscaling_tg_arn:
-            print(
-                f"Skipping deletion of shared autoscaling "
-                f"target group: {target_group_arn}"
-            )
-
-        # Note: Stale assignment cleanup is now handled by premium_cleanup Lambda
-        # running on scheduled basis (hourly)
-
-        # 5. Check if we can scale down premium instances by stopping idle ones
-        try:
-            scale_down_if_possible()
-        except Exception as scale_error:
-            print(f" Scale down failed but continuing: {str(scale_error)}")
-
-        # 6. Immediately convert idle instances to standby if no premium users are left
-        try:
-            active_users = count_active_premium_users()
-            if active_users == 0:
+                assignment = remove_user_assignment(user_id)
+                instance_id = assignment["instance_id"]
+                target_group_arn = (
+                    assignment["target_group_arn"] or ""
+                ).strip() or None
+                rule_arn = (assignment["alb_rule_arn"] or "").strip() or None
+                print(f"Hard-released user {user_id} from instance {instance_id}")
+            except Exception as assignment_error:
                 print(
-                    "No premium users remaining, converting idle "
-                    "instances to standby immediately"
+                    f"No assignment found for user {user_id}: "
+                    f"{str(assignment_error)}"
                 )
-                converted_count = convert_idle_instances_to_standby_immediate()
-                if converted_count > 0:
-                    print(
-                        f"Immediately converted {converted_count} idle instances "
-                        f"to standby after user logout"
-                    )
-        except Exception as standby_error:
-            print(f" Standby conversion failed but continuing: {str(standby_error)}")
+                target_group_arn = None
+                rule_arn = None
 
-        # Always return success - don't block user logout
-        message = f"Premium user {user_id} release completed"
+            errors = _teardown_alb_resources(user_id, rule_arn, target_group_arn)
+        else:
+            # Soft release: mark as pending_release, keep ALB/TG intact
+            assignment = soft_release_user_assignment(user_id)
+            if assignment:
+                instance_id = assignment["instance_id"]
+                print(
+                    f"Soft-released user {user_id} from instance "
+                    f"{instance_id} (grace period "
+                    f"{PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS}s)"
+                )
+            else:
+                print(
+                    f"No active assignment to release for user {user_id} "
+                    f"(may already be pending_release or removed)"
+                )
+
+        # Skip scale-down for soft releases (instance still allocated)
+        if hard:
+            try:
+                scale_down_if_possible()
+            except Exception as scale_error:
+                print(f" Scale down failed but continuing: {str(scale_error)}")
+
+            try:
+                active_users = count_active_premium_users()
+                if active_users == 0:
+                    print(
+                        "No premium users remaining, converting idle "
+                        "instances to standby immediately"
+                    )
+                    converted_count = convert_idle_instances_to_standby_immediate()
+                    if converted_count > 0:
+                        print(
+                            f"Immediately converted {converted_count} idle "
+                            f"instances to standby after user logout"
+                        )
+            except Exception as standby_error:
+                print(
+                    f" Standby conversion failed but continuing: "
+                    f"{str(standby_error)}"
+                )
+
+        release_type = "hard" if hard else "soft"
+        message = f"Premium user {user_id} {release_type} release completed"
         if instance_id:
             message += f" from instance {instance_id}"
         if errors:
@@ -3883,7 +4161,6 @@ def release_premium_user(user_id: int) -> Dict[str, Any]:
         }
 
     except Exception as e:
-        # Even on critical errors, return success to prevent blocking user logout
         error_msg = f"Error releasing premium user {user_id}: {str(e)}"
         print(f" {error_msg}")
         return {

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -674,6 +674,14 @@ def _finalize_expired_pending_releases_transaction(connection):
 
         for assignment in expired:
             uid = assignment["user_id"]
+            # Close usage log defensively before delete (soft_release should
+            # have already closed it, but guard against edge cases)
+            cursor.execute(
+                """UPDATE instance_usage_log SET ended_at = NOW()
+                   WHERE user_id = %s AND tier = 'premium'
+                   AND ended_at IS NULL""",
+                (uid,),
+            )
             cursor.execute(
                 "DELETE FROM premium_user_assignments WHERE user_id = %s",
                 (uid,),
@@ -2526,6 +2534,8 @@ def assign_premium_user(
                     {
                         "message": "Premium assignment restored",
                         "instance_id": restored["instance_id"],
+                        "target_group_arn": restored["target_group_arn"],
+                        "rule_arn": restored["alb_rule_arn"],
                         "assigned": True,
                         "is_shared": bool(restored.get("is_shared", False)),
                         "assignment_source": "restored_from_pending_release",
@@ -2564,12 +2574,12 @@ def assign_premium_user(
                 ]
                 for instance in running_instances:
                     candidate_id = instance["instance_id"]
+                    assigned = get_assigned_users_for_instance(candidate_id)
+                    if len(assigned) > 0:
+                        continue
                     if not check_instance_readiness_with_retry(
                         candidate_id, max_wait_seconds=10, retry_interval=5
                     ):
-                        continue
-                    assigned = get_assigned_users_for_instance(candidate_id)
-                    if len(assigned) > 0:
                         continue
                     # Found a ready, empty dedicated instance — migrate now
                     print(

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -683,8 +683,9 @@ def _finalize_expired_pending_releases_transaction(connection):
                 (uid,),
             )
             cursor.execute(
-                "DELETE FROM premium_user_assignments WHERE user_id = %s",
-                (uid,),
+                "DELETE FROM premium_user_assignments"
+                " WHERE user_id = %s AND status = %s",
+                (uid, PremiumAssignment.PENDING_RELEASE),
             )
             print(
                 f"Finalized pending_release: deleted user {uid} -> "
@@ -2233,12 +2234,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     "body": json.dumps({"error": str(e)}),
                 }
 
-            if action == "assign":
+            if action == PremiumAssignment.ACTION_ASSIGN:
                 return assign_premium_user(user_id, body_data, user_uid)
-            elif action == "release":
+            elif action == PremiumAssignment.ACTION_RELEASE:
                 hard = body_data.get("hard", False)
                 return release_premium_user(user_id, hard=hard)
-            elif action == "update_activity":
+            elif action == PremiumAssignment.ACTION_UPDATE_ACTIVITY:
                 return handle_activity_update(user_id)
             else:
                 return {

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -296,13 +296,18 @@ class PremiumAssignmentService:
                 "requires_retry": False,
             }
 
-    async def release_premium_user(self, user_id: int, user_uid: str) -> Dict[str, any]:
+    async def release_premium_user(
+        self, user_id: int, user_uid: str, *, hard: bool = False
+    ) -> Dict[str, any]:
         """
         Release a premium user from their assigned instance and clear rate limiting.
 
         Args:
             user_id: The database ID of the premium user (for internal tracking)
             user_uid: The Firebase UID of the premium user (sent to Lambda)
+            hard: If True, immediately delete assignment + ALB resources.
+                  If False (default), soft-release with grace period so a
+                  page refresh can restore the assignment instantly.
 
         Returns:
             Dict containing release result:
@@ -311,8 +316,9 @@ class PremiumAssignmentService:
             - released_instance: str (if successful)
         """
         try:
+            release_type = "hard" if hard else "soft"
             logger.info(
-                f"Releasing premium user "
+                f"Releasing ({release_type}) premium user "
                 f"{user_id} (uid: {user_uid}) from assigned instance"
             )
 
@@ -329,6 +335,7 @@ class PremiumAssignmentService:
                         "action": "release",
                         "user_id": user_uid,
                         "tier": SubscriptionType.PREMIUM.value,
+                        "hard": hard,
                     }
                 ),
             }

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -142,14 +142,15 @@ async def release_premium_instance(current_user: User = Depends(get_current_user
     """
     Release current user from their assigned premium instance.
     This endpoint should be called on logout for premium users.
+    Hard-release: immediately deletes assignment + ALB resources.
     """
     try:
         invalidate_activity_cache(current_user.id)
         mark_user_logged_out(current_user.id)
 
-        # Call the premium assignment service
+        # Hard release on explicit logout (no grace period)
         result = await premium_assignment_service.release_premium_user(
-            current_user.id, current_user.uid
+            current_user.id, current_user.uid, hard=True
         )
 
         if result["success"]:

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -712,6 +712,42 @@ class TestEarlyCheckAndCleanup:
                 mock_get_existing.assert_called_once_with(test_user_id)
                 assert not mock_elbv2.create_rule.called
 
+    def test_restore_pending_release_returns_alb_fields(self, mock_env_vars_premium):
+        """Restored pending_release response includes
+        target_group_arn and rule_arn."""
+        test_user_id = 12345
+
+        restored_assignment = {
+            "user_id": test_user_id,
+            "instance_id": TEST_INSTANCE_ID,
+            "target_group_arn": "arn:aws:tg/restored",
+            "alb_rule_arn": "arn:aws:rule/restored",
+            "status": "terminating",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ), patch("premium_manager.restore_pending_release") as mock_restore:
+            mock_restore.return_value = restored_assignment
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(
+                test_user_id, {"tier": "premium"}, "firebase_uid_123"
+            )
+
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            assert status_code == 200
+            assert response_body["assignment_source"] == "restored_from_pending_release"
+            assert response_body["target_group_arn"] == "arn:aws:tg/restored"
+            assert response_body["rule_arn"] == "arn:aws:rule/restored"
+            assert response_body["instance_id"] == TEST_INSTANCE_ID
+            mock_restore.assert_called_once_with(test_user_id)
+
 
 class TestDictCursorFix:
     """DictCursor fix tests."""

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -50,6 +50,9 @@ class TestPremiumManagerEvents:
             mock_connection = setup_db_mock(
                 fetchone_values=[
                     MockRow({"id": 123}),
+                    # restore_pending_release: no pending_release row
+                    None,
+                    # get_existing_user_assignment: no existing assignment
                     None,
                     MockRow({"count": 1}),
                     MockRow({"count": 0}),


### PR DESCRIPTION
### Content

#### Summary
- Premium users assigned to the temporary `autoscaling-pool` fallback get stuck in an infinite retry loop when dedicated instances become available. The assign endpoint detects the shared assignment, fires an async migration Lambda, and returns `is_shared: True`. The frontend sees this and retries assignment, but the async migration never completes because the migration lock is already held or times out.
- The fix adds inline migration to the assign endpoint: when a user has an `autoscaling-pool` or shared assignment and a dedicated instance is ready and unoccupied, the endpoint migrates the user synchronously and returns the new dedicated assignment with `is_shared: False`, breaking the loop.
- Async migration is retained as a fallback for cases where no dedicated instance is ready yet (e.g., still booting).

#### Design Decisions
- **Inline migration in the assign path instead of fixing the async lock** -- The async migration architecture has multiple failure modes (60-second lock timeout, 10-minute max wait, lock contention between concurrent invocations). Rather than patching the lock mechanism, the assign endpoint now resolves the common case (instances are running but user is stuck on autoscaling-pool) directly. This is simpler and gives the user immediate feedback.
- **Short readiness timeout (10s) for inline migration** -- The inline check uses `max_wait_seconds=10` vs the normal 30s to avoid blocking the assign HTTP response. If no instance passes readiness in 10s, the code falls through to async migration, so no functionality is lost.
- **Async migration kept as safety net** -- If all dedicated instances are still booting (no candidates pass readiness), the existing `invoke_migration_async()` path still fires. This preserves the original behavior for cold-start scenarios.

### Evidence

#### Observed failure (2026-03-24 19:15 UTC)

Initial assignment — all premium instances stopped, user 33 gets autoscaling-pool fallback:
```
2026-03-24 19:15:35,053  assign_premium_user():154 - Assigning premium user 33 (uid: xnUWJG0uQDW8ycrwktKUszHfT5E3) to dedicated instance
2026-03-24 19:15:54,192  assign_premium_user():234 - Successfully assigned premium user 33 to instance autoscaling-pool
```

Frontend sees `is_shared: True`, retries, creating the loop:
```
2026-03-24 19:15:54,342  log_premium_ui_event():421 - Premium UI event: user=33 event=waiting_popup_shown details={'is_assigning': False, 'has_assignment': True, 'is_shared': True, 'instance_id': 'autoscaling-pool'}
2026-03-24 19:16:24,337  assign_premium_user():154 - Assigning premium user 33 (uid: xnUWJG0uQDW8ycrwktKUszHfT5E3) to dedicated instance
```

Lambda confirms user is stuck — migration lock held, skipped:
```
User 33 already has active assignment to instance autoscaling-pool
User 33 needs migration (instance=autoscaling-pool, shared=1), triggering migration check...
Lock 'migrate_users_lock' is held
Migration Lambda already running, skipping
```

Meanwhile, 3 premium instances were running and available:
```
Instance discovery summary:
- Premium instances matched: 3
- States: [('i-075b57d1ac079df9a', 'running'), ('i-0158d4868c2c5c26d', 'running'), ('i-09a04004643ea3431', 'running')]
```

The assign endpoint returned `autoscaling-pool` with `is_shared: True` on every call despite running dedicated instances being available.

### References
- Manual fix applied: released user 33's stale assignment via `aws lambda invoke` with `action: release`

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add inline migration attempt in `assign_premium_user()` when user has autoscaling-pool or shared assignment; scans running instances for a ready, unoccupied candidate and calls `migrate_user_to_dedicated_instance()` synchronously before falling back to async migration

### Manual Testcases

#### Scenario 1: User stuck on autoscaling-pool with available dedicated instances
1. Assign a premium user when all dedicated instances are stopped (user lands on `autoscaling-pool`)
2. Start the dedicated instances and wait for them to reach `running` state
3. Trigger another assign call for the same user
4. Verify the response contains `assignment_source: "inline_migration"` and `is_shared: false`
5. Verify the user is now assigned to a dedicated instance (not `autoscaling-pool`)

#### Scenario 2: User stuck on autoscaling-pool with no ready instances
1. Assign a premium user when all dedicated instances are stopped
2. Trigger another assign call while instances are still booting
3. Verify the response still returns `autoscaling-pool` with `is_shared: true`
4. Verify `invoke_migration_async()` is called (check Lambda logs for async migration trigger)

#### Scenario 3: User with existing dedicated assignment
1. Assign a premium user to a running dedicated instance
2. Trigger another assign call for the same user
3. Verify the response returns the existing dedicated assignment with `assignment_source: "existing"` (inline migration is not attempted)

### Unit, Integration, Contract Test Coverage
- `infrastructure/scripts/test_premium_lambda.py` -- existing Lambda integration tests cover the `assign` action path
- No unit test for inline migration path yet; the migration function `migrate_user_to_dedicated_instance()` is already tested in `studio/tests/infrastructure/test_premium_manager.py`

### Others

#### Difficulties
- The root cause was non-obvious: the assign endpoint, async migration Lambda, and frontend retry loop formed a three-way deadlock. The assign endpoint always returned the stale shared assignment, the migration Lambda couldn't acquire the lock, and the frontend kept retrying because it saw `is_shared: True`.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Inline migration in assign path | Medium | Adds EC2 readiness checks and a migration call to the synchronous assign path, increasing latency by up to 10s when migration is attempted. If `migrate_user_to_dedicated_instance()` fails, falls through to existing async path — no regression. |
| Readiness timeout (10s) | Low | Shorter than the normal 30s check. Worst case: a ready instance is missed and async migration handles it. No false positives. |
| Concurrent assign calls | Low | `migrate_user_to_dedicated_instance()` uses database-level locking via `try_reserve_instance_for_migration()`. Two concurrent inline migrations for the same user would not both succeed. |
