### PR TITLE
Set colour scale to same as thumbnail

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
@@ -198,8 +198,10 @@ const ImageView = memo(function ImageView({
     {
       z: frame,
       type: "heatmap",
-      colorscale: "Greys",
-      reversescale: true,
+      colorscale: [
+        [0, "rgb(0,0,0)"],
+        [1, "rgb(255,255,255)"],
+      ],
     },
   ]
 


### PR DESCRIPTION
### Content

Update scaling on structured data display. 

### References

https://github.com/arayabrain/araya-optinist/issues/473

### Testcase

Check tutorial 4 with new scaling
NEW:
<img width="615" height="610" alt="Screenshot 2026-04-06 at 17 33 23" src="https://github.com/user-attachments/assets/7f41ae41-764c-4bfa-9741-9e18d957e4c3" />

PREVIOUS:
<img width="543" height="585" alt="Screenshot 2026-04-03 at 14 41 01" src="https://github.com/user-attachments/assets/2cd46d17-f685-48ff-87e7-0e3f496444b3" />



