### PR TITLE
Move DB update after observe_overall success

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1019,7 +1019,7 @@ def get_dynamic_max_capacity():
         # Production scenario - scale based on subscriber count
         max_capacity = min(total_premium_subscribers + EXTRA_CAPACITY, ABSOLUTE_MAX)
 
-    print("🏗️ Dynamic capacity calculation:")
+    print("Dynamic capacity calculation:")
     print(f"- Premium subscribers: {total_premium_subscribers}")
     print(f"- Extra capacity (buffer + standby): {EXTRA_CAPACITY}")
     print(f"- Current standby count: {standby_count}")
@@ -2935,7 +2935,7 @@ def assign_premium_user(
                 and len(running_instances) < active_users + 1
             ):
                 needs_scaling = True
-                print("→ Flagged for background scaling after assignment")
+                print("Flagged for background scaling after assignment")
 
         # PRIORITY 2.5: Temporary assignment to autoscaling pool for immediate login
         no_premium_available = len(running_instances) == 0 or not available_dedicated
@@ -2952,9 +2952,9 @@ def assign_premium_user(
             assignment_source = "autoscaling_temp"
             needs_scaling = True  # Always trigger scaling for premium instance
 
-            print(f"→ User {user_id} will login via autoscaling pool")
-            print("→ Scaling premium instances in background")
-            print("→ User will be migrated to dedicated instance once ready")
+            print(f"User {user_id} will login via autoscaling pool")
+            print("Scaling premium instances in background")
+            print("User will be migrated to dedicated instance once ready")
 
         # 3. PRIORITY 3: Start standby instance (5-15 second assignment)
         if not instance_to_use and standby_instances:
@@ -3875,7 +3875,7 @@ def update_premium_service_desired_count():
         if running_premium_count != current_desired_count:
             print(
                 f"Updating ECS service desired count: {current_desired_count} "
-                f"→ {running_premium_count}"
+                f"-> {running_premium_count}"
             )
             ecs.update_service(
                 cluster=cluster_name,

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -192,24 +192,35 @@ def _snakemake_execute_process(
 
     try:
         # Update workflow processing results
+        observe_success = False
         try:
             asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+            observe_success = True
         except Exception as e:
             logger.error(
                 f"snakemake_execute post process (WorkflowResult) failed: {e}",
                 exc_info=True,
             )
 
-        # Update experiment database record
-        if ExperimentRecordService.is_available():
+        # Update experiment database record if observe_overall() succeeded
+        if observe_success and ExperimentRecordService.is_available():
             ExperimentRecordService.regist_record_on_workflow_completed(
                 workspace_id, unique_id
             )
 
         # Data usage calculation
-        WorkspaceDataCapacityService.update_experiment_data_usage(
-            workspace_id, unique_id
-        )
+        if observe_success:
+            WorkspaceDataCapacityService.update_experiment_data_usage(
+                workspace_id, unique_id
+            )
+
+        if not observe_success:
+            logger.warning(
+                "Skipped experiment record registration and data usage update "
+                "due to observe_overall() failure. [workspace: %s] [unique_id: %s]",
+                workspace_id,
+                unique_id,
+            )
     except Exception as e:
         logger.error(f"snakemake_execute post process failed: {e}", exc_info=True)
 

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -319,7 +319,7 @@ class S3StorageController(BaseRemoteStorageController):
 
             if not all_s3_objects:
                 logger.warning(
-                    "remote data is not exists. [%s] [%s]",
+                    "Remote data does not exist. [%s] [%s]",
                     self.bucket_name,
                     input_data_remote_path,
                 )
@@ -927,7 +927,7 @@ class S3StorageController(BaseRemoteStorageController):
 
             if not all_s3_objects:
                 logger.warning(
-                    "Remote data is not exists. [%s] [%s]",
+                    "Remote data does not exist. [%s] [%s]",
                     self.bucket_name,
                     experiment_remote_path,
                 )

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for the post-process logic in _snakemake_execute_process.
+
+These tests verify that experiment record registration and data usage
+updates are skipped when observe_overall() fails, and that a warning
+is logged.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+MODULE = "studio.app.common.core.snakemake.snakemake_executor"
+
+WORKSPACE_ID = "test_workspace"
+UNIQUE_ID = "test_unique_id"
+
+
+@pytest.fixture()
+def _patch_snakemake_execution():
+    """Patch everything except the post-process block under test."""
+    with (
+        patch(f"{MODULE}.SmkStatusLogger"),
+        patch(f"{MODULE}.join_filepath", return_value="/tmp/fake"),
+        patch(f"{MODULE}.SnakemakeApi") as mock_api_cls,
+        patch(f"{MODULE}.RemoteStorageController") as mock_remote,
+        patch(f"{MODULE}.RemoteSyncLockFileUtil"),
+        patch(f"{MODULE}.RemoteSyncStatusFileUtil"),
+        patch(f"{MODULE}.get_pickle_file"),
+        patch(f"{MODULE}.DIRPATH"),
+    ):
+        # Make snakemake execution itself succeed
+        mock_ctx = MagicMock()
+        mock_api_cls.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_api_cls.return_value.__exit__ = MagicMock(return_value=False)
+        dag_mock = MagicMock()
+        mock_ctx.dag.return_value.__enter__ = MagicMock(return_value=dag_mock)
+        mock_ctx.dag.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_remote.is_available.return_value = False
+        yield
+
+
+@pytest.fixture()
+def mock_observe():
+    """Patch WorkflowResult and its observe_overall method."""
+    with patch(f"{MODULE}.WorkflowResult") as mock_cls:
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+        mock_instance.observe_overall = AsyncMock()
+        yield mock_instance
+
+
+@pytest.fixture()
+def mock_experiment_record():
+    with patch(f"{MODULE}.ExperimentRecordService") as mock_svc:
+        mock_svc.is_available.return_value = True
+        yield mock_svc
+
+
+@pytest.fixture()
+def mock_data_capacity():
+    with patch(f"{MODULE}.WorkspaceDataCapacityService") as mock_svc:
+        yield mock_svc
+
+
+class TestPostProcessObserveSuccess:
+    """When observe_overall() succeeds, downstream services should run."""
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_calls_record_and_data_usage(
+        self, mock_observe, mock_experiment_record, mock_data_capacity
+    ):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        mock_data_capacity.update_experiment_data_usage.assert_called_once_with(
+            WORKSPACE_ID, UNIQUE_ID
+        )
+
+
+class TestPostProcessObserveFailure:
+    """When observe_overall() fails, downstream services should be skipped."""
+
+    @pytest.fixture(autouse=True)
+    def _fail_observe(self, mock_observe):
+        mock_observe.observe_overall = AsyncMock(
+            side_effect=RuntimeError("observe failed")
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_skips_record_and_data_usage(
+        self, mock_observe, mock_experiment_record, mock_data_capacity
+    ):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        mock_experiment_record.regist_record_on_workflow_completed.assert_not_called()
+        mock_data_capacity.update_experiment_data_usage.assert_not_called()
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_logs_warning(
+        self, mock_observe, mock_experiment_record, mock_data_capacity, caplog
+    ):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        assert any(
+            "Skipped experiment record registration and data usage update"
+            in record.message
+            and WORKSPACE_ID in record.message
+            and UNIQUE_ID in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
### Content

#### Summary
- Gate experiment record registration and data usage calculation behind successful completion of `observe_overall()` in the snakemake post-process, preventing inconsistent state when observation fails.
- Add a warning log when post-process steps are skipped so missing records are diagnosable.
- Remove emoji/unicode characters from `premium_manager.py` print statements for cleaner log output.
- Fix grammar in `s3_storage_controller.py` log warnings.

#### Design Decisions
- **Flag-based gating over try/except restructuring** -- A simple `observe_success` boolean keeps the existing control flow intact and makes the skip condition explicit at each downstream call site. Restructuring into nested try blocks would obscure the intent.
- **Warning log on skip** -- Without this, a transient `observe_overall()` failure would silently leave no experiment record and no data usage entry, making the gap hard to diagnose from logs alone.
- **Data usage also gated** -- Recording storage usage for a workflow whose results were never observed would create an inconsistency: usage counted but no corresponding experiment record.

### Evidence
- Unit tests cover both success and failure paths (see test coverage section below).

### References
- Related to ROI path handling on `fix/edit-roi-path` branch

#### Files changed

#### Backend
- `studio/app/common/core/snakemake/snakemake_executor.py` -- Gate `regist_record_on_workflow_completed` and `update_experiment_data_usage` behind `observe_success`; add warning log when skipped
- `studio/app/common/core/storage/s3_storage_controller.py` -- Fix grammar in two log warnings ("is not exists" -> "does not exist")
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Replace emoji/unicode arrows with ASCII equivalents in print statements

#### Tests
- `studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py` -- New: unit tests for post-process gating on observe_overall success/failure and warning log

### Manual Testcases
1. Trigger a workflow where `observe_overall()` succeeds -- verify experiment record and data usage are both written
2. Simulate an `observe_overall()` failure (e.g., by temporarily breaking the result path) -- verify no experiment record or data usage entry is created, and a warning log appears with workspace and unique_id
3. Run `pytest studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py -v` -- all 3 tests pass

### Unit, Integration, Contract Test Coverage
- 3 new unit tests covering: success path (both services called), failure path (both services skipped), failure path (warning logged with identifiers)

### Others

#### Difficulties
- None

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Post-process gating | Medium | Behavioral change: previously experiment records were written even on observe failure. Any process relying on records existing regardless of observe outcome would be affected. |
| Warning log | Low | Additive logging only, no behavioral impact. |
| Premium manager print cleanup | Low | Cosmetic string changes in print statements, no logic change. |
| S3 storage log grammar | Low | Log message text only, no logic change. |
