### PR TITLE
Fix lambda scope, and ghost instance issue

### DIFF
--- a/infrastructure/terraform/free_manager_package/free_manager.py
+++ b/infrastructure/terraform/free_manager_package/free_manager.py
@@ -927,7 +927,9 @@ def get_available_instance_ids(cluster_name: str, service_name: str) -> List[str
         ]
         for container_status in container_statuses:
             response = ecs_client.list_container_instances(
-                cluster=cluster_name, status=container_status
+                cluster=cluster_name,
+                status=container_status,
+                filter="attribute:tier == free",
             )
             arns = response.get("containerInstanceArns", [])
             if arns:

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -184,7 +184,10 @@ def _get_ecs_container_instance_arn(
     """Map EC2 instance ID to ECS container instance ARN."""
     ecs: "ECSClient" = boto3.client("ecs")
     try:
-        response = ecs.list_container_instances(cluster=cluster_name)
+        response = ecs.list_container_instances(
+            cluster=cluster_name,
+            filter="attribute:tier == premium",
+        )
         arns = response.get("containerInstanceArns", [])
         if not arns:
             return None

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -397,10 +397,16 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           }
         }
       },
-      # EC2 CreateTags/DeleteTags (tagging new instances + ghost cleanup grace period)
+      # EC2 CreateTags (unrestricted — needed by RunInstances TagSpecifications)
       {
         Effect   = "Allow"
-        Action   = ["ec2:CreateTags", "ec2:DeleteTags"]
+        Action   = "ec2:CreateTags"
+        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+      },
+      # EC2 DeleteTags (scoped to ghost cleanup grace period tag only)
+      {
+        Effect   = "Allow"
+        Action   = "ec2:DeleteTags"
         Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
         Condition = {
           "ForAllValues:StringEquals" = {

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -397,11 +397,16 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           }
         }
       },
-      # EC2 CreateTags (unrestricted to allow tagging new instances)
+      # EC2 CreateTags/DeleteTags (tagging new instances + ghost cleanup grace period)
       {
         Effect   = "Allow"
-        Action   = "ec2:CreateTags"
+        Action   = ["ec2:CreateTags", "ec2:DeleteTags"]
         Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "aws:TagKeys" = ["optinist:agent-disconnected-at"]
+          }
+        }
       },
       # EC2 RunInstances (requires multiple resource types)
       {

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3877,15 +3877,21 @@ def get_ecs_container_instance_id(
     try:
         print(f"Looking up ECS container instance for EC2 instance {ec2_instance_id}")
 
-        # List all container instances in the cluster
-        response = ecs.list_container_instances(cluster=cluster_name)
+        # List only premium container instances in the cluster
+        response = ecs.list_container_instances(
+            cluster=cluster_name,
+            filter="attribute:tier == premium",
+        )
         container_instance_arns = response.get("containerInstanceArns", [])
 
         if not container_instance_arns:
-            print(f"No container instances found in cluster {cluster_name}")
+            print(f"No premium container instances found in cluster {cluster_name}")
             return None
 
-        print(f" Found {len(container_instance_arns)} container instances in cluster")
+        print(
+            f" Found {len(container_instance_arns)} premium container instances "
+            f"in cluster"
+        )
 
         # Describe container instances to find the one matching our EC2 instance
         describe_response = ecs.describe_container_instances(
@@ -5073,20 +5079,22 @@ def cleanup_failed_standby_instances():
         print(f"Error cleaning up failed standby instances: {str(e)}")
 
 
+_DISCONNECT_TAG_KEY = "optinist:agent-disconnected-at"
+_AGENT_DISCONNECT_GRACE_SECONDS = 300
+
+
 def cleanup_ghost_ecs_registrations():
-    """
-    Clean up ghost ECS container instance registrations.
+    """Deregister ghost premium container instances from the ECS cluster.
 
-    When EC2 instances are stopped or terminated outside of our normal flow
-    (e.g., instance crashes, manual stops via AWS console), the ECS container
-    instance registration may remain as a "ghost" entry with a disconnected agent.
-    This confuses the ECS scheduler which tries to place tasks on these instances.
+    Only targets instances with attribute:tier == premium.
 
-    This function finds and deregisters any container instances where:
-    - The ECS agent is not connected, OR
-    - The underlying EC2 instance is stopped/terminated
+    Deregistration rules:
+      - EC2 stopped/terminated/gone: deregister immediately.
+      - EC2 running + agent disconnected: tag with a timestamp on first
+        sighting, deregister after _AGENT_DISCONNECT_GRACE_SECONDS.
+        The tag is cleared automatically if the agent reconnects.
 
-    Called periodically by handle_scheduled_monitoring (every 15 minutes).
+    Called every 15 minutes by handle_scheduled_monitoring.
     """
     ecs: "ECSClient" = boto3.client("ecs")
     ec2: "EC2Client" = boto3.client("ec2")
@@ -5100,12 +5108,17 @@ def cleanup_ghost_ecs_registrations():
         return
 
     try:
-        # List all container instances in the premium cluster
-        response = ecs.list_container_instances(cluster=cluster_name)
+        # List only premium container instances in the cluster
+        response = ecs.list_container_instances(
+            cluster=cluster_name,
+            filter="attribute:tier == premium",
+        )
         container_instance_arns = response.get("containerInstanceArns", [])
 
         if not container_instance_arns:
-            print("No container instances found in cluster - nothing to cleanup")
+            print(
+                "No premium container instances found in cluster - nothing to cleanup"
+            )
             return
 
         # Describe container instances to check agent status and EC2 mapping
@@ -5114,51 +5127,130 @@ def cleanup_ghost_ecs_registrations():
         )
 
         ghost_instances = []
+        reconnected_ec2_ids = []
+
         for container_instance in describe_response.get("containerInstances", []):
             container_instance_arn = container_instance.get("containerInstanceArn")
             ec2_instance_id = container_instance.get("ec2InstanceId")
             agent_connected = container_instance.get("agentConnected", False)
             status = container_instance.get("status", "UNKNOWN")
 
-            # Check if this is a ghost registration
-            is_ghost = False
-            reason = ""
+            # Agent reconnected — clear any disconnect tag (best-effort)
+            if agent_connected:
+                if ec2_instance_id:
+                    reconnected_ec2_ids.append(ec2_instance_id)
+                continue
 
-            # Case 1: Agent is not connected
-            if not agent_connected:
-                is_ghost = True
-                reason = "ECS agent disconnected"
+            # Agent is disconnected — check EC2 state to decide what to do
+            if not ec2_instance_id:
+                # No EC2 mapping at all — deregister immediately
+                ghost_instances.append(
+                    {
+                        "container_instance_arn": container_instance_arn,
+                        "ec2_instance_id": ec2_instance_id,
+                        "reason": "Disconnected agent with no EC2 instance mapping",
+                        "status": status,
+                    }
+                )
+                continue
 
-            # Case 2: Check if EC2 instance is stopped/terminated
-            if ec2_instance_id and not is_ghost:
+            if ec2_instance_id:
                 try:
                     ec2_response = ec2.describe_instances(InstanceIds=[ec2_instance_id])
                     if ec2_response["Reservations"]:
-                        instance_state = ec2_response["Reservations"][0]["Instances"][
-                            0
-                        ]["State"]["Name"]
+                        instance = ec2_response["Reservations"][0]["Instances"][0]
+                        instance_state = instance["State"]["Name"]
+
+                        # EC2 is dead → deregister immediately
                         if instance_state in [
                             InstanceState.STOPPED,
                             InstanceState.TERMINATED,
                             InstanceState.SHUTTING_DOWN,
                         ]:
-                            is_ghost = True
-                            reason = f"EC2 instance is {instance_state}"
-                except Exception as e:
-                    # Instance might not exist
-                    if "InvalidInstanceID" in str(e):
-                        is_ghost = True
-                        reason = "EC2 instance does not exist"
+                            ghost_instances.append(
+                                {
+                                    "container_instance_arn": container_instance_arn,
+                                    "ec2_instance_id": ec2_instance_id,
+                                    "reason": f"EC2 instance is {instance_state}",
+                                    "status": status,
+                                }
+                            )
+                            continue
 
-            if is_ghost:
-                ghost_instances.append(
-                    {
-                        "container_instance_arn": container_instance_arn,
-                        "ec2_instance_id": ec2_instance_id,
-                        "reason": reason,
-                        "status": status,
-                    }
+                        # EC2 is running but agent disconnected — apply grace period
+                        tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+                        first_seen = tags.get(_DISCONNECT_TAG_KEY)
+
+                        if not first_seen:
+                            now_str = datetime.now(timezone.utc).isoformat()
+                            print(
+                                f"Agent disconnected on {ec2_instance_id}, "
+                                f"starting grace period"
+                            )
+                            ec2.create_tags(
+                                Resources=[ec2_instance_id],
+                                Tags=[
+                                    {
+                                        "Key": _DISCONNECT_TAG_KEY,
+                                        "Value": now_str,
+                                    }
+                                ],
+                            )
+                            continue
+
+                        # Tag exists — check if grace period has elapsed
+                        try:
+                            first_seen_dt = datetime.fromisoformat(first_seen)
+                        except (ValueError, TypeError):
+                            first_seen_dt = datetime.now(timezone.utc)
+
+                        elapsed = (
+                            datetime.now(timezone.utc) - first_seen_dt
+                        ).total_seconds()
+
+                        if elapsed < _AGENT_DISCONNECT_GRACE_SECONDS:
+                            print(
+                                f"Agent disconnected on {ec2_instance_id} "
+                                f"for {int(elapsed)}s, within grace period"
+                            )
+                            continue
+
+                        ghost_instances.append(
+                            {
+                                "container_instance_arn": container_instance_arn,
+                                "ec2_instance_id": ec2_instance_id,
+                                "reason": (
+                                    f"ECS agent disconnected for "
+                                    f"{int(elapsed)}s (grace period "
+                                    f"{_AGENT_DISCONNECT_GRACE_SECONDS}s)"
+                                ),
+                                "status": status,
+                            }
+                        )
+                        continue
+
+                except Exception as e:
+                    if "InvalidInstanceID" in str(e):
+                        ghost_instances.append(
+                            {
+                                "container_instance_arn": container_instance_arn,
+                                "ec2_instance_id": ec2_instance_id,
+                                "reason": "EC2 instance does not exist",
+                                "status": status,
+                            }
+                        )
+                        continue
+                    raise
+
+        # Clear disconnect tags on instances whose agents have reconnected
+        if reconnected_ec2_ids:
+            try:
+                ec2.delete_tags(
+                    Resources=reconnected_ec2_ids,
+                    Tags=[{"Key": _DISCONNECT_TAG_KEY}],
                 )
+            except Exception as e:
+                print(f"Warning: failed to clear disconnect tags: {str(e)}")
 
         if not ghost_instances:
             print("No ghost ECS registrations found")
@@ -5180,6 +5272,15 @@ def cleanup_ghost_ecs_registrations():
                     containerInstance=ghost["container_instance_arn"],
                     force=True,
                 )
+                # Clean up the disconnect tag after successful deregistration
+                if ghost["ec2_instance_id"]:
+                    try:
+                        ec2.delete_tags(
+                            Resources=[ghost["ec2_instance_id"]],
+                            Tags=[{"Key": _DISCONNECT_TAG_KEY}],
+                        )
+                    except Exception:
+                        pass
                 cleanup_count += 1
             except Exception as e:
                 print(
@@ -5209,9 +5310,11 @@ def cleanup_orphaned_ec2_instances():
         ecs: "ECSClient" = boto3.client("ecs")
         ec2: "EC2Client" = boto3.client("ec2")
 
-        # Collect EC2 IDs of all ACTIVE ECS container instances
+        # Collect EC2 IDs of ACTIVE premium ECS container instances
         ci_response = ecs.list_container_instances(
-            cluster=cluster_name, status="ACTIVE"
+            cluster=cluster_name,
+            status="ACTIVE",
+            filter="attribute:tier == premium",
         )
         ci_arns = ci_response.get("containerInstanceArns", [])
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2328,3 +2328,327 @@ class TestGetPremiumUserStatus:
             # Original assignment returned with terminating status
             assert body["status"] == "terminating"
             assert body["assigned_at"] == assigned_at.isoformat()
+
+
+class TestCleanupGhostECSRegistrations:
+    """cleanup_ghost_ecs_registrations must only deregister premium
+    instances, and must apply a grace period for agent disconnects
+    on running EC2 instances."""
+
+    def _make_clients(self, mock_boto3):
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+
+        def client_factory(service):
+            if service == "ecs":
+                return mock_ecs
+            if service == "ec2":
+                return mock_ec2
+            return MagicMock()
+
+        mock_boto3.side_effect = client_factory
+        return mock_ecs, mock_ec2
+
+    def test_uses_premium_tier_filter(self, mock_env_vars_premium):
+        """list_container_instances must include the premium tier filter."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, _ = self._make_clients(mock_boto3)
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": []
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.list_container_instances.assert_called_once_with(
+                cluster="test-cluster",
+                filter="attribute:tier == premium",
+            )
+
+    def test_deregisters_stopped_ec2_immediately(self, mock_env_vars_premium):
+        """Instance whose EC2 is stopped gets deregistered with no grace."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/ghost1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-stopped1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "stopped"}, "Tags": []}]}
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
+
+    def test_tags_running_instance_on_first_disconnect(self, mock_env_vars_premium):
+        """Running EC2 with disconnected agent gets tagged but not deregistered."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/disc1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-running1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "running"}, "Tags": []}]}
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_not_called()
+            mock_ec2.create_tags.assert_called_once()
+            tag_call = mock_ec2.create_tags.call_args
+            assert tag_call.kwargs["Resources"] == ["i-running1"]
+            assert tag_call.kwargs["Tags"][0]["Key"] == "optinist:agent-disconnected-at"
+
+    def test_skips_within_grace_period(self, mock_env_vars_premium):
+        """Running EC2 tagged recently is within grace period — skip."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/grace1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-grace1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            # Tagged 2 minutes ago — within the 5-minute grace
+            recent = (datetime.now(timezone.utc) - timedelta(minutes=2)).isoformat()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "optinist:agent-disconnected-at",
+                                        "Value": recent,
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_not_called()
+
+    def test_deregisters_after_grace_period(self, mock_env_vars_premium):
+        """Running EC2 tagged over 5 minutes ago gets deregistered."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/expired1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-expired1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            # Tagged 10 minutes ago — past the 5-minute grace
+            old = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "State": {"Name": "running"},
+                                "Tags": [
+                                    {
+                                        "Key": "optinist:agent-disconnected-at",
+                                        "Value": old,
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
+
+    def test_clears_tag_on_reconnect(self, mock_env_vars_premium):
+        """Connected agent triggers delete_tags to clear disconnect tag."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/healthy1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-healthy1",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_not_called()
+            mock_ec2.delete_tags.assert_called_once_with(
+                Resources=["i-healthy1"],
+                Tags=[{"Key": "optinist:agent-disconnected-at"}],
+            )
+
+    def test_mixed_cluster_only_deregisters_ghost(self, mock_env_vars_premium):
+        """With a healthy and a stopped instance in the filtered results,
+        only the stopped one is deregistered."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            healthy_arn = "arn:aws:ecs:r:a:ci/healthy"
+            ghost_arn = "arn:aws:ecs:r:a:ci/ghost"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [healthy_arn, ghost_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": healthy_arn,
+                        "ec2InstanceId": "i-healthy",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "containerInstanceArn": ghost_arn,
+                        "ec2InstanceId": "i-ghost",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "terminated"}, "Tags": []}]}
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            # Only the ghost gets deregistered
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ghost_arn,
+                force=True,
+            )
+            # EC2 describe only called for the disconnected instance
+            mock_ec2.describe_instances.assert_called_once_with(InstanceIds=["i-ghost"])
+            # Healthy instance's tag is cleared
+            mock_ec2.delete_tags.assert_any_call(
+                Resources=["i-healthy"],
+                Tags=[{"Key": "optinist:agent-disconnected-at"}],
+            )
+
+    def test_deregisters_disconnected_without_ec2_id(self, mock_env_vars_premium):
+        """Container instance with disconnected agent and no ec2InstanceId
+        is deregistered immediately."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/no-ec2"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
+            # No EC2 calls should be made
+            mock_ec2.describe_instances.assert_not_called()


### PR DESCRIPTION
### Content

#### Summary
- The `cleanup_ghost_ecs_registrations()` function in `premium_manager` caused a production outage (503 on araya-optinist.com) by force-deregistering the free-tier container instance from the shared ECS cluster. The function had no tier filter, so it operated on all instances — not just premium ones.
- Five `list_container_instances` calls across three Lambda packages (`premium_manager`, `premium_cleanup`, `free_manager`) were missing tier-scoped `filter` parameters, allowing each to read or act on container instances belonging to other tiers.
- Additionally, the `agentConnected=False` check in ghost cleanup was too aggressive — a single transient disconnect triggered immediate force-deregistration with no grace period. Added a 5-minute grace period using an EC2 tag to track first-seen disconnect time.

#### Design Decisions
- Used the existing ECS `attribute:tier` filter (already used by `update_premium_service_desired_count`) rather than Python-side filtering, so non-target instances are never returned by the API call in the first place.
- Grace period state is tracked via an EC2 tag (`optinist:agent-disconnected-at`) rather than DynamoDB or SSM Parameter Store. Tags are co-located with the resource, require no additional infrastructure, and are automatically cleaned up when the instance is terminated. The `optinist:` prefix avoids potential conflicts with AWS reserved tag namespaces (e.g., `aws:`, `ecs:`).
- The 5-minute grace period balances safety (transient agent restarts typically recover in seconds) against premium user impact (worst case ~20 minutes before a genuinely stuck agent is cleaned up, given the 15-minute polling interval).
- EC2 stopped/terminated/gone instances are still deregistered immediately — the grace period only applies to running instances with disconnected agents.

### Evidence
- See `REPORT.md` for the full outage investigation, including ECS agent logs, CloudTrail events, and root cause chain.
- ECS agent log from `i-0339a1b43ad55ab67` showing the crash loop after force-deregistration:
  ```
  level=error msg="Unable to register as a container instance with ECS"
    error="ClientException: Referenced container instance 35b0fbc18a774b3bad7b96866cb5596e not registered."
  level=error msg="Received terminal error from RegisterContainerInstance call, exiting"
  ```

### References
- `REPORT.md` — full production outage report (2026-04-06)
- Incident: 503 on https://www.araya-optinist.com/ due to empty ALB target group

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add `filter="attribute:tier == premium"` to `cleanup_ghost_ecs_registrations()`, `get_ecs_container_instance_id()`, and `cleanup_orphaned_ec2_instances()`. Rework ghost cleanup to use a grace period for agent-disconnected-but-running instances. Handle disconnected container instances with no EC2 ID by deregistering immediately.
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` -- Add `filter="attribute:tier == premium"` to `_get_ecs_container_instance_arn()`.
- `infrastructure/terraform/free_manager_package/free_manager.py` -- Add `filter="attribute:tier == free"` to `get_available_instance_ids()`.
- `infrastructure/terraform/premium_manager.tf` -- Add `ec2:DeleteTags` permission to the Lambda IAM role (required for clearing the grace period tag). Scope `CreateTags`/`DeleteTags` to only the `optinist:agent-disconnected-at` tag key via IAM condition.
- `studio/tests/infrastructure/test_premium_manager.py` -- Add 8 unit tests for `cleanup_ghost_ecs_registrations()` covering tier filter, grace period, no-EC2-ID edge case, and mixed-cluster scenarios.

### Manual Testcases
- Deploy the updated `subscr-premium-manager` Lambda. Verify in CloudWatch Logs that `cleanup_ghost_ecs_registrations` logs "No premium container instances found" (when no premium instances are running) instead of listing free/background instances.
- Start a premium instance, then simulate a brief agent disconnect (e.g., `sudo systemctl stop ecs && sleep 30 && sudo systemctl start ecs`). Verify the instance gets tagged with `optinist:agent-disconnected-at` but is NOT deregistered. Verify the tag is cleared on the next monitoring run after the agent reconnects.
- Stop a premium instance. Verify its container instance is deregistered immediately (no grace period).
- Verify the free-tier and background services remain unaffected by premium ghost cleanup across multiple monitoring cycles.

### Unit, Integration, Contract Test Coverage
- 8 new tests in `TestCleanupGhostECSRegistrations` (63 total pass):
  - `test_uses_premium_tier_filter` — asserts the `filter="attribute:tier == premium"` parameter is passed to the API
  - `test_deregisters_stopped_ec2_immediately` — stopped EC2 is cleaned up with no delay
  - `test_tags_running_instance_on_first_disconnect` — first disconnect only tags, no deregistration
  - `test_skips_within_grace_period` — tagged <5 min ago, left alone
  - `test_deregisters_after_grace_period` — tagged >5 min ago, deregistered
  - `test_clears_tag_on_reconnect` — reconnected agent's tag is removed
  - `test_mixed_cluster_only_deregisters_ghost` — healthy + stopped instance together, only stopped is deregistered
  - `test_deregisters_disconnected_without_ec2_id` — container instance with no EC2 mapping is deregistered immediately
- Run: `pytest studio/tests/infrastructure/test_premium_manager.py -v -- all 63 tests pass`
- Note: Cross-tier isolation is enforced at the AWS API level by the `filter` parameter. Unit tests verify the filter is passed; full cross-tier integration testing requires a real multi-tier cluster (covered by manual testcases above).

### Others

#### Difficulties
- Initial investigation was complicated by the background service's container instance (`402578fc`, a t3.micro with 940 MB) being misidentified as a corrupted registration of the free-tier t3.large. Resolved by checking the `ec2InstanceId` and `tier` attribute on the container instance.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| premium_manager ghost cleanup | Low | Strictly reduces blast radius — adds tier filter, grace period, and no-EC2-ID handling |
| premium_manager instance lookup | Low | Adds filter to read-only lookup; no behavioral change beyond scoping |
| premium_manager orphan cleanup | Low | Adds filter to ECS query; EC2-side was already premium-filtered |
| premium_cleanup instance lookup | Low | Same pattern as premium_manager lookup fix |
| free_manager instance discovery | Medium | Adds tier filter to rebalancing logic; if free instances lack the `tier=free` ECS attribute, they would be excluded from rebalancing. Verify ECS config sets the attribute on free-tier ASG instances. |
| IAM policy (CreateTags/DeleteTags) | Low | Scoped to only the `optinist:agent-disconnected-at` tag key via `ForAllValues:StringEquals` condition. Instance launch tags use `RunInstances` TagSpecifications which does not require separate `CreateTags` permission. |
