### PR TITLE
Fix RDS Proxy target registration after dev scheduler restore

### DIFF
--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -78,6 +78,7 @@ resource "aws_lambda_function" "dev_scheduler" {
       RDS_SUBNET_GROUP_NAME         = aws_db_subnet_group.main.name
       RDS_SECURITY_GROUP_IDS        = aws_security_group.rds.id
       RDS_PARAMETER_GROUP_NAME      = aws_db_parameter_group.main.name
+      RDS_PROXY_NAME                = aws_db_proxy.main.name
       NAT_INSTANCE_ID               = aws_instance.nat.id
       BACKGROUND_INSTANCE_ID        = aws_instance.background.id
       PREMIUM_INSTANCE_IDS          = join(",", aws_instance.premium[*].id)
@@ -192,9 +193,12 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
           "rds:AddTagsToResource",
           "rds:StartDBInstance",
           "rds:StopDBInstance",
+          "rds:RegisterDBProxyTargets",
+          "rds:DescribeDBProxyTargets",
         ]
         Resource = [
           aws_db_instance.main.arn,
+          aws_db_proxy.main.arn,
           # RestoreDBInstanceFromDBSnapshot requires access to the
           # parameter group, subnet group, security group, and snapshot
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:pg:${aws_db_parameter_group.main.name}",

--- a/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
+++ b/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
@@ -484,6 +484,22 @@ def restore_rds(instance_id, snapshot_id, config):
             PubliclyAccessible=False,
         )
         print(f"RDS {instance_id}: restoring from snapshot {snapshot_id}")
+
+        # Re-register with RDS Proxy. The proxy deregisters its target when the
+        # instance is deleted, and does NOT auto-register when a new instance is
+        # restored with the same identifier.
+        proxy_name = os.environ.get("RDS_PROXY_NAME")
+        if proxy_name:
+            try:
+                rds.register_db_proxy_targets(
+                    DBProxyName=proxy_name,
+                    DBInstanceIdentifiers=[instance_id],
+                )
+                print(f"RDS Proxy {proxy_name}: registered target {instance_id}")
+            except Exception as proxy_err:
+                # Log but don't fail — verify-start (+15 min) will retry
+                print(f"RDS Proxy {proxy_name}: registration warning - {proxy_err}")
+
         return "restoring"
     except Exception as e:
         print(f"RDS {instance_id}: error - {e}")


### PR DESCRIPTION
## Summary                                                                                      
  - Re-register the RDS instance with the RDS Proxy after restoring from snapshot in the dev
  scheduler                                                                                       
  - Add required IAM permissions and environment variable for the proxy registration            
                                                                                                  
  ## Context                                                                                    
  On 2026-04-03, the development environment was down from 08:00 to ~09:15 JST because the RDS    
  Proxy had no registered targets after the nightly destroy/restore cycle. All ECS services failed
   to connect to the database (`ERROR 9501: Timed-out waiting to acquire database connection`),
  causing containers to crash in a loop.                                                          
                                                                                                
  When the dev scheduler deletes the RDS instance at 22:00, the proxy automatically deregisters   
  the target. When the instance is restored from snapshot at 08:00 (with the same identifier), the
   proxy does **not** automatically re-register it. The restore function was missing this step.   
  
  ## Changes                                                                                      
                  
  - **`dev_scheduler.py`** — After `restore_db_instance_from_db_snapshot`, call                   
  `rds.register_db_proxy_targets()` to re-associate the restored instance with the proxy. Logs a
  warning on failure but does not block — the verify-start invocation (+15 min) will retry since  
  all operations are idempotent.
  - **`dev_schedule.tf`** — Added `RDS_PROXY_NAME = aws_db_proxy.main.name` to Lambda environment
  variables.                                                                                      
  - **`dev_schedule.tf`** — Added `rds:RegisterDBProxyTargets` and `rds:DescribeDBProxyTargets` to
   the IAM policy, with `aws_db_proxy.main.arn` in the resource list.                             
                  
  ## Test plan                                                                                    
  - [x] Deploy to development
  - [x] Trigger a manual stop+start cycle:                                                        
    ```bash                                                                                       
    aws lambda invoke --function-name development-dev-scheduler \                                 
      --payload '{"action":"stop"}' --region ap-northeast-1 /dev/stdout                           
    # Wait for RDS to be deleted (~2 min)                                                         
    aws lambda invoke --function-name development-dev-scheduler \                                 
      --payload '{"action":"start"}' --region ap-northeast-1 /dev/stdout                          
  - Verify Lambda logs show RDS Proxy development-optinist-rds-proxy: registered target           
  development-optinist-cloud-rds                                                                  
  - Verify aws rds describe-db-proxy-targets --db-proxy-name development-optinist-rds-proxy shows 
  State: AVAILABLE                                                                                
  - Verify ECS tasks connect to DB successfully (no ERROR 9501) 