### PR TITLE
Fix premium manager stale assignment bugs and reorder assignment priorities (fixed)

### DIFF
--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -213,11 +213,6 @@ const handlePremiumRoutingError = async (
     return Promise.reject(error)
   }
 
-  // Premium instance not ready, falling back to free tier.
-  // Clear premiumAssigned so subsequent requests don't keep sending
-  // stale routing headers that cause repeated 503s.
-  routingService.setPremiumAssigned(false)
-
   const retryConfig = { ...originalRequest }
   delete retryConfig.headers[RoutingHeaders.USER_TIER]
   delete retryConfig.headers[RoutingHeaders.ROUTING_ID]

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -214,6 +214,10 @@ const handlePremiumRoutingError = async (
   }
 
   // Premium instance not ready, falling back to free tier.
+  // Clear premiumAssigned so subsequent requests don't keep sending
+  // stale routing headers that cause repeated 503s.
+  routingService.setPremiumAssigned(false)
+
   const retryConfig = { ...originalRequest }
   delete retryConfig.headers[RoutingHeaders.USER_TIER]
   delete retryConfig.headers[RoutingHeaders.ROUTING_ID]

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -246,14 +246,13 @@ axios.interceptors.response.use(
       return handleUnauthorizedError(error)
     }
 
-    // ALB 502/503 when premium instance is unavailable (target group empty
-    // or unhealthy after environment restart).
-    // Also handle network errors (ERR_FAILED / no response)
-    const is502or503 =
-      error?.response?.status === 502 || error?.response?.status === 503
+    // ALB returns 503 when the premium target group is empty or unhealthy.
+    // 502 is excluded — it signals a backend/Lambda failure, not stale routing.
+    // Network errors (ERR_FAILED / no response) are also treated as routing failures.
+    const isAlb503 = error?.response?.status === 503
     const isNetworkError = !error?.response && !!error?.config
     if (
-      (is502or503 || isNetworkError) &&
+      (isAlb503 || isNetworkError) &&
       routingService.requiresPremiumRouting()
     ) {
       return handlePremiumRoutingError(error)

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -568,7 +568,7 @@ PREMIUM_IDLE_TIMEOUT_HOURS   # Hours before stale assignment cleanup (code defau
 | `handle_scheduled_monitoring()` | 15-min monitoring cycle (10 operations) |
 | `scale_down_if_possible()` | Conservative scaling algorithm |
 | `update_premium_service_desired_count()` | Sync ECS desired count |
-| `assign_premium_user()` | Real-time user assignment (API) |
+| `assign_premium_user()` | Real-time user assignment (API) - 5-tier priority: dedicated > shared > standby > autoscaling pool > stopped > new |
 | `release_premium_user()` | Real-time user release (API) |
 | `handle_activity_update()` | Heartbeat/activity timestamp update (API) |
 | `get_premium_user_status()` | Get user assignment status (API) |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -12,14 +12,15 @@
 1. **Priority-Based Assignment**
    - Tier 1: Dedicated running instances (0s wait)
    - Tier 2: Shared instances for immediate login (0s wait)
-   - Tier 2.5: Autoscaling pool as temporary fallback (0s wait)
    - Tier 3: Standby instances (5-15s startup)
+   - Tier 3.5: Autoscaling pool as temporary fallback (0s wait, only if no standby)
    - Tier 4: AWS stopped instances fallback (60-90s startup)
    - Tier 5: Scale new instances (4-8 minutes)
 
 2. **User Experience First**
-   - Users get immediate login via autoscaling pool if no premium ready
-   - Background migration to dedicated premium instance
+   - Users get dedicated instance from standby pool when available (5-15s)
+   - Falls back to autoscaling pool only when no standby instances exist
+   - Background migration to dedicated premium instance from shared/pool
    - No user-visible delays or retry loops
 
 3. **Standby Pool Management**
@@ -45,9 +46,9 @@ graph TB
 
         B -->|Dedicated Available| C1[Tier 1: Assign to Dedicated]
         B -->|No Dedicated, Has Shared| C2[Tier 2: Share Instance]
-        B -->|No Premium Ready| C3[Tier 2.5: Assign to Autoscaling Pool]
         B -->|Has Standby| C4[Tier 3: Start Standby Instance]
-        B -->|Has Stopped| C5[Tier 4: Start AWS Instance]
+        B -->|No Standby Either| C3[Tier 3.5: Assign to Autoscaling Pool]
+        B -->|Has Stopped, Not Standby| C5[Tier 4: Start AWS Instance]
         B -->|None Available| C6[Tier 5: Create New Instance]
 
         C1 --> D[Create Target Group + ALB Rule]
@@ -82,8 +83,8 @@ graph TB
 |------|--------|-----------|-----------------|------|----------|
 | 1 | Dedicated Running | 0s | Best (exclusive) | Highest | Active user pool |
 | 2 | Shared Instance | 0s | Good (shared) | Medium | Burst capacity |
-| 2.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Cold start fallback |
-| 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning |
+| 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning / re-login |
+| 3.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Last-resort fallback (no standby) |
 | 4 | AWS Stopped | 60-90s | Acceptable | Low | Fallback recovery |
 | 5 | New Instance | 4-8 min | Poor (scaling) | Highest | Last resort |
 
@@ -116,13 +117,6 @@ sequenceDiagram
         PM->>PM: invoke_migration_async()
         PM-->>User: Assigned to shared (0s wait)
         Note over PM: Will migrate when new instance ready
-    else Tier 2.5: Autoscaling Pool Fallback
-        DB-->>PM: No premium instances ready
-        PM->>DB: Assign to "autoscaling-pool"
-        PM->>PM: scale_premium_instances_if_needed()
-        PM->>PM: invoke_migration_async()
-        PM-->>User: Assigned to temp pool (0s wait)
-        Note over PM: User logs in immediately, migrates later
     else Tier 3: Start Standby
         DB-->>PM: Found standby instance (is_standby=1)
         PM->>EC2: Start Instance
@@ -131,6 +125,13 @@ sequenceDiagram
         PM->>ALB: Create Target Group + Rule
         PM->>PM: create_and_stop_standby_instance() (replenish)
         PM-->>User: Assigned (5-15s wait)
+    else Tier 3.5: Autoscaling Pool Fallback
+        DB-->>PM: No premium or standby instances ready
+        PM->>DB: Assign to "autoscaling-pool"
+        PM->>PM: scale_premium_instances_if_needed()
+        PM->>PM: invoke_migration_async()
+        PM-->>User: Assigned to temp pool (0s wait)
+        Note over PM: User logs in immediately, migrates later
     end
 ```
 
@@ -229,10 +230,13 @@ graph TB
   reserve first instance with 0 users via `SELECT FOR UPDATE`
 - **Tier 2 (Shared):** Use least-loaded running instance, trigger
   scaling if `launching == 0 and running < active_users + 1`
-- **Tier 2.5 (Autoscaling Pool):** Assign to `"autoscaling-pool"` as
-  temporary fallback, always trigger scaling
 - **Tier 3 (Standby):** Start a stopped standby instance
-  (`is_standby=1`), replenish pool immediately
+  (`is_standby=1`), replenish pool immediately. This runs BEFORE
+  autoscaling pool to ensure returning users get a dedicated instance
+  instead of being stuck in the shared pool.
+- **Tier 3.5 (Autoscaling Pool):** Assign to `"autoscaling-pool"` as
+  temporary fallback only when no standby instances exist, always
+  trigger scaling
 - **Tier 4 (AWS Stopped):** Start non-standby stopped instance,
   wait up to 6 minutes for running state
 - **Tier 5 (Scale New):** If launching instances exist, return 202;
@@ -412,8 +416,9 @@ existing assignment, and inserts a reservation with marker values
 **Solution:** Automatic replenishment + fallback chain:
 - On standby consumption: immediately call
   `create_and_stop_standby_instance()` to replenish
-- If standby pool empty: fall back to Tier 4
-  (start non-standby stopped instances)
+- If standby pool empty: fall back to Tier 3.5
+  (autoscaling pool for immediate login)
+- Then Tier 4 (start non-standby stopped instances)
 - If nothing stopped: fall back to Tier 5
   (`scale_premium_instances_if_needed()`, return 202)
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -489,7 +489,7 @@ def _store_user_assignment_transaction(
             ),
         )
 
-        # Log premium usage session (skip standby — no real user)
+        # Log premium usage session (skip standby  - no real user)
         if user_id is not None and not is_standby:
             cursor.execute(
                 """INSERT INTO instance_usage_log
@@ -670,11 +670,15 @@ def _restore_pending_release_transaction(connection, user_id: int):
                 # Instance ID not recognised by AWS (already terminated/gone)
                 ec2_state = None
 
-            if ec2_state in (InstanceState.TERMINATED, InstanceState.SHUTTING_DOWN, None):
-                # Instance is gone — delete the stale DB record
+            if ec2_state in (
+                InstanceState.TERMINATED,
+                InstanceState.SHUTTING_DOWN,
+                None,
+            ):
+                # Instance is gone  - delete the stale DB record
                 print(
                     f"Instance {instance_id} is {ec2_state or 'not found'} "
-                    f"— removing stale assignment for user {user_id}"
+                    f" - removing stale assignment for user {user_id}"
                 )
                 cursor.execute(
                     "DELETE FROM premium_user_assignments "
@@ -694,9 +698,7 @@ def _restore_pending_release_transaction(connection, user_id: int):
                 target_group_arn = (
                     assignment.get("target_group_arn") or ""
                 ).strip() or None
-                rule_arn = (
-                    assignment.get("alb_rule_arn") or ""
-                ).strip() or None
+                rule_arn = (assignment.get("alb_rule_arn") or "").strip() or None
                 if target_group_arn or rule_arn:
                     try:
                         _teardown_alb_resources(user_id, rule_arn, target_group_arn)
@@ -1078,7 +1080,7 @@ def get_dynamic_max_capacity():
         # Production scenario - scale based on subscriber count
         max_capacity = min(total_premium_subscribers + EXTRA_CAPACITY, ABSOLUTE_MAX)
 
-    print("🏗️ Dynamic capacity calculation:")
+    print("Dynamic capacity calculation:")
     print(f"- Premium subscribers: {total_premium_subscribers}")
     print(f"- Extra capacity (buffer + standby): {EXTRA_CAPACITY}")
     print(f"- Current standby count: {standby_count}")
@@ -1778,6 +1780,52 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                         ),
                     }
 
+                # Verify instance liveness for active assignments
+                instance_id = assignment["instance_id"]
+                if (
+                    assignment["status"] == PremiumAssignment.ACTIVE
+                    and instance_id != PremiumAssignment.AUTOSCALING_POOL
+                ):
+                    try:
+                        ec2: "EC2Client" = boto3.client("ec2")
+                        resp = ec2.describe_instances(InstanceIds=[instance_id])
+                        reservations = resp.get("Reservations", [])
+                        if reservations and reservations[0].get("Instances"):
+                            ec2_state = reservations[0]["Instances"][0]["State"]["Name"]
+                        else:
+                            ec2_state = None
+                    except ClientError:
+                        ec2_state = None
+
+                    if ec2_state in (
+                        InstanceState.TERMINATED,
+                        InstanceState.SHUTTING_DOWN,
+                        None,
+                    ):
+                        print(
+                            f"Instance {instance_id} is "
+                            f"{ec2_state or 'not found'}  - removing "
+                            f"stale active assignment for user {user_id}"
+                        )
+                        try:
+                            remove_user_assignment(user_id)
+                        except Exception as cleanup_err:
+                            print(
+                                f"Warning: cleanup failed for user "
+                                f"{user_id}: {cleanup_err}"
+                            )
+                        return {
+                            "statusCode": 404,
+                            "body": json.dumps(
+                                {
+                                    "error": (
+                                        f"No premium assignment found "
+                                        f"for user {user_id}"
+                                    )
+                                }
+                            ),
+                        }
+
                 # Restore pending_release on status check (user refreshed)
                 if assignment["status"] == PremiumAssignment.PENDING_RELEASE:
                     try:
@@ -1794,7 +1842,7 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                             # Return 404 so frontend triggers a fresh assign
                             print(
                                 f"Stale assignment removed for user {user_id} "
-                                f"— returning 404 for fresh assignment"
+                                f" - returning 404 for fresh assignment"
                             )
                             return {
                                 "statusCode": 404,
@@ -2669,7 +2717,7 @@ def assign_premium_user(
                     if ec2_state == InstanceState.STOPPING:
                         print(
                             f"Assigned instance {existing_instance_id} is "
-                            f"stopping — waiting for stopped state"
+                            f"stopping  - waiting for stopped state"
                         )
                         stop_waiter = ec2.get_waiter("instance_stopped")
                         stop_waiter.wait(
@@ -2681,7 +2729,7 @@ def assign_premium_user(
                     if ec2_state == InstanceState.STOPPED:
                         print(
                             f"Assigned instance {existing_instance_id} is "
-                            f"stopped — restarting for user {user_id}"
+                            f"stopped  - restarting for user {user_id}"
                         )
                         ec2.start_instances(InstanceIds=[existing_instance_id])
                         waiter = ec2.get_waiter("instance_running")
@@ -2740,7 +2788,7 @@ def assign_premium_user(
                     ):
                         print(
                             f"Assigned instance {existing_instance_id} is "
-                            f"{ec2_state or 'gone'} — removing stale "
+                            f"{ec2_state or 'gone'}  - removing stale "
                             f"assignment for user {user_id}"
                         )
                         existing_assignment = None
@@ -2751,7 +2799,7 @@ def assign_premium_user(
                     if error_code == "InvalidInstanceID.NotFound":
                         print(
                             f"Instance {existing_instance_id} no longer "
-                            f"exists — removing stale assignment"
+                            f"exists  - removing stale assignment"
                         )
                         existing_assignment = None
                         remove_user_assignment(user_id)
@@ -2763,6 +2811,7 @@ def assign_premium_user(
                         f"{existing_instance_id}: {state_err}"
                     )
                     existing_assignment = None
+                    remove_user_assignment(user_id)
 
             # Trigger migration for autoscaling-pool or shared
             if existing_assignment and (
@@ -2790,7 +2839,7 @@ def assign_premium_user(
                         candidate_id, max_wait_seconds=10, retry_interval=5
                     ):
                         continue
-                    # Found a ready, empty dedicated instance — migrate now
+                    # Found a ready, empty dedicated instance - migrate now
                     print(
                         f"Inline migration: migrating user {user_id} "
                         f"from {existing_instance_id} to {candidate_id}"
@@ -2820,7 +2869,7 @@ def assign_premium_user(
                                 ),
                             }
 
-                # No inline migration possible — fall back to async
+                # No inline migration possible - fall back to async
                 print(
                     f"Inline migration not possible for user {user_id}, "
                     f"falling back to async migration"
@@ -2922,7 +2971,7 @@ def assign_premium_user(
         min_users = float("inf")
 
         print(
-            f"PRIORITY 1: Evaluating {len(running_instances)} running "
+            f"Evaluating {len(running_instances)} running "
             f"instances for immediate assignment"
         )
 
@@ -2971,7 +3020,7 @@ def assign_premium_user(
             else:
                 print(f"Instance {instance_id} has {user_count} users (not optimal)")
 
-        print(" PRIORITY 1 Results:")
+        print("Dedicated instance search results:")
         print(
             f"- Available dedicated: "
             f"{available_dedicated['instance_id'] if available_dedicated else 'None'}"  # noqa: E501
@@ -2989,11 +3038,11 @@ def assign_premium_user(
             instance_state = InstanceState.RUNNING
             assignment_source = "dedicated"
             print(
-                f"PRIORITY 1 SUCCESS: Using dedicated running instance "
+                f"Using dedicated running instance "
                 f"{instance_to_use['instance_id']} for user {user_id}"
             )
         else:
-            print(" PRIORITY 1 FAILED: No dedicated instances available")
+            print("No dedicated instances available")
 
         # PRIORITY 2: Share with least loaded instance
         if not instance_to_use and least_loaded_instance:
@@ -3002,7 +3051,7 @@ def assign_premium_user(
             instance_state = InstanceState.RUNNING
             assignment_source = "shared"
             print(
-                f"PRIORITY 2: Sharing instance {instance_to_use['instance_id']} "
+                f"Sharing instance {instance_to_use['instance_id']} "
                 f"for user {user_id} (least loaded with {min_users} users)"
             )
 
@@ -3012,7 +3061,7 @@ def assign_premium_user(
                 and len(running_instances) < active_users + 1
             ):
                 needs_scaling = True
-                print("→ Flagged for background scaling after assignment")
+                print("-> Flagged for background scaling after assignment")
 
         # 3. PRIORITY 3: Start standby instance (5-15 second assignment)
         # NOTE: Must run BEFORE autoscaling pool fallback, so that stopped
@@ -3020,7 +3069,7 @@ def assign_premium_user(
         # shared pool where migration may never complete.
         if not instance_to_use and standby_instances:
             print(
-                f"PRIORITY 3: No running instances available, "
+                f"No running instances available, "
                 f"starting standby instance ({standby_count} available)"
             )
 
@@ -3053,10 +3102,12 @@ def assign_premium_user(
         # PRIORITY 3.5: Temporary assignment to autoscaling pool for immediate login
         # Only used when no standby instances are available either
         if not instance_to_use:
-            no_premium_available = len(running_instances) == 0 or not available_dedicated
+            no_premium_available = (
+                len(running_instances) == 0 or not available_dedicated
+            )
             if no_premium_available:
                 print(
-                    "PRIORITY 3.5: No premium or standby instances ready "
+                    "No premium or standby instances ready "
                     "- using autoscaling pool for immediate login"
                 )
 
@@ -3067,9 +3118,9 @@ def assign_premium_user(
                 assignment_source = "autoscaling_temp"
                 needs_scaling = True  # Always trigger scaling for premium instance
 
-                print(f"→ User {user_id} will login via autoscaling pool")
-                print("→ Scaling premium instances in background")
-                print("→ User will be migrated to dedicated instance once ready")
+                print(f"-> User {user_id} will login via autoscaling pool")
+                print("-> Scaling premium instances in background")
+                print("-> User will be migrated to dedicated instance once ready")
 
         # 4. PRIORITY 4: Fallback to AWS stopped instances not in database
         if not instance_to_use:
@@ -3311,7 +3362,7 @@ def assign_premium_user(
             except ClientError as desc_err:
                 if "TargetGroupNotFound" not in str(desc_err):
                     raise
-                # No existing TG with this name — proceed normally
+                # No existing TG with this name - proceed normally
 
             # Normal path: create a dedicated target group for the premium instance
             target_group_response = elbv2.create_target_group(
@@ -3981,7 +4032,7 @@ def update_premium_service_desired_count():
         if running_premium_count != current_desired_count:
             print(
                 f"Updating ECS service desired count: {current_desired_count} "
-                f"→ {running_premium_count}"
+                f"-> {running_premium_count}"
             )
             ecs.update_service(
                 cluster=cluster_name,

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -673,12 +673,16 @@ def _restore_pending_release_transaction(connection, user_id: int):
             if ec2_state in (
                 InstanceState.TERMINATED,
                 InstanceState.SHUTTING_DOWN,
+                InstanceState.STOPPED,
+                InstanceState.STOPPING,
                 None,
             ):
-                # Instance is gone  - delete the stale DB record
+                # Instance is gone or not running — delete the stale DB
+                # record so the frontend triggers a fresh assignment which
+                # can restart the instance or pick a different one.
                 print(
                     f"Instance {instance_id} is {ec2_state or 'not found'} "
-                    f" - removing stale assignment for user {user_id}"
+                    f"— removing stale assignment for user {user_id}"
                 )
                 cursor.execute(
                     "DELETE FROM premium_user_assignments "
@@ -1800,11 +1804,13 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                     if ec2_state in (
                         InstanceState.TERMINATED,
                         InstanceState.SHUTTING_DOWN,
+                        InstanceState.STOPPED,
+                        InstanceState.STOPPING,
                         None,
                     ):
                         print(
                             f"Instance {instance_id} is "
-                            f"{ec2_state or 'not found'}  - removing "
+                            f"{ec2_state or 'not found'} — removing "
                             f"stale active assignment for user {user_id}"
                         )
                         try:

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1784,11 +1784,31 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                         ),
                     }
 
-                # Verify instance liveness for active assignments
+                # Autoscaling pool is a temporary fallback — return 404
+                # so the frontend calls /premium/assign which runs the
+                # full assignment logic and can find a dedicated instance.
                 instance_id = assignment["instance_id"]
+                if instance_id == PremiumAssignment.AUTOSCALING_POOL:
+                    print(
+                        f"User {user_id} is on autoscaling-pool "
+                        f"(temporary) — returning 404 to trigger "
+                        f"fresh assignment"
+                    )
+                    return {
+                        "statusCode": 404,
+                        "body": json.dumps(
+                            {
+                                "error": (
+                                    f"No premium assignment found "
+                                    f"for user {user_id}"
+                                )
+                            }
+                        ),
+                    }
+
+                # Verify instance liveness for active assignments
                 if (
                     assignment["status"] == PremiumAssignment.ACTIVE
-                    and instance_id != PremiumAssignment.AUTOSCALING_POOL
                 ):
                     try:
                         ec2: "EC2Client" = boto3.client("ec2")

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2897,10 +2897,10 @@ def assign_premium_user(
         # Fail fast if we can't verify assignment status
         print(f"Error: Failed to check existing assignment: {check_error}")
         return {
-            "statusCode": 503,
+            "statusCode": 500,
             "body": json.dumps(
                 {
-                    "error": "Service temporarily unavailable",
+                    "error": "Internal error",
                     "message": "Unable to verify assignment status. Please retry.",
                     "assigned": False,
                 }

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -633,7 +633,12 @@ def soft_release_user_assignment(user_id: int):
 def _restore_pending_release_transaction(connection, user_id: int):
     """Restore a pending_release assignment back to active.
 
-    Returns the restored assignment dict, or None if no pending_release exists.
+    Before restoring, verifies the assigned EC2 instance still exists and is
+    not terminated. If the instance is gone, deletes the stale assignment and
+    cleans up ALB resources so the caller can trigger a fresh assignment.
+
+    Returns the restored assignment dict, or None if no pending_release exists
+    (or if the assignment was stale and removed).
     """
     with connection.cursor() as cursor:
         cursor.execute(
@@ -648,6 +653,60 @@ def _restore_pending_release_transaction(connection, user_id: int):
 
         if not assignment:
             return None
+
+        instance_id = assignment["instance_id"]
+
+        # Autoscaling pool is a virtual marker, not a real EC2 instance
+        if instance_id != PremiumAssignment.AUTOSCALING_POOL:
+            try:
+                ec2: "EC2Client" = boto3.client("ec2")
+                resp = ec2.describe_instances(InstanceIds=[instance_id])
+                reservations = resp.get("Reservations", [])
+                if reservations and reservations[0].get("Instances"):
+                    ec2_state = reservations[0]["Instances"][0]["State"]["Name"]
+                else:
+                    ec2_state = None
+            except ClientError:
+                # Instance ID not recognised by AWS (already terminated/gone)
+                ec2_state = None
+
+            if ec2_state in (InstanceState.TERMINATED, InstanceState.SHUTTING_DOWN, None):
+                # Instance is gone — delete the stale DB record
+                print(
+                    f"Instance {instance_id} is {ec2_state or 'not found'} "
+                    f"— removing stale assignment for user {user_id}"
+                )
+                cursor.execute(
+                    "DELETE FROM premium_user_assignments "
+                    "WHERE user_id = %s AND status = %s",
+                    (user_id, PremiumAssignment.PENDING_RELEASE),
+                )
+                # Close usage log if open
+                cursor.execute(
+                    """UPDATE instance_usage_log SET ended_at = NOW()
+                       WHERE user_id = %s AND tier = 'premium'
+                       AND ended_at IS NULL""",
+                    (user_id,),
+                )
+                connection.commit()
+
+                # Best-effort ALB resource cleanup
+                target_group_arn = (
+                    assignment.get("target_group_arn") or ""
+                ).strip() or None
+                rule_arn = (
+                    assignment.get("alb_rule_arn") or ""
+                ).strip() or None
+                if target_group_arn or rule_arn:
+                    try:
+                        _teardown_alb_resources(user_id, rule_arn, target_group_arn)
+                    except Exception as alb_err:
+                        print(
+                            f"ALB cleanup warning for stale user {user_id}: "
+                            f"{alb_err}"
+                        )
+
+                return None
 
         cursor.execute(
             """UPDATE premium_user_assignments
@@ -1730,6 +1789,24 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                                 f"Restored pending_release on status check "
                                 f"for user {user_id}"
                             )
+                        else:
+                            # Stale assignment was removed (instance terminated)
+                            # Return 404 so frontend triggers a fresh assign
+                            print(
+                                f"Stale assignment removed for user {user_id} "
+                                f"— returning 404 for fresh assignment"
+                            )
+                            return {
+                                "statusCode": 404,
+                                "body": json.dumps(
+                                    {
+                                        "error": (
+                                            f"No premium assignment found "
+                                            f"for user {user_id}"
+                                        )
+                                    }
+                                ),
+                            }
                     except Exception as restore_err:
                         print(
                             f"Failed to restore pending_release: " f"{str(restore_err)}"
@@ -2937,28 +3014,15 @@ def assign_premium_user(
                 needs_scaling = True
                 print("→ Flagged for background scaling after assignment")
 
-        # PRIORITY 2.5: Temporary assignment to autoscaling pool for immediate login
-        no_premium_available = len(running_instances) == 0 or not available_dedicated
-        if not instance_to_use and no_premium_available:
-            print(
-                "PRIORITY 2.5: No premium instances ready "
-                "- using autoscaling pool for immediate login"
-            )
-
-            # Use special marker for autoscaling pool assignment
-            instance_to_use = {"instance_id": PremiumAssignment.AUTOSCALING_POOL}
-            is_shared = True  # This is a temporary shared assignment
-            instance_state = InstanceState.RUNNING
-            assignment_source = "autoscaling_temp"
-            needs_scaling = True  # Always trigger scaling for premium instance
-
-            print(f"→ User {user_id} will login via autoscaling pool")
-            print("→ Scaling premium instances in background")
-            print("→ User will be migrated to dedicated instance once ready")
-
         # 3. PRIORITY 3: Start standby instance (5-15 second assignment)
+        # NOTE: Must run BEFORE autoscaling pool fallback, so that stopped
+        # standby instances are started instead of sending users to the
+        # shared pool where migration may never complete.
         if not instance_to_use and standby_instances:
-            print("No dedicated instances available, starting standby instance")
+            print(
+                f"PRIORITY 3: No running instances available, "
+                f"starting standby instance ({standby_count} available)"
+            )
 
             # Use oldest standby instance
             standby_to_start = standby_instances[0]
@@ -2985,6 +3049,27 @@ def assign_premium_user(
                     f"Failed to start standby instance {standby_instance_id}, "
                     f"falling back to other options"
                 )
+
+        # PRIORITY 3.5: Temporary assignment to autoscaling pool for immediate login
+        # Only used when no standby instances are available either
+        if not instance_to_use:
+            no_premium_available = len(running_instances) == 0 or not available_dedicated
+            if no_premium_available:
+                print(
+                    "PRIORITY 3.5: No premium or standby instances ready "
+                    "- using autoscaling pool for immediate login"
+                )
+
+                # Use special marker for autoscaling pool assignment
+                instance_to_use = {"instance_id": PremiumAssignment.AUTOSCALING_POOL}
+                is_shared = True  # This is a temporary shared assignment
+                instance_state = InstanceState.RUNNING
+                assignment_source = "autoscaling_temp"
+                needs_scaling = True  # Always trigger scaling for premium instance
+
+                print(f"→ User {user_id} will login via autoscaling pool")
+                print("→ Scaling premium instances in background")
+                print("→ User will be migrated to dedicated instance once ready")
 
         # 4. PRIORITY 4: Fallback to AWS stopped instances not in database
         if not instance_to_use:
@@ -3207,9 +3292,30 @@ def assign_premium_user(
                 )
             print(f"Autoscaling target group: {target_group_arn}")
         else:
+            # Clean up any orphaned target group with the same name before
+            # creating a new one, to avoid reusing a stale ARN that a
+            # concurrent cleanup may be deleting.
+            tg_name = f"premium-{user_id}-tg"
+            try:
+                old_tgs = elbv2.describe_target_groups(Names=[tg_name])
+                for old_tg in old_tgs.get("TargetGroups", []):
+                    old_arn = old_tg["TargetGroupArn"]
+                    print(
+                        f"Cleaning up orphaned target group {tg_name} "
+                        f"({old_arn}) before creating new one"
+                    )
+                    try:
+                        elbv2.delete_target_group(TargetGroupArn=old_arn)
+                    except Exception as del_err:
+                        print(f"Warning: could not delete orphaned TG: {del_err}")
+            except ClientError as desc_err:
+                if "TargetGroupNotFound" not in str(desc_err):
+                    raise
+                # No existing TG with this name — proceed normally
+
             # Normal path: create a dedicated target group for the premium instance
             target_group_response = elbv2.create_target_group(
-                Name=f"premium-{user_id}-tg",
+                Name=tg_name,
                 Protocol="HTTP",
                 Port=8000,
                 VpcId=vpc_id,

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -121,7 +121,7 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
             }
         else:
             raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=result["message"],
             )
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2116,9 +2116,7 @@ class TestGetPremiumUserStatus:
             mock_pymysql.return_value = mock_connection
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {"Instances": [{"State": {"Name": "running"}}]}
-                ]
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
             }
             mock_boto3.return_value = mock_ec2
 
@@ -2172,9 +2170,7 @@ class TestGetPremiumUserStatus:
             mock_pymysql.return_value = mock_connection
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {"Instances": [{"State": {"Name": "running"}}]}
-                ]
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
             }
             mock_boto3.return_value = mock_ec2
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2098,7 +2098,7 @@ class TestGetPremiumUserStatus:
 
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "pymysql.connect"
-        ) as mock_pymysql:
+        ) as mock_pymysql, patch("boto3.client") as mock_boto3:
             mock_connection = setup_db_mock(
                 fetchone_values=[
                     MockRow(
@@ -2114,6 +2114,14 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            # Mock EC2 describe_instances to return running instance
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
+            }
+            mock_boto3.return_value = mock_ec2
 
             from premium_manager import get_premium_user_status
 
@@ -2147,7 +2155,7 @@ class TestGetPremiumUserStatus:
         """Returns assigned_at as null when the column value is None."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "pymysql.connect"
-        ) as mock_pymysql:
+        ) as mock_pymysql, patch("boto3.client") as mock_boto3:
             mock_connection = setup_db_mock(
                 fetchone_values=[
                     MockRow(
@@ -2163,6 +2171,14 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            # Mock EC2 describe_instances to return running instance
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
+            }
+            mock_boto3.return_value = mock_ec2
 
             from premium_manager import get_premium_user_status
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2098,7 +2098,7 @@ class TestGetPremiumUserStatus:
 
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "pymysql.connect"
-        ) as mock_pymysql:
+        ) as mock_pymysql, patch("boto3.client") as mock_boto3:
             mock_connection = setup_db_mock(
                 fetchone_values=[
                     MockRow(
@@ -2114,6 +2114,13 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
+            }
+            mock_boto3.return_value = mock_ec2
 
             from premium_manager import get_premium_user_status
 
@@ -2147,7 +2154,7 @@ class TestGetPremiumUserStatus:
         """Returns assigned_at as null when the column value is None."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "pymysql.connect"
-        ) as mock_pymysql:
+        ) as mock_pymysql, patch("boto3.client") as mock_boto3:
             mock_connection = setup_db_mock(
                 fetchone_values=[
                     MockRow(
@@ -2163,6 +2170,13 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
+            }
+            mock_boto3.return_value = mock_ec2
 
             from premium_manager import get_premium_user_status
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2114,9 +2114,12 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            # Mock EC2 describe_instances to return running instance
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
             }
             mock_boto3.return_value = mock_ec2
 
@@ -2168,9 +2171,12 @@ class TestGetPremiumUserStatus:
                 ],
             )
             mock_pymysql.return_value = mock_connection
+            # Mock EC2 describe_instances to return running instance
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}}]}
+                ]
             }
             mock_boto3.return_value = mock_ec2
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2117,9 +2117,7 @@ class TestGetPremiumUserStatus:
             # Mock EC2 describe_instances to return running instance
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {"Instances": [{"State": {"Name": "running"}}]}
-                ]
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
             }
             mock_boto3.return_value = mock_ec2
 
@@ -2174,9 +2172,7 @@ class TestGetPremiumUserStatus:
             # Mock EC2 describe_instances to return running instance
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {"Instances": [{"State": {"Name": "running"}}]}
-                ]
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
             }
             mock_boto3.return_value = mock_ec2
 


### PR DESCRIPTION
## Fix premium manager stale assignment bugs and reorder assignment priorities                  
                                                                                                  
  ### Summary                                                                                     
  - **Reorder assignment priorities**: Move autoscaling pool fallback (Tier 2.5 → 3.5) to run     
  after standby instance startup (Tier 3), preventing users from being stuck in the shared pool   
  when standby instances are available                      
  - **Fix stale assignment restore**: `_restore_pending_release_transaction` now verifies the EC2 
  instance is still alive before restoring a `pending_release` assignment — if the instance is    
  terminated, the stale DB record and ALB resources are cleaned up
  - **Fix stale status check loop**: `get_premium_user_status` now checks instance liveness for   
  active assignments — if the instance is terminated, the assignment is removed and 404 is        
  returned so the frontend triggers a fresh assignment
  - **Fix stale stopped instance handling**: Both `_restore_pending_release_transaction` and      
  `get_premium_user_status` detect stopped/stopping instances and clean up assignments, preventing
   users from being stuck on non-running instances
                                                                                                  
  ### Changes                                               
  | File | Description |
  |------|-------------|                                                                          
  | `infrastructure/terraform/premium_manager_package/premium_manager.py` | Reorder priority      
  2.5→3.5, add instance health check in restore and status check, handle stopped/stopping         
  instances |                                                                                     
  | `infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md` | Update assignment tier            
  documentation and diagrams to reflect new priority order |                                      
  | `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md` | Update function reference
  table with 5-tier priority description |                                                        
                                                            
  ### Problem                                                                                     
  Three related bugs were causing premium assignment failures in the dev environment:
                                                                                                  
  1. **Stale restore loop**: When an EC2 instance was terminated (e.g., by dev scheduler), the DB 
  assignment record persisted. On every status check, the Lambda restored it from `terminating` → 
  `active`, making the frontend believe the user was assigned to a dead instance. The user could  
  never get a fresh assignment.                             

  2. **Stopped instance restore**: Same issue as above but for stopped instances — the restore    
  logic did not detect stopped/stopping states, so users remained assigned to non-running
  instances.                                                                                      
                                                            
  3. **Autoscaling pool priority too high**: Tier 2.5 (autoscaling pool) ran before Tier 3        
  (standby instances), causing users to be assigned to the shared pool and potentially never
  migrated, even when stopped standby instances were available for quick startup.                                  
                                                                                                  
  ### Test plan                                             
  - [x] All 102 Lambda tests pass (`make test_lambda`)                                            
  - [x] Deploy to dev: `terraform apply -var-file=environments/development.tfvars`                
  - [x] Verify a premium user can log in and get assigned to a dedicated instance                 
  - [x] Verify that after instance termination, the next login triggers a clean reassignment (no  
  stale restore loop)                                                                             
  - [x] Verify that after instance stop, the next status check cleans up and triggers reassignment