### PR TITLE
Fix: Wait for SSM Agent before sending checkpoint cleanup command

### DIFF
--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -494,7 +494,8 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Effect = "Allow"
         Action = [
           "ssm:SendCommand",
-          "ssm:GetCommandInvocation"
+          "ssm:GetCommandInvocation",
+          "ssm:DescribeInstanceInformation"
         ]
         Resource = "*"
       },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1664,6 +1664,36 @@ def create_and_stop_standby_instance():
 ECS_CHECKPOINT_PATH = "/var/lib/ecs/data/agent.db"
 SSM_POLL_INTERVAL_SECONDS = 5
 SSM_POLL_MAX_WAIT_SECONDS = 30
+SSM_AGENT_WAIT_MAX_SECONDS = 120
+SSM_AGENT_WAIT_INTERVAL_SECONDS = 5
+
+
+def wait_for_ssm_agent(instance_id: str) -> bool:
+    """Wait until SSM agent is online for the given instance.
+
+    After an EC2 instance reaches 'running' state, the SSM agent may still
+    need additional time to boot and register with Systems Manager.
+    """
+    ssm = boto3.client("ssm")
+    elapsed = 0
+    while elapsed < SSM_AGENT_WAIT_MAX_SECONDS:
+        try:
+            resp = ssm.describe_instance_information(
+                Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+            )
+            info_list = resp.get("InstanceInformationList", [])
+            if info_list and info_list[0].get("PingStatus") == "Online":
+                print(f"SSM agent online for {instance_id}")
+                return True
+        except ClientError as e:
+            print(f"Error checking SSM agent status for {instance_id}: {e}")
+        time.sleep(SSM_AGENT_WAIT_INTERVAL_SECONDS)
+        elapsed += SSM_AGENT_WAIT_INTERVAL_SECONDS
+    print(
+        f"SSM agent not online for {instance_id}"
+        f" after {SSM_AGENT_WAIT_MAX_SECONDS}s"
+    )
+    return False
 
 
 def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
@@ -1672,6 +1702,9 @@ def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
     Non-fatal: returns False on failure so the caller can proceed
     (the readiness check will catch unregistered instances).
     """
+    if not wait_for_ssm_agent(instance_id):
+        return False
+
     ssm = boto3.client("ssm")
     command = f"rm -f {ECS_CHECKPOINT_PATH} && systemctl restart ecs"
     try:

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1509,6 +1509,9 @@ class TestClearEcsAgentCheckpoint:
         ) as mock_boto3, patch("premium_manager.time.sleep"):
             mock_ssm = MagicMock()
             mock_boto3.return_value = mock_ssm
+            mock_ssm.describe_instance_information.return_value = {
+                "InstanceInformationList": [{"PingStatus": "Online"}]
+            }
             mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-123"}}
             mock_ssm.get_command_invocation.return_value = {
                 "Status": "Success",
@@ -1531,6 +1534,9 @@ class TestClearEcsAgentCheckpoint:
         ) as mock_boto3, patch("premium_manager.time.sleep"):
             mock_ssm = MagicMock()
             mock_boto3.return_value = mock_ssm
+            mock_ssm.describe_instance_information.return_value = {
+                "InstanceInformationList": [{"PingStatus": "Online"}]
+            }
             mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-456"}}
             mock_ssm.get_command_invocation.return_value = {
                 "Status": "Failed",

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1555,9 +1555,12 @@ class TestClearEcsAgentCheckpoint:
 
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
-        ) as mock_boto3:
+        ) as mock_boto3, patch("premium_manager.time.sleep"):
             mock_ssm = MagicMock()
             mock_boto3.return_value = mock_ssm
+            mock_ssm.describe_instance_information.return_value = {
+                "InstanceInformationList": [{"PingStatus": "Online"}]
+            }
             mock_ssm.send_command.side_effect = ClientError(
                 {"Error": {"Code": "InvalidInstanceId"}},
                 "SendCommand",
@@ -1576,6 +1579,9 @@ class TestClearEcsAgentCheckpoint:
         ) as mock_boto3, patch("premium_manager.time.sleep"):
             mock_ssm = MagicMock()
             mock_boto3.return_value = mock_ssm
+            mock_ssm.describe_instance_information.return_value = {
+                "InstanceInformationList": [{"PingStatus": "Online"}]
+            }
             mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-789"}}
             mock_ssm.get_command_invocation.return_value = {
                 "Status": "InProgress",


### PR DESCRIPTION
## Summary

Added SSM Agent online readiness check before executing `SendCommand` in `clear_ecs_agent_checkpoint`. This resolves the intermittent `InvalidInstanceId` error that occurs when the SSM Agent has not yet registered after an EC2 instance reaches `running` state.

## Problem

When starting stopped EC2 instances, the `clear_ecs_agent_checkpoint` function sends an SSM `RunShellScript` command immediately after the EC2 `instance_running` waiter completes. However, the EC2 `running` state only indicates that the VM has started booting — it does **not** guarantee that the SSM Agent process has started and registered with AWS Systems Manager.

This race condition causes the following error:

```
SSM checkpoint cleanup failed for i-0ff6a5be7a0411ad8:
An error occurred (InvalidInstanceId) when calling the SendCommand operation:
Instances not in a valid state for account
```

### Why is this intermittent?

- SSM Agent startup time varies depending on OS boot speed, EBS volume warm-up, and AZ load.
- Instances that boot quickly enough for the SSM Agent to register before `SendCommand` is called do not trigger the error.

## Root Cause

```
EC2 start_instances
        │
        ▼
instance_running waiter ── EC2 API reports "running"
        │
        ▼
clear_ecs_agent_checkpoint
        │
        ▼
ssm.send_command  ──────── SSM Agent NOT YET online → InvalidInstanceId
```

The gap between EC2 `running` state and SSM Agent registration was not accounted for.

## Changes

### File: `infrastructure/terraform/premium_manager_package/premium_manager.py`

| Change | Description |
|--------|-------------|
| Added `SSM_AGENT_WAIT_MAX_SECONDS` constant | Maximum wait time (120s) for SSM Agent to come online |
| Added `SSM_AGENT_WAIT_INTERVAL_SECONDS` constant | Polling interval (5s) for SSM Agent status checks |
| Added `wait_for_ssm_agent()` function | Polls `ssm.describe_instance_information` until `PingStatus == "Online"` or timeout |
| Modified `clear_ecs_agent_checkpoint()` | Calls `wait_for_ssm_agent()` before `send_command`; returns `False` early if agent never comes online |

### Affected Call Sites

All three call sites of `clear_ecs_agent_checkpoint` are automatically covered by this fix:

1. `start_standby_instance()` — starting a single standby instance
2. Instance reuse path — reusing an existing stopped instance for a new user
3. Batch start path — starting multiple stopped instances to meet capacity demand (the path observed in the error log)

## Before / After

### Before

```python
def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
    ssm = boto3.client("ssm")
    command = f"rm -f {ECS_CHECKPOINT_PATH} && systemctl restart ecs"
    try:
        resp = ssm.send_command(...)  # May fail if SSM Agent not ready
```

### After

```python
def wait_for_ssm_agent(instance_id: str) -> bool:
    """Wait until SSM agent is online for the given instance."""
    ssm = boto3.client("ssm")
    elapsed = 0
    while elapsed < SSM_AGENT_WAIT_MAX_SECONDS:
        resp = ssm.describe_instance_information(
            Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
        )
        info_list = resp.get("InstanceInformationList", [])
        if info_list and info_list[0].get("PingStatus") == "Online":
            return True
        time.sleep(SSM_AGENT_WAIT_INTERVAL_SECONDS)
        elapsed += SSM_AGENT_WAIT_INTERVAL_SECONDS
    return False

def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
    if not wait_for_ssm_agent(instance_id):  # NEW: wait for agent
        return False
    ssm = boto3.client("ssm")
    command = f"rm -f {ECS_CHECKPOINT_PATH} && systemctl restart ecs"
    try:
        resp = ssm.send_command(...)  # Agent is confirmed online
```

## Risk Assessment

- **Low risk**: The function is already non-fatal by design (`returns False` on failure). Adding the wait only improves reliability.
- **Timeout consideration**: The maximum additional wait time is 120 seconds. This is acceptable because the Lambda timeout is long enough to accommodate instance startup flows, and the alternative (failing immediately) provides no benefit.
- **No behavioral change on success**: When the SSM Agent comes online quickly, the added latency is minimal (one API call returning immediately).

## Test Plan

- [x] Verify that stopped instances start and successfully clear ECS checkpoint without `InvalidInstanceId` errors
- [x] Verify that logs show `SSM agent online for <instance_id>` before the cleanup command is sent
- [x] Verify that if an SSM Agent never comes online (e.g., broken instance), the function times out gracefully and returns `False`
- [x] Run existing unit tests in `test_premium_manager.py` for `clear_ecs_agent_checkpoint`

### Manual test

- [x] 1. Initial assign (sign in) from a state where no premium instance exists
- [x] 2. Reassign from a state where a premium instance exists
- [x] 3. Reassign after manually forcibly stopping a premium instance
  -> It took longer than expected (over 30 minutes), but it seems that the premium instance assignment was ultimately successful.