### PR TITLE
Fix cross-environment contamination in Lambda packages and CloudWatch namespaces

### DIFF
--- a/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
+++ b/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-- **Cost Tracker Lambda** publishes hourly cost and utilization metrics to the `Optinist/CostTracking` CloudWatch namespace
+- **Cost Tracker Lambda** publishes hourly cost and utilization metrics to the `OptiNiSt/CostTracking` CloudWatch namespace
 - **Usage-based cost reporting** uses the `instance_usage_log` table to compute per-user costs from actual session hours rather than assuming 24/7 usage
 - **Actual AWS spend** queried from Cost Explorer and compared against projected budget to trigger cost alarms
 - **Session lifecycle** tracked across all user flows (login, logout, cleanup, assignment, release) to ensure accurate hour accounting
@@ -58,7 +58,7 @@ graph TB
     end
 
     subgraph "Outputs"
-        M --> N[CloudWatch: Optinist/CostTracking]
+        M --> N[CloudWatch: OptiNiSt/CostTracking]
         N --> O[CloudWatch Dashboard]
         N --> P[Cost High Alarm -> SNS]
     end
@@ -287,7 +287,7 @@ free_utilization    = (active_free_users / (running_free_instances * 5)) * 100
 
 ### CloudWatch Metrics Published
 
-**Namespace:** `Optinist/CostTracking`
+**Namespace:** `OptiNiSt/CostTracking`
 **Frequency:** Hourly (via EventBridge `rate(1 hour)`)
 
 | Metric Name | Formula / Source | Unit |
@@ -338,7 +338,7 @@ The report queries and includes:
 | Section | Contents |
 |---------|----------|
 | **1. AWS Cost Review** | 3-month cost trend by service (from Cost Explorer), filtered to tagged resources. Flags services with >20% month-over-month increase. |
-| **1b. Cost Tracker Metrics** | Latest value for all 11 `Optinist/CostTracking` metrics (spend, budget, per-user costs, utilization, session hours, instance/user counts). |
+| **1b. Cost Tracker Metrics** | Latest value for all 11 `OptiNiSt/CostTracking` metrics (spend, budget, per-user costs, utilization, session hours, instance/user counts). |
 | **2. RDS Health Check** | Backup status, free storage (GB), slow query count (30 days), RDS error log count. |
 | **3. Lambda Log Review** | Error counts per Lambda function over past 30 days (days with errors + total). |
 | **4. Alarm Summary** | Count of ALARM transitions in past 30 days, list of unique alarms that fired. |
@@ -408,7 +408,7 @@ The report queries and includes:
 | `query_actual_spend()` | Query Cost Explorer for month-to-date UnblendedCost |
 | `query_usage_hours()` | Aggregate session hours from `instance_usage_log` by tier |
 | `calculate_metrics()` | Derive per-user costs, utilization, and budget projections |
-| `publish_metrics()` | Publish 12 metrics to CloudWatch `Optinist/CostTracking` |
+| `publish_metrics()` | Publish 12 metrics to CloudWatch `OptiNiSt/CostTracking` |
 | `get_db_connection()` | Context manager for pymysql connection via RDS Proxy |
 
 **In Usage Log Writers (other components):**

--- a/infrastructure/scripts/monthly-maintenance.sh
+++ b/infrastructure/scripts/monthly-maintenance.sh
@@ -293,7 +293,7 @@ cat >> "$REPORT" <<'EOF'
 
 EOF
 
-# 1b. Cost Tracker Custom Metrics (from Optinist/CostTracking namespace)
+# 1b. Cost Tracker Custom Metrics (from OptiNiSt/CostTracking namespace)
 echo "  Querying cost tracker metrics..."
 COST_METRICS=(
   "ActualMonthToDateSpend"
@@ -314,7 +314,7 @@ cost_tracker_table="| Metric | Latest Value |
 
 for metric in "${COST_METRICS[@]}"; do
   val=$(aws cloudwatch get-metric-statistics \
-    --namespace "Optinist/CostTracking" \
+    --namespace "OptiNiSt/CostTracking/${ENV_PREFIX:-subscr}" \
     --metric-name "$metric" \
     --start-time "$(iso_days_ago 2)" \
     --end-time "$NOW_ISO" \
@@ -343,7 +343,7 @@ cat >> "$REPORT" <<EOF
 
 $cost_tracker_table
 
-> Source: \`Optinist/CostTracking\` CloudWatch namespace (published hourly by \`subscr-cost-tracker\` Lambda).
+> Source: \`OptiNiSt/CostTracking\` CloudWatch namespace (published hourly by \`subscr-cost-tracker\` Lambda).
 
 EOF
 

--- a/infrastructure/terraform/cost_tracker_package/cost_tracker.py
+++ b/infrastructure/terraform/cost_tracker_package/cost_tracker.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import boto3
 import pymysql
-from aws_constants import DatabaseConfig
+from aws_constants import DatabaseConfig, PremiumInstanceConfig
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -27,7 +27,7 @@ logger.setLevel(logging.INFO)
 PREMIUM_HOURLY_RATE = float(os.environ.get("PREMIUM_HOURLY_RATE", "0.1088"))
 FREE_HOURLY_RATE = float(os.environ.get("FREE_HOURLY_RATE", "0.1088"))
 
-NAMESPACE = "Optinist/CostTracking"
+NAMESPACE = f"Optinist/CostTracking/{PremiumInstanceConfig.get_env_prefix()}"
 
 SSL_ARGS = {"check_hostname": False}
 
@@ -98,11 +98,19 @@ def get_db_connection():
 
 
 def track_premium_instances(ec2_client) -> Dict[str, Any]:
-    """Track premium instance counts using EC2 DescribeInstances with tag filter."""
+    """Track premium instance counts using EC2 DescribeInstances with tag filter.
+
+    Filters by environment Name tag pattern to prevent counting instances
+    from another environment (e.g., dev counting prod instances).
+    """
     try:
         response = ec2_client.describe_instances(
             Filters=[
-                {"Name": "tag:Service", "Values": ["premium-tier"]},
+                {"Name": "tag:Service", "Values": [PremiumInstanceConfig.SERVICE_TAG]},
+                {
+                    "Name": "tag:Name",
+                    "Values": [PremiumInstanceConfig.get_instance_name_pattern()],
+                },
                 {
                     "Name": "instance-state-name",
                     "Values": ["running", "stopped", "pending"],

--- a/infrastructure/terraform/cost_tracker_package/cost_tracker.py
+++ b/infrastructure/terraform/cost_tracker_package/cost_tracker.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.INFO)
 PREMIUM_HOURLY_RATE = float(os.environ.get("PREMIUM_HOURLY_RATE", "0.1088"))
 FREE_HOURLY_RATE = float(os.environ.get("FREE_HOURLY_RATE", "0.1088"))
 
-NAMESPACE = f"Optinist/CostTracking/{PremiumInstanceConfig.get_env_prefix()}"
+NAMESPACE = f"OptiNiSt/CostTracking/{PremiumInstanceConfig.get_env_prefix()}"
 
 SSL_ARGS = {"check_hostname": False}
 

--- a/infrastructure/terraform/free_cleanup_package/free_cleanup.py
+++ b/infrastructure/terraform/free_cleanup_package/free_cleanup.py
@@ -123,7 +123,7 @@ def cleanup_test_user_sessions(connection, user_emails: List[str]) -> Dict[str, 
     Usage (from test scripts):
         lambda_client = boto3.client('lambda')
         response = lambda_client.invoke(
-            FunctionName='subscr-free-cleanup',
+            FunctionName='{env}-free-cleanup',
             InvocationType='RequestResponse',
             Payload=json.dumps({
                 "action": "cleanup_test_users",

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -68,6 +68,9 @@ resource "aws_lambda_function" "free_manager" {
       # Autoscaling configuration
       ASG_NAME = aws_autoscaling_group.main.name
 
+      # Environment prefix for scoped CloudWatch namespaces
+      ENV_PREFIX = var.environment
+
       # Free tier configuration
       FREE_USER_THRESHOLD         = "5"  # Trigger scaling at 5 active users
       FREE_IDLE_THRESHOLD_MINUTES = "5"  # Consider user idle after 5 minutes (reduced from 10)

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -358,6 +358,9 @@ resource "aws_lambda_function" "free_cleanup" {
       RDS_USER     = var.mysql_user
       RDS_PASSWORD = var.mysql_password
       RDS_DATABASE = var.mysql_database
+
+      # Environment prefix for consistency with other Lambdas
+      ENV_PREFIX = var.environment
     }
   }
 

--- a/infrastructure/terraform/free_manager_package/free_manager.py
+++ b/infrastructure/terraform/free_manager_package/free_manager.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # Add parent directory to path for shared imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from aws_constants import ECSTaskStatus, PremiumInstanceConfig  # noqa: E402
+from aws_constants import ECSTaskStatus  # noqa: E402
 
 # Import utility functions
 from free_user_utils import (  # noqa: E402
@@ -297,7 +297,7 @@ def is_scaling_in_progress() -> bool:
                         "Metric": {
                             "Namespace": (
                                 "OptiNiSt/FreeManager/"
-                                f"{PremiumInstanceConfig.get_env_prefix()}"
+                                f"{os.environ['ENV_PREFIX']}"
                             ),
                             "MetricName": "ScalingInProgress",
                         },
@@ -330,7 +330,7 @@ def set_scaling_lock(in_progress: bool) -> None:
     """
     try:
         cloudwatch_client.put_metric_data(
-            Namespace=f"OptiNiSt/FreeManager/{PremiumInstanceConfig.get_env_prefix()}",
+            Namespace=f"OptiNiSt/FreeManager/{os.environ['ENV_PREFIX']}",
             MetricData=[
                 {
                     "MetricName": "ScalingInProgress",
@@ -1039,7 +1039,7 @@ def publish_active_user_metric(active_user_count: int) -> None:
     """
     try:
         cloudwatch_client.put_metric_data(
-            Namespace=f"OptiNiSt/FreeUsers/{PremiumInstanceConfig.get_env_prefix()}",
+            Namespace=f"OptiNiSt/FreeUsers/{os.environ['ENV_PREFIX']}",
             MetricData=[
                 {
                     "MetricName": "ActiveLogins",

--- a/infrastructure/terraform/free_manager_package/free_manager.py
+++ b/infrastructure/terraform/free_manager_package/free_manager.py
@@ -295,7 +295,10 @@ def is_scaling_in_progress() -> bool:
                     "Id": "scaling_lock",
                     "MetricStat": {
                         "Metric": {
-                            "Namespace": f"OptiNiSt/FreeManager/{PremiumInstanceConfig.get_env_prefix()}",
+                            "Namespace": (
+                                "OptiNiSt/FreeManager/"
+                                f"{PremiumInstanceConfig.get_env_prefix()}"
+                            ),
                             "MetricName": "ScalingInProgress",
                         },
                         "Period": 900,  # 15 minutes

--- a/infrastructure/terraform/free_manager_package/free_manager.py
+++ b/infrastructure/terraform/free_manager_package/free_manager.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # Add parent directory to path for shared imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from aws_constants import ECSTaskStatus  # noqa: E402
+from aws_constants import ECSTaskStatus, PremiumInstanceConfig  # noqa: E402
 
 # Import utility functions
 from free_user_utils import (  # noqa: E402
@@ -295,7 +295,7 @@ def is_scaling_in_progress() -> bool:
                     "Id": "scaling_lock",
                     "MetricStat": {
                         "Metric": {
-                            "Namespace": "OptiNiSt/FreeManager",
+                            "Namespace": f"OptiNiSt/FreeManager/{PremiumInstanceConfig.get_env_prefix()}",
                             "MetricName": "ScalingInProgress",
                         },
                         "Period": 900,  # 15 minutes
@@ -327,7 +327,7 @@ def set_scaling_lock(in_progress: bool) -> None:
     """
     try:
         cloudwatch_client.put_metric_data(
-            Namespace="OptiNiSt/FreeManager",
+            Namespace=f"OptiNiSt/FreeManager/{PremiumInstanceConfig.get_env_prefix()}",
             MetricData=[
                 {
                     "MetricName": "ScalingInProgress",
@@ -1036,7 +1036,7 @@ def publish_active_user_metric(active_user_count: int) -> None:
     """
     try:
         cloudwatch_client.put_metric_data(
-            Namespace="OptiNiSt/FreeUsers",
+            Namespace=f"OptiNiSt/FreeUsers/{PremiumInstanceConfig.get_env_prefix()}",
             MetricData=[
                 {
                     "MetricName": "ActiveLogins",

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_log_metric_filter" "user_cpu_usage" {
 
   metric_transformation {
     name      = "UserCPUUsage"
-    namespace = "OptiNiSt/Application"
+    namespace = "OptiNiSt/Application/${var.environment}"
     value     = "$cpu_usage"
   }
 }
@@ -396,12 +396,12 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 6
         properties = {
           metrics = [
-            ["Optinist/CostTracking", "ActualMonthToDateSpend", { "label" : "Actual MTD Spend ($)", "yAxis" : "left" }],
-            ["Optinist/CostTracking", "ExpectedMonthlyBudget", { "label" : "Expected Budget ($)", "yAxis" : "left" }],
-            ["Optinist/CostTracking", "PremiumInstanceCount", { "label" : "Premium Instances", "yAxis" : "right" }],
-            ["Optinist/CostTracking", "FreeInstanceCount", { "label" : "Free Tier Instances", "yAxis" : "right" }],
-            ["Optinist/CostTracking", "ActivePremiumUsers", { "label" : "Active Premium Users", "yAxis" : "right" }],
-            ["Optinist/CostTracking", "ActiveFreeUsers", { "label" : "Active Free Users", "yAxis" : "right" }]
+            ["Optinist/CostTracking/${var.environment}", "ActualMonthToDateSpend", { "label" : "Actual MTD Spend ($)", "yAxis" : "left" }],
+            ["Optinist/CostTracking/${var.environment}", "ExpectedMonthlyBudget", { "label" : "Expected Budget ($)", "yAxis" : "left" }],
+            ["Optinist/CostTracking/${var.environment}", "PremiumInstanceCount", { "label" : "Premium Instances", "yAxis" : "right" }],
+            ["Optinist/CostTracking/${var.environment}", "FreeInstanceCount", { "label" : "Free Tier Instances", "yAxis" : "right" }],
+            ["Optinist/CostTracking/${var.environment}", "ActivePremiumUsers", { "label" : "Active Premium Users", "yAxis" : "right" }],
+            ["Optinist/CostTracking/${var.environment}", "ActiveFreeUsers", { "label" : "Active Free Users", "yAxis" : "right" }]
           ]
           view    = "timeSeries"
           stacked = false
@@ -451,10 +451,10 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 6
         properties = {
           metrics = [
-            ["OptiNiSt/FreeUsers", "ActiveLogins", { "label" : "Active Free Tier Users", "yAxis" : "left" }],
-            ["OptiNiSt/Premium", "ActiveAssignments", { "label" : "Active Premium Users", "yAxis" : "left" }],
-            ["OptiNiSt/Premium", "InstanceUtilization", { "label" : "Premium Instance Utilization %", "yAxis" : "right" }],
-            ["OptiNiSt/Application", "UserCPUUsage", { "label" : "User CPU Usage", "stat" : "Average", "yAxis" : "right" }],
+            ["OptiNiSt/FreeUsers/${var.environment}", "ActiveLogins", { "label" : "Active Free Tier Users", "yAxis" : "left" }],
+            ["OptiNiSt/Premium/${var.environment}", "ActiveAssignments", { "label" : "Active Premium Users", "yAxis" : "left" }],
+            ["OptiNiSt/Premium/${var.environment}", "InstanceUtilization", { "label" : "Premium Instance Utilization %", "yAxis" : "right" }],
+            ["OptiNiSt/Application/${var.environment}", "UserCPUUsage", { "label" : "User CPU Usage", "stat" : "Average", "yAxis" : "right" }],
             ["AWS/Lambda", "Duration", "FunctionName", aws_lambda_function.premium_manager.function_name, { "label" : "Premium Manager Duration (ms)", "yAxis" : "right" }],
             ["AWS/Lambda", "Errors", "FunctionName", aws_lambda_function.premium_manager.function_name, { "label" : "Premium Manager Errors", "yAxis" : "left" }]
           ]

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -396,12 +396,12 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 6
         properties = {
           metrics = [
-            ["Optinist/CostTracking/${var.environment}", "ActualMonthToDateSpend", { "label" : "Actual MTD Spend ($)", "yAxis" : "left" }],
-            ["Optinist/CostTracking/${var.environment}", "ExpectedMonthlyBudget", { "label" : "Expected Budget ($)", "yAxis" : "left" }],
-            ["Optinist/CostTracking/${var.environment}", "PremiumInstanceCount", { "label" : "Premium Instances", "yAxis" : "right" }],
-            ["Optinist/CostTracking/${var.environment}", "FreeInstanceCount", { "label" : "Free Tier Instances", "yAxis" : "right" }],
-            ["Optinist/CostTracking/${var.environment}", "ActivePremiumUsers", { "label" : "Active Premium Users", "yAxis" : "right" }],
-            ["Optinist/CostTracking/${var.environment}", "ActiveFreeUsers", { "label" : "Active Free Users", "yAxis" : "right" }]
+            ["OptiNiSt/CostTracking/${var.environment}", "ActualMonthToDateSpend", { "label" : "Actual MTD Spend ($)", "yAxis" : "left" }],
+            ["OptiNiSt/CostTracking/${var.environment}", "ExpectedMonthlyBudget", { "label" : "Expected Budget ($)", "yAxis" : "left" }],
+            ["OptiNiSt/CostTracking/${var.environment}", "PremiumInstanceCount", { "label" : "Premium Instances", "yAxis" : "right" }],
+            ["OptiNiSt/CostTracking/${var.environment}", "FreeInstanceCount", { "label" : "Free Tier Instances", "yAxis" : "right" }],
+            ["OptiNiSt/CostTracking/${var.environment}", "ActivePremiumUsers", { "label" : "Active Premium Users", "yAxis" : "right" }],
+            ["OptiNiSt/CostTracking/${var.environment}", "ActiveFreeUsers", { "label" : "Active Free Users", "yAxis" : "right" }]
           ]
           view    = "timeSeries"
           stacked = false

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -610,8 +610,13 @@ def cleanup_duplicate_alb_rules() -> Dict[str, Any]:
 
 
 def get_all_premium_instances_with_states():
-    """Get all premium instances with their AWS states (copied from premium_manager)"""
+    """Get all premium instances with their AWS states.
+
+    Filters by environment prefix (ENV_PREFIX) to prevent cross-environment
+    contamination (e.g., development Lambda discovering production instances).
+    """
     ec2: "EC2Client" = boto3.client("ec2")
+    env_prefix = PremiumInstanceConfig.get_env_prefix()
     try:
         # Get instances with premium tags (use multiple filters for robust discovery)
         response = ec2.describe_instances(
@@ -637,10 +642,8 @@ def get_all_premium_instances_with_states():
             instance_id = instance["InstanceId"]
 
             # Check multiple criteria for premium instances
-            name_match = (
-                PremiumInstanceConfig.INSTANCE_IDENTIFIER
-                in tags.get("Name", "").lower()
-            )
+            name_tag = tags.get("Name", "")
+            name_match = PremiumInstanceConfig.INSTANCE_IDENTIFIER in name_tag.lower()
             tier_match = (
                 tags.get("Tier", "").lower()
                 == PremiumInstanceConfig.INSTANCE_IDENTIFIER
@@ -650,16 +653,32 @@ def get_all_premium_instances_with_states():
                 in tags.get("Type", "").lower()
             )
 
+            is_premium = name_match or tier_match or type_match
+
+            # Filter by environment prefix to prevent cross-environment
+            # contamination. Instance Name tags follow the pattern:
+            # "{env_prefix}-premium-running" (e.g., "development-premium-running"
+            # vs "subscr-premium-running"). Reject instances whose Name tag
+            # doesn't start with this Lambda's ENV_PREFIX.
+            if is_premium and name_tag:
+                env_match = name_tag.lower().startswith(env_prefix.lower())
+                if not env_match:
+                    print(
+                        f"Skipping instance {instance_id}: "
+                        f"Name '{name_tag}' does not match "
+                        f"environment prefix '{env_prefix}'"
+                    )
+                    return False
+
             # Debug logging for tag matching
             print(f"Instance {instance_id} tag analysis:")
-            print(f"- Name: '{tags.get('Name', '')}' -> name_match: {name_match}")
+            print(f"- Name: '{name_tag}' -> name_match: {name_match}")
             print(f"- Tier: '{tags.get('Tier', '')}' -> tier_match: {tier_match}")
             print(f"- Type: '{tags.get('Type', '')}' -> type_match: {type_match}")
             print(f"- All tags: {tags}")
 
-            result = name_match or tier_match or type_match
-            print(f"- Final match result: {result}")
-            return result
+            print(f"- Final match result: {is_premium}")
+            return is_premium
 
         instances = []
         all_instances_found = 0
@@ -1073,7 +1092,7 @@ def cleanup_test_user_assignments(connection, user_emails: List[str]) -> Dict[st
         # Invoke this Lambda with:
         lambda_client = boto3.client('lambda')
         response = lambda_client.invoke(
-            FunctionName='subscr-premium-cleanup',
+            FunctionName='{env}-premium-cleanup',
             InvocationType='RequestResponse',
             Payload=json.dumps({
                 "action": "cleanup_test_users",

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -660,6 +660,11 @@ def get_all_premium_instances_with_states():
             # "{env_prefix}-premium-running" (e.g., "development-premium-running"
             # vs "subscr-premium-running"). Reject instances whose Name tag
             # doesn't start with this Lambda's ENV_PREFIX.
+            #
+            # Note: instances without a Name tag are intentionally allowed
+            # through. All Terraform-managed and dynamically-created instances
+            # have Name tags, but we don't block tagless instances to avoid
+            # rejecting legitimate instances in transient states.
             if is_premium and name_tag:
                 env_match = name_tag.lower().startswith(env_prefix.lower())
                 if not env_match:

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -659,15 +659,13 @@ def get_all_premium_instances_with_states():
             # contamination. Instance Name tags follow the pattern:
             # "{env_prefix}-premium-running" (e.g., "development-premium-running"
             # vs "subscr-premium-running"). Reject instances whose Name tag
-            # doesn't start with this Lambda's ENV_PREFIX.
-            #
-            # Note: instances without a Name tag are intentionally allowed
-            # through. All Terraform-managed and dynamically-created instances
-            # have Name tags, but we don't block tagless instances to avoid
-            # rejecting legitimate instances in transient states.
-            if is_premium and name_tag:
-                env_match = name_tag.lower().startswith(env_prefix.lower())
-                if not env_match:
+            # doesn't start with this Lambda's ENV_PREFIX, or that have no
+            # Name tag at all (tagless instances cannot be verified as belonging
+            # to this environment).
+            if is_premium:
+                if not name_tag or not name_tag.lower().startswith(
+                    env_prefix.lower()
+                ):
                     print(
                         f"Skipping instance {instance_id}: "
                         f"Name '{name_tag}' does not match "

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -586,7 +586,7 @@ resource "aws_cloudwatch_log_metric_filter" "premium_assignments" {
 
   metric_transformation {
     name      = "ActiveAssignments"
-    namespace = "OptiNiSt/Premium"
+    namespace = "OptiNiSt/Premium/${var.environment}"
     value     = "1"
   }
 }
@@ -644,6 +644,7 @@ resource "aws_lambda_function" "cost_tracker" {
       RDS_DATABASE        = var.mysql_database
       PREMIUM_HOURLY_RATE = "0.1088"
       FREE_HOURLY_RATE    = "0.1088"
+      ENV_PREFIX          = var.environment
     }
   }
 
@@ -768,7 +769,7 @@ resource "aws_cloudwatch_metric_alarm" "monthly_cost_high" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "ExpectedMonthlyBudget"
-  namespace           = "Optinist/CostTracking"
+  namespace           = "Optinist/CostTracking/${var.environment}"
   period              = "86400"
   statistic           = "Maximum"
   threshold           = var.monthly_budget_usd

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -769,7 +769,7 @@ resource "aws_cloudwatch_metric_alarm" "monthly_cost_high" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "ExpectedMonthlyBudget"
-  namespace           = "Optinist/CostTracking/${var.environment}"
+  namespace           = "OptiNiSt/CostTracking/${var.environment}"
   period              = "86400"
   statistic           = "Maximum"
   threshold           = var.monthly_budget_usd

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -905,10 +905,13 @@ def get_all_premium_instances_with_states():
             # contamination. Instance Name tags follow the pattern:
             # "{env_prefix}-premium-running" (e.g., "development-premium-running"
             # vs "subscr-premium-running"). Reject instances whose Name tag
-            # doesn't start with this Lambda's ENV_PREFIX.
-            if is_premium and name_tag:
-                env_match = name_tag.lower().startswith(env_prefix.lower())
-                if not env_match:
+            # doesn't start with this Lambda's ENV_PREFIX, or that have no
+            # Name tag at all (tagless instances cannot be verified as belonging
+            # to this environment).
+            if is_premium:
+                if not name_tag or not name_tag.lower().startswith(
+                    env_prefix.lower()
+                ):
                     print(
                         f"Skipping instance {instance_id}: "
                         f"Name '{name_tag}' does not match "

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1997,7 +1997,10 @@ def is_premium_scaling_in_progress() -> bool:
                     "Id": "scaling_lock",
                     "MetricStat": {
                         "Metric": {
-                            "Namespace": f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
+                            "Namespace": (
+                                "OptiNiSt/PremiumManager/"
+                                f"{PremiumInstanceConfig.get_env_prefix()}"
+                            ),
                             "MetricName": "ScalingInProgress",
                         },
                         "Period": 900,  # 15 minutes
@@ -2032,7 +2035,9 @@ def set_premium_scaling_lock(in_progress: bool) -> None:
 
     try:
         cloudwatch.put_metric_data(
-            Namespace=f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
+            Namespace=(
+                "OptiNiSt/PremiumManager/" f"{PremiumInstanceConfig.get_env_prefix()}"
+            ),
             MetricData=[
                 {
                     "MetricName": "ScalingInProgress",
@@ -2064,7 +2069,9 @@ def publish_premium_metrics(
 
     try:
         cloudwatch.put_metric_data(
-            Namespace=f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
+            Namespace=(
+                "OptiNiSt/PremiumManager/" f"{PremiumInstanceConfig.get_env_prefix()}"
+            ),
             MetricData=[
                 {
                     "MetricName": "ActivePremiumUsers",

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1997,7 +1997,7 @@ def is_premium_scaling_in_progress() -> bool:
                     "Id": "scaling_lock",
                     "MetricStat": {
                         "Metric": {
-                            "Namespace": "OptiNiSt/PremiumManager",
+                            "Namespace": f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
                             "MetricName": "ScalingInProgress",
                         },
                         "Period": 900,  # 15 minutes
@@ -2032,7 +2032,7 @@ def set_premium_scaling_lock(in_progress: bool) -> None:
 
     try:
         cloudwatch.put_metric_data(
-            Namespace="OptiNiSt/PremiumManager",
+            Namespace=f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
             MetricData=[
                 {
                     "MetricName": "ScalingInProgress",
@@ -2054,7 +2054,7 @@ def publish_premium_metrics(
     """
     Publish premium tier monitoring metrics to CloudWatch.
 
-    Metrics published to namespace OptiNiSt/PremiumManager:
+    Metrics published to namespace OptiNiSt/PremiumManager/{env_prefix}:
     - ActivePremiumUsers: Count of users with active assignments
     - IdlePremiumUsers: Count of users with inactive/no assignments
     - RunningInstances: Count of running EC2 instances
@@ -2064,7 +2064,7 @@ def publish_premium_metrics(
 
     try:
         cloudwatch.put_metric_data(
-            Namespace="OptiNiSt/PremiumManager",
+            Namespace=f"OptiNiSt/PremiumManager/{PremiumInstanceConfig.get_env_prefix()}",
             MetricData=[
                 {
                     "MetricName": "ActivePremiumUsers",

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -575,8 +575,9 @@ class DataCleanupJob:
 
             cloudwatch = boto3.client("cloudwatch")
 
+            env_prefix = os.environ.get("ENV_PREFIX", "default")
             cloudwatch.put_metric_data(
-                Namespace="OptiNiSt/BackgroundJobs",
+                Namespace=f"OptiNiSt/BackgroundJobs/{env_prefix}",
                 MetricData=[
                     {
                         "MetricName": "DataCleanupCount",

--- a/studio/app/common/core/background/expiration_lifecycle_job.py
+++ b/studio/app/common/core/background/expiration_lifecycle_job.py
@@ -577,7 +577,10 @@ class ExpirationLifecycleJob:
             now = get_current_datetime()
             cloudwatch = boto3.client("cloudwatch")
             cloudwatch.put_metric_data(
-                Namespace=ExpirationDeletion.METRIC_NAMESPACE,
+                Namespace=(
+                    f"{ExpirationDeletion.METRIC_NAMESPACE_BASE}"
+                    f"/{os.environ.get('ENV_PREFIX', 'default')}"
+                ),
                 MetricData=[
                     {
                         "MetricName": ExpirationDeletion.METRIC_PROCESSED,

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -619,9 +619,10 @@ class PublishedExperimentSyncJob:
         try:
             import boto3
 
+            env_prefix = os.environ.get("ENV_PREFIX", "default")
             cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
             cloudwatch.put_metric_data(
-                Namespace="OptiNiSt/BackgroundJobs",
+                Namespace=f"OptiNiSt/BackgroundJobs/{env_prefix}",
                 MetricData=[
                     {
                         "MetricName": "PersistentSyncFailure",
@@ -666,9 +667,11 @@ class PublishedExperimentSyncJob:
             total = synced_count + error_count
             error_rate = float(error_count / total * 100) if total > 0 else 0.0
             timestamp = get_current_datetime()
+            env_prefix = os.environ.get("ENV_PREFIX", "default")
+            namespace = f"OptiNiSt/BackgroundJobs/{env_prefix}"
 
             cloudwatch.put_metric_data(
-                Namespace="OptiNiSt/BackgroundJobs",
+                Namespace=namespace,
                 MetricData=[
                     {
                         "MetricName": "ExperimentsSynced",
@@ -686,7 +689,7 @@ class PublishedExperimentSyncJob:
             )
 
             cloudwatch.put_metric_data(
-                Namespace="OptiNiSt/BackgroundJobs",
+                Namespace=namespace,
                 MetricData=[
                     {
                         "MetricName": "SyncErrorRate",

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -455,7 +455,7 @@ class ExpirationDeletion:
     FREE_QUOTA_BYTES = StorageQuota.FREE * StorageSize.GB  # 5 GB
     REPROCESS_COOLDOWN_DAYS = 7  # Days before re-processing a user
     # CloudWatch metrics
-    METRIC_NAMESPACE = "OptiNiSt/BackgroundJobs"
+    METRIC_NAMESPACE_BASE = "OptiNiSt/BackgroundJobs"
     METRIC_PROCESSED = "ExpirationDeletionProcessed"
     METRIC_ERRORS = "ExpirationDeletionErrors"
 

--- a/studio/tests/app/common/core/background/test_sync_job.py
+++ b/studio/tests/app/common/core/background/test_sync_job.py
@@ -838,12 +838,14 @@ class TestPublishMetrics:
             assert pct_data[0]["Timestamp"] == ts
 
     def test_uses_correct_namespace(self):
-        """All calls use the OptiNiSt/BackgroundJobs namespace"""
-        with patch("boto3.client") as mock_boto:
+        """All calls use the env-scoped OptiNiSt/BackgroundJobs namespace"""
+        with patch.dict("os.environ", {"ENV_PREFIX": "test"}), patch(
+            "boto3.client"
+        ) as mock_boto:
             mock_cw = MagicMock()
             mock_boto.return_value = mock_cw
 
             PublishedExperimentSyncJob._publish_metrics(1, 0)
 
             for call in mock_cw.put_metric_data.call_args_list:
-                assert call[1]["Namespace"] == "OptiNiSt/BackgroundJobs"
+                assert call[1]["Namespace"] == "OptiNiSt/BackgroundJobs/test"

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -89,6 +89,7 @@ MOCK_ENV_VARS_PREMIUM = {
 
 MOCK_ENV_VARS_FREE = {
     **MOCK_ENV_VARS_BASE,
+    "ENV_PREFIX": "test",
     "CLUSTER_NAME": "test-cluster",
     "FREE_SERVICE_NAME": "subscr-optinist-cloud-service",
     "ASG_NAME": "test-free-asg",

--- a/studio/tests/infrastructure/test_free_manager.py
+++ b/studio/tests/infrastructure/test_free_manager.py
@@ -212,7 +212,7 @@ class TestPublishActiveUserMetric:
 
             mock_cw.put_metric_data.assert_called_once()
             call_kwargs = mock_cw.put_metric_data.call_args[1]
-            assert call_kwargs["Namespace"] == "OptiNiSt/FreeUsers"
+            assert call_kwargs["Namespace"] == "OptiNiSt/FreeUsers/test"
             metric = call_kwargs["MetricData"][0]
             assert metric["MetricName"] == "ActiveLogins"
             assert metric["Value"] == 42

--- a/studio/tests/infrastructure/test_free_manager.py
+++ b/studio/tests/infrastructure/test_free_manager.py
@@ -199,6 +199,7 @@ class TestPublishActiveUserMetric:
 
     def test_publishes_metric(self, mock_env_vars_free):
         """Calls cloudwatch_client.put_metric_data."""
+        env_prefix = mock_env_vars_free["ENV_PREFIX"]
         with patch.dict("os.environ", mock_env_vars_free), patch(
             "free_manager.ecs_client"
         ), patch("free_manager.autoscaling_client"), patch(
@@ -212,7 +213,7 @@ class TestPublishActiveUserMetric:
 
             mock_cw.put_metric_data.assert_called_once()
             call_kwargs = mock_cw.put_metric_data.call_args[1]
-            assert call_kwargs["Namespace"] == "OptiNiSt/FreeUsers/test"
+            assert call_kwargs["Namespace"] == f"OptiNiSt/FreeUsers/{env_prefix}"
             metric = call_kwargs["MetricData"][0]
             assert metric["MetricName"] == "ActiveLogins"
             assert metric["Value"] == 42

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from aws_constants import ECSTaskStatus, PremiumAssignment, RoutingHeaders
+from aws_constants import ECSTaskStatus, PremiumAssignment, PremiumInstanceConfig, RoutingHeaders
 from conftest import MockRow, setup_db_mock
 
 TEST_INSTANCE_ID = "i-testlambda123"
@@ -989,3 +989,123 @@ class TestReconcileSingleInstance:
             # ALB rule should be deleted, but shared TG should NOT
             mock_elbv2.delete_rule.assert_called_once_with(RuleArn=rule_arn)
             mock_elbv2.delete_target_group.assert_not_called()
+
+
+class TestGetAllPremiumInstancesEnvFilter:
+    """Environment prefix filter tests for get_all_premium_instances_with_states."""
+
+    def test_same_env_instance_passes(self, mock_env_vars_premium):
+        """Instance with matching env prefix is included."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-same-env",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": (
+                                            PremiumInstanceConfig.get_instance_name()
+                                        ),
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": (
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                                        ),
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_cleanup import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert len(result) == 1
+            assert result[0]["instance_id"] == "i-same-env"
+
+    def test_cross_env_instance_skipped(self, mock_env_vars_premium):
+        """Instance with different env prefix is excluded."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-cross-env",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "production-premium-running",
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": (
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                                        ),
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_cleanup import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert len(result) == 0
+
+    def test_tagless_instance_skipped(self, mock_env_vars_premium):
+        """Premium instance without Name tag is excluded."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-no-name",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": (
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                                        ),
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_cleanup import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert len(result) == 0

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-from aws_constants import ECSTaskStatus, PremiumAssignment, PremiumInstanceConfig, RoutingHeaders
+from aws_constants import (
+    ECSTaskStatus,
+    PremiumAssignment,
+    PremiumInstanceConfig,
+    RoutingHeaders,
+)
 from conftest import MockRow, setup_db_mock
 
 TEST_INSTANCE_ID = "i-testlambda123"
@@ -690,8 +695,8 @@ class TestReconcileSingleInstance:
             "boto3.client"
         ) as mock_boto3:
             mock_ec2 = MagicMock()
-            mock_boto3.side_effect = (
-                lambda service: mock_ec2 if service == "ec2" else MagicMock()
+            mock_boto3.side_effect = lambda service: (
+                mock_ec2 if service == "ec2" else MagicMock()
             )
 
             mock_ec2.describe_instances.return_value = {
@@ -842,8 +847,8 @@ class TestReconcileSingleInstance:
             "boto3.client"
         ) as mock_boto3:
             mock_ec2 = MagicMock()
-            mock_boto3.side_effect = (
-                lambda service: mock_ec2 if service == "ec2" else MagicMock()
+            mock_boto3.side_effect = lambda service: (
+                mock_ec2 if service == "ec2" else MagicMock()
             )
 
             # describe_instances will fail for non-real instance ID

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1479,6 +1479,80 @@ class TestGetAllPremiumInstances:
             result = get_all_premium_instances_with_states()
             assert result == []
 
+    def test_cross_env_instance_skipped(self, mock_env_vars_premium):
+        """Instance with different env prefix is excluded."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-cross-env",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "production-premium-running",
+                                    },
+                                    {
+                                        "Key": "Tier",
+                                        "Value": (
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                                        ),
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert len(result) == 0
+
+    def test_tagless_instance_skipped(self, mock_env_vars_premium):
+        """Premium instance without Name tag is excluded."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-no-name",
+                                "InstanceType": "t3.large",
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "Tier",
+                                        "Value": (
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                                        ),
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import get_all_premium_instances_with_states
+
+            result = get_all_premium_instances_with_states()
+            assert len(result) == 0
+
 
 class TestStartStandbyInstance:
     """start_standby_instance tests."""


### PR DESCRIPTION
## Summary

- Scope all CloudWatch namespaces by environment to prevent metric collision and scaling lock interference between production and development
- Add `ENV_PREFIX` filtering to remaining Lambdas that discover EC2 instances without environment scoping
- Fix hardcoded production Lambda names in docstrings

## Context

Production (`subscr`) and development (`development`) share the same AWS account. The premium manager Lambda was previously fixed to filter by `ENV_PREFIX` when discovering EC2 instances ([PR #456](https://github.com/arayabrain/araya-optinist/pull/456)), but the same cross-environment contamination pattern remained in several other places.

On 2026-04-03, the production `subscr-premium-manager` Lambda stopped the development premium instance `i-05ce937ed998dffdf` because it discovered it as an unassigned idle instance. CloudTrail confirmed: `StopInstances` at 08:41 JST by `subscr-premium-manager`.

### Three categories of issues found:

1. **Scaling lock collision** (most critical): `premium_manager` and `free_manager` use CloudWatch metrics as distributed locks (`ScalingInProgress`). Both environments wrote to the same namespace, meaning a dev scaling operation could block production scaling and vice versa.
2. **Metric blending**: Cost tracking, user counts, and instance metrics from both environments were published to shared namespaces, corrupting dashboards and alarms.
3. **Instance discovery**: `premium_cleanup` Lambda could discover and reconcile production instances from the development environment.

## Changes

### Lambda Code

| File | Change |
|---|---|
| `premium_manager.py` | `OptiNiSt/PremiumManager` → `OptiNiSt/PremiumManager/{env_prefix}` (scaling lock read/write + metrics publish) |
| `free_manager.py` | `OptiNiSt/FreeManager` → `OptiNiSt/FreeManager/{env_prefix}` (scaling lock read/write) |
| `free_manager.py` | `OptiNiSt/FreeUsers` → `OptiNiSt/FreeUsers/{env_prefix}` (active user metric) |
| `free_manager.py` | Added `PremiumInstanceConfig` import for `get_env_prefix()` |
| `premium_cleanup.py` | Added `ENV_PREFIX` filter to `get_all_premium_instances_with_states()` — matches the fix already in `premium_manager.py` |
| `cost_tracker.py` | Added `tag:Name` filter using `PremiumInstanceConfig.get_instance_name_pattern()` to `track_premium_instances()` |
| `cost_tracker.py` | `Optinist/CostTracking` → `Optinist/CostTracking/{env_prefix}` |
| `free_cleanup.py` | Docstring: `subscr-free-cleanup` → `{env}-free-cleanup` |
| `premium_cleanup.py` | Docstring: `subscr-premium-cleanup` → `{env}-premium-cleanup` |

### Terraform

| File | Change |
|---|---|
| `free_manager.tf` | Added `ENV_PREFIX = var.environment` to free manager Lambda env vars |
| `premium_manager.tf` | Added `ENV_PREFIX = var.environment` to cost tracker Lambda env vars |
| `premium_manager.tf` | Cost alarm namespace → `Optinist/CostTracking/${var.environment}` |
| `premium_manager.tf` | Metric filter namespace → `OptiNiSt/Premium/${var.environment}` |
| `monitoring.tf` | Application metric filter namespace → `OptiNiSt/Application/${var.environment}` |
| `monitoring.tf` | Dashboard widgets updated to environment-scoped namespaces |

### Tests

| File | Change |
|---|---|
| `conftest.py` | Added `ENV_PREFIX: "test"` to `MOCK_ENV_VARS_FREE` |
| `test_free_manager.py` | Updated expected namespace to `OptiNiSt/FreeUsers/test` |

## Deployment Notes

- **No crashes or functional issues** — scaling locks switch atomically with the Lambda deployment
- **Metric history breaks** — old namespaces stop receiving data, new namespaces start fresh. Historical data is preserved in the old namespace but dashboards will show a gap
- **Alarms may briefly show INSUFFICIENT_DATA** — resolves within 1 hour once new metrics are published
- **Recommended**: deploy to development first, then production during low-activity hours

## Test Plan

- [x] 109/110 infrastructure tests pass (1 pre-existing `fastapi` import failure unrelated)
- [x] Deploy to development — verify CloudWatch logs show `"Skipping instance"` for `subscr-premium-running` instances
- [x] Verify scaling lock metrics publish to `OptiNiSt/PremiumManager/development` namespace
- [x] Verify cost tracker publishes to `OptiNiSt/CostTracking/development` namespace
- [ ] Deploy to production — verify alarms recover from INSUFFICIENT_DATA within 1 hour
- [ ] Verify production dashboard shows metrics under new namespaces