### PR TITLE
Increase active users before scale up

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3546,14 +3546,8 @@ def assign_premium_user(
                 )
                 connection.commit()
 
-        # Trigger scaling before DB write so failures don't block retries
-        if needs_scaling:
-            print("Triggering scaling for shared assignment...")
-            scale_premium_instances_if_needed()
-            print("Triggering async migration for autoscaling-pool user...")
-            invoke_migration_async()
-
-        # Store assignment last - orphaned AWS resources cleaned up hourly
+        # Store assignment before scaling so that active_users count
+        # then scale_premium_instances_if_needed
         store_user_assignment(
             user_id,
             instance_id,
@@ -3563,6 +3557,12 @@ def assign_premium_user(
             is_shared,
         )
         assignment_stored = True
+
+        if needs_scaling:
+            print("Triggering scaling for shared assignment...")
+            scale_premium_instances_if_needed()
+            print("Triggering async migration for autoscaling-pool user...")
+            invoke_migration_async()
 
         # Initialize activity tracking for the new assignment
         try:


### PR DESCRIPTION
### Content

#### Summary
- Fix a deadlock where premium users could never get assigned a dedicated instance when zero premium EC2 instances exist.
- The root cause: `scale_premium_instances_if_needed()` was called **before** `store_user_assignment()`, so `count_active_premium_users()` always returned 0 at scaling decision time. The check `running_count (0) >= active_users (0)` evaluated to True and returned early -- never reaching the instance creation code.
- The fix moves `store_user_assignment()` before the scaling call, so the active user count reflects the requesting user's demand when the scaling decision is made.

#### Design Decisions
- **Store assignment before scaling, not after** -- The previous ordering (`scale -> store`) was intentional ("failures don't block retries"), but it created a chicken-and-egg problem: no instance can be created without active users, and no user can become active without an instance. Storing first means a failed scaling attempt leaves an autoscaling-pool assignment in the DB, but this is already handled -- the existing assignment flow detects stale assignments and cleans them up on retry.
- **No subscriber-based cold-start guard** -- An alternative was to check `total_subscribers > 0` when `total_instances == 0` and force-create an instance. This was rejected because it would trigger instance creation even when nobody is logged in, creating a spin-up/tear-down loop between the monitoring scale-down and the cold-start guard.
- **No changes to `handle_scheduled_monitoring()`** -- The monitoring function only scales down. Adding a scale-up safety net was considered but rejected for the same spin-up/tear-down loop reason. The fix in the assignment path is sufficient because scaling only needs to happen when a user actively requests assignment.

### Evidence

CloudWatch logs from **2026-03-31** across three log groups confirm the deadlock in production:

**`/aws/lambda/subscr-premium-manager`** (00:11 UTC) -- Lambda finds zero premium instances despite 6 subscribers:
> `[00:11:27] Total premium subscribers (from subscription tables): 6`
> `[00:11:29] - Premium instances matched: 0`
> `[00:11:29] - Premium instance IDs: []`
> `[00:11:29] Monitoring: 0 active users, 6 total users, 0 running instances, 0 idle instances`
> `[00:11:32] ECS Service Status: desired=0, running=0`

All 7 EC2 instances evaluated had no premium tags:
> `[00:11:29] Instance i-0dfb5009146b8cbb1 tag analysis:`
> `[00:11:29] - Name: 'subscr-optinist-background' -> name_match: False`
> `[00:11:29] - Tier: 'background' -> tier_match: False`
> `[00:11:29] - Type: 'Background-Instance' -> type_match: False`

**`/ecs/subscr-optinist-cloud-taskdef`** (16:15-17:03 UTC) -- Premium users falling through to standard instance, then timing out on assignment:
> `[16:15:36] [FRONTEND] [WARN] user=kdcnvDXNpjNouTbcJd9lBxbuvNj1 url=https://www.araya-optinist.com/dataview: Conditions not met for auto-assignment: {"isPremiumUser":false,"hasCurrentUser":true}`

> `[17:02:13] Assignment timeout for user 73, attempt 1/3, retrying in 2s`
> `[17:03:15] Assignment timeout for user 73, attempt 2/3, retrying in 4s`

**`/ecs/subscr-premium-optinist-cloud-taskdef`** (15:09-17:47 UTC) -- A premium instance eventually appeared (likely manually launched) with 4 container restarts in 2.5 hours, one with Secrets Manager warnings:
> `[17:06:08] WARNING: Could not fetch Firebase config from Secrets Manager. Using defaults.`
> `[17:47:21] Assigning premium user 71 (uid: 7OHAeQebrKccbIRjOFzJBapefz03) to dedicated instance`
> `[17:47:38] Successfully assigned premium user 71 to instance i-0d316b36229cc0369`

### References
- Parent branch: `patch/premium_manager_tag` (premium manager tag-matching fixes)
- Related: version 1.1.0 premium instance assignment failures reported by users

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Move `store_user_assignment()` before `scale_premium_instances_if_needed()` call in `assign_premium_user()` so active user count is accurate at scaling decision time

### Manual Testcases
1. With zero premium instances running, log in as a premium user -- expect: user is temporarily assigned to autoscaling pool, `scale_premium_instances_if_needed()` sees `active_users=1 > running_count=0`, creates a new premium instance
2. With one premium instance already running, log in as a second premium user -- expect: normal assignment flow unchanged (assigned to existing instance or triggers scale-up as before)
3. With zero premium instances and no premium subscribers, trigger monitoring -- expect: no instance creation (no spin-up/tear-down loop)
4. If `store_user_assignment()` succeeds but scaling fails -- expect: user gets autoscaling-pool assignment, next login attempt detects existing assignment and retries migration

### Unit, Integration, Contract Test Coverage
- No existing test suite covers the premium manager Lambda functions

### Others

#### Difficulties
- The original ordering was intentional (comment: "Trigger scaling before DB write so failures don't block retries"). The trade-off is that a failed scaling attempt now leaves a stale autoscaling-pool assignment, but this is already handled by the existing assignment flow which checks for and cleans up stale assignments on retry.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Assignment ordering | Low | Only affects the autoscaling-pool fallback path (Priority 3.5). All other assignment priorities (dedicated, shared, standby, stopped) are unaffected -- they don't set `needs_scaling`. |
| Stale assignment on scaling failure | Low | Existing code at lines 2757-2866 already handles stale/orphaned assignments: checks instance state, removes assignments for terminated/missing instances, and retries. |
| Scaling decision accuracy | Low | `active_users` now includes the requesting user, making the count accurate rather than stale-by-one. This is strictly more correct than the previous behavior. |
