### PR TITLE
Fix monitoring email

### DIFF
--- a/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
+++ b/infrastructure/documentation/COST_TRACKING_ARCHITECTURE.md
@@ -314,7 +314,7 @@ free_utilization    = (active_free_users / (running_free_instances * 5)) * 100
 | **Threshold** | `var.monthly_budget_usd` (set in `terraform.tfvars`, not in repo) |
 | **Condition** | Projected monthly spend > budget |
 | **Evaluation** | 1 × 24h period |
-| **Action (ALARM)** | SNS `subscr-optinist-critical-alerts` → email `support@araya-optinist.com` |
+| **Action (ALARM)** | SNS `subscr-optinist-critical-alerts` → email `optinist-support@araya.org` |
 | **Action (OK)** | Same SNS topic (sends recovery notification) |
 | **Defined in** | `premium_manager.tf` → `aws_cloudwatch_metric_alarm.monthly_cost_high` |
 

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -471,7 +471,7 @@ When an alarm fires, follow the procedure for that alarm category.
 
 ## Reference: Critical Alert Configuration
 
-Critical CloudWatch alarms send email notifications to `support@araya-optinist.com` via an SNS topic (`subscr-optinist-critical-alerts`, defined in `monitoring.tf`). Both `alarm_actions` and `ok_actions` are wired so the team is notified when an alarm fires and when it recovers.
+Critical CloudWatch alarms send email notifications to `optinist-support@araya.org` via an SNS topic (`subscr-optinist-critical-alerts`, defined in `monitoring.tf`). Both `alarm_actions` and `ok_actions` are wired so the team is notified when an alarm fires and when it recovers.
 
 **Note:** After the initial `terraform apply`, AWS sends a confirmation email to the subscription endpoint. The subscription must be confirmed before alerts are delivered.
 
@@ -664,7 +664,7 @@ curl -s -o /dev/null -w "%{http_code}" https://araya-optinist.com/health
 
 ## Reference: Support Email Monitoring
 
-**Support email:** `support@araya-optinist.com` (registered and active)
+**Support email:** `optinist-support@araya.org` (requires SNS confirmation after terraform apply)
 
 Critical CloudWatch alarms are configured to send notifications to this address via SNS (see [Critical Alert Configuration](#reference-critical-alert-configuration)).
 

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -35,7 +35,7 @@ resource "aws_sns_topic_subscription" "critical_alerts_email" {
   count     = var.environment == "subscr" ? 1 : 0
   topic_arn = aws_sns_topic.critical_alerts[0].arn
   protocol  = "email"
-  endpoint  = "support@araya-optinist.com"
+  endpoint  = "optinist-support@araya.org"
 }
 
 locals {


### PR DESCRIPTION
### Content

#### Summary
- The SNS critical alerts subscription was configured with an incorrect email (`support@araya-optinist.com`). The subscription was never confirmed, so no alarm notifications were being delivered.
- Updated to the correct address (`optinist-support@araya.org`).

#### Design Decisions
- Terraform will destroy the old pending subscription and create a new one. The new subscription requires email confirmation before notifications are delivered.

### Evidence
- SNS topic `subscr-optinist-critical-alerts` had 0 confirmed subscriptions and 1 pending to the wrong address:
  ```json
  {
    "SubscriptionsConfirmed": "0",
    "SubscriptionsPending": "1"
  }
  ```
  ```json
  {
    "protocol": "email",
    "endpoint": "support@araya-optinist.com",
    "status": "PendingConfirmation"
  }
  ```
- `subscr-monthly-cost-high` alarm is currently in ALARM state with no notification delivered.
- Correct email confirmed via `docs/other/contact.md`.

### References
- Related test case: BT-1120 (alarm notification verification)
- `docs/other/contact.md` — canonical support email

#### Files changed
- `infrastructure/terraform/monitoring.tf` -- Fix SNS alert subscription email from `support@araya-optinist.com` to `optinist-support@araya.org`

### Manual Testcases
- Apply Terraform: `terraform apply -var-file=environments/production.tfvars`
- Check `optinist-support@araya.org` inbox for SNS confirmation email and click confirm
- Verify `subscr-monthly-cost-high` alarm (currently in ALARM state) delivers a notification to the confirmed address

### Unit, Integration, Contract Test Coverage
- No code-level tests — infrastructure-only change.
- Verify with: `terraform plan -var-file=environments/production.tfvars` — should show SNS subscription replacement.

### Others

#### Difficulties
None.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| SNS subscription | Low | Replacing a never-confirmed subscription; no existing notification flow is disrupted |
