### PR TITLE
Fix s3 permission for production

### DIFF
--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -486,7 +486,9 @@ resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
         ]
         Resource = [
           "arn:aws:s3:::${local.env_prefix}-*",
-          "arn:aws:s3:::${local.env_prefix}-*/*"
+          "arn:aws:s3:::${local.env_prefix}-*/*",
+          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*",
+          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*/*"
         ]
       },
       # S3: Explicitly deny CRUD on other environments' buckets

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -504,7 +504,9 @@ resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
         ]
         NotResource = [
           "arn:aws:s3:::${local.env_prefix}-*",
-          "arn:aws:s3:::${local.env_prefix}-*/*"
+          "arn:aws:s3:::${local.env_prefix}-*/*",
+          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*",
+          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*/*"
         ]
       },
       {


### PR DESCRIPTION
## Fix S3 permission for production per-user buckets
                                                                                                  
  ### Summary                                                                                     
  Add per-user S3 bucket prefix to the `DenyS3CrossEnvironment` IAM policy's `NotResource` list,
  allowing production to access `optinist-user-*` buckets.                                        
                                                            
  ### Problem                                                                                     
  Production users were getting `AccessDenied` errors when uploading experiment files to their
  per-user S3 buckets:                                                                            
                                                            
  An error occurred (AccessDenied) when calling the PutObject operation:                          
  User: arn:aws:iam::637423646530:user/subscr-optinist-cloud-user is not authorized
  to perform: s3:PutObject on resource: "arn:aws:s3:::optinist-user-74-cbd002c130/..."            
  with an explicit deny in an identity-based policy                                               
                                                                                                  
  The `DenyS3CrossEnvironment` policy denies access to any bucket not matching                    
  `subscr-optinist-*`. Production per-user buckets are named `optinist-user-<id>-<hash>`, which   
  doesn't match that pattern — so they were explicitly denied.
                                                                                                  
  ### Root Cause                                                                                  
  The IAM policy's `NotResource` only included `${local.env_prefix}-*` (`subscr-optinist-*`), but
  per-user buckets use a separate prefix (`optinist-user-*`) that wasn't listed as an exception.  
                                                            
  ### Fix                                                                                         
  Add `${var.s3_user_bucket_prefix}-*` to the `NotResource` list in the `DenyS3CrossEnvironment`
  policy.                                                                                         
                                                            
  ### Cross-Environment Safety                                                                    
  Each environment uses a different `s3_user_bucket_prefix`:
                                                                                                  
  | Environment | `s3_user_bucket_prefix` | User bucket pattern |                                 
  |---|---|---|                                                                                   
  | Production | `optinist-user` | `optinist-user-*` |                                            
  | Development | `development-optinist-user` | `development-optinist-user-*` |                   
                                                                                                  
  Since the prefix is environment-specific, development cannot access production's user buckets   
  and vice versa.