### PR TITLE
Edit ROI to use absolute path

### DIFF
--- a/studio/app/optinist/routers/roi.py
+++ b/studio/app/optinist/routers/roi.py
@@ -11,13 +11,24 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageReader,
     RemoteSyncStatusFileUtil,
 )
+from studio.app.common.core.utils.filepath_creater import (
+    join_filepath,
+    normalize_output_path,
+)
 from studio.app.common.core.workspace.workspace_dependencies import is_workspace_owner
+from studio.app.dir_path import DIRPATH
 from studio.app.optinist.core.edit_ROI import EditROI, EditRoiUtils
 from studio.app.optinist.schemas.roi import RoiList, RoiPos, RoiStatus
 
 router = APIRouter(prefix="/outputs", tags=["outputs"])
 
 logger = AppLogger.get_logger()
+
+
+def to_absolute_output_path(filepath: str) -> str:
+    """Normalize and convert to absolute path for filesystem operations."""
+    filepath = normalize_output_path(filepath)
+    return join_filepath([DIRPATH.OUTPUT_DIR, filepath])
 
 
 async def ensure_experiment_synced_for_edit(
@@ -72,6 +83,7 @@ async def status_roi(
     filepath: str,
     remote_bucket_name: str = Depends(get_user_remote_bucket_name),
 ):
+    filepath = to_absolute_output_path(filepath)
     # Ensure experiment is synced before Edit ROI operations
     await ensure_experiment_synced_for_edit(filepath, remote_bucket_name)
     return EditROI(file_path=filepath).get_status()
@@ -83,6 +95,7 @@ async def status_roi(
     dependencies=[Depends(is_workspace_owner)],
 )
 async def add_roi(filepath: str, pos: RoiPos):
+    filepath = to_absolute_output_path(filepath)
     EditROI(file_path=filepath).add(pos)
     return True
 
@@ -93,6 +106,7 @@ async def add_roi(filepath: str, pos: RoiPos):
     dependencies=[Depends(is_workspace_owner)],
 )
 async def merge_roi(filepath: str, roi_list: RoiList):
+    filepath = to_absolute_output_path(filepath)
     EditROI(file_path=filepath).merge(roi_list.ids)
     return True
 
@@ -103,6 +117,7 @@ async def merge_roi(filepath: str, roi_list: RoiList):
     dependencies=[Depends(is_workspace_owner)],
 )
 async def delete_roi(filepath: str, roi_list: RoiList):
+    filepath = to_absolute_output_path(filepath)
     EditROI(file_path=filepath).delete(roi_list.ids)
     return True
 
@@ -116,6 +131,7 @@ async def commit_edit(
     filepath: str,
     remote_bucket_name: str = Depends(get_user_remote_bucket_name),
 ):
+    filepath = to_absolute_output_path(filepath)
     try:
         EditRoiUtils.execute(filepath, remote_bucket_name)
 
@@ -138,5 +154,6 @@ async def commit_edit(
     dependencies=[Depends(is_workspace_owner)],
 )
 async def cancel_edit(filepath: str):
+    filepath = to_absolute_output_path(filepath)
     EditROI(file_path=filepath).cancel()
     return True


### PR DESCRIPTION
### Content

#### Summary
- Edit ROI operations (status, add, merge, delete, commit, cancel) were returning 400 errors because the backend received relative paths from the frontend but passed them directly to `EditROI`, which requires absolute paths to parse workspace/experiment IDs from the directory hierarchy.
- Added a `to_absolute_output_path()` helper that normalizes the incoming path and prepends `DIRPATH.OUTPUT_DIR`, matching the pattern already used in the common outputs router.
- Applied the conversion to all 6 ROI endpoints so they behave consistently with the rest of the outputs API.

#### Design Decisions
- **Centralized helper instead of inline conversion** -- All 6 endpoints need the same two-step conversion (normalize then join), so a shared `to_absolute_output_path()` avoids duplication and makes the pattern explicit.
- **Reused existing `normalize_output_path` + `join_filepath` utilities** -- These are the same functions the common outputs router (`studio/app/common/routers/outputs.py`) uses for its `image`, `data`, and `html` endpoints. No new path logic was introduced.
- **Conversion applied before `ensure_experiment_synced_for_edit`** -- This function also calls `os.path.dirname()` and `ExptOutputPathIds()`, so it equally requires an absolute path. Placing the conversion at the top of each endpoint ensures all downstream code receives the correct path.

### Evidence
- 400 errors observed on all Edit ROI operations (status, add, merge, delete, commit, cancel) when the frontend sent relative paths like `93/tutorial1/suite2p/cell_roi.json`.
- `EditROI.__init__` uses `os.path.dirname(file_path)` to extract `node_dirpath` and then parses workspace/experiment IDs via `ExptOutputPathIds`. With a relative path, this produces incorrect directory components, causing failures.

### References
- Common outputs router uses the same pattern: `studio/app/common/routers/outputs.py` lines 707-708, 738-741

#### Files changed
- `studio/app/optinist/routers/roi.py` -- Add `to_absolute_output_path()` helper using `normalize_output_path` + `join_filepath`; call it at the top of all 6 ROI endpoints to convert the frontend's relative path to an absolute filesystem path

### Manual Testcases

#### Scenario 1: Edit ROI status check
1. Run a workflow that produces ROI output (e.g., suite2p)
2. Open the ROI image in the Visualize panel
3. Click Edit ROI -- verify the status endpoint returns successfully (no 400 error)

#### Scenario 2: Add, merge, delete ROI
1. In Edit ROI mode, draw a new ROI region -- verify add succeeds
2. Select multiple ROIs and merge -- verify merge succeeds
3. Select an ROI and delete -- verify delete succeeds

#### Scenario 3: Commit and cancel
1. Make ROI edits and click Commit -- verify changes are saved
2. Make ROI edits and click Cancel -- verify changes are discarded

### Unit, Integration, Contract Test Coverage
- No existing tests for the ROI router endpoints. The path conversion uses well-tested utility functions (`normalize_output_path`, `join_filepath`).

### Others

#### Difficulties
- The root cause was not immediately obvious from the 400 error alone -- the frontend was sending paths in the same format as other output endpoints, but the ROI router was the only one missing the relative-to-absolute conversion.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Path conversion in ROI endpoints | Low | Uses the same `normalize_output_path` + `join_filepath` pattern proven in the common outputs router. `normalize_output_path` is idempotent, so already-absolute paths are handled safely. |
| `ensure_experiment_synced_for_edit` | Low | Now receives an absolute path as intended. Previously broken with relative paths -- this is strictly a fix, not a behavior change. |
