### PR TITLE
Premium users stuck when instance stopped, but they log in again

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -574,11 +574,11 @@ def _update_instance_state_to_running(connection, instance_id: str):
     with connection.cursor() as cursor:
         cursor.execute(
             """UPDATE premium_user_assignments
-               SET instance_state = 'running',
+               SET instance_state = %s,
                    last_state_check = NOW()
                WHERE instance_id = %s
                AND is_standby = 0""",
-            (instance_id,),
+            (InstanceState.RUNNING, instance_id),
         )
 
 
@@ -1537,10 +1537,10 @@ def start_standby_instance(instance_id: str):
             with connection.cursor() as cursor:
                 cursor.execute(
                     """UPDATE premium_user_assignments
-                       SET instance_state = 'running',
+                       SET instance_state = %s,
                            last_state_check = NOW()
                        WHERE instance_id = %s AND is_standby = 0""",
-                    (instance_id,),
+                    (InstanceState.RUNNING, instance_id),
                 )
                 connection.commit()  # Commit the state update
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -569,6 +569,20 @@ def remove_user_assignment(user_id: int):
 
 
 @with_transaction
+def _update_instance_state_to_running(connection, instance_id: str):
+    """Update instance state to running after restart"""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """UPDATE premium_user_assignments
+               SET instance_state = 'running',
+                   last_state_check = NOW()
+               WHERE instance_id = %s
+               AND is_standby = 0""",
+            (instance_id,),
+        )
+
+
+@with_transaction
 def _get_existing_user_assignment_transaction(
     connection, user_id: int
 ) -> Optional[Dict[str, Any]]:
@@ -2345,8 +2359,115 @@ def assign_premium_user(
                 f"instance {existing_instance_id}"
             )
 
+            # Check if the assigned instance is stopped and restart it
+            if existing_instance_id != PremiumAssignment.AUTOSCALING_POOL:
+                try:
+                    resp = ec2.describe_instances(InstanceIds=[existing_instance_id])
+                    reservations = resp.get("Reservations", [])
+                    ec2_state = None
+                    if reservations and reservations[0].get("Instances"):
+                        ec2_state = reservations[0]["Instances"][0]["State"]["Name"]
+
+                    if ec2_state == InstanceState.STOPPING:
+                        print(
+                            f"Assigned instance {existing_instance_id} is "
+                            f"stopping — waiting for stopped state"
+                        )
+                        stop_waiter = ec2.get_waiter("instance_stopped")
+                        stop_waiter.wait(
+                            InstanceIds=[existing_instance_id],
+                            WaiterConfig={"Delay": 5, "MaxAttempts": 24},
+                        )
+                        ec2_state = InstanceState.STOPPED
+
+                    if ec2_state == InstanceState.STOPPED:
+                        print(
+                            f"Assigned instance {existing_instance_id} is "
+                            f"stopped — restarting for user {user_id}"
+                        )
+                        ec2.start_instances(InstanceIds=[existing_instance_id])
+                        waiter = ec2.get_waiter("instance_running")
+                        waiter.wait(
+                            InstanceIds=[existing_instance_id],
+                            WaiterConfig={"Delay": 5, "MaxAttempts": 24},
+                        )
+                        clear_ecs_agent_checkpoint(existing_instance_id)
+                        _update_instance_state_to_running(existing_instance_id)
+
+                        # Wait for ECS task readiness before returning
+                        if check_instance_readiness_with_retry(
+                            existing_instance_id,
+                            max_wait_seconds=120,
+                            retry_interval=10,
+                        ):
+                            print(
+                                f"Restarted instance {existing_instance_id} "
+                                f"is ready for user {user_id}"
+                            )
+                            return {
+                                "statusCode": 200,
+                                "body": json.dumps(
+                                    {
+                                        "message": f"User {user_id} assigned "
+                                        f"to restarted instance "
+                                        f"{existing_instance_id}",
+                                        "instance_id": existing_instance_id,
+                                        "target_group_arn": existing_assignment[
+                                            "target_group_arn"
+                                        ],
+                                        "rule_arn": existing_assignment["alb_rule_arn"],
+                                        "is_shared": bool(
+                                            existing_assignment.get("is_shared", False)
+                                        ),
+                                        "assignment_source": "restarted_instance",
+                                    }
+                                ),
+                            }
+                        else:
+                            print(
+                                f"WARNING: Instance {existing_instance_id} "
+                                f"started but ECS not ready after 120s, "
+                                f"cleaning up stale assignment"
+                            )
+                            existing_assignment = None
+                            remove_user_assignment(user_id)
+
+                    elif (
+                        ec2_state
+                        in (
+                            InstanceState.TERMINATED,
+                            InstanceState.SHUTTING_DOWN,
+                        )
+                        or ec2_state is None
+                    ):
+                        print(
+                            f"Assigned instance {existing_instance_id} is "
+                            f"{ec2_state or 'gone'} — removing stale "
+                            f"assignment for user {user_id}"
+                        )
+                        existing_assignment = None
+                        remove_user_assignment(user_id)
+
+                except ClientError as ec2_err:
+                    error_code = ec2_err.response["Error"]["Code"]
+                    if error_code == "InvalidInstanceID.NotFound":
+                        print(
+                            f"Instance {existing_instance_id} no longer "
+                            f"exists — removing stale assignment"
+                        )
+                        existing_assignment = None
+                        remove_user_assignment(user_id)
+                    else:
+                        raise
+                except Exception as state_err:
+                    print(
+                        f"Error checking instance state for "
+                        f"{existing_instance_id}: {state_err}"
+                    )
+                    existing_assignment = None
+
             # Trigger migration for autoscaling-pool or shared
-            if (
+            if existing_assignment and (
                 existing_instance_id == PremiumAssignment.AUTOSCALING_POOL
                 or existing_assignment.get("is_shared")
             ):
@@ -2358,20 +2479,23 @@ def assign_premium_user(
                 )
                 invoke_migration_async()
 
-            return {
-                "statusCode": 200,
-                "body": json.dumps(
-                    {
-                        "message": f"User {user_id} already assigned to "
-                        f"instance {existing_instance_id}",
-                        "instance_id": existing_instance_id,
-                        "target_group_arn": existing_assignment["target_group_arn"],
-                        "rule_arn": existing_assignment["alb_rule_arn"],
-                        "is_shared": bool(existing_assignment.get("is_shared", False)),
-                        "assignment_source": "existing",
-                    }
-                ),
-            }
+            if existing_assignment:
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps(
+                        {
+                            "message": f"User {user_id} already assigned to "
+                            f"instance {existing_instance_id}",
+                            "instance_id": existing_instance_id,
+                            "target_group_arn": existing_assignment["target_group_arn"],
+                            "rule_arn": existing_assignment["alb_rule_arn"],
+                            "is_shared": bool(
+                                existing_assignment.get("is_shared", False)
+                            ),
+                            "assignment_source": "existing",
+                        }
+                    ),
+                }
     except Exception as check_error:
         # Fail fast if we can't verify assignment status
         print(f"Error: Failed to check existing assignment: {check_error}")

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -709,6 +709,332 @@ class TestEarlyCheckAndCleanup:
                 mock_get_existing.assert_called_once_with(test_user_id)
                 assert not mock_elbv2.create_rule.called
 
+    def test_stopped_instance_restarted_on_assign(self, mock_env_vars_premium):
+        """Assign restarts a stopped dedicated instance
+        and returns it once ECS is ready."""
+        test_user_id = 12345
+
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": TEST_INSTANCE_ID,
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "stopped",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_existing, patch(
+            "premium_manager.check_instance_readiness_with_retry"
+        ) as mock_readiness, patch(
+            "premium_manager.clear_ecs_agent_checkpoint"
+        ) as mock_clear_ecs, patch(
+            "premium_manager._update_instance_state_to_running"
+        ) as mock_update_state:
+            mock_get_existing.return_value = existing_assignment
+            mock_readiness.return_value = True
+
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": TEST_INSTANCE_ID,
+                                "State": {"Name": "stopped"},
+                            }
+                        ]
+                    }
+                ]
+            }
+            mock_ec2.get_waiter.return_value = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(
+                test_user_id, {"tier": "premium"}, "firebase_uid_123"
+            )
+
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            assert status_code == 200
+            assert response_body["instance_id"] == TEST_INSTANCE_ID
+            assert response_body["assignment_source"] == "restarted_instance"
+            mock_ec2.start_instances.assert_called_once_with(
+                InstanceIds=[TEST_INSTANCE_ID]
+            )
+            mock_clear_ecs.assert_called_once_with(TEST_INSTANCE_ID)
+            mock_update_state.assert_called_once_with(TEST_INSTANCE_ID)
+            mock_readiness.assert_called_once_with(
+                TEST_INSTANCE_ID, max_wait_seconds=120, retry_interval=10
+            )
+
+    def test_stopping_instance_waits_then_restarts(self, mock_env_vars_premium):
+        """Assign waits for a stopping instance to reach stopped
+        state before restarting it."""
+        test_user_id = 12345
+
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": TEST_INSTANCE_ID,
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "stopping",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_existing, patch(
+            "premium_manager.check_instance_readiness_with_retry"
+        ) as mock_readiness, patch(
+            "premium_manager.clear_ecs_agent_checkpoint"
+        ) as mock_clear_ecs, patch(
+            "premium_manager._update_instance_state_to_running"
+        ):
+            mock_get_existing.return_value = existing_assignment
+            mock_readiness.return_value = True
+
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": TEST_INSTANCE_ID,
+                                "State": {"Name": "stopping"},
+                            }
+                        ]
+                    }
+                ]
+            }
+            mock_stop_waiter = MagicMock()
+            mock_run_waiter = MagicMock()
+
+            def get_waiter_side_effect(waiter_name):
+                if waiter_name == "instance_stopped":
+                    return mock_stop_waiter
+                if waiter_name == "instance_running":
+                    return mock_run_waiter
+                return MagicMock()
+
+            mock_ec2.get_waiter.side_effect = get_waiter_side_effect
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(
+                test_user_id, {"tier": "premium"}, "firebase_uid_123"
+            )
+
+            status_code = result["statusCode"]
+            response_body = json.loads(result["body"])
+
+            assert status_code == 200
+            assert response_body["assignment_source"] == "restarted_instance"
+            mock_stop_waiter.wait.assert_called_once()
+            mock_ec2.start_instances.assert_called_once_with(
+                InstanceIds=[TEST_INSTANCE_ID]
+            )
+            mock_clear_ecs.assert_called_once_with(TEST_INSTANCE_ID)
+
+    def test_terminated_instance_triggers_fresh_assignment(self, mock_env_vars_premium):
+        """Assign removes stale assignment for a terminated
+        instance and does not return the stale record."""
+        test_user_id = 12345
+
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": TEST_INSTANCE_ID,
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        patches = {
+            "premium_manager.register_orphaned_stopped_instances": None,
+            "premium_manager.get_all_premium_instances_with_states": [],
+            "premium_manager.count_active_premium_users": 0,
+            "premium_manager.get_available_standby_instances": [],
+        }
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            patchers = []
+            for target, rv in patches.items():
+                p = patch(target, return_value=rv)
+                p.start()
+                patchers.append(p)
+
+            try:
+                with patch.object(
+                    premium_manager, "get_existing_user_assignment"
+                ) as mock_get_existing, patch.object(
+                    premium_manager, "remove_user_assignment"
+                ) as mock_remove, patch(
+                    "boto3.client"
+                ) as mock_boto3, patch(
+                    "pymysql.connect"
+                ) as mock_pymysql:
+                    mock_get_existing.return_value = existing_assignment
+                    mock_pymysql.return_value = setup_db_mock(
+                        fetchone_values=[None] * 20,
+                        fetchall_values=[[] for _ in range(10)],
+                    )
+
+                    mock_ec2 = MagicMock()
+                    mock_ec2.describe_instances.return_value = {
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": TEST_INSTANCE_ID,
+                                        "State": {"Name": "terminated"},
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+
+                    mock_elbv2 = MagicMock()
+                    mock_elbv2.create_target_group.return_value = {
+                        "TargetGroups": [{"TargetGroupArn": "arn:aws:tg/new"}]
+                    }
+                    mock_elbv2.create_rule.return_value = {
+                        "Rules": [{"RuleArn": "arn:aws:rule/new"}]
+                    }
+
+                    def boto3_client_side_effect(service):
+                        if service == "ec2":
+                            return mock_ec2
+                        if service == "elbv2":
+                            return mock_elbv2
+                        return MagicMock()
+
+                    mock_boto3.side_effect = boto3_client_side_effect
+
+                    result = premium_manager.assign_premium_user(
+                        test_user_id, {"tier": "premium"}, "firebase_uid_123"
+                    )
+
+                    mock_remove.assert_called_once_with(test_user_id)
+                    # Should NOT return the stale assignment
+                    response_body = json.loads(result["body"])
+                    assert response_body.get("assignment_source") != "existing"
+            finally:
+                for p in patchers:
+                    p.stop()
+
+    def test_ec2_not_found_cleans_up_stale_assignment(self, mock_env_vars_premium):
+        """Assign removes stale assignment when EC2 instance
+        no longer exists (InvalidInstanceID.NotFound)."""
+        from botocore.exceptions import ClientError
+
+        test_user_id = 12345
+
+        existing_assignment = {
+            "user_id": test_user_id,
+            "instance_id": "i-deleted999",
+            "target_group_arn": "arn:aws:tg/existing",
+            "alb_rule_arn": "arn:aws:rule/existing",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        patches = {
+            "premium_manager.register_orphaned_stopped_instances": None,
+            "premium_manager.get_all_premium_instances_with_states": [],
+            "premium_manager.count_active_premium_users": 0,
+            "premium_manager.get_available_standby_instances": [],
+        }
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            patchers = []
+            for target, rv in patches.items():
+                p = patch(target, return_value=rv)
+                p.start()
+                patchers.append(p)
+
+            try:
+                with patch.object(
+                    premium_manager, "get_existing_user_assignment"
+                ) as mock_get_existing, patch.object(
+                    premium_manager, "remove_user_assignment"
+                ) as mock_remove, patch(
+                    "boto3.client"
+                ) as mock_boto3, patch(
+                    "pymysql.connect"
+                ) as mock_pymysql:
+                    mock_get_existing.return_value = existing_assignment
+                    mock_pymysql.return_value = setup_db_mock(
+                        fetchone_values=[None] * 20,
+                        fetchall_values=[[] for _ in range(10)],
+                    )
+
+                    mock_ec2 = MagicMock()
+                    mock_ec2.describe_instances.side_effect = ClientError(
+                        {
+                            "Error": {
+                                "Code": "InvalidInstanceID.NotFound",
+                                "Message": "Instance not found",
+                            }
+                        },
+                        "DescribeInstances",
+                    )
+
+                    mock_elbv2 = MagicMock()
+                    mock_elbv2.create_target_group.return_value = {
+                        "TargetGroups": [{"TargetGroupArn": "arn:aws:tg/new"}]
+                    }
+                    mock_elbv2.create_rule.return_value = {
+                        "Rules": [{"RuleArn": "arn:aws:rule/new"}]
+                    }
+
+                    def boto3_client_side_effect(service):
+                        if service == "ec2":
+                            return mock_ec2
+                        if service == "elbv2":
+                            return mock_elbv2
+                        return MagicMock()
+
+                    mock_boto3.side_effect = boto3_client_side_effect
+
+                    result = premium_manager.assign_premium_user(
+                        test_user_id, {"tier": "premium"}, "firebase_uid_123"
+                    )
+
+                    mock_remove.assert_called_once_with(test_user_id)
+                    response_body = json.loads(result["body"])
+                    assert response_body.get("assignment_source") != "existing"
+            finally:
+                for p in patchers:
+                    p.stop()
+
 
 class TestDictCursorFix:
     """DictCursor fix tests."""


### PR DESCRIPTION
### Content

#### Summary
- Premium users whose dedicated instance was stopped for inactivity get stuck: the assign endpoint finds an active RDS assignment and returns it, but the instance is stopped. The user cannot use the platform until cleanup removes the stale assignment record (runs hourly), after which a fresh instance is provisioned.
- The fix adds an EC2 state check in the assign path: when the user's assigned instance is stopped, the endpoint restarts it inline, waits for EC2 running + ECS task readiness, and returns the assignment. For terminated or missing instances, the stale assignment is removed and the user falls through to fresh assignment.
- The existing migration and autoscaling-pool paths are unchanged.

#### Design Decisions
- **EC2 state check before returning existing assignment** -- The DB `instance_state` field can be stale (updated only on explicit transitions, not when the monitoring Lambda stops idle instances). Querying EC2 `describe_instances` is the only reliable way to know the real state. This adds one API call per assign request when the user already has an assignment, which is acceptable. Reuses the `ec2` client created at the top of `assign_premium_user` rather than creating a second client.
- **Inline restart with 2-minute EC2 wait + 2-minute ECS readiness** -- Stopped instances resume in ~30-60s. The EC2 waiter uses `Delay=5, MaxAttempts=24` (~2 min max) matching the existing `start_standby_instance()` pattern. ECS readiness uses `max_wait_seconds=120` to allow the ECS agent to re-register and start the premium task. This is faster than a full cold-start assignment (Priority 3-5) and preserves the user's existing ALB rule and target group.
- **STOPPING → STOPPED wait before restart** -- An instance in `stopping` state cannot be started directly (AWS throws `IncorrectInstanceState`). The code waits for the instance to reach `stopped` via `instance_stopped` waiter before issuing `start_instances`.
- **Stale assignment cleanup for terminated/missing instances** -- If the instance is terminated, shutting down, or not found in EC2, the assignment is removed and `existing_assignment` is set to `None` so the code falls through to the fresh assignment flow (Priority 1-5). `existing_assignment` is set to `None` **before** calling `remove_user_assignment()` so that if the removal throws, the stale record is never returned to the user.
- **Guard on `existing_assignment` for migration and return paths** -- After cleanup, `existing_assignment` is set to `None` to prevent the downstream code from returning a deleted assignment or triggering migration for a non-existent record. The catch-all `except Exception` also sets `existing_assignment = None` to avoid returning a potentially broken assignment.
- **Non-NotFound `ClientError` re-raised** -- Unknown EC2 errors (throttling, permissions) are re-raised to the outer handler rather than silently swallowed, since they may indicate a systemic issue.
- **DB update via `@with_transaction`** -- The instance state update after restart uses a new `_update_instance_state_to_running()` function decorated with `@with_transaction`, consistent with all other DB writes in the file (e.g., `_remove_user_assignment_transaction`, `_store_user_assignment_transaction`).

### Evidence

#### Scenario (reported by coworker)
1. Premium user is assigned to a dedicated instance, assignment stored in RDS
2. Instance is stopped by the idle-timeout monitoring Lambda
3. User returns and calls assign — endpoint finds active RDS record, returns it pointing to stopped instance
4. User is stuck until hourly cleanup deletes the stale assignment
5. Only then can a fresh instance be provisioned

#### Expected behavior after fix
- Step 3: assign detects stopped instance via EC2 API, restarts it, waits for readiness, returns assignment with `assignment_source: "restarted_instance"`
- User sees ~1-2 minute wait instead of being stuck indefinitely

### References
- Related: commit 6247a9680 (autoscaling-pool inline migration fix)
- PULL_REQUEST.md (autoscaling-pool loop fix, same branch)

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add EC2 state check in assign path: restart stopped instances (with STOPPING wait), clean up terminated/missing instances, guard downstream paths with `existing_assignment` nullability. Extract `_update_instance_state_to_running()` as `@with_transaction` function. Re-raise non-NotFound `ClientError`s. Reuse existing `ec2` client instead of creating a second one.
- `studio/tests/infrastructure/test_premium_manager.py` -- Add 4 new tests for stopped/stopping/terminated/not-found instance handling; fix `test_assign_event` mock sequence off-by-one from `restore_pending_release` fetchone added in 6247a9680

### Manual Testcases
1. **Premium user with stopped instance calls assign**
   - Precondition: User has active assignment in RDS, but the EC2 instance is stopped (e.g., stopped by idle monitoring)
   - Action: User logs in or refreshes, triggering assign endpoint
   - Expected: Instance restarts, ECS task becomes ready, response returns `assignment_source: "restarted_instance"` with the same instance_id
2. **Premium user with terminated instance calls assign**
   - Precondition: User has active assignment in RDS, but the EC2 instance was terminated
   - Action: User logs in, triggering assign endpoint
   - Expected: Stale assignment removed, user falls through to fresh assignment flow (Priority 1-5)
3. **Premium user with running instance calls assign (no change)**
   - Precondition: User has active assignment, instance is running
   - Action: User calls assign
   - Expected: Existing assignment returned as before with `assignment_source: "existing"`
4. **Premium user with stopping instance calls assign**
   - Precondition: User has active assignment in RDS, EC2 instance is in `stopping` state (e.g., idle-timeout Lambda just triggered)
   - Action: User logs in, triggering assign endpoint
   - Expected: Endpoint waits for instance to reach `stopped`, then restarts it, waits for ECS readiness, returns `assignment_source: "restarted_instance"`
5. **Autoscaling-pool user calls assign (no change)**
   - Precondition: User assigned to autoscaling-pool
   - Action: User calls assign
   - Expected: Inline migration or async migration triggers as before (EC2 state check is skipped for autoscaling-pool)
6. `make test_lambda` -- all tests pass

### Unit, Integration, Contract Test Coverage
- `make test_lambda` -- all passed, 0 failed
- New tests:
  - `test_stopped_instance_restarted_on_assign` -- Verifies EC2 restart flow, ECS readiness wait, DB state update via `_update_instance_state_to_running`, and `assignment_source: "restarted_instance"` response
  - `test_stopping_instance_waits_then_restarts` -- Verifies STOPPING → wait for stopped → restart flow, asserts `instance_stopped` waiter is called before `start_instances`
  - `test_terminated_instance_triggers_fresh_assignment` -- Verifies stale assignment cleanup and fall-through to fresh assignment
  - `test_ec2_not_found_cleans_up_stale_assignment` -- Verifies `InvalidInstanceID.NotFound` error handling and stale assignment cleanup

### Others

#### Difficulties (if any)
- None

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Assign endpoint latency | Medium | Restarting a stopped instance adds ~1-2 min to the assign response. A `stopping` instance adds additional wait time. This is expected and preferable to the user being stuck. The 120s ECS readiness timeout is a worst case; typical restart is 30-60s. |
| Lambda timeout | Medium | Worst case: STOPPING wait (~2 min) + start wait (~2 min) + ECS readiness (~2 min) = ~6 min. Confirm Lambda timeout is >= 6 min or adjust waiter configs. |
| EC2 API call on every existing-assignment path | Low | One `describe_instances` call per assign when user already has an assignment. Well within API rate limits. |
| Stale assignment cleanup | Low | `remove_user_assignment` is an existing, tested function. `existing_assignment` is set to `None` before the call so failures in removal cannot result in returning a stale record. |
| Non-NotFound ClientError re-raised | Low | Unknown EC2 errors now propagate to the outer handler (503 response) instead of being silently logged. This surfaces systemic issues (throttling, IAM) rather than hiding them. |
