### PR TITLE
Fix potential clashing url logs to log-report

### DIFF
--- a/frontend/src/utils/__tests__/errorReporter.test.ts
+++ b/frontend/src/utils/__tests__/errorReporter.test.ts
@@ -114,7 +114,7 @@ describe("errorReporter", () => {
     flushErrors()
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${MOCK_BASE_URL}/logs/frontend-errors`,
+      `${MOCK_BASE_URL}/log-report/frontend-errors`,
       expect.objectContaining({
         method: "POST",
         keepalive: true,

--- a/frontend/src/utils/errorReporter.ts
+++ b/frontend/src/utils/errorReporter.ts
@@ -4,7 +4,7 @@ import { getToken } from "utils/auth/AuthUtils"
 export const MAX_QUEUE_SIZE = 20
 export const MAX_MESSAGE_LENGTH = 2000
 const FLUSH_INTERVAL_MS = 5000
-const ENDPOINT = `${BASE_URL}/logs/frontend-errors`
+const ENDPOINT = `${BASE_URL}/log-report/frontend-errors`
 
 const FRONTEND_LOG_LEVELS = ["error", "warn"] as const
 type FrontendLogLevel = (typeof FRONTEND_LOG_LEVELS)[number]

--- a/studio/app/common/routers/log_report.py
+++ b/studio/app/common/routers/log_report.py
@@ -9,7 +9,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.log_reader import FRONTEND_LOG_PREFIX
 from studio.app.common.schemas.users import User
 
-router = APIRouter(prefix="/logs", tags=["logs"])
+router = APIRouter(prefix="/log-report", tags=["logs"])
 
 logger = AppLogger.get_logger()
 

--- a/studio/tests/app/common/routers/test_log_report.py
+++ b/studio/tests/app/common/routers/test_log_report.py
@@ -1,5 +1,5 @@
 """
-Unit tests for POST /logs/frontend-errors endpoint.
+Unit tests for POST /log-report/frontend-errors endpoint.
 
 Tests the endpoint handler, rate limiting, and stale entry cleanup.
 """

--- a/studio/tests/app/common/routers/test_log_report_api_contract.py
+++ b/studio/tests/app/common/routers/test_log_report_api_contract.py
@@ -1,12 +1,12 @@
 """
 Contract Tests for Frontend Error Reporting API
 
-Verifies that the POST /logs/frontend-errors endpoint response shape
+Verifies that the POST /log-report/frontend-errors endpoint response shape
 matches the frontend ErrorEntry interface in:
   frontend/src/utils/errorReporter.ts
 
 Tested endpoint:
-  - POST /logs/frontend-errors -> { count: number }
+  - POST /log-report/frontend-errors -> { count: number }
 
 Request body contract (FrontendErrorBatch):
   { errors: FrontendErrorItem[] }
@@ -96,7 +96,7 @@ class TestFrontendErrorsContract:
     """Verify response shape matches frontend expectations."""
 
     def test_response_has_count_field(self, client):
-        response = client.post("/logs/frontend-errors", json=VALID_REQUEST_BODY)
+        response = client.post("/log-report/frontend-errors", json=VALID_REQUEST_BODY)
         assert response.status_code == 200
         data = response.json()
         for field, expected_type in RESPONSE_REQUIRED_FIELDS.items():
@@ -107,14 +107,14 @@ class TestFrontendErrorsContract:
             )
 
     def test_count_matches_batch_size(self, client):
-        response = client.post("/logs/frontend-errors", json=VALID_REQUEST_BODY)
+        response = client.post("/log-report/frontend-errors", json=VALID_REQUEST_BODY)
         data = response.json()
         assert data["count"] == len(VALID_REQUEST_BODY["errors"])
 
     def test_accepts_minimal_error_item(self, client):
         """Minimal payload: only required fields."""
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={"errors": [{"level": "error", "message": "test"}]},
         )
         assert response.status_code == 200
@@ -122,27 +122,27 @@ class TestFrontendErrorsContract:
 
     def test_accepts_warn_level(self, client):
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={"errors": [{"level": "warn", "message": "warning"}]},
         )
         assert response.status_code == 200
 
     def test_rejects_invalid_level(self, client):
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={"errors": [{"level": "info", "message": "test"}]},
         )
         assert response.status_code == 422
 
     def test_rejects_empty_errors_list(self, client):
         """Backend should accept empty list (no errors to log)."""
-        response = client.post("/logs/frontend-errors", json={"errors": []})
+        response = client.post("/log-report/frontend-errors", json={"errors": []})
         assert response.status_code == 200
         assert response.json()["count"] == 0
 
     def test_rejects_missing_message(self, client):
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={"errors": [{"level": "error"}]},
         )
         assert response.status_code == 422
@@ -150,7 +150,7 @@ class TestFrontendErrorsContract:
     def test_rejects_oversized_batch(self, client):
         """Batch exceeding max_items=20 should be rejected."""
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={
                 "errors": [{"level": "error", "message": f"msg {i}"} for i in range(21)]
             },
@@ -163,7 +163,7 @@ class TestFrontendErrorsContract:
 
         _frontend_error_timestamps[mock_user.id] = [time.time()] * 10
         response = client.post(
-            "/logs/frontend-errors",
+            "/log-report/frontend-errors",
             json={"errors": [{"level": "error", "message": "test"}]},
         )
         assert response.status_code == 429


### PR DESCRIPTION
### Content

Changed prefix to /log-report instead, so the endpoint is now POST /log-report/frontend-errors. This avoids the conflict with the existing logs.py router which already uses /logs. 

- Related to #417