### PR TITLE
Display platform information in Log viewer

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/service.ts
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/service.ts
@@ -20,6 +20,11 @@ export type TParams<T = unknown> = {
 
 export type TParamQueryLogs = TParams & { reverse?: boolean; offset: number }
 
+export type TPlatformInfo = {
+  service_name: string
+  task_id: string
+}
+
 export const fetchAvailableLogLevels = async (): Promise<TLevelsLog[]> => {
   const { data } = await axios.get("/logs/level")
   return (data.levels as string[]).map(
@@ -36,5 +41,6 @@ export const serviceLogs = async (params: TParamQueryLogs) => {
     data: data.data.map((e: string) => ({ text: e, id: uuidv4() })),
     params: config.params,
     offset: { next: data.next_offset, pre: data.prev_offset },
+    platform: data.platform as TPlatformInfo | undefined,
   }
 }

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
@@ -4,6 +4,7 @@ import {
   serviceLogs,
   TLevelsLog,
   TParams,
+  TPlatformInfo,
 } from "components/Workspace/FlowChart/ModalLogs/helpers/service"
 
 export type TLogs = { text: string; id: string }
@@ -16,6 +17,7 @@ export const useLogs = (
   isRealtime: boolean,
 ) => {
   const [logs, setLogs] = useState<TLogs[]>([])
+  const [platform, setPlatform] = useState<TPlatformInfo | undefined>()
   const [isError, setIsError] = useState(false)
   const timeout = useRef<NodeJS.Timeout>()
   const paginate = useRef({ next: -1, pre: -1 })
@@ -43,8 +45,12 @@ export const useLogs = (
   const getPrevLogsApi = useCallback(
     async (_params: TParams<{ offset: number }>) => {
       _params.levels = levelsRef.current
-      const { data, offset } = await serviceLogs({ ..._params, reverse: true })
+      const { data, offset, platform } = await serviceLogs({
+        ..._params,
+        reverse: true,
+      })
       paginate.current.pre = offset.pre
+      if (platform) setPlatform(platform)
       return data
     },
     [],
@@ -54,8 +60,12 @@ export const useLogs = (
     async (_params: TParams<{ offset: number }>) => {
       _params.levels = levelsRef.current
       const { pre } = paginate.current
-      const { data, offset } = await serviceLogs({ ..._params, reverse: false })
+      const { data, offset, platform } = await serviceLogs({
+        ..._params,
+        reverse: false,
+      })
       paginate.current.next = offset.next
+      if (platform) setPlatform(platform)
       if (!data.length && pre === -1) {
         const dataPre = await getPrevLogsApi({ ..._params, offset: offset.pre })
         return dataPre
@@ -118,5 +128,5 @@ export const useLogs = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onNextSearchApi])
 
-  return { onPrevSearchApi, onNextSearchApi, logs, isError, reset }
+  return { onPrevSearchApi, onNextSearchApi, logs, isError, reset, platform }
 }

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
@@ -57,11 +57,8 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
       .catch(() => setAvailableLevels(Object.values(TLevelsLog)))
   }, [isOpen])
 
-  const { logs, onPrevSearchApi, onNextSearchApi, isError, reset } = useLogs(
-    levels,
-    keyword,
-    !visibleScrollEnd,
-  )
+  const { logs, onPrevSearchApi, onNextSearchApi, isError, reset, platform } =
+    useLogs(levels, keyword, !visibleScrollEnd)
   const logsRef = useRef(logs)
   const scrollLogs = useRef<HTMLDivElement>(null)
   const modalContent = useRef<HTMLDivElement>(null)
@@ -358,6 +355,12 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
             <KeyboardDoubleArrowDownIcon />
           </BoxScrollDown>
         ) : null}
+        {platform ? (
+          <PlatformInfoBox>
+            <span>Platform service name: {platform.service_name}</span>
+            <span>task id: {platform.task_id}</span>
+          </PlatformInfoBox>
+        ) : null}
       </Content>
     </Modal>
   )
@@ -512,6 +515,24 @@ const BoxScrollDown = styled(Box)`
   height: 30px;
   animation: ${rotate} 2s linear infinite;
   cursor: pointer;
+`
+
+const PlatformInfoBox = styled(Box)`
+  position: absolute;
+  bottom: 12px;
+  right: 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  background-color: rgba(92, 92, 92, 0.8);
+  border-radius: 4px;
+  padding: 4px 10px;
+  color: rgba(255, 255, 255);
+  font-size: 12px;
+  line-height: 1;
+  user-select: text;
+  cursor: text;
 `
 
 export default ModalLogs

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 import yaml
 
-from studio.app.common.core.platform_metadata import ECS_TASK_ID
 from studio.app.common.core.mode import MODE
+from studio.app.common.core.platform_metadata import ECS_TASK_ID
 from studio.app.common.core.utils.datetime_utils import get_current_datetime_formatted
 from studio.app.dir_path import DIRPATH
 

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -1,16 +1,15 @@
 import hashlib
-import json
 import logging
 import logging.config
 import os
 import platform
 import traceback
-import urllib.request
 from contextvars import ContextVar
 from typing import Optional
 
 import yaml
 
+from studio.app.common.core.platform_metadata import ECS_TASK_ID
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.datetime_utils import get_current_datetime_formatted
 from studio.app.dir_path import DIRPATH
@@ -22,48 +21,7 @@ _client_id_context: ContextVar[Optional[str]] = ContextVar(
     LOGGING_CLIENT_ID_KEY, default=None
 )
 
-NO_ECS_TASK_DEFAULT = "local"
-NO_ECS_SERVICE_DEFAULT = "none"
-_ECS_METADATA_TIMEOUT = 2
 VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
-
-
-def _get_ecs_task_id() -> str:
-    """Fetch the short ECS task ID from the container metadata
-    endpoint (v4). Returns a default value outside ECS."""
-    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
-    if not meta_uri:
-        return NO_ECS_TASK_DEFAULT
-    try:
-        req = urllib.request.Request(f"{meta_uri}/task")
-        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
-            data = json.loads(resp.read())
-        # TaskARN: arn:aws:ecs:region:account:task/cluster/id
-        task_arn = data.get("TaskARN", "")
-        return task_arn.rsplit("/", 1)[-1] if "/" in task_arn else NO_ECS_TASK_DEFAULT
-    except Exception:
-        return NO_ECS_TASK_DEFAULT
-
-
-def _get_ecs_service_name() -> str:
-    """Fetch the ECS service name from the container metadata
-    endpoint (v4). Returns a default value if not available."""
-    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
-    if not meta_uri:
-        return NO_ECS_SERVICE_DEFAULT
-    try:
-        req = urllib.request.Request(f"{meta_uri}/task")
-        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
-            data = json.loads(resp.read())
-        # ServiceName is only available for tasks started by a service
-        service_name = data.get("ServiceName", "")
-        return service_name if service_name else NO_ECS_SERVICE_DEFAULT
-    except Exception:
-        return NO_ECS_SERVICE_DEFAULT
-
-
-ECS_TASK_ID: str = _get_ecs_task_id()
-ECS_SERVICE_NAME: str = _get_ecs_service_name()
 
 
 class LoggingConfigHelper:

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -23,6 +23,7 @@ _client_id_context: ContextVar[Optional[str]] = ContextVar(
 )
 
 NO_ECS_TASK_DEFAULT = "local"
+NO_ECS_SERVICE_DEFAULT = "none"
 _ECS_METADATA_TIMEOUT = 2
 VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
 
@@ -44,7 +45,25 @@ def _get_ecs_task_id() -> str:
         return NO_ECS_TASK_DEFAULT
 
 
+def _get_ecs_service_name() -> str:
+    """Fetch the ECS service name from the container metadata
+    endpoint (v4). Returns a default value if not available."""
+    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+    if not meta_uri:
+        return NO_ECS_SERVICE_DEFAULT
+    try:
+        req = urllib.request.Request(f"{meta_uri}/task")
+        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        # ServiceName is only available for tasks started by a service
+        service_name = data.get("ServiceName", "")
+        return service_name if service_name else NO_ECS_SERVICE_DEFAULT
+    except Exception:
+        return NO_ECS_SERVICE_DEFAULT
+
+
 ECS_TASK_ID: str = _get_ecs_task_id()
+ECS_SERVICE_NAME: str = _get_ecs_service_name()
 
 
 class LoggingConfigHelper:

--- a/studio/app/common/core/platform_metadata.py
+++ b/studio/app/common/core/platform_metadata.py
@@ -1,0 +1,55 @@
+"""Platform / infrastructure metadata retrieved from the ECS container
+metadata endpoint (v4).
+
+The public module-level constants ``ECS_TASK_ID`` and ``ECS_SERVICE_NAME``
+are resolved once at process startup and may be imported by any module
+that needs to identify the running platform context (logging, API
+responses, etc.).
+"""
+
+import json
+import os
+import urllib.request
+
+_ECS_METADATA_TIMEOUT = 2
+
+NO_ECS_TASK_DEFAULT = "local"
+NO_ECS_SERVICE_DEFAULT = "none"
+
+
+def _get_ecs_task_id() -> str:
+    """Fetch the short ECS task ID from the container metadata
+    endpoint (v4). Returns a default value outside ECS."""
+    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+    if not meta_uri:
+        return NO_ECS_TASK_DEFAULT
+    try:
+        req = urllib.request.Request(f"{meta_uri}/task")
+        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        # TaskARN: arn:aws:ecs:region:account:task/cluster/id
+        task_arn = data.get("TaskARN", "")
+        return task_arn.rsplit("/", 1)[-1] if "/" in task_arn else NO_ECS_TASK_DEFAULT
+    except Exception:
+        return NO_ECS_TASK_DEFAULT
+
+
+def _get_ecs_service_name() -> str:
+    """Fetch the ECS service name from the container metadata
+    endpoint (v4). Returns a default value if not available."""
+    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+    if not meta_uri:
+        return NO_ECS_SERVICE_DEFAULT
+    try:
+        req = urllib.request.Request(f"{meta_uri}/task")
+        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        # ServiceName is only available for tasks started by a service
+        service_name = data.get("ServiceName", "")
+        return service_name if service_name else NO_ECS_SERVICE_DEFAULT
+    except Exception:
+        return NO_ECS_SERVICE_DEFAULT
+
+
+ECS_TASK_ID: str = _get_ecs_task_id()
+ECS_SERVICE_NAME: str = _get_ecs_service_name()

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -6,9 +6,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing_extensions import Optional
 
 from studio.app.common.core.auth.auth_dependencies import get_current_user
-from studio.app.common.core.logger import VALID_LOG_LEVELS, AppLogger
+from studio.app.common.core.logger import (
+    ECS_SERVICE_NAME,
+    ECS_TASK_ID,
+    VALID_LOG_LEVELS,
+    AppLogger,
+)
 from studio.app.common.core.utils.log_reader import LogLevel, LogReader
-from studio.app.common.schemas.outputs import PaginatedLineResult
+from studio.app.common.schemas.outputs import PaginatedLineResult, PlatformInfo
 from studio.app.common.schemas.users import User
 
 router = APIRouter(prefix="/logs", tags=["logs"])
@@ -71,6 +76,9 @@ async def get_log_data(
     levels: List[LogLevel] = Query(default=[LogLevel.ALL]),
 ):
     try:
+        platform = PlatformInfo(
+            service_name=ECS_SERVICE_NAME, task_id=ECS_TASK_ID
+        )
         stop_offset = None
         log_reader = LogReader(
             levels=levels, filter_user_id=current_user.uid if current_user else None
@@ -85,6 +93,7 @@ async def get_log_data(
                     next_offset=offset,
                     prev_offset=offset,
                     data=[],
+                    platform=platform,
                 )
 
             logs = log_reader.read_from_offset(
@@ -106,14 +115,17 @@ async def get_log_data(
                     if reverse
                     else logs.data + extra_logs.data
                 ),
+                platform=platform,
             )
 
-        return log_reader.read_from_offset(
+        result = log_reader.read_from_offset(
             offset=offset,
             stop_offset=stop_offset,
             limit=limit,
             reverse=reverse,
         )
+        result.platform = platform
+        return result
     except Exception as e:
         logger.error(e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing_extensions import Optional
 
 from studio.app.common.core.auth.auth_dependencies import get_current_user
-from studio.app.common.core.platform_metadata import ECS_SERVICE_NAME, ECS_TASK_ID
 from studio.app.common.core.logger import VALID_LOG_LEVELS, AppLogger
+from studio.app.common.core.platform_metadata import ECS_SERVICE_NAME, ECS_TASK_ID
 from studio.app.common.core.utils.log_reader import LogLevel, LogReader
 from studio.app.common.schemas.outputs import PaginatedLineResult, PlatformInfo
 from studio.app.common.schemas.users import User

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -6,12 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing_extensions import Optional
 
 from studio.app.common.core.auth.auth_dependencies import get_current_user
-from studio.app.common.core.logger import (
-    ECS_SERVICE_NAME,
-    ECS_TASK_ID,
-    VALID_LOG_LEVELS,
-    AppLogger,
-)
+from studio.app.common.core.platform_metadata import ECS_SERVICE_NAME, ECS_TASK_ID
+from studio.app.common.core.logger import VALID_LOG_LEVELS, AppLogger
 from studio.app.common.core.utils.log_reader import LogLevel, LogReader
 from studio.app.common.schemas.outputs import PaginatedLineResult, PlatformInfo
 from studio.app.common.schemas.users import User
@@ -76,9 +72,7 @@ async def get_log_data(
     levels: List[LogLevel] = Query(default=[LogLevel.ALL]),
 ):
     try:
-        platform = PlatformInfo(
-            service_name=ECS_SERVICE_NAME, task_id=ECS_TASK_ID
-        )
+        platform = PlatformInfo(service_name=ECS_SERVICE_NAME, task_id=ECS_TASK_ID)
         stop_offset = None
         log_reader = LogReader(
             levels=levels, filter_user_id=current_user.uid if current_user else None

--- a/studio/app/common/schemas/outputs.py
+++ b/studio/app/common/schemas/outputs.py
@@ -34,7 +34,14 @@ class TextPosition:
 
 
 @dataclass
+class PlatformInfo:
+    service_name: str
+    task_id: str
+
+
+@dataclass
 class PaginatedLineResult:
     next_offset: int
     prev_offset: int
     data: "list[str]"
+    platform: Optional[PlatformInfo] = None


### PR DESCRIPTION
### Content

This is a feature primarily for developers, but I've added a function to display platform information in the Log Viewer.

- This can be used to verify whether the application is running in the appropriate environment.
- It's also intended to be used as log information provided by general users in the event of system problems.

<img width="924" height="221" alt="image" src="https://github.com/user-attachments/assets/b1c369f2-abb8-49f2-96f7-b89fe6c39c19" />

#### UI Design Intent

- I considered recording the service name in the logging, but this was rejected because it would make each log line too long and redundant.
- This additional information could have been displayed elsewhere (not in the log viewer), but the log viewer is easily accessible, and being able to view platform information and logs simultaneously is somewhat convenient during testing, so it is displayed in the log viewer.

### Testcase

- [x] Verification in a local environment
  - In the local environment, the following settings are fixed.
    > Platform service name: none
    > task id: local
- [x] Verification in a cloud environment
