### PR TITLE
Inactive instances not terminated

### DIFF
--- a/frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts
+++ b/frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts
@@ -27,6 +27,8 @@ class SleepDetectionSimulator {
   private sleepThresholdMultiplier: number
   private onWake: () => void
   private interval: ReturnType<typeof setInterval> | null = null
+  private hiddenTick = false
+  private hiddenAt: number | null = null
 
   constructor(
     onWake: () => void,
@@ -42,12 +44,33 @@ class SleepDetectionSimulator {
     this.lastTick = Date.now()
   }
 
+  private handleVisibilityChange = (): void => {
+    if (document.visibilityState === "hidden") {
+      this.hiddenAt = Date.now()
+      this.hiddenTick = false
+    } else if (document.visibilityState === "visible") {
+      if (!this.hiddenTick && this.hiddenAt !== null) {
+        const now = Date.now()
+        const elapsed = now - this.hiddenAt
+        const threshold = this.checkIntervalMs * this.sleepThresholdMultiplier
+
+        if (elapsed > threshold) {
+          this.onWake()
+        }
+      }
+      this.lastTick = Date.now()
+      this.hiddenAt = null
+      this.hiddenTick = false
+    }
+  }
+
   start(): void {
     this.lastTick = Date.now()
     this.interval = setInterval(
       () => this.checkForSleep(),
       this.checkIntervalMs,
     )
+    document.addEventListener("visibilitychange", this.handleVisibilityChange)
   }
 
   stop(): void {
@@ -55,6 +78,10 @@ class SleepDetectionSimulator {
       clearInterval(this.interval)
       this.interval = null
     }
+    document.removeEventListener(
+      "visibilitychange",
+      this.handleVisibilityChange,
+    )
   }
 
   private checkForSleep(): void {
@@ -62,8 +89,12 @@ class SleepDetectionSimulator {
     const elapsed = now - this.lastTick
     const threshold = this.checkIntervalMs * this.sleepThresholdMultiplier
 
-    if (elapsed > threshold && document.visibilityState === "visible") {
-      this.onWake()
+    if (document.visibilityState === "visible") {
+      if (elapsed > threshold) {
+        this.onWake()
+      }
+    } else {
+      this.hiddenTick = true
     }
 
     this.lastTick = now
@@ -88,6 +119,18 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
     jest.useRealTimers()
     jest.restoreAllMocks()
   })
+
+  const setVisibility = (state: "visible" | "hidden") => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => state,
+    })
+  }
+
+  const changeVisibility = (state: "visible" | "hidden") => {
+    setVisibility(state)
+    document.dispatchEvent(new Event("visibilitychange"))
+  }
 
   describe("Sleep Detection Configuration", () => {
     it("should check for sleep every 30 seconds", () => {
@@ -217,6 +260,29 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         jest.advanceTimersByTime(30000)
 
         expect(onWake).not.toHaveBeenCalled()
+        simulator.stop()
+      })
+
+      it("should detect sleep-while-hidden via visibilitychange", () => {
+        // We need a mutable currentTime to simulate sleep without firing ticks
+        let now = Date.now()
+        jest.spyOn(Date, "now").mockImplementation(() => now)
+
+        const onWake = jest.fn()
+        const simulator = new SleepDetectionSimulator(onWake)
+        simulator.start()
+
+        // Tab goes hidden (records hiddenAt, resets hiddenTick)
+        changeVisibility("hidden")
+
+        // Device sleeps — CPU suspended, no ticks fire, just time passes
+        now += 600000 // 10 min
+
+        // User opens laptop, tab becomes visible — no ticks fired so
+        // visibilitychange detects the gap as real sleep
+        changeVisibility("visible")
+        expect(onWake).toHaveBeenCalledTimes(1)
+
         simulator.stop()
       })
 

--- a/frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts
+++ b/frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts
@@ -15,8 +15,8 @@ import {
 } from "@jest/globals"
 
 // Configuration from useSleepDetection
-const DEFAULT_CHECK_INTERVAL_MS = 10000
-const SLEEP_DETECTION_MULTIPLIER = 2
+const DEFAULT_CHECK_INTERVAL_MS = 30000
+const SLEEP_DETECTION_MULTIPLIER = 5
 
 /**
  * Simulates the sleep detection logic from useSleepDetection
@@ -62,7 +62,7 @@ class SleepDetectionSimulator {
     const elapsed = now - this.lastTick
     const threshold = this.checkIntervalMs * this.sleepThresholdMultiplier
 
-    if (elapsed > threshold) {
+    if (elapsed > threshold && document.visibilityState === "visible") {
       this.onWake()
     }
 
@@ -77,24 +77,30 @@ class SleepDetectionSimulator {
 describe("Sleep Detection Integration (Cases 50-51)", () => {
   beforeEach(() => {
     jest.useFakeTimers()
+    // Default: tab is visible
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    })
   })
 
   afterEach(() => {
     jest.useRealTimers()
+    jest.restoreAllMocks()
   })
 
   describe("Sleep Detection Configuration", () => {
-    it("should check for sleep every 10 seconds", () => {
-      expect(DEFAULT_CHECK_INTERVAL_MS).toBe(10000)
+    it("should check for sleep every 30 seconds", () => {
+      expect(DEFAULT_CHECK_INTERVAL_MS).toBe(30000)
     })
 
-    it("should detect sleep when interval fires 2x late", () => {
-      expect(SLEEP_DETECTION_MULTIPLIER).toBe(2)
+    it("should detect sleep when interval fires 5x late", () => {
+      expect(SLEEP_DETECTION_MULTIPLIER).toBe(5)
     })
 
-    it("should detect sleep after 20+ second gap", () => {
+    it("should detect sleep after 150+ second gap", () => {
       const threshold = DEFAULT_CHECK_INTERVAL_MS * SLEEP_DETECTION_MULTIPLIER
-      expect(threshold).toBe(20000)
+      expect(threshold).toBe(150000)
     })
   })
 
@@ -104,7 +110,7 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(onWake)
       simulator.start()
 
-      jest.advanceTimersByTime(10000)
+      jest.advanceTimersByTime(30000)
 
       expect(onWake).not.toHaveBeenCalled()
       simulator.stop()
@@ -115,8 +121,8 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(onWake)
       simulator.start()
 
-      simulator.simulateSleep(25000)
-      jest.advanceTimersByTime(10000)
+      simulator.simulateSleep(200000)
+      jest.advanceTimersByTime(30000)
 
       expect(onWake).toHaveBeenCalledTimes(1)
       simulator.stop()
@@ -127,15 +133,15 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(onWake)
       simulator.start()
 
-      simulator.simulateSleep(25000)
-      jest.advanceTimersByTime(10000)
+      simulator.simulateSleep(200000)
+      jest.advanceTimersByTime(30000)
       expect(onWake).toHaveBeenCalledTimes(1)
 
-      jest.advanceTimersByTime(10000)
+      jest.advanceTimersByTime(30000)
       expect(onWake).toHaveBeenCalledTimes(1)
 
-      simulator.simulateSleep(30000)
-      jest.advanceTimersByTime(10000)
+      simulator.simulateSleep(200000)
+      jest.advanceTimersByTime(30000)
       expect(onWake).toHaveBeenCalledTimes(2)
 
       simulator.stop()
@@ -150,7 +156,7 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         simulator.start()
 
         simulator.simulateSleep(30 * 60 * 1000)
-        jest.advanceTimersByTime(10000)
+        jest.advanceTimersByTime(30000)
 
         expect(activityRecorded).toHaveBeenCalledTimes(1)
         simulator.stop()
@@ -166,8 +172,8 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         const simulator = new SleepDetectionSimulator(recordActivity)
         simulator.start()
 
-        simulator.simulateSleep(25000)
-        jest.advanceTimersByTime(10000)
+        simulator.simulateSleep(200000)
+        jest.advanceTimersByTime(30000)
 
         expect(recordActivity).toHaveBeenCalled()
         expect(showInactivityWarning).toBe(false)
@@ -182,7 +188,7 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         simulator.start()
 
         simulator.simulateSleep(30 * 60 * 1000)
-        jest.advanceTimersByTime(10000)
+        jest.advanceTimersByTime(30000)
 
         expect(onWake).toHaveBeenCalled()
         simulator.stop()
@@ -194,20 +200,21 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         simulator.start()
 
         for (let i = 0; i < 10; i++) {
-          jest.advanceTimersByTime(10000)
+          jest.advanceTimersByTime(30000)
         }
 
         expect(onWake).not.toHaveBeenCalled()
         simulator.stop()
       })
 
-      it("should handle short sleep periods correctly", () => {
+      it("should not trigger for browser background throttle gaps", () => {
         const onWake = jest.fn()
         const simulator = new SleepDetectionSimulator(onWake)
         simulator.start()
 
-        // Advance time normally - elapsed will be ~10000ms which is below 20000 threshold
-        jest.advanceTimersByTime(10000)
+        // 60s gap is typical of Chromium background tab throttling
+        simulator.simulateSleep(60000)
+        jest.advanceTimersByTime(30000)
 
         expect(onWake).not.toHaveBeenCalled()
         simulator.stop()
@@ -218,8 +225,8 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
         const simulator = new SleepDetectionSimulator(onWake)
         simulator.start()
 
-        simulator.simulateSleep(21000)
-        jest.advanceTimersByTime(10000)
+        simulator.simulateSleep(151000)
+        jest.advanceTimersByTime(30000)
 
         expect(onWake).toHaveBeenCalled()
         simulator.stop()
@@ -233,8 +240,8 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(onWake)
       simulator.start()
 
-      simulator.simulateSleep(25000)
-      jest.advanceTimersByTime(10000)
+      simulator.simulateSleep(200000)
+      jest.advanceTimersByTime(30000)
       expect(onWake).toHaveBeenCalledTimes(1)
 
       jest.advanceTimersByTime(1000)
@@ -274,10 +281,10 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(errorOnWake)
       simulator.start()
 
-      simulator.simulateSleep(25000)
+      simulator.simulateSleep(200000)
 
       expect(() => {
-        jest.advanceTimersByTime(10000)
+        jest.advanceTimersByTime(30000)
       }).toThrow("Callback error")
 
       simulator.stop()
@@ -303,8 +310,8 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
 
       const initialTime = lastActivityTime
 
-      simulator.simulateSleep(25000)
-      jest.advanceTimersByTime(10000)
+      simulator.simulateSleep(200000)
+      jest.advanceTimersByTime(30000)
 
       await Promise.resolve()
 
@@ -324,10 +331,10 @@ describe("Sleep Detection Integration (Cases 50-51)", () => {
       const simulator = new SleepDetectionSimulator(handleDeviceWake)
       simulator.start()
 
-      simulator.simulateSleep(25000)
+      simulator.simulateSleep(200000)
 
       expect(() => {
-        jest.advanceTimersByTime(10000)
+        jest.advanceTimersByTime(30000)
       }).not.toThrow()
 
       await Promise.resolve()

--- a/frontend/src/hooks/__tests__/useSleepDetection.test.ts
+++ b/frontend/src/hooks/__tests__/useSleepDetection.test.ts
@@ -2,7 +2,8 @@
  * Tests for Sleep Detection Hook (Cases 50-51)
  *
  * Tests verify that the hook correctly detects when a device wakes from sleep
- * by monitoring interval timing gaps.
+ * by monitoring interval timing gaps, while ignoring false positives from
+ * browser background-tab timer throttling.
  */
 
 import {
@@ -24,6 +25,11 @@ describe("useSleepDetection (Cases 50-51)", () => {
     currentTime = 1000000
     jest.useFakeTimers()
     jest.spyOn(Date, "now").mockImplementation(() => currentTime)
+    // Default: tab is visible
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    })
   })
 
   afterEach(() => {
@@ -36,12 +42,19 @@ describe("useSleepDetection (Cases 50-51)", () => {
     jest.advanceTimersByTime(ms)
   }
 
+  const setVisibility = (state: "visible" | "hidden") => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => state,
+    })
+  }
+
   it("should not call onWake during normal interval ticks", () => {
     const onWake = jest.fn()
     renderHook(() => useSleepDetection(onWake))
 
     act(() => {
-      advanceTime(10000)
+      advanceTime(30000)
     })
 
     expect(onWake).not.toHaveBeenCalled()
@@ -52,12 +65,40 @@ describe("useSleepDetection (Cases 50-51)", () => {
     renderHook(() => useSleepDetection(onWake))
 
     act(() => {
-      // Simulate sleep: advance Date.now() by more than the interval fires
-      currentTime += 25000
-      jest.advanceTimersByTime(10000)
+      // Simulate sleep: advance Date.now() by more than the threshold (150s)
+      currentTime += 200000
+      jest.advanceTimersByTime(30000)
     })
 
     expect(onWake).toHaveBeenCalledTimes(1)
+  })
+
+  it("should not call onWake when tab is hidden (background throttling)", () => {
+    const onWake = jest.fn()
+    renderHook(() => useSleepDetection(onWake))
+
+    setVisibility("hidden")
+
+    act(() => {
+      // Large gap but tab is hidden — this is browser throttling, not sleep
+      currentTime += 200000
+      jest.advanceTimersByTime(30000)
+    })
+
+    expect(onWake).not.toHaveBeenCalled()
+  })
+
+  it("should not trigger on 60s gap (browser background throttle)", () => {
+    const onWake = jest.fn()
+    renderHook(() => useSleepDetection(onWake))
+
+    act(() => {
+      // 60s gap is typical of Chromium background tab throttling
+      currentTime += 60000
+      jest.advanceTimersByTime(30000)
+    })
+
+    expect(onWake).not.toHaveBeenCalled()
   })
 
   it("should call onWake multiple times for multiple sleep events", () => {
@@ -66,21 +107,21 @@ describe("useSleepDetection (Cases 50-51)", () => {
 
     // First sleep event
     act(() => {
-      currentTime += 25000
-      jest.advanceTimersByTime(10000)
+      currentTime += 200000
+      jest.advanceTimersByTime(30000)
     })
     expect(onWake).toHaveBeenCalledTimes(1)
 
     // Normal tick - no wake
     act(() => {
-      advanceTime(10000)
+      advanceTime(30000)
     })
     expect(onWake).toHaveBeenCalledTimes(1)
 
     // Second sleep event
     act(() => {
-      currentTime += 25000
-      jest.advanceTimersByTime(10000)
+      currentTime += 200000
+      jest.advanceTimersByTime(30000)
     })
     expect(onWake).toHaveBeenCalledTimes(2)
   })
@@ -95,9 +136,9 @@ describe("useSleepDetection (Cases 50-51)", () => {
     })
     expect(onWake).not.toHaveBeenCalled()
 
-    // Sleep event - time jumped more than 2x the 5s interval (>10s)
+    // Sleep event - time jumped more than 5x the 5s interval (>25s)
     act(() => {
-      currentTime += 15000
+      currentTime += 30000
       jest.advanceTimersByTime(5000)
     })
     expect(onWake).toHaveBeenCalled()
@@ -132,7 +173,7 @@ describe("useSleepDetection (Cases 50-51)", () => {
     renderHook(() => useSleepDetection(onWake, { enabled: false }))
 
     act(() => {
-      currentTime += 60000
+      currentTime += 300000
       jest.advanceTimersByTime(60000)
     })
 
@@ -163,11 +204,98 @@ describe("useSleepDetection (Cases 50-51)", () => {
 
     // Simulate sleep event
     act(() => {
-      currentTime += 25000
-      jest.advanceTimersByTime(10000)
+      currentTime += 200000
+      jest.advanceTimersByTime(30000)
     })
 
     expect(onWake1).not.toHaveBeenCalled()
     expect(onWake2).toHaveBeenCalled()
+  })
+
+  it("should not fire onWake when tab is hidden despite large gap", () => {
+    const onWake = jest.fn()
+    renderHook(() => useSleepDetection(onWake))
+
+    // Device sleeps — tab goes hidden, large gap detected but suppressed
+    setVisibility("hidden")
+    act(() => {
+      currentTime += 600000 // 10 min sleep
+      jest.advanceTimersByTime(30000)
+    })
+    expect(onWake).not.toHaveBeenCalled()
+
+    // Tab becomes visible — but lastTick was already updated while hidden,
+    // so the next normal tick has no gap. This is correct: the inactivity
+    // check (not sleep detection) handles the idle-user-returns case.
+    setVisibility("visible")
+    act(() => {
+      advanceTime(30000)
+    })
+    expect(onWake).not.toHaveBeenCalled()
+  })
+
+  it("should fire onWake when real sleep happens with tab visible", () => {
+    const onWake = jest.fn()
+    renderHook(() => useSleepDetection(onWake))
+
+    // Laptop lid closes and reopens — tab stays visible the whole time
+    // (common when external monitor keeps session alive)
+    act(() => {
+      currentTime += 600000 // 10 min gap
+      jest.advanceTimersByTime(30000)
+    })
+    expect(onWake).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Simulates the exact production scenario that caused premium EC2 instances
+   * to run overnight (2026-04-01).
+   *
+   * Chromium throttles setInterval in background tabs to fire at most once per
+   * ~60 seconds. With the old threshold (10s interval × 2 = 20s), every
+   * throttled tick appeared as a "sleep wake" and fired recordActivity() →
+   * sendPremiumHeartbeat() → Lambda update_activity, keeping last_activity
+   * perpetually fresh and preventing the cleanup Lambda from ever marking
+   * assignments as stale.
+   *
+   * This test runs 8 hours of simulated Chromium background-tab throttling
+   * and verifies that zero false wake events are produced.
+   */
+  it("should produce zero false wakes during 8h of Chromium background throttling", () => {
+    const onWake = jest.fn()
+    renderHook(() => useSleepDetection(onWake))
+
+    // User switches to another tab — Chromium throttles timers to ~60s
+    setVisibility("hidden")
+
+    // Simulate 8 hours of background throttling:
+    // The real setInterval(30000) fires every ~60s in a background tab.
+    // Each tick sees a ~60s gap (> 30s interval but < 150s threshold).
+    const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000
+    const CHROMIUM_THROTTLED_TICK_MS = 60000
+
+    for (
+      let elapsed = 0;
+      elapsed < EIGHT_HOURS_MS;
+      elapsed += CHROMIUM_THROTTLED_TICK_MS
+    ) {
+      act(() => {
+        currentTime += CHROMIUM_THROTTLED_TICK_MS
+        jest.advanceTimersByTime(CHROMIUM_THROTTLED_TICK_MS)
+      })
+    }
+
+    // After 8 hours of background throttling: zero false wakes
+    expect(onWake).not.toHaveBeenCalled()
+
+    // User returns — tab becomes visible, normal ticks resume
+    setVisibility("visible")
+    act(() => {
+      advanceTime(30000)
+    })
+
+    // Still no wake — the gap is only 30s (normal tick after lastTick update)
+    // The 2-hour inactivity check handles this case, not sleep detection
+    expect(onWake).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/__tests__/useSleepDetection.test.ts
+++ b/frontend/src/hooks/__tests__/useSleepDetection.test.ts
@@ -49,6 +49,12 @@ describe("useSleepDetection (Cases 50-51)", () => {
     })
   }
 
+  /** Change visibility and fire the corresponding event (like a real browser). */
+  const changeVisibility = (state: "visible" | "hidden") => {
+    setVisibility(state)
+    document.dispatchEvent(new Event("visibilitychange"))
+  }
+
   it("should not call onWake during normal interval ticks", () => {
     const onWake = jest.fn()
     renderHook(() => useSleepDetection(onWake))
@@ -212,26 +218,24 @@ describe("useSleepDetection (Cases 50-51)", () => {
     expect(onWake2).toHaveBeenCalled()
   })
 
-  it("should not fire onWake when tab is hidden despite large gap", () => {
+  it("should detect sleep-while-hidden via visibilitychange", () => {
     const onWake = jest.fn()
     renderHook(() => useSleepDetection(onWake))
 
-    // Device sleeps — tab goes hidden, large gap detected but suppressed
-    setVisibility("hidden")
+    // Tab goes hidden — hook records hiddenAt timestamp
     act(() => {
-      currentTime += 600000 // 10 min sleep
-      jest.advanceTimersByTime(30000)
+      changeVisibility("hidden")
     })
-    expect(onWake).not.toHaveBeenCalled()
 
-    // Tab becomes visible — but lastTick was already updated while hidden,
-    // so the next normal tick has no gap. This is correct: the inactivity
-    // check (not sleep detection) handles the idle-user-returns case.
-    setVisibility("visible")
+    // Device sleeps — CPU suspended, no interval ticks fire, time passes
+    currentTime += 600000 // 10 min
+
+    // User opens laptop, tab becomes visible — no ticks fired while hidden
+    // so visibilitychange detects the gap as real sleep
     act(() => {
-      advanceTime(30000)
+      changeVisibility("visible")
     })
-    expect(onWake).not.toHaveBeenCalled()
+    expect(onWake).toHaveBeenCalledTimes(1)
   })
 
   it("should fire onWake when real sleep happens with tab visible", () => {
@@ -288,14 +292,11 @@ describe("useSleepDetection (Cases 50-51)", () => {
     // After 8 hours of background throttling: zero false wakes
     expect(onWake).not.toHaveBeenCalled()
 
-    // User returns — tab becomes visible, normal ticks resume
-    setVisibility("visible")
+    // User returns — visibilitychange fires. lastTick was kept fresh by
+    // throttled ticks (~60s apart), so gap is only ~60s — below threshold.
     act(() => {
-      advanceTime(30000)
+      changeVisibility("visible")
     })
-
-    // Still no wake — the gap is only 30s (normal tick after lastTick update)
-    // The 2-hour inactivity check handles this case, not sleep detection
     expect(onWake).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useSleepDetection.ts
+++ b/frontend/src/hooks/useSleepDetection.ts
@@ -3,12 +3,16 @@
  *
  * Detects when a device wakes from sleep by monitoring interval timing gaps.
  * When the interval fires much later than expected, we assume the device slept.
+ *
+ * The 150s threshold avoids false positives from Chromium's background-tab
+ * timer throttling (~60s). We also require tab visibility so throttled
+ * background tabs don't trigger a wake event.
  */
 
 import { useEffect, useRef, useCallback } from "react"
 
-const DEFAULT_CHECK_INTERVAL_MS = 10000
-const SLEEP_DETECTION_MULTIPLIER = 2
+const DEFAULT_CHECK_INTERVAL_MS = 30000
+const SLEEP_DETECTION_MULTIPLIER = 5
 
 interface UseSleepDetectionOptions {
   checkIntervalMs?: number
@@ -44,7 +48,7 @@ export const useSleepDetection = (
     const elapsed = now - lastTickRef.current
     const expectedInterval = checkIntervalMs * sleepThresholdMultiplier
 
-    if (elapsed > expectedInterval) {
+    if (elapsed > expectedInterval && document.visibilityState === "visible") {
       onWakeRef.current()
     }
 

--- a/frontend/src/hooks/useSleepDetection.ts
+++ b/frontend/src/hooks/useSleepDetection.ts
@@ -4,9 +4,9 @@
  * Detects when a device wakes from sleep by monitoring interval timing gaps.
  * When the interval fires much later than expected, we assume the device slept.
  *
- * The 150s threshold avoids false positives from Chromium's background-tab
- * timer throttling (~60s). We also require tab visibility so throttled
- * background tabs don't trigger a wake event.
+ * Two detection paths: (1) interval fires late while tab is visible,
+ * (2) on hidden→visible, no ticks fired while hidden (real sleep suspends
+ * the CPU; background throttling still fires ticks at ~60s).
  */
 
 import { useEffect, useRef, useCallback } from "react"
@@ -38,6 +38,11 @@ export const useSleepDetection = (
 
   const lastTickRef = useRef(Date.now())
   const onWakeRef = useRef(onWake)
+  // Tracks whether any interval ticks fired while tab was hidden.
+  // If none fired, the CPU was suspended (real sleep, not throttling).
+  const hiddenTickRef = useRef(false)
+  // Timestamp when the tab went hidden, for gap measurement.
+  const hiddenAtRef = useRef<number | null>(null)
 
   useEffect(() => {
     onWakeRef.current = onWake
@@ -48,8 +53,13 @@ export const useSleepDetection = (
     const elapsed = now - lastTickRef.current
     const expectedInterval = checkIntervalMs * sleepThresholdMultiplier
 
-    if (elapsed > expectedInterval && document.visibilityState === "visible") {
-      onWakeRef.current()
+    if (document.visibilityState === "visible") {
+      if (elapsed > expectedInterval) {
+        onWakeRef.current()
+      }
+    } else {
+      // Tab is hidden — record that a tick fired (CPU is running, not sleep)
+      hiddenTickRef.current = true
     }
 
     lastTickRef.current = now
@@ -61,6 +71,33 @@ export const useSleepDetection = (
     lastTickRef.current = Date.now()
     const interval = setInterval(checkForSleep, checkIntervalMs)
 
-    return () => clearInterval(interval)
-  }, [enabled, checkIntervalMs, checkForSleep])
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now()
+        hiddenTickRef.current = false
+      } else if (document.visibilityState === "visible") {
+        // If no interval ticks fired while hidden, the CPU was suspended
+        // (real sleep). Check whether the gap exceeds the threshold.
+        if (!hiddenTickRef.current && hiddenAtRef.current !== null) {
+          const now = Date.now()
+          const elapsed = now - hiddenAtRef.current
+          const threshold = checkIntervalMs * sleepThresholdMultiplier
+
+          if (elapsed > threshold) {
+            onWakeRef.current()
+          }
+        }
+        lastTickRef.current = Date.now()
+        hiddenAtRef.current = null
+        hiddenTickRef.current = false
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [enabled, checkIntervalMs, checkForSleep, sleepThresholdMultiplier])
 }

--- a/studio/app/common/core/middleware/constants.py
+++ b/studio/app/common/core/middleware/constants.py
@@ -1,3 +1,7 @@
 # Paths that should skip authentication-related middleware processing.
 # These endpoints are either public (login, refresh) or internal (health check).
 SKIP_AUTH_PATHS = ["/health", "/auth/login", "/auth/refresh"]
+
+# Authenticated paths that should NOT update last_activity (automated/timer
+# requests whose activity would prevent inactivity cleanup from working).
+SKIP_ACTIVITY_PATHS = ["/log-report/frontend-errors"]

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -34,7 +34,10 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.middleware.constants import SKIP_AUTH_PATHS
+from studio.app.common.core.middleware.constants import (
+    SKIP_ACTIVITY_PATHS,
+    SKIP_AUTH_PATHS,
+)
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
@@ -104,6 +107,11 @@ class UserActivityMiddleware:
 
         # Skip health check, auth endpoints, and system-internal API endpoints
         if path in SKIP_AUTH_PATHS or path.startswith("/system-internal/"):
+            await self.app(scope, receive, send)
+            return
+
+        # Skip activity tracking for automated endpoints (auth still applies)
+        if path in SKIP_ACTIVITY_PATHS:
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
### Content

#### Summary
- Premium EC2 instances ran overnight (2026-04-01, 22+ hours) because the inactivity shutdown chain never triggered. Three `subscr-premium-running` instances with users 71, 72, 73 assigned were never scaled down.
- Two independent bugs combined to prevent shutdown:
  1. **Sleep detection false positives (primary):** `useSleepDetection` used a 20-second threshold to detect device sleep by monitoring `setInterval` timing gaps. Chromium throttles background-tab timers to ~60 seconds, which exceeded the 20s threshold every tick -- firing a false "wake" event that called `recordActivity()` -> `sendPremiumHeartbeat()` -> Lambda `update_activity` once per minute, keeping `last_activity` perpetually fresh.
  2. **Error reporter as activity source (secondary):** The `errorReporter` flushes `console.warn` messages to `/log-report/frontend-errors` with an auth token. The `UserActivityMiddleware` intercepted these requests and updated `last_activity`, creating another path that could defeat inactivity detection.

#### Design Decisions
- **150s threshold (30s interval x 5 multiplier) instead of 20s (10s x 2)** -- Real device sleep produces gaps of minutes to hours. Chromium background throttling produces ~60s gaps. A 150s threshold cleanly separates the two. The exact values (30s/5x) were chosen to give headroom above 60s while still detecting short sleep events (>2.5 min).
- **Two detection paths (interval + visibilitychange)** -- The interval check detects sleep when the tab is visible (e.g. laptop lid close/open with tab in foreground). The `visibilitychange` listener detects sleep that happened while the tab was hidden: on hidden→visible, if zero interval ticks fired while hidden, the CPU was suspended (real sleep). Background throttling still fires ticks at ~60s, so the `hiddenTick` flag distinguishes the two. This covers all four scenarios: sleep-while-visible, sleep-while-hidden, background throttling (no false positive), and long background stay without sleep (no false positive).
- **`document.visibilityState === "visible"` guard on interval check** -- Belt-and-suspenders alongside the threshold increase. Background tabs should never trigger wake events via the interval regardless of gap size, since the gap is caused by throttling, not sleep.
- **`SKIP_ACTIVITY_PATHS` instead of adding to `SKIP_AUTH_PATHS`** -- The error reporter endpoint still needs authentication (to identify which user sent the errors). A separate skip list preserves auth while excluding the path from activity tracking.
- **No changes to the cleanup or scale-down Lambda logic** -- The cleanup Lambda (`premium_cleanup`) and manager Lambda (`premium_manager`) were working correctly. They checked `last_activity` and instance assignments as designed. The bugs were upstream: `last_activity` was kept fresh by false heartbeats.

### Evidence

CloudWatch logs from **2026-04-01 04:26 JST** to **2026-04-02 02:41 JST** across three log groups confirm the failure chain:

**`/aws/lambda/subscr-premium-cleanup`** -- Ran hourly, found zero stale assignments every time (22 consecutive runs):
> `[every hour] Starting cleanup of assignments idle for >3h`
> `[every hour] No stale assignments found`

Cleanup never removed assignments because `last_activity` was always fresh (<3h old).

**`/aws/lambda/subscr-premium-manager`** -- Ran every ~30 min, consistently saw 3 occupied / 0 idle instances:
> `[04/01 15:26 JST] Scale-down analysis: 6 total, 3 occupied, 0 idle, 3 active users, 6 total premium users (max capacity: 7)`
> `[04/01 15:26 JST] No scale-down: running=3, min_needed=4, idle=0`
>
> `[04/01 22:11 JST] Scale-down analysis: 3 total, 3 occupied, 0 idle, 3 active users, 6 total premium users (max capacity: 7)`
> `[04/01 22:11 JST] No scale-down: running=3, min_needed=4, idle=0`
>
> `[04/02 00:11 JST] Scale-down analysis: 3 total, 3 occupied, 0 idle, 3 active users, 6 total premium users (max capacity: 7)`
> `[04/02 00:11 JST] No scale-down: running=3, min_needed=4, idle=0`
>
> `[04/02 02:41 JST] Scale-down analysis: 3 total, 3 occupied, 0 idle, 3 active users, 6 total premium users (max capacity: 7)`
> `[04/02 02:41 JST] No scale-down: running=3, min_needed=4, idle=0`

The manager saw `3 occupied, 0 idle` continuously for 22+ hours because the DB assignments were never cleaned up.

**`/aws/lambda/subscr-premium-manager` (activity updates)** -- False heartbeats fired every 60 seconds, including at 3am JST when no users were active:

> `[04/02 03:00:56 JST] Premium manager received event: {"httpMethod": "POST", "body": "{\"action\": \"update_activity\", \"user_id\": \"7OHAeQebrKccbIRjOFzJBapefz03\", \"tier\": \"premium\"}"}`
> `[04/02 03:00:56 JST] Premium manager received event: {"httpMethod": "POST", "body": "{\"action\": \"update_activity\", \"user_id\": \"wpv2Vy6GlBcygbfuFFs5RNuzlUS2\", \"tier\": \"premium\"}"}`
> `[04/02 03:01:56 JST] Premium manager received event: {"httpMethod": "POST", "body": "{\"action\": \"update_activity\", \"user_id\": \"7OHAeQebrKccbIRjOFzJBapefz03\", \"tier\": \"premium\"}"}`
> `[04/02 03:01:56 JST] Premium manager received event: {"httpMethod": "POST", "body": "{\"action\": \"update_activity\", \"user_id\": \"wpv2Vy6GlBcygbfuFFs5RNuzlUS2\", \"tier\": \"premium\"}"}`

Per-user cadence analysis (03:00-03:30 JST): user `7OHAeQeb...` sent **29 updates in 30 minutes** at exactly 60-second intervals. User `wpv2Vy6G...` sent **28 updates in 30 minutes** at the same cadence. This matches Chromium's 1-minute background tab timer throttle.

Hourly activity update counts show the false heartbeats never stopped overnight:

| Hour (JST) | Activity updates |
|-------------|-----------------|
| 04/01 17:00 | 121 |
| 04/01 18:00 | 123 |
| 04/01 19:00 | 130 |
| 04/01 20:00 | 129 |
| 04/01 21:00 | 128 |
| 04/01 22:00 | 130 |
| 04/01 23:00 | 178 |
| 04/02 00:00 | 126 |
| 04/02 01:00 | 163 |
| 04/02 02:00 | 180 |

**Database state** (queried 2026-04-02 ~11:30 JST):
```
+---------+---------------------+---------------------+--------+------------+--------------------+
| user_id | instance_id         | last_activity       | status | is_standby | heartbeat_failures |
+---------+---------------------+---------------------+--------+------------+--------------------+
|      72 | i-0562d8862891d5228 | 2026-04-02 02:29:39 | active |          0 |                  0 |
|      73 | i-08a45300ef99836c5 | 2026-04-02 02:29:26 | active |          0 |                  0 |
|      71 | i-0fbf3a6290189c6bb | 2026-04-02 02:29:26 | active |          0 |                  0 |
+---------+---------------------+---------------------+--------+------------+--------------------+
```

All three assignments had `heartbeat_failures = 0` and `last_activity` within the last hour -- confirming heartbeats were succeeding continuously and preventing stale detection.

### References
- Chromium background tab timer throttling: tabs not in the foreground have `setInterval` clamped to a minimum of ~60 seconds
- Inactivity shutdown chain: `premium_cleanup` (hourly, removes stale assignments where `last_activity > 3h`) -> `premium_manager` (every 15 min, stops instances with zero assignments)
- The `useSleepDetection` hook was introduced for Cases 50-51 (sleep/wake detection for premium users)

#### Files changed

##### Frontend
- `frontend/src/hooks/useSleepDetection.ts` -- Raise check interval from 10s to 30s, raise multiplier from 2x to 5x (threshold: 20s -> 150s). Add `document.visibilityState === "visible"` guard on interval check. Add `visibilitychange` listener with `hiddenTick`/`hiddenAt` refs to detect sleep that happened while the tab was hidden (no ticks fired = CPU was suspended).

##### Backend
- `studio/app/common/core/middleware/constants.py` -- Add `SKIP_ACTIVITY_PATHS` list with `/log-report/frontend-errors` to prevent automated error reporting from counting as user activity
- `studio/app/common/core/middleware/user_activity_middleware.py` -- Import and apply `SKIP_ACTIVITY_PATHS` to skip activity tracking for automated endpoints while preserving authentication

##### Tests
- `frontend/src/hooks/__tests__/useSleepDetection.test.ts` -- Update all test values for new defaults, add visibility guard tests, add sleep-while-hidden detection test, add 8-hour Chromium background throttle simulation that verifies zero false wakes (13 tests)
- `frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts` -- Update simulator to mirror two-detection-path logic (interval + visibilitychange), update constants and thresholds, add sleep-while-hidden test (18 tests)

### Manual Testcases
1. Open the app as a premium user with a dedicated instance assigned
2. Switch to another browser tab (backgrounding the app tab) and wait 5 minutes
3. Check CloudWatch `/aws/lambda/{env}-premium-manager` -- expect: no `update_activity` events during the background period
4. Switch back to the app tab -- expect: normal operation resumes, no disruption
5. Close the laptop lid for 5 minutes, then reopen -- expect: sleep detection fires once, heartbeat sent, activity updated
6. Background the tab, close the laptop lid for 5 minutes, then reopen and switch back to the tab -- expect: sleep detected via visibilitychange on tab return
7. Leave the app tab open (visible) and idle for 2+ hours -- expect: inactivity warning at 1 hour, auto-release at 2 hours (sleep detection does NOT interfere)
8. Run frontend tests:
  `cd frontend && npx react-app-rewired test --watchAll=false --no-coverage --testPathPattern="useSleepDetection.test|PremiumSleepDetection.test"` -- all 31 tests pass
9. Run backend middleware tests:
  `python -m pytest studio/tests/app/common/core/middleware/test_user_activity_middleware.py -x -q` -- all 38 tests pass

### Unit, Integration, Contract Test Coverage
- `useSleepDetection.test.ts` -- 13 tests including 8-hour Chromium throttle simulation and sleep-while-hidden via visibilitychange
- `PremiumSleepDetection.test.ts` -- 18 tests with two-detection-path simulator (interval + visibilitychange)
- `test_user_activity_middleware.py` -- 38 existing tests pass unchanged (skip logic uses same code path as existing `SKIP_AUTH_PATHS`)

### Others

#### Difficulties
- The root cause was not obvious from the code alone. The `useSleepDetection` hook looked correct in isolation -- the false positive only manifests when Chromium applies background tab throttling, which is a browser runtime behavior not visible in the source. Diagnosis required correlating CloudWatch Lambda logs (activity update cadence) with the browser's timer throttle behavior.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Sleep detection threshold | Low | Only increases the minimum gap required to trigger. Real sleep events (minutes to hours) are well above 150s. No false negatives possible for real sleep. |
| Visibility guard + visibilitychange listener | Low | `document.visibilityState` and `visibilitychange` are supported in all modern browsers. Worst case if visibility API is unavailable: falls back to interval-only detection (same as before, with the higher 150s threshold). |
| `SKIP_ACTIVITY_PATHS` | Low | Only affects `/log-report/frontend-errors`. Auth is preserved. The endpoint is fire-and-forget error reporting with no user-facing behavior. |
| Inactivity auto-release (2h) | Low | Not changed by this PR. The fix removes interference that was preventing the existing 2h auto-release from working. |
