### PR TITLE
Missing iam permission

### DIFF
--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -467,6 +467,7 @@ resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
           "cloudwatch:ListMetrics",
           "cloudwatch:GetMetricStatistics",
           "cloudwatch:DescribeAlarms",
+          "cloudwatch:PutMetricData",
           "autoscaling:DescribeAutoScalingGroups",
           "ecs:ListClusters",
           "ecs:ListContainerInstances"


### PR DESCRIPTION
### Content

#### Summary
- Background jobs (sync, cleanup, expiration lifecycle) running in the ECS background service fail to publish CloudWatch custom metrics (`ExperimentsSynced`, `SyncErrors`, `SyncErrorRate`, `DataCleanupCount`, `CleanupErrors`) due to a missing IAM permission.
- The `subscr-optinist-cloud-user` IAM policy had read-only CloudWatch actions (`ListMetrics`, `GetMetricStatistics`, `DescribeAlarms`) but was missing `cloudwatch:PutMetricData`.
- The Lambda roles (`premium_manager`, `free_manager`) already had `PutMetricData` — only the ECS user policy was affected.

#### Design Decisions
- Added `PutMetricData` to the existing wildcard-resource CloudWatch statement rather than creating a scoped statement, because `PutMetricData` does not support resource-level restrictions (AWS requires `Resource: "*"` for this action).
- No namespace-level restriction is possible via IAM; the application code already scopes writes to `OptiNiSt/BackgroundJobs`.

### Evidence
- CloudWatch logs from `/ecs/subscr-background-optinist-cloud-taskdef` (task `ead405e2`):
  ```
  2026-04-03 15:10:04,816 ERROR: Failed to publish metrics: An error occurred (AccessDenied)
    when calling the PutMetricData operation: User: arn:aws:iam::637423646530:user/subscr-optinist-cloud-user
    is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows
    the cloudwatch:PutMetricData action
  ```
- Confirmed the sync job runs every 5 minutes and completes, but metrics are silently dropped.
- Verified Lambda roles in `premium_manager.tf` and `free_manager.tf` already have `PutMetricData` — no change needed there.

### References
- Related test cases: BT-1110, BT-1111, BT-1112, BT-1113 (CloudWatch custom metrics verification)
- IAM reference: [PutMetricData does not support resource-level permissions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-cw-condition-keys-namespace.html)

#### Files changed
- `infrastructure/terraform/security.tf` -- Add `cloudwatch:PutMetricData` to the `subscr-optinist-cloud-user-policy` IAM policy

### Manual Testcases
- Apply Terraform: `terraform apply -var-file=environments/production.tfvars`
- Wait for the next background sync cycle (runs every 5 minutes)
- Check CloudWatch logs for the background service — verify no `AccessDenied` errors on `PutMetricData`
- Check CloudWatch > Metrics > `OptiNiSt/BackgroundJobs` — verify `ExperimentsSynced`, `SyncErrors`, `SyncErrorRate` have new datapoints
- Publish an experiment, wait for the next sync cycle, verify `ExperimentsSynced` increments

### Unit, Integration, Contract Test Coverage
- No code-level tests affected — this is an infrastructure-only IAM policy change.
- Verify with: `terraform plan -var-file=environments/production.tfvars` — should show only the IAM policy update.

### Others

#### Difficulties
None — straightforward missing permission identified via CloudWatch error logs during BT-1110 test case verification.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| IAM policy scope | Low | `PutMetricData` requires `Resource: "*"` per AWS design; no broader access granted than necessary |
| Background jobs | Low | Jobs already run and succeed — only the metric publication step was failing silently |
| Other services | Low | Only affects `subscr-optinist-cloud-user`; Lambda roles are unchanged |
