### PR TITLE
Event-driven cleanup when an EC2 instance terminate

### DIFF
--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -12,7 +12,9 @@ Does NOT:
 - Stop or start instances (premium_manager handles that)
 - Update ECS service count (premium_manager handles that)
 
-Triggered by CloudWatch Events hourly.
+Triggered by:
+- CloudWatch Events hourly (full 5-step cleanup)
+- EventBridge EC2 state-change events (single-instance reconcile on termination)
 Coordinates with premium_manager which handles all compute/capacity decisions.
 """
 
@@ -43,6 +45,44 @@ if TYPE_CHECKING:
     from mypy_boto3_ec2 import EC2Client
     from mypy_boto3_ecs import ECSClient
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
+
+
+def _cleanup_assignment_alb_resources(
+    elbv2: "ElasticLoadBalancingv2Client",
+    user_id: Any,
+    alb_rule_arn: str | None,
+    target_group_arn: str | None,
+) -> None:
+    """Delete ALB rule and target group for an assignment.
+
+    Skips standby markers and the shared autoscaling target group.
+    Errors are logged but not raised — callers proceed with DB cleanup.
+    """
+    # Delete ALB rule (skip standby markers)
+    if alb_rule_arn and alb_rule_arn.lower() != PremiumAssignment.STANDBY:
+        try:
+            elbv2.delete_rule(RuleArn=alb_rule_arn)
+            print(f"Deleted ALB rule for user {user_id}: {alb_rule_arn}")
+        except Exception as e:
+            print(f"Warning: Failed to delete ALB rule {alb_rule_arn}: {e}")
+
+    # Delete target group (skip standby markers and shared autoscaling TG)
+    autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
+    if (
+        target_group_arn
+        and target_group_arn.lower() != PremiumAssignment.STANDBY
+        and target_group_arn != autoscaling_tg_arn
+    ):
+        try:
+            elbv2.delete_target_group(TargetGroupArn=target_group_arn)
+            print(f"Deleted target group for user {user_id}: {target_group_arn}")
+        except Exception as e:
+            print(f"Warning: Failed to delete target group {target_group_arn}: {e}")
+    elif target_group_arn == autoscaling_tg_arn:
+        print(
+            f"Skipping deletion of shared autoscaling "
+            f"target group: {target_group_arn}"
+        )
 
 
 def get_required_env_var(var_name: str, default_value: str | None = None) -> str:
@@ -256,35 +296,9 @@ def cleanup_stale_assignments(connection) -> Dict[str, Any]:
 
                 try:
                     print(f"Cleaning stale assignment for user {user_id}")
-
-                    # Delete ALB rule and target group (skip marker values)
-                    if (
-                        alb_rule_arn
-                        and alb_rule_arn.lower() != PremiumAssignment.STANDBY
-                    ):
-                        try:
-                            elbv2.delete_rule(RuleArn=alb_rule_arn)
-                            print(f"Deleted ALB rule: {alb_rule_arn}")
-                        except Exception as e:
-                            print(f"Warning: Failed to delete ALB rule: {e}")
-
-                    # Skip deletion of shared autoscaling target group
-                    autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
-                    if (
-                        target_group_arn
-                        and target_group_arn.lower() != PremiumAssignment.STANDBY
-                        and target_group_arn != autoscaling_tg_arn
-                    ):
-                        try:
-                            elbv2.delete_target_group(TargetGroupArn=target_group_arn)
-                            print(f"Deleted target group: {target_group_arn}")
-                        except Exception as e:
-                            print(f"Warning: Failed to delete target group: {e}")
-                    elif target_group_arn == autoscaling_tg_arn:
-                        print(
-                            f"Skipping deletion of shared autoscaling "
-                            f"target group: {target_group_arn}"
-                        )
+                    _cleanup_assignment_alb_resources(
+                        elbv2, user_id, alb_rule_arn, target_group_arn
+                    )
 
                     # Close usage log before deleting assignment
                     cursor.execute(
@@ -891,38 +905,9 @@ def _reconcile_instance_states_transaction(
                 # Clean up ALB resources before DB deletion
                 target_group_arn = assignment.get("target_group_arn")
                 alb_rule_arn = assignment.get("alb_rule_arn")
-
-                # Delete ALB rule (skip standby markers)
-                if alb_rule_arn and alb_rule_arn.lower() != PremiumAssignment.STANDBY:
-                    try:
-                        elbv2.delete_rule(RuleArn=alb_rule_arn)
-                        print(f"Deleted ALB rule for user {user_id}: {alb_rule_arn}")
-                    except Exception as e:
-                        print(f"Warning: Failed to delete ALB rule {alb_rule_arn}: {e}")
-
-                # Delete target group (skip standby markers and shared autoscaling TG)
-                autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
-                if (
-                    target_group_arn
-                    and target_group_arn.lower() != PremiumAssignment.STANDBY
-                    and target_group_arn != autoscaling_tg_arn
-                ):
-                    try:
-                        elbv2.delete_target_group(TargetGroupArn=target_group_arn)
-                        print(
-                            f"Deleted target group for user "
-                            f"{user_id}: {target_group_arn}"
-                        )
-                    except Exception as e:
-                        print(
-                            f"Warning: Failed to delete target group "
-                            f"{target_group_arn}: {e}"
-                        )
-                elif target_group_arn == autoscaling_tg_arn:
-                    print(
-                        f"Skipping deletion of shared autoscaling "
-                        f"target group: {target_group_arn}"
-                    )
+                _cleanup_assignment_alb_resources(
+                    elbv2, user_id, alb_rule_arn, target_group_arn
+                )
 
                 cursor.execute(
                     "DELETE FROM premium_user_assignments WHERE id = %s",
@@ -951,6 +936,124 @@ def _reconcile_instance_states_transaction(
         "update_count": update_count,
         "total_aws_instances": len(aws_instance_map),
         "total_db_assignments": len(db_assignments),
+    }
+
+
+def reconcile_single_instance(instance_id: str) -> Dict[str, Any]:
+    """
+    Reconcile a single instance — triggered by EventBridge when an EC2
+    instance enters shutting-down or terminated state.
+
+    Fast-path complement to the full reconcile_instance_states() which
+    runs hourly. Only checks the specified instance.
+    """
+    try:
+        ec2: "EC2Client" = boto3.client("ec2")
+        try:
+            response = ec2.describe_instances(InstanceIds=[instance_id])
+            reservations = response.get("Reservations", [])
+            if reservations:
+                instance = reservations[0]["Instances"][0]
+                tags = {
+                    tag.get("Key"): tag.get("Value") for tag in instance.get("Tags", [])
+                }
+                name_match = (
+                    PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                    in tags.get("Name", "").lower()
+                )
+                tier_match = (
+                    tags.get("Tier", "").lower()
+                    == PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                )
+                type_match = (
+                    PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                    in tags.get("Type", "").lower()
+                )
+                if not (name_match or tier_match or type_match):
+                    print(
+                        f"Instance {instance_id} is not a "
+                        f"premium instance, skipping"
+                    )
+                    return {
+                        "skipped": True,
+                        "reason": "not_premium_instance",
+                    }
+        except Exception as e:
+            # Instance may be fully terminated and gone from API.
+            # Fall through to DB check — if it's in our DB, clean it.
+            print(
+                f"Could not describe instance {instance_id} "
+                f"(may be fully terminated, checking DB): {e}"
+            )
+
+        # Skip autoscaling-pool — it's a virtual marker, not a real instance
+        if instance_id == PremiumAssignment.AUTOSCALING_POOL:
+            print("Skipping autoscaling-pool marker (not a real instance)")
+            return {
+                "skipped": True,
+                "reason": "autoscaling_pool_marker",
+            }
+
+        return _reconcile_single_instance_transaction(instance_id)
+
+    except Exception as e:
+        print(f"Error in reconcile_single_instance " f"for {instance_id}: {e}")
+        return {"error": str(e), "instance_id": instance_id}
+
+
+@with_transaction
+def _reconcile_single_instance_transaction(
+    connection, instance_id: str
+) -> Dict[str, Any]:
+    """
+    Clean up DB records and ALB resources for a single
+    terminated instance. Transaction-safe via decorator.
+    """
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+    cleanup_count = 0
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """SELECT id, user_id, instance_id,
+                      target_group_arn, alb_rule_arn
+               FROM premium_user_assignments
+               WHERE instance_id = %s AND status = %s
+               FOR UPDATE""",
+            (instance_id, PremiumAssignment.ACTIVE),
+        )
+        assignments = cursor.fetchall()
+
+        if not assignments:
+            print(f"No active assignments for instance " f"{instance_id}")
+            return {
+                "cleanup_count": 0,
+                "instance_id": instance_id,
+            }
+
+        print(
+            f"Found {len(assignments)} assignments to clean "
+            f"up for terminated instance {instance_id}"
+        )
+
+        for assignment in assignments:
+            assignment_id = assignment["id"]
+            user_id = assignment["user_id"]
+            target_group_arn = assignment.get("target_group_arn")
+            alb_rule_arn = assignment.get("alb_rule_arn")
+
+            _cleanup_assignment_alb_resources(
+                elbv2, user_id, alb_rule_arn, target_group_arn
+            )
+
+            cursor.execute(
+                "DELETE FROM premium_user_assignments " "WHERE id = %s",
+                (assignment_id,),
+            )
+            cleanup_count += 1
+
+    return {
+        "cleanup_count": cleanup_count,
+        "instance_id": instance_id,
     }
 
 
@@ -1055,26 +1158,9 @@ def cleanup_test_user_assignments(connection, user_emails: List[str]) -> Dict[st
                 alb_rule_arn = assignment["alb_rule_arn"]
 
                 try:
-                    # Delete ALB rule and target group (skip standby markers)
-                    if (
-                        alb_rule_arn
-                        and alb_rule_arn.lower() != PremiumAssignment.STANDBY
-                    ):
-                        try:
-                            elbv2.delete_rule(RuleArn=alb_rule_arn)
-                            print(f"Deleted ALB rule for user {user_id}")
-                        except Exception as e:
-                            print(f"Warning: Failed to delete ALB rule: {e}")
-
-                    if (
-                        target_group_arn
-                        and target_group_arn.lower() != PremiumAssignment.STANDBY
-                    ):
-                        try:
-                            elbv2.delete_target_group(TargetGroupArn=target_group_arn)
-                            print(f"Deleted target group for user {user_id}")
-                        except Exception as e:
-                            print(f"Warning: Failed to delete target group: {e}")
+                    _cleanup_assignment_alb_resources(
+                        elbv2, user_id, alb_rule_arn, target_group_arn
+                    )
 
                     # Close usage log before deleting assignment
                     cursor.execute(
@@ -1325,6 +1411,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     - reconcile: Reconcile DB instance states with AWS reality
       Event: {"action": "reconcile"}
+
+    - reconcile_instance: Reconcile a single instance (EventBridge)
+      Event: {"action": "reconcile_instance",
+              "instance_id": "i-abc123",
+              "instance_state": "terminated",
+              "source": "ec2_state_change"}
     """
 
     print(f"Premium cleanup triggered by event: {json.dumps(event)}")
@@ -1401,6 +1493,26 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                         }
                     }
                 ),
+            }
+
+        elif action == "reconcile_instance":
+            instance_id = event.get("instance_id")
+            if not instance_id:
+                return {
+                    "statusCode": 400,
+                    "body": json.dumps(
+                        {"error": ("Missing required parameter:" " instance_id")}
+                    ),
+                }
+            source = event.get("source", "manual")
+            print(
+                f"Targeted instance reconciliation for "
+                f"{instance_id} (source: {source})"
+            )
+            result = reconcile_single_instance(instance_id)
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"result": result}),
             }
 
         elif action == "reconcile":

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -151,6 +151,57 @@ resource "aws_lambda_permission" "allow_cloudwatch_cleanup" {
   source_arn    = aws_cloudwatch_event_rule.premium_cleanup_schedule.arn
 }
 
+# ==========================================
+# EventBridge: EC2 State Change → Cleanup
+# ==========================================
+
+# Trigger cleanup Lambda when any EC2 instance enters shutting-down or
+# terminated state. EventBridge EC2 state-change events do not include
+# tags, so the Lambda checks premium tags and exits early for non-premium
+# instances. Manager-initiated terminations already clean up inline, so
+# those invocations are no-ops.
+
+resource "aws_cloudwatch_event_rule" "premium_ec2_state_change" {
+  name        = "${var.environment}-premium-ec2-state-change"
+  description = "Trigger cleanup on EC2 instance termination"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance State-change Notification"]
+    detail = {
+      state = ["shutting-down", "terminated"]
+    }
+  })
+
+  tags = {
+    Name    = "Premium EC2 State Change"
+    Type    = "Premium-CloudWatch"
+    Service = "premium-tier"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "premium_ec2_state_change_target" {
+  rule      = aws_cloudwatch_event_rule.premium_ec2_state_change.name
+  target_id = "PremiumEC2StateChangeCleanup"
+  arn       = aws_lambda_function.premium_cleanup.arn
+
+  input_transformer {
+    input_paths = {
+      instance_id = "$.detail.instance-id"
+      state       = "$.detail.state"
+    }
+    input_template = "{\"action\":\"reconcile_instance\",\"instance_id\":<instance_id>,\"instance_state\":<state>,\"source\":\"ec2_state_change\"}"
+  }
+}
+
+resource "aws_lambda_permission" "allow_eventbridge_ec2_state_change" {
+  statement_id  = "AllowExecutionFromEC2StateChange"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.premium_cleanup.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.premium_ec2_state_change.arn
+}
+
 # Create ZIP file for premium manager Lambda with dependencies
 # Install dependencies first
 resource "null_resource" "install_dependencies" {

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -609,3 +609,383 @@ class TestReconcileInstanceStates:
             result = reconcile_instance_states()
             assert result["cleanup_count"] == 0
             assert result["update_count"] == 0
+
+
+class TestReconcileSingleInstance:
+    """Tests for EventBridge-triggered single-instance reconcile."""
+
+    def test_cleans_up_premium_instance(self, mock_env_vars_premium):
+        """Terminated premium instance with active assignments
+        gets ALB and DB cleaned up."""
+        instance_id = "i-terminated123"
+        tg_arn = "arn:aws:elasticloadbalancing:tg/premium-user"
+        rule_arn = "arn:aws:elasticloadbalancing:rule/premium-user"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": instance_id,
+                                "State": {"Name": "terminated"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 1,
+                                "user_id": 100,
+                                "instance_id": instance_id,
+                                "target_group_arn": tg_arn,
+                                "alb_rule_arn": rule_arn,
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["cleanup_count"] == 1
+            assert result["instance_id"] == instance_id
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
+            mock_elbv2.delete_target_group.assert_called_once_with(
+                TargetGroupArn=tg_arn
+            )
+
+    def test_skips_non_premium_instance(self, mock_env_vars_premium):
+        """Non-premium instance returns skipped."""
+        instance_id = "i-notpremium456"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.side_effect = (
+                lambda service: mock_ec2 if service == "ec2" else MagicMock()
+            )
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": instance_id,
+                                "State": {"Name": "terminated"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "web-server-1",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["skipped"] is True
+            assert result["reason"] == "not_premium_instance"
+
+    def test_idempotent_no_assignments(self, mock_env_vars_premium):
+        """Instance with no DB assignments returns cleanup_count 0."""
+        instance_id = "i-alreadyclean789"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": instance_id,
+                                "State": {"Name": "terminated"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[[]],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["cleanup_count"] == 0
+            assert result["instance_id"] == instance_id
+
+    def test_handler_missing_instance_id(self, mock_env_vars_premium):
+        """Handler returns 400 when instance_id is missing."""
+        event = {
+            "action": "reconcile_instance",
+            "source": "ec2_state_change",
+        }
+        mock_context = MagicMock()
+        mock_context.function_name = "test-premium-cleanup"
+
+        with patch.dict("os.environ", mock_env_vars_premium):
+            from premium_cleanup import handler
+
+            result = handler(event, mock_context)
+            assert result["statusCode"] == 400
+
+    def test_describe_instances_failure_falls_through_to_db(
+        self, mock_env_vars_premium
+    ):
+        """When describe_instances fails (instance gone), still checks
+        DB and cleans up if assignment exists."""
+        instance_id = "i-fullygone999"
+        tg_arn = "arn:aws:elasticloadbalancing:tg/premium-gone"
+        rule_arn = "arn:aws:elasticloadbalancing:rule/premium-gone"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            # Simulate instance fully gone from AWS API
+            mock_ec2.describe_instances.side_effect = Exception(
+                "InvalidInstanceID.NotFound"
+            )
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 5,
+                                "user_id": 200,
+                                "instance_id": instance_id,
+                                "target_group_arn": tg_arn,
+                                "alb_rule_arn": rule_arn,
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["cleanup_count"] == 1
+            assert result["instance_id"] == instance_id
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
+            mock_elbv2.delete_target_group.assert_called_once_with(
+                TargetGroupArn=tg_arn
+            )
+
+    def test_skips_autoscaling_pool_marker(self, mock_env_vars_premium):
+        """Autoscaling-pool virtual marker is skipped."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.side_effect = (
+                lambda service: mock_ec2 if service == "ec2" else MagicMock()
+            )
+
+            # describe_instances will fail for non-real instance ID
+            mock_ec2.describe_instances.side_effect = Exception(
+                "InvalidInstanceID.Malformed"
+            )
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(PremiumAssignment.AUTOSCALING_POOL)
+            assert result["skipped"] is True
+            assert result["reason"] == "autoscaling_pool_marker"
+
+    def test_skips_standby_alb_resources(self, mock_env_vars_premium):
+        """Standby ALB markers are not deleted."""
+        instance_id = "i-standbytest123"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": instance_id,
+                                "State": {"Name": "terminated"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 10,
+                                "user_id": 300,
+                                "instance_id": instance_id,
+                                "target_group_arn": "standby",
+                                "alb_rule_arn": "standby",
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["cleanup_count"] == 1
+            # Standby markers should NOT trigger ALB API calls
+            mock_elbv2.delete_rule.assert_not_called()
+            mock_elbv2.delete_target_group.assert_not_called()
+
+    def test_skips_shared_autoscaling_target_group(self, mock_env_vars_premium):
+        """Shared autoscaling target group is not deleted."""
+        instance_id = "i-sharedtg123"
+        shared_tg_arn = "arn:aws:elasticloadbalancing:tg/autoscaling-shared"
+        rule_arn = "arn:aws:elasticloadbalancing:rule/user-rule"
+
+        env_with_tg = {
+            **mock_env_vars_premium,
+            "AUTOSCALING_TARGET_GROUP_ARN": shared_tg_arn,
+        }
+
+        with patch.dict("os.environ", env_with_tg), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("pymysql.connect") as mock_pymysql:
+            mock_ec2 = MagicMock()
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ec2":
+                    return mock_ec2
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": instance_id,
+                                "State": {"Name": "terminated"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": "premium",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "id": 11,
+                                "user_id": 400,
+                                "instance_id": instance_id,
+                                "target_group_arn": shared_tg_arn,
+                                "alb_rule_arn": rule_arn,
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import reconcile_single_instance
+
+            result = reconcile_single_instance(instance_id)
+            assert result["cleanup_count"] == 1
+            # ALB rule should be deleted, but shared TG should NOT
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
+            mock_elbv2.delete_target_group.assert_not_called()


### PR DESCRIPTION
### Content

#### Summary
- Add event-driven cleanup that fires immediately when an EC2 instance terminates, complementing the existing hourly full reconciliation.
- An EventBridge rule captures EC2 `shutting-down` and `terminated` state-change events and invokes the cleanup Lambda with the affected instance ID.
- The Lambda checks premium tags, cleans up ALB resources and DB assignments for the terminated instance, and exits early for non-premium instances.
- Extract duplicated ALB cleanup logic (rule + target group deletion with standby/autoscaling guards) into a shared `_cleanup_assignment_alb_resources` helper, consolidating 4 call sites and fixing a latent bug where `cleanup_test_user_assignments` was missing the shared autoscaling target group guard.

#### Design Decisions
- **EventBridge rule matches all EC2 terminations** -- EC2 state-change events do not support tag-based filtering. The Lambda performs a `describe_instances` tag check and exits early for non-premium instances. This also future-proofs for ASG/sticky session routing cleanup.
- **Both `shutting-down` and `terminated` states** -- `shutting-down` can get stuck in rare cases (EBS detach issues, instance store-backed instances). Catching both ensures cleanup is attempted even if the instance never reaches `terminated`. The second invocation is a safe no-op due to `FOR UPDATE` row locking and idempotent deletes.
- **`FOR UPDATE` in single-instance query** -- Unlike the bulk reconcile, the single-instance path can receive concurrent invocations (shutting-down + terminated events, or simultaneous with manager-initiated cleanup). Row-level locking prevents double-cleanup races.
- **Fall-through on `describe_instances` failure** -- If the instance is fully gone from the AWS API, the code falls through to the DB check. If the instance has no DB assignments, it's a no-op. This avoids missing cleanup for instances that disappear between the event and the Lambda invocation.
- **Inline `input_template` instead of heredoc** -- The Terraform `input_template` uses an inline string rather than `<<-EOF` to avoid trailing newline issues in the rendered JSON payload.

### Evidence
- `make test_lambda` -- all 110 tests pass (8 new tests for single-instance reconcile)

### References
- Complements the existing hourly CloudWatch-triggered full reconciliation
- EventBridge EC2 state-change event documentation: AWS EC2 User Guide

#### Files changed

#### Infrastructure
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` -- Add `_cleanup_assignment_alb_resources` shared helper; add `reconcile_single_instance` and `_reconcile_single_instance_transaction` for event-driven cleanup; add `reconcile_instance` action to handler; refactor 4 call sites to use shared helper
- `infrastructure/terraform/premium_manager.tf` -- Add EventBridge rule for EC2 state-change events, input transformer to reshape events, and Lambda permission for EventBridge invocation

#### Tests
- `studio/tests/infrastructure/test_premium_cleanup.py` -- Add 8 tests: premium instance cleanup, non-premium skip, idempotent no-assignments, missing instance_id validation, describe_instances failure fall-through, autoscaling-pool skip, standby ALB marker skip, shared autoscaling target group skip

### Manual Testcases
1. Deploy the updated Terraform -- expect: new EventBridge rule `${environment}-premium-ec2-state-change` appears in CloudWatch Events
2. Terminate a premium EC2 instance -- expect: Lambda invoked within seconds, CloudWatch logs show assignment cleanup with correct ALB resource deletion
3. Terminate a non-premium EC2 instance -- expect: Lambda invoked, logs show "not a premium instance, skipping", no DB or ALB changes
4. Terminate a premium instance that the manager already cleaned up -- expect: Lambda invoked, logs show "No active assignments for instance", cleanup_count 0 (idempotent)
5. Invoke Lambda manually with `{"action": "reconcile_instance"}` (no instance_id) -- expect: 400 response with error message
6. Run `make test_lambda` -- all 110 tests pass

### Unit, Integration, Contract Test Coverage
- 8 new tests in `TestReconcileSingleInstance` covering all code paths: happy path, non-premium skip, idempotency, handler validation, API failure fall-through, autoscaling-pool guard, standby marker guard, shared target group guard

### Others

#### Difficulties
- EventBridge EC2 state-change events do not include instance tags, requiring a `describe_instances` call inside the Lambda. For fully terminated instances where the API call fails, the code falls through to a DB-only check, which is safe but adds a code path that needed explicit testing.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| EventBridge rule scope | Low | Fires for all EC2 terminations in the account; non-premium invocations exit early after one API call. Cost is negligible (~200ms Lambda invocation per non-premium termination). |
| ALB helper extraction | Low | Pure refactor of 4 call sites into shared function. Same logic, same guards. Fixes a latent bug in `cleanup_test_user_assignments` (missing autoscaling TG guard). |
| Concurrent invocations | Low | `FOR UPDATE` row lock prevents double-cleanup. Manager-initiated terminations that already cleaned up inline result in a no-op (empty fetchall). |
| `describe_instances` fall-through | Medium | If API fails for a non-premium instance that somehow has a matching DB row, the row would be cleaned up. Extremely unlikely (instance IDs are unique) but the path is permissive by design. |
