### PR TITLE
ALB creation retry to fix race condition

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1840,9 +1840,7 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
                     }
 
                 # Verify instance liveness for active assignments
-                if (
-                    assignment["status"] == PremiumAssignment.ACTIVE
-                ):
+                if assignment["status"] == PremiumAssignment.ACTIVE:
                     try:
                         ec2: "EC2Client" = boto3.client("ec2")
                         resp = ec2.describe_instances(InstanceIds=[instance_id])
@@ -2649,6 +2647,43 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
                 print(f"Failed to retrieve existing target group: {describe_error}")
                 raise
         raise
+
+
+def create_alb_rule(
+    listener_arn: str,
+    conditions: list,
+    actions: list,
+    start_priority: int = 100,
+    max_retries: int = 3,
+) -> dict:
+    """Create an ALB rule, retrying with a fresh priority on PriorityInUse.
+
+    Concurrent Lambda invocations can race between get_next_available_priority()
+    and create_rule(). This wrapper catches PriorityInUse and re-queries for the
+    next free priority, up to max_retries times.
+    """
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+
+    for attempt in range(1, max_retries + 1):
+        priority = get_next_available_priority(listener_arn, start_priority)
+        try:
+            response = elbv2.create_rule(
+                ListenerArn=listener_arn,
+                Priority=priority,
+                Conditions=conditions,
+                Actions=actions,
+            )
+            return response
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "PriorityInUse":
+                print(
+                    f"Priority {priority} taken (attempt {attempt}/{max_retries}), "
+                    f"retrying with next available priority"
+                )
+                if attempt == max_retries:
+                    raise
+            else:
+                raise
 
 
 def get_next_available_priority(listener_arn: str, start_priority: int = 100) -> int:
@@ -3465,12 +3500,10 @@ def assign_premium_user(
         )
 
         cleanup_duplicate_rules_for_routing_id(alb_listener_arn, routing_id)
-        priority = get_next_available_priority(alb_listener_arn, start_priority=100)
 
-        rule_response = elbv2.create_rule(
-            ListenerArn=alb_listener_arn,
-            Priority=priority,
-            Conditions=[
+        rule_response = create_alb_rule(
+            listener_arn=alb_listener_arn,
+            conditions=[
                 {
                     "Field": "http-header",
                     "HttpHeaderConfig": {
@@ -3486,7 +3519,7 @@ def assign_premium_user(
                     },
                 },
             ],
-            Actions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
+            actions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
         rule_arn = rule_response["Rules"][0]["RuleArn"]
@@ -4284,15 +4317,9 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         user_uid = get_user_uid_from_id(connection, user_id)
                         routing_id = generate_routing_id(user_uid, routing_secret_key)
 
-                        # Get next available priority
-                        priority = get_next_available_priority(
-                            alb_listener_arn, start_priority=100
-                        )
-
-                        rule_response = elbv2.create_rule(
-                            ListenerArn=alb_listener_arn,
-                            Priority=priority,
-                            Conditions=[
+                        rule_response = create_alb_rule(
+                            listener_arn=alb_listener_arn,
+                            conditions=[
                                 {
                                     "Field": "http-header",
                                     "HttpHeaderConfig": {
@@ -4310,7 +4337,7 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                                     },
                                 },
                             ],
-                            Actions=[
+                            actions=[
                                 {
                                     "Type": "forward",
                                     "TargetGroupArn": new_target_group_arn,


### PR DESCRIPTION
### Content

#### Summary
- Concurrent Lambda invocations can race between `get_next_available_priority()` and `elbv2.create_rule()`. When two calls query the same next-free priority before either commits it, the second call fails with `PriorityInUse`.
- Extracted a new `create_alb_rule()` helper that catches `PriorityInUse`, re-queries for the next free priority, and retries up to 3 times.
- Replaced the two inline `get_next_available_priority` + `create_rule` sequences in `assign_premium_user` and `migrate_user_to_dedicated_instance` with calls to the new helper.

#### Design Decisions
- **Retry with re-query, not increment** -- After a `PriorityInUse` failure the helper calls `get_next_available_priority()` again rather than blindly incrementing the colliding priority. This is safer because another concurrent call may have claimed adjacent priorities as well.
- **3 retries** -- The race window is narrow (two Lambdas must call `get_next_available_priority` before either calls `create_rule`), so 3 attempts is more than sufficient while keeping the blast radius small.
- **Helper co-located with `get_next_available_priority`** -- Both functions operate on the same ALB listener concept, so placing them together avoids an extra import layer and makes the relationship obvious.

### Evidence
- N/A -- infrastructure-level fix; verified by code review.

### References
- Race condition observed when multiple premium user assignments run concurrently via parallel Lambda invocations.

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add `create_alb_rule()` retry wrapper that catches `PriorityInUse` and re-queries priority; replace inline `get_next_available_priority` + `elbv2.create_rule` calls in `assign_premium_user` and `migrate_user_to_dedicated_instance` with the new helper.

### Manual Testcases
1. Trigger two concurrent premium user assignments (e.g., invoke the Lambda twice in quick succession with different user IDs targeting the same ALB listener).
2. Verify both succeed without `PriorityInUse` errors in CloudWatch logs.
3. If a retry fires, confirm the log line `Priority <N> taken (attempt X/3), retrying with next available priority` appears.
4. Verify a single assignment still works identically to before (no regressions).

### Unit, Integration, Contract Test Coverage
- No existing automated tests for this Lambda; manual verification required.

### Others

#### Difficulties
- The ALB API has no atomic "create rule with next available priority" operation. The gap between reading available priorities and creating a rule is inherently non-atomic, so a retry loop is the only viable mitigation without introducing external locking (e.g., DynamoDB).

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| ALB rule creation | Low | Retry is bounded (3 attempts) and only activates on the specific `PriorityInUse` error; all other errors propagate immediately |
| `assign_premium_user` | Low | Behavioral change is limited to retrying on a previously-fatal error |
| `migrate_user_to_dedicated_instance` | Low | Same retry logic applied; no other behavior changes |
