### PR TITLE
Premium instance termination bug 2

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1277,7 +1277,7 @@ def register_orphaned_stopped_instances():
                     instance_id=instance_id,
                     target_group_arn=PremiumAssignment.STANDBY,
                     rule_arn=PremiumAssignment.STANDBY,
-                    instance_state=InstanceState.LAUNCHING,
+                    instance_state=InstanceState.STOPPED,
                     is_shared=False,
                     is_standby=True,
                 )
@@ -2178,7 +2178,13 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # (remove DB entries for terminated instances)
             cleanup_failed_standby_instances()
 
-            # 8. Terminate stopped standby instances older than
+            # 8a. Register any stopped instances that are missing
+            # from the database (e.g. store_user_assignment failed
+            # after ec2.stop_instances, or a waiter timed out in
+            # convert_running_instance_to_standby).
+            register_orphaned_stopped_instances()
+
+            # 8b. Terminate stopped standby instances older than
             # PREMIUM_STOPPED_MAX_AGE_HOURS
             terminate_aged_stopped_instances()
 
@@ -4666,6 +4672,30 @@ def scale_down_if_possible():
 
                 ec2.stop_instances(InstanceIds=idle_instance_ids)
 
+                # Register stopped instances as standby in DB so
+                # terminate_aged_stopped_instances() can find and
+                # terminate them after PREMIUM_STOPPED_MAX_AGE_HOURS.
+                for instance_id in idle_instance_ids:
+                    try:
+                        store_user_assignment(
+                            user_id=None,
+                            instance_id=instance_id,
+                            target_group_arn=PremiumAssignment.STANDBY,
+                            rule_arn=PremiumAssignment.STANDBY,
+                            instance_state=InstanceState.STOPPED,
+                            is_shared=False,
+                            is_standby=True,
+                        )
+                        print(
+                            f"Registered stopped instance {instance_id} "
+                            f"as standby in database"
+                        )
+                    except Exception as e:
+                        print(
+                            f"Failed to register standby for "
+                            f"{instance_id}: {str(e)}"
+                        )
+
                 # Update ECS service desired count to match remaining running instances
                 update_premium_service_desired_count()
             else:
@@ -5270,6 +5300,24 @@ def cleanup_orphaned_ec2_instances():
                 print(f"Stopping orphaned EC2 instance {iid}")
                 ec2.stop_instances(InstanceIds=[iid])
                 stopped_count += 1
+
+                # Register as standby so terminate_aged_stopped_instances()
+                # can find and terminate after PREMIUM_STOPPED_MAX_AGE_HOURS.
+                try:
+                    store_user_assignment(
+                        user_id=None,
+                        instance_id=iid,
+                        target_group_arn=PremiumAssignment.STANDBY,
+                        rule_arn=PremiumAssignment.STANDBY,
+                        instance_state=InstanceState.STOPPED,
+                        is_shared=False,
+                        is_standby=True,
+                    )
+                    print(
+                        f"Registered orphaned instance {iid} " f"as standby in database"
+                    )
+                except Exception as e:
+                    print(f"Failed to register standby for " f"{iid}: {str(e)}")
 
         print(f"Orphan cleanup: stopped {stopped_count} " f"instance(s)")
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1941,16 +1941,207 @@ class TestRoutingIdContract:
                 self._patchers = []
 
 
+class TestScaleDownIfPossible:
+    """scale_down_if_possible stops idle instances and registers
+    them as standby in the database for later termination."""
+
+    def _make_instance(self, instance_id, state="running"):
+        return {"instance_id": instance_id, "state": state}
+
+    def test_stops_idle_and_registers_standby(self, mock_env_vars_premium):
+        """Idle instances are stopped, deregistered from ECS,
+        and registered as standby in the DB."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_dynamic_max_capacity", return_value=10
+        ), patch(
+            "premium_manager.count_active_premium_users", return_value=0
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=5
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states"
+        ) as mock_get_instances, patch(
+            "premium_manager.get_assigned_users_for_instance"
+        ) as mock_get_users, patch(
+            "premium_manager.deregister_container_instance_from_ecs"
+        ) as mock_deregister, patch(
+            "premium_manager.store_user_assignment"
+        ) as mock_store, patch(
+            "premium_manager.update_premium_service_desired_count"
+        ):
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            # 3 running, 0 users -> 3 idle (>= 2), min_needed = 1
+            mock_get_instances.return_value = [
+                self._make_instance("i-idle1"),
+                self._make_instance("i-idle2"),
+                self._make_instance("i-idle3"),
+            ]
+            mock_get_users.return_value = []
+
+            from premium_manager import scale_down_if_possible
+
+            scale_down_if_possible()
+
+            # Should stop idle instances
+            mock_ec2.stop_instances.assert_called_once()
+            stopped_ids = mock_ec2.stop_instances.call_args[1]["InstanceIds"]
+            assert len(stopped_ids) >= 1
+
+            # Each stopped instance should be deregistered from ECS
+            for iid in stopped_ids:
+                mock_deregister.assert_any_call(iid)
+
+            # Each stopped instance should be registered as standby
+            assert mock_store.call_count == len(stopped_ids)
+            for call in mock_store.call_args_list:
+                assert call[1]["user_id"] is None
+                assert call[1]["instance_state"] == "stopped"
+                assert call[1]["is_standby"] is True
+
+    def test_no_scale_down_when_idle_below_threshold(self, mock_env_vars_premium):
+        """No scale-down when fewer than 2 idle instances."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_dynamic_max_capacity", return_value=10
+        ), patch(
+            "premium_manager.count_active_premium_users", return_value=0
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=5
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states"
+        ) as mock_get_instances, patch(
+            "premium_manager.get_assigned_users_for_instance"
+        ) as mock_get_users, patch(
+            "premium_manager.store_user_assignment"
+        ) as mock_store:
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            # 1 running, 0 users -> 1 idle (< 2 threshold)
+            mock_get_instances.return_value = [
+                self._make_instance("i-only1"),
+            ]
+            mock_get_users.return_value = []
+
+            from premium_manager import scale_down_if_possible
+
+            scale_down_if_possible()
+
+            mock_ec2.stop_instances.assert_not_called()
+            mock_store.assert_not_called()
+
+    def test_standby_registration_failure_does_not_block(self, mock_env_vars_premium):
+        """If store_user_assignment fails for one instance, the
+        remaining instances are still registered."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_dynamic_max_capacity", return_value=10
+        ), patch(
+            "premium_manager.count_active_premium_users", return_value=0
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=5
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states"
+        ) as mock_get_instances, patch(
+            "premium_manager.get_assigned_users_for_instance"
+        ) as mock_get_users, patch(
+            "premium_manager.deregister_container_instance_from_ecs"
+        ), patch(
+            "premium_manager.store_user_assignment"
+        ) as mock_store, patch(
+            "premium_manager.update_premium_service_desired_count"
+        ):
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            # 4 running, 0 users -> 4 idle
+            mock_get_instances.return_value = [
+                self._make_instance(f"i-idle{i}") for i in range(4)
+            ]
+            mock_get_users.return_value = []
+
+            # First call fails, rest succeed
+            mock_store.side_effect = [
+                Exception("DB error"),
+                None,
+                None,
+            ]
+
+            from premium_manager import scale_down_if_possible
+
+            # Should not raise despite the DB error
+            scale_down_if_possible()
+
+            mock_ec2.stop_instances.assert_called_once()
+            # All stopped instances attempted registration
+            assert mock_store.call_count == len(
+                mock_ec2.stop_instances.call_args[1]["InstanceIds"]
+            )
+
+    def test_occupied_instances_not_stopped(self, mock_env_vars_premium):
+        """Instances with assigned users are never stopped."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_dynamic_max_capacity", return_value=10
+        ), patch(
+            "premium_manager.count_active_premium_users", return_value=1
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=5
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states"
+        ) as mock_get_instances, patch(
+            "premium_manager.get_assigned_users_for_instance"
+        ) as mock_get_users, patch(
+            "premium_manager.deregister_container_instance_from_ecs"
+        ), patch(
+            "premium_manager.store_user_assignment"
+        ) as mock_store, patch(
+            "premium_manager.update_premium_service_desired_count"
+        ):
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+
+            # 4 running: 1 occupied + 3 idle
+            mock_get_instances.return_value = [
+                self._make_instance("i-occupied"),
+                self._make_instance("i-idle1"),
+                self._make_instance("i-idle2"),
+                self._make_instance("i-idle3"),
+            ]
+
+            def users_side_effect(iid):
+                if iid == "i-occupied":
+                    return [{"user_id": 42}]
+                return []
+
+            mock_get_users.side_effect = users_side_effect
+
+            from premium_manager import scale_down_if_possible
+
+            scale_down_if_possible()
+
+            stopped_ids = mock_ec2.stop_instances.call_args[1]["InstanceIds"]
+            assert "i-occupied" not in stopped_ids
+            # All stopped instances registered as standby
+            assert mock_store.call_count == len(stopped_ids)
+
+
 class TestCleanupOrphanedEC2Instances:
     """cleanup_orphaned_ec2_instances stops unregistered
     instances past the grace period and skips the rest."""
 
     def test_stops_orphaned_past_grace_period(self, mock_env_vars_premium):
         """EC2 instance running 20 min and NOT in ECS
-        container instances gets stopped."""
+        container instances gets stopped and registered as standby."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
-        ) as mock_boto3:
+        ) as mock_boto3, patch("premium_manager.store_user_assignment") as mock_store:
             mock_ecs = MagicMock()
             mock_ec2 = MagicMock()
 
@@ -1996,6 +2187,64 @@ class TestCleanupOrphanedEC2Instances:
             cleanup_orphaned_ec2_instances()
 
             mock_ec2.stop_instances.assert_called_once_with(InstanceIds=["i-orphan1"])
+            mock_store.assert_called_once()
+            call_kwargs = mock_store.call_args[1]
+            assert call_kwargs["user_id"] is None
+            assert call_kwargs["instance_id"] == "i-orphan1"
+            assert call_kwargs["instance_state"] == "stopped"
+            assert call_kwargs["is_standby"] is True
+
+    def test_orphan_standby_registration_failure_does_not_block(
+        self, mock_env_vars_premium
+    ):
+        """If store_user_assignment fails for one orphan, remaining
+        orphans are still stopped and registered."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_manager.store_user_assignment") as mock_store:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "ecs":
+                    return mock_ecs
+                if service == "ec2":
+                    return mock_ec2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": []
+            }
+
+            launch_time = datetime.now(timezone.utc) - timedelta(minutes=20)
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": f"i-orphan{i}",
+                                "State": {"Name": "running"},
+                                "LaunchTime": launch_time,
+                            }
+                            for i in range(2)
+                        ]
+                    }
+                ]
+            }
+
+            # First registration fails, second succeeds
+            mock_store.side_effect = [Exception("DB error"), None]
+
+            from premium_manager import cleanup_orphaned_ec2_instances
+
+            cleanup_orphaned_ec2_instances()
+
+            # Both instances should be stopped
+            assert mock_ec2.stop_instances.call_count == 2
+            # Both registrations attempted
+            assert mock_store.call_count == 2
 
     def test_skips_instance_within_grace_period(self, mock_env_vars_premium):
         """EC2 instance running 5 min is within grace period
@@ -2108,6 +2357,66 @@ class TestCleanupOrphanedEC2Instances:
             cleanup_orphaned_ec2_instances()
 
             mock_ec2.stop_instances.assert_not_called()
+
+
+class TestHandleScheduledMonitoring:
+    """handle_scheduled_monitoring registers orphaned stopped
+    instances before attempting to terminate aged ones."""
+
+    def test_registers_orphans_before_terminating_aged(self, mock_env_vars_premium):
+        """register_orphaned_stopped_instances runs before
+        terminate_aged_stopped_instances so ghost instances
+        become visible to the terminator."""
+        call_order = []
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.is_premium_scaling_in_progress", return_value=False
+        ), patch("premium_manager.set_premium_scaling_lock"), patch(
+            "premium_manager.count_active_premium_users", return_value=0
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=0
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states",
+            return_value=[],
+        ), patch(
+            "premium_manager.get_assigned_users_for_instance",
+            return_value=[],
+        ), patch(
+            "premium_manager.publish_premium_metrics"
+        ), patch(
+            "premium_manager.scale_down_if_possible"
+        ), patch(
+            "premium_manager.update_premium_service_desired_count"
+        ), patch(
+            "premium_manager.cleanup_failed_standby_instances"
+        ), patch(
+            "premium_manager.register_orphaned_stopped_instances",
+            side_effect=lambda: call_order.append("register_orphans"),
+        ), patch(
+            "premium_manager.terminate_aged_stopped_instances",
+            side_effect=lambda: call_order.append("terminate_aged"),
+        ), patch(
+            "premium_manager.get_standby_count", return_value=0
+        ), patch(
+            "premium_manager.finalize_expired_pending_releases",
+            return_value=[],
+        ), patch(
+            "premium_manager.cleanup_ghost_ecs_registrations"
+        ), patch(
+            "premium_manager.cleanup_orphaned_ec2_instances"
+        ), patch(
+            "premium_manager.fix_incorrect_is_shared_flags",
+            return_value={"fixed_count": 0},
+        ), patch(
+            "premium_manager.process_shared_instance_optimization",
+            return_value={"migrations_performed": 0, "shared_instances_found": 0},
+        ):
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+            assert result["statusCode"] == 200
+
+            assert call_order == ["register_orphans", "terminate_aged"]
 
 
 class TestGetUserUidFromId:


### PR DESCRIPTION
### Content

#### Summary
- Stopped premium EC2 instances were never terminated because `scale_down_if_possible()` stopped instances via EC2 API but never registered them as standby in the `premium_user_assignments` database table.
- `terminate_aged_stopped_instances()` queries `WHERE is_standby = 1 AND instance_state = 'stopped'` to find instances eligible for termination, but the rows it needed were never created. Stopped instances accumulated in EC2, incurring EBS costs indefinitely.
- A secondary bug in `register_orphaned_stopped_instances()` inserted orphaned stopped instances with `instance_state = 'launching'` instead of `'stopped'`, so even the safety-net path produced rows invisible to the termination query.
- `cleanup_orphaned_ec2_instances()` had the same missing-registration bug — it stopped orphaned EC2 instances not in ECS but never wrote a standby DB row, making them invisible to aged termination.
- `register_orphaned_stopped_instances()` only ran during user assignment, so ghost instances from any failed DB write could linger indefinitely during low-traffic periods. It now also runs in the 15-minute monitoring loop.

#### Design Decisions
- **Inline standby registration after batch stop** rather than switching to `convert_running_instance_to_standby()` per instance. The existing function uses an EC2 waiter (up to 5 min per instance) which would risk Lambda timeouts when stopping multiple instances. The batch `ec2.stop_instances()` call is preserved for performance; the DB rows are created immediately after, before the instances have fully stopped. This is safe because `terminate_aged_stopped_instances()` re-checks EC2 state and `StateTransitionReason` before terminating.
- **Per-instance try/except on DB registration** so a failure for one instance does not prevent registration of the others. The instance is already stopped in EC2 at this point, so best-effort DB registration is better than none.
- **Fixed `register_orphaned_stopped_instances()` to use `InstanceState.STOPPED`** so the safety-net path also creates rows findable by the termination query.
- **Added standby registration to `cleanup_orphaned_ec2_instances()`** — same missing-registration pattern as `scale_down_if_possible()`. Orphaned EC2 instances stopped by this function were also invisible to the aged terminator.
- **Added `register_orphaned_stopped_instances()` to `handle_scheduled_monitoring()`** (step 8a, before `terminate_aged_stopped_instances`). This is a catch-all safety net: every 15 minutes, any ghost instances — from failed DB writes in `scale_down_if_possible`, waiter timeouts in `convert_running_instance_to_standby`, or any other path — get registered so the terminator can find them. Previously this only ran during user assignment, which could be arbitrarily far away in low-traffic periods.

### Evidence
- CloudWatch logs from the weekend (2026-04-03 to 2026-04-06) show `terminate_aged_stopped_instances()` running every 30 minutes but consistently logging `No stopped standby instances to check`, despite 3 stopped premium instances visible in EC2.
- On 2026-04-04 (Saturday), monitoring confirmed `0 running instances, 0 idle instances` with 3 premium instances matched — all stopped, none terminated.
- Manual test on development (2026-04-06, `PREMIUM_STOPPED_MAX_AGE_HOURS=0`) confirmed the full chain end-to-end:
  1. `Stopping 1 idle instances: ['i-0aca4adefdfea24d5']` — scale-down stopped an idle instance
  2. `Registered stopped instance i-0aca4adefdfea24d5 as standby in database` — DB row created immediately after stop
  3. `Found 0 orphaned stopped instances` — monitoring loop ran the orphan check (no orphans because step 2 already registered it)
  4. `Found 2 stopped standby instances older than 0 hours` — terminator found both stopped instances
  5. `Terminated aged stopped instance i-0a0288bbc9b390158 (stopped since: 2026-04-06 05:01:11)` — older instance terminated
  6. `Terminated aged stopped instance i-0aca4adefdfea24d5 (stopped since: 2026-04-06 07:57:16)` — just-stopped instance also terminated (max_age=0)

### References
- Related: #300 (original report of stopped-but-not-terminated instances)
- PR #460 — Event-driven cleanup when EC2 instance terminates (merged 2026-04-02)
- PR #464 — Fix inactive instances not terminated via sleep detection (merged 2026-04-02)

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py` -- Add standby DB registration in `scale_down_if_possible()` and `cleanup_orphaned_ec2_instances()` after `ec2.stop_instances()` so terminated-age logic can find and terminate them. Fix `register_orphaned_stopped_instances()` to use `InstanceState.STOPPED` instead of `InstanceState.LAUNCHING`. Add `register_orphaned_stopped_instances()` call to `handle_scheduled_monitoring()` before `terminate_aged_stopped_instances()` as a periodic catch-all for ghost instances.
- `studio/tests/infrastructure/test_premium_manager.py` -- Add `TestScaleDownIfPossible` (4 tests), `TestCleanupOrphanedEC2Instances` updates (standby registration + failure resilience), and `TestHandleScheduledMonitoring` (call-order verification).

### Manual Testcases
- [x] Deploy to development. Invoke monitoring. Verify `register_orphaned_stopped_instances` runs in the monitoring loop (CloudWatch: `Found N orphaned stopped instances to register as standby`).
- [x] Trigger scale-down with idle instances. Verify CloudWatch logs show `Registered stopped instance i-xxx as standby in database` for each stopped instance.
- [x] Set `PREMIUM_STOPPED_MAX_AGE_HOURS=0`. Invoke monitoring. Verify `terminate_aged_stopped_instances()` logs `Found N stopped standby instances older than 0 hours` and `Terminated aged stopped instance i-xxx`.
- [x] Verify the full chain end-to-end: scale-down stop -> DB registration -> orphan check -> aged termination (see Evidence section for log output).
- [x] Restore `PREMIUM_STOPPED_MAX_AGE_HOURS=4` after testing.
- [x] `pytest studio/tests/infrastructure/test_premium_manager.py` -- all 61 tests pass

### Unit, Integration, Contract Test Coverage
- 4 new tests in `TestScaleDownIfPossible`:
  - `test_stops_idle_and_registers_standby` — verifies EC2 stop + ECS deregister + standby DB row with `instance_state='stopped'` and `is_standby=True`
  - `test_no_scale_down_when_idle_below_threshold` — no stop or DB write when <2 idle instances
  - `test_standby_registration_failure_does_not_block` — DB error on one instance does not prevent registration of others
  - `test_occupied_instances_not_stopped` — instances with assigned users are never stopped or registered
- Updated `TestCleanupOrphanedEC2Instances`:
  - `test_stops_orphaned_past_grace_period` — now also verifies standby DB registration with correct state
  - `test_orphan_standby_registration_failure_does_not_block` — DB failure on one orphan does not prevent stopping/registering others
- 1 new test in `TestHandleScheduledMonitoring`:
  - `test_registers_orphans_before_terminating_aged` — verifies `register_orphaned_stopped_instances` is called before `terminate_aged_stopped_instances` in the monitoring loop
- Run: `make test_lambda` -- all tests pass

### Others

#### Difficulties
- Initial investigation was misled by CloudWatch log query pagination (200-event limit) which made the Lambda appear to run only ~2 hours/day. CloudWatch Metrics confirmed 4 invocations/hour across all 24 hours. The real issue was purely the missing DB registration.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `scale_down_if_possible()` standby registration | Low | Additive change — existing stop logic is unchanged. DB registration is best-effort with per-instance error handling. If it fails, behavior is the same as before this fix (instance stopped but not tracked). |
| `cleanup_orphaned_ec2_instances()` standby registration | Low | Same additive pattern as `scale_down_if_possible()`. Per-instance try/except. Failure is no worse than current behavior. |
| `register_orphaned_stopped_instances()` state fix | Low | Changes `LAUNCHING` to `STOPPED` for orphaned stopped instances. This is a correctness fix — the previous value was always wrong for stopped instances. Only affects the safety-net path during user assignment. |
| `handle_scheduled_monitoring()` orphan registration | Low | Adds one extra function call every 15 minutes. `register_orphaned_stopped_instances()` is already called during user assignment — this extends it to the monitoring loop. The function is idempotent (skips instances already registered). Adds one `describe_instances` API call and one DB query per monitoring cycle. |
