### PR TITLE
Update gitignore and deployment procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ tensorflow-*.whl
 
 .env*
 !*.env*.example
+
+# Terraform provisioner build artifacts (copied/installed by terraform apply)
+infrastructure/terraform/*/aws_constants.py
+infrastructure/terraform/aws_constants_layer/
+infrastructure/terraform/*_package/pymysql/
+infrastructure/terraform/*_package/pymysql-*.dist-info/

--- a/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
@@ -55,55 +55,40 @@ aws configure
 
 Use this method if you have access to `infrastructure/terraform/terraform.tfvars`.
 
+> For environment setup, switching between dev/production, and ECR management, see [INFRA_DEPLOYMENT_PROCEDURE.md](INFRA_DEPLOYMENT_PROCEDURE.md).
+
 ### Prerequisites for Method 1
 
 - Access to `infrastructure/terraform/terraform.tfvars`
 - Terraform installed (v1.0+)
 - Firebase credentials (already configured in terraform.tfvars)
 
-### 1.1 Standard Deployment (Image Update Only)
+### 1.1 Deployment Steps
 
-Use this when you only need to update the application code without infrastructure changes.
-
-```bash
-cd infrastructure/scripts
-./ecr_build_push.sh
-```
-
-This script will:
-
-1. Read configuration from Terraform outputs (domain, port, protocol)
-2. Build the frontend with the correct environment variables
-3. Build and tag the Docker image
-4. Push the image to ECR
-
-**Note:** Pushing to ECR alone does NOT trigger ECS redeployment. To deploy the new image, run `terraform apply` (which calls `aws ecs update-service --force-new-deployment`) or manually force a new deployment via the AWS console/CLI.
-
-### 1.2 Deployment with Infrastructure Changes
-
-Use this when you need to update AWS infrastructure (VPC, ALB, RDS, etc.) in addition to the application.
+After merging, run the deployment:
 
 ```bash
-# From the repository root:
+# Step 1: Apply infrastructure and Lambda changes
 cd infrastructure/terraform
-
-# Review planned changes
-terraform plan
-
-# Apply infrastructure changes (automatically builds and pushes image)
+terraform plan     # Review changes before applying
 terraform apply
+
+# Step 2: Build and push the Docker image (if studio/ or frontend/ code changed)
+cd ../scripts
+./ecr_build_push.sh
+
+# Step 3: Force ECS to pull the new image
+#   AWS Console → ECS → Cluster → Service → Update → check "Force new deployment"
 ```
 
-**Note:** `terraform apply` automatically runs `ecr_build_push.sh` via the `null_resource.build_and_deploy` provisioner. There is no need to run it manually first.
+**What each step does:**
 
-**What gets updated:**
-
-- VPC, subnets, security groups (if modified)
-- Load balancers and target groups
-- ECS services and task definitions
-- RDS database configuration
-- Auto Scaling Groups
-- Route53 and ACM certificates
+- **`terraform apply`** updates infrastructure and Lambdas:
+  - Infrastructure (VPC, ALB, RDS, ECS, Auto Scaling, Route53, ACM)
+  - Lambda function code and layers
+  - Copies `infrastructure/aws_constants.py` to all Lambda packages via provisioners
+- **`ecr_build_push.sh`** builds the frontend and studio app into a Docker image and pushes it to ECR. It reads terraform outputs (domain, port, protocol) to configure the frontend build, so terraform must run first. Skip this step if only Lambda/infrastructure code changed.
+- **Force new deployment** tells ECS to pull the latest image from ECR. Required after pushing a new image; skip if only Lambda/infrastructure changed.
 
 ---
 

--- a/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
@@ -1,6 +1,6 @@
 # Infrastructure Deployment Procedure
 
-> See also: [Architecture](TERRAFORM_ARCHITECTURE.md) | [Security](INFRA_SECURITY_MODEL.md) | [Dev Schedule](../scripts/DEV_SCHEDULE_GUIDE.md)
+> See also: [Deployment Procedure](DEPLOYMENT_PROCEDURE.md) | [Architecture](TERRAFORM_ARCHITECTURE.md) | [Security](INFRA_SECURITY_MODEL.md) | [Dev Schedule](../scripts/DEV_SCHEDULE_GUIDE.md)
 
 ---
 


### PR DESCRIPTION
### Content

#### Summary
- Added `.gitignore` entries for Terraform provisioner build artifacts (`aws_constants.py` copies, `aws_constants_layer/`, `pymysql/` packages) that are generated by `terraform apply` and should not be committed.
- Simplified `DEPLOYMENT_PROCEDURE.md` by replacing the split "image-only" vs "infrastructure" sections with a single linear 3-step flow (terraform apply, ecr build/push, force ECS deployment) and clarifying what each step does and when it can be skipped.
- Added reciprocal cross-links between `DEPLOYMENT_PROCEDURE.md` and `INFRA_DEPLOYMENT_PROCEDURE.md` so readers can navigate between them.

#### Design Decisions
- **Single linear deployment flow** -- The previous two-section layout implied the image-only path was self-contained, but `ecr_build_push.sh` depends on terraform outputs, and ECS still needs a forced redeployment after a push. A single ordered sequence makes the dependencies explicit and removes the incorrect note that `terraform apply` auto-runs the build script.
- **Glob patterns in `.gitignore`** -- `*/aws_constants.py` and `*_package/pymysql/` use directory-level wildcards so new Lambda packages added in the future are covered automatically without updating `.gitignore` again.

### Evidence
- `infrastructure/terraform/*/aws_constants.py`, `aws_constants_layer/`, and `*_package/pymysql/` directories are present on disk after `terraform apply` but are generated artifacts, not source code.

### References
- Related provisioner logic in Terraform config that copies these files during `terraform apply`

#### Files changed
- `.gitignore` -- Add 6 patterns to ignore Terraform provisioner build artifacts (Lambda `aws_constants.py` copies, `aws_constants_layer/`, `pymysql/` packages and dist-info)
- `infrastructure/documentation/DEPLOYMENT_PROCEDURE.md` -- Replace split image-only / infrastructure sections with a single 3-step deployment flow; add cross-link to INFRA_DEPLOYMENT_PROCEDURE.md
- `infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md` -- Add cross-link back to DEPLOYMENT_PROCEDURE.md in the "See also" header

### Manual Testcases

#### Scenario 1: Gitignore effectiveness
1. Run `terraform apply` in `infrastructure/terraform/`
2. Run `git status` -- verify `aws_constants.py` copies, `aws_constants_layer/`, and `pymysql/` packages do not appear as untracked files

#### Scenario 2: Documentation accuracy
1. Follow the 3-step deployment flow in DEPLOYMENT_PROCEDURE.md against a dev environment
2. Verify each step works as described and the "What each step does" section is accurate
3. Verify cross-links between DEPLOYMENT_PROCEDURE.md and INFRA_DEPLOYMENT_PROCEDURE.md resolve correctly

### Unit, Integration, Contract Test Coverage
- Documentation and gitignore changes only -- no automated tests applicable.

### Others

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `.gitignore` additions | Low | Only ignores build artifacts that are already untracked. No effect on existing tracked files. |
| Deployment docs rewrite | Low | Documentation only. No code behavior change. Reviewed against actual terraform config and script behavior. |
