### PR TITLE
Split error messages based on error type

### DIFF
--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -246,14 +246,13 @@ axios.interceptors.response.use(
       return handleUnauthorizedError(error)
     }
 
-    // ALB 502/503 when premium instance is unavailable (target group empty
-    // or unhealthy after environment restart).
-    // Also handle network errors (ERR_FAILED / no response)
-    const is502or503 =
-      error?.response?.status === 502 || error?.response?.status === 503
+    // ALB returns 503 when the premium target group is empty or unhealthy.
+    // 502 is excluded — it signals a backend/Lambda failure, not stale routing.
+    // Network errors (ERR_FAILED / no response) are also treated as routing failures.
+    const isAlb503 = error?.response?.status === 503
     const isNetworkError = !error?.response && !!error?.config
     if (
-      (is502or503 || isNetworkError) &&
+      (isAlb503 || isNetworkError) &&
       routingService.requiresPremiumRouting()
     ) {
       return handlePremiumRoutingError(error)

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2897,10 +2897,10 @@ def assign_premium_user(
         # Fail fast if we can't verify assignment status
         print(f"Error: Failed to check existing assignment: {check_error}")
         return {
-            "statusCode": 503,
+            "statusCode": 500,
             "body": json.dumps(
                 {
-                    "error": "Service temporarily unavailable",
+                    "error": "Internal error",
                     "message": "Unable to verify assignment status. Please retry.",
                     "assigned": False,
                 }

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -121,7 +121,7 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
             }
         else:
             raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=result["message"],
             )
 


### PR DESCRIPTION
### Content

#### Summary
- Separate ALB routing errors (503) from backend/Lambda assignment failures (502/500) so the frontend interceptor only fires on genuine stale-routing scenarios.
- Previously, a Lambda failure during `/premium/assign` returned 503, which the axios interceptor mistakenly treated as an ALB routing issue -- stripping headers and retrying instead of surfacing the error to `PremiumAssignmentContext`.
- Lambda catch-all now returns 500 (internal error), backend router returns 502 (bad gateway), and the frontend interceptor only intercepts 503 for ALB routing fallback.

#### Design Decisions
- **502 for backend assignment failures over keeping 503** -- 503 is the ALB's signal for an unhealthy target group. Using it for Lambda failures made the frontend unable to distinguish the two cases. 502 (Bad Gateway) accurately describes "upstream service failed" and avoids the collision.
- **500 for Lambda catch-all over 503** -- The exception at this point is unexpected (failed to verify assignment status), not a planned "service temporarily unavailable." 500 reflects this.
- **Remove 502 from frontend interceptor rather than adding a URL guard** -- Cleaner than checking request URLs. 502 now propagates to callers normally, letting `PremiumAssignmentContext` handle it with appropriate error UI.

### Evidence
- Observed in production logs (2026-03-31): Lambda returned 503 on `/premium/assign` due to SSM `InvalidInstanceId` on a force-stopped instance. Frontend interceptor caught it as a routing error, showed misleading "Falling back to shared resources" message instead of surfacing the assignment failure.

### References
- GitHub issue: 503 error after force-stopping premium instance
- PR #434 (related frontend fix for clearing stale routing state)

#### Files changed

#### Frontend
- `frontend/src/utils/axios.ts` -- Remove 502 from ALB routing fallback condition; rename `is502or503` to `isAlb503`; update comments to explain why 502 is excluded

#### Backend
- `studio/app/common/routers/users_me.py` -- Change non-retryable assignment failure from 503 to 502
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Change catch-all exception in `assign_premium_user` from 503 to 500; update error label from "Service temporarily unavailable" to "Internal error"

### Manual Testcases
1. Premium user signs in, gets assigned to a dedicated instance
2. Force-stop the assigned instance via EC2 console
3. Refresh browser -- expect: first request gets 503 from ALB, interceptor strips headers and retries on free tier; no misleading 502 interception
4. Trigger `/premium/assign` when Lambda cannot verify assignment status -- expect: 502 response propagates to `PremiumAssignmentContext` error state, not caught by routing interceptor

### Unit, Integration, Contract Test Coverage
- No new tests; existing axios test suite covers logout/queue behavior (unaffected)

### Others

#### Difficulties
- None

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Frontend interceptor (502 removal) | Medium | Any backend 502 that previously got silently retried will now surface to callers. This is correct behavior but could expose previously-hidden errors. |
| Lambda status code change (503->500) | Low | Only affects the catch-all exception path; no change to success or retry flows. |
| Backend router (503->502) | Low | Only the non-retryable failure branch changes; success and retry paths unchanged. |
