### PR TITLE
Add Environment tag to dynamically-created resources

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -71,27 +71,27 @@ class SubscriptionType:
     PREMIUM = "premium"
 
 
-class PremiumInstanceConfig:
+class EnvironmentConfig:
     """
-    Configuration constants for premium EC2 instances.
+    Deployment environment constants.
 
-    These values are used for identifying and filtering premium instances
-    in EC2, ECS, and ALB operations.
+    Provides the environment prefix (read from the ENV_PREFIX env var)
+    and a validated human-readable label for AWS resource tagging.
+    Must match Terraform var.environment / local.environment_label.
     """
 
-    # Identifier used in EC2 instance Name/Tier/Type tags
-    INSTANCE_IDENTIFIER = "premium"
-    # EC2 Type tag value for premium instances
-    INSTANCE_TYPE_TAG = "Premium-Instance"
-    # EC2 Service tag value for premium instances
-    SERVICE_TAG = "premium-tier"
     # Environment variable name for the deployment prefix
     ENV_PREFIX_VAR = "ENV_PREFIX"
     # Known environment prefix values (must match Terraform var.environment)
-    PRODUCTION_ENV_PREFIX = "subscr"
-    DEVELOPMENT_ENV_PREFIX = "development"
-    # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-running")
-    INSTANCE_NAME_SUFFIX = "premium-running"
+    PRODUCTION = "subscr"
+    DEVELOPMENT = "development"
+
+    # Map of known prefixes to human-readable labels.
+    # Matches the Terraform local.environment_label convention.
+    _LABELS = {
+        PRODUCTION: "Production",
+        DEVELOPMENT: "Development",
+    }
 
     @classmethod
     def get_env_prefix(cls) -> str:
@@ -111,13 +111,6 @@ class PremiumInstanceConfig:
             )
         return prefix
 
-    # Map of known environment prefixes to their human-readable labels.
-    # Matches the Terraform local.environment_label convention.
-    ENV_PREFIX_LABELS = {
-        "subscr": "Production",
-        "development": "Development",
-    }
-
     @classmethod
     def get_environment_label(cls) -> str:
         """Get the human-readable environment label for AWS tags.
@@ -126,13 +119,31 @@ class PremiumInstanceConfig:
         to prevent silent mis-tagging of resources.
         """
         prefix = cls.get_env_prefix()
-        label = cls.ENV_PREFIX_LABELS.get(prefix)
+        label = cls._LABELS.get(prefix)
         if label is None:
             raise ValueError(
                 f"Unknown environment prefix '{prefix}'. "
-                f"Expected one of: {sorted(cls.ENV_PREFIX_LABELS)}"
+                f"Expected one of: {sorted(cls._LABELS)}"
             )
         return label
+
+
+class PremiumInstanceConfig:
+    """
+    Configuration constants for premium EC2 instances.
+
+    These values are used for identifying and filtering premium instances
+    in EC2, ECS, and ALB operations.
+    """
+
+    # Identifier used in EC2 instance Name/Tier/Type tags
+    INSTANCE_IDENTIFIER = "premium"
+    # EC2 Type tag value for premium instances
+    INSTANCE_TYPE_TAG = "Premium-Instance"
+    # EC2 Service tag value for premium instances
+    SERVICE_TAG = "premium-tier"
+    # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-running")
+    INSTANCE_NAME_SUFFIX = "premium-running"
 
     @classmethod
     def get_instance_name_pattern(cls) -> str:
@@ -141,7 +152,7 @@ class PremiumInstanceConfig:
         Returns e.g. 'development-premium-*' or 'subscr-premium-*'.
         Used in AWS API tag:Name filters.
         """
-        return f"{cls.get_env_prefix()}-{cls.INSTANCE_IDENTIFIER}-*"
+        return f"{EnvironmentConfig.get_env_prefix()}-{cls.INSTANCE_IDENTIFIER}-*"
 
     @classmethod
     def get_instance_name(cls) -> str:
@@ -149,7 +160,7 @@ class PremiumInstanceConfig:
 
         Returns e.g. 'development-premium-running' or 'subscr-premium-running'.
         """
-        return f"{cls.get_env_prefix()}-{cls.INSTANCE_NAME_SUFFIX}"
+        return f"{EnvironmentConfig.get_env_prefix()}-{cls.INSTANCE_NAME_SUFFIX}"
 
 
 class RoutingHeaders:

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -109,6 +109,16 @@ class PremiumInstanceConfig:
         return prefix
 
     @classmethod
+    def get_environment_label(cls) -> str:
+        """Get the human-readable environment label for AWS tags.
+
+        Returns 'Production' for subscr, 'Development' for everything else.
+        Matches the Terraform local.environment_label convention.
+        """
+        prefix = cls.get_env_prefix()
+        return "Production" if prefix == "subscr" else "Development"
+
+    @classmethod
     def get_instance_name_pattern(cls) -> str:
         """Get the EC2 Name tag wildcard pattern for this environment.
 

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -87,6 +87,9 @@ class PremiumInstanceConfig:
     SERVICE_TAG = "premium-tier"
     # Environment variable name for the deployment prefix
     ENV_PREFIX_VAR = "ENV_PREFIX"
+    # Known environment prefix values (must match Terraform var.environment)
+    PRODUCTION_ENV_PREFIX = "subscr"
+    DEVELOPMENT_ENV_PREFIX = "development"
     # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-running")
     INSTANCE_NAME_SUFFIX = "premium-running"
 
@@ -108,15 +111,28 @@ class PremiumInstanceConfig:
             )
         return prefix
 
+    # Map of known environment prefixes to their human-readable labels.
+    # Matches the Terraform local.environment_label convention.
+    ENV_PREFIX_LABELS = {
+        "subscr": "Production",
+        "development": "Development",
+    }
+
     @classmethod
     def get_environment_label(cls) -> str:
         """Get the human-readable environment label for AWS tags.
 
-        Returns 'Production' for subscr, 'Development' for everything else.
-        Matches the Terraform local.environment_label convention.
+        Raises ValueError if the prefix is not a recognised environment name,
+        to prevent silent mis-tagging of resources.
         """
         prefix = cls.get_env_prefix()
-        return "Production" if prefix == "subscr" else "Development"
+        label = cls.ENV_PREFIX_LABELS.get(prefix)
+        if label is None:
+            raise ValueError(
+                f"Unknown environment prefix '{prefix}'. "
+                f"Expected one of: {sorted(cls.ENV_PREFIX_LABELS)}"
+            )
+        return label
 
     @classmethod
     def get_instance_name_pattern(cls) -> str:

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -161,9 +161,18 @@ resource "aws_launch_template" "ecs" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      Name    = "${local.env_prefix}-asg-instance"
-      Type    = "ECS-ASG"
-      Service = "autoscaling"
+      Name        = "${local.env_prefix}-asg-instance"
+      Type        = "ECS-ASG"
+      Service     = "autoscaling"
+      Environment = local.environment_label
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      Name        = "${local.env_prefix}-asg-vol"
+      Environment = local.environment_label
     }
   }
 
@@ -373,10 +382,19 @@ resource "aws_launch_template" "premium" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      Name    = "${local.env_prefix}-premium-instance"
-      Type    = "ECS-Premium"
-      Tier    = "premium"
-      Service = "premium-spot-fleet"
+      Name        = "${local.env_prefix}-premium-instance"
+      Type        = "ECS-Premium"
+      Tier        = "premium"
+      Service     = "premium-spot-fleet"
+      Environment = local.environment_label
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      Name        = "${local.env_prefix}-premium-vol"
+      Environment = local.environment_label
     }
   }
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -291,8 +291,12 @@ data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}
 
 locals {
+  # Known environment prefix values — single source of truth for Terraform.
+  # Python equivalent: PremiumInstanceConfig.PRODUCTION_ENV_PREFIX in aws_constants.py
+  production_env_prefix = "subscr"
+
   env_prefix        = "${var.environment}-optinist"
-  environment_label = var.environment == "subscr" ? "Production" : "Development"
+  environment_label = var.environment == local.production_env_prefix ? "Production" : "Development"
 
   # Resolve frontend host/port from ALB DNS when no custom domain is configured
   # - Production: uses custom domain on port 443

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_log_group" "premium_ecs" {
 # SNS Topic for Critical Alert Notifications
 # ==================================================
 resource "aws_sns_topic" "critical_alerts" {
-  count = var.environment == "subscr" ? 1 : 0
+  count = var.environment == local.production_env_prefix ? 1 : 0
   name  = "${var.environment}-optinist-critical-alerts"
 
   tags = {
@@ -32,14 +32,14 @@ resource "aws_sns_topic" "critical_alerts" {
 }
 
 resource "aws_sns_topic_subscription" "critical_alerts_email" {
-  count     = var.environment == "subscr" ? 1 : 0
+  count     = var.environment == local.production_env_prefix ? 1 : 0
   topic_arn = aws_sns_topic.critical_alerts[0].arn
   protocol  = "email"
   endpoint  = "optinist-support@araya.org"
 }
 
 locals {
-  critical_alerts_actions = var.environment == "subscr" ? [aws_sns_topic.critical_alerts[0].arn] : []
+  critical_alerts_actions = var.environment == local.production_env_prefix ? [aws_sns_topic.critical_alerts[0].arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1320,6 +1320,8 @@ def create_running_instance():
                 )
 
                 # Launch instance using the premium launch template
+                env_label = PremiumInstanceConfig.get_environment_label()
+                inst_name = PremiumInstanceConfig.get_instance_name()
                 response = ec2.run_instances(
                     LaunchTemplate={
                         "LaunchTemplateId": launch_template_id,
@@ -1351,7 +1353,7 @@ def create_running_instance():
                                 },
                                 {
                                     "Key": "Environment",
-                                    "Value": PremiumInstanceConfig.get_environment_label(),
+                                    "Value": env_label,
                                 },
                             ],
                         },
@@ -1360,11 +1362,11 @@ def create_running_instance():
                             "Tags": [
                                 {
                                     "Key": "Name",
-                                    "Value": f"{PremiumInstanceConfig.get_instance_name()}-vol",
+                                    "Value": f"{inst_name}-vol",
                                 },
                                 {
                                     "Key": "Environment",
-                                    "Value": PremiumInstanceConfig.get_environment_label(),
+                                    "Value": env_label,
                                 },
                             ],
                         },
@@ -1593,9 +1595,18 @@ def create_and_stop_standby_instance():
                         f"/{len(subnet_ids)})"
                     )
 
+                    env_label = (
+                        PremiumInstanceConfig.get_environment_label()
+                    )
+                    env_prefix = (
+                        PremiumInstanceConfig.get_env_prefix()
+                    )
+                    inst_id = (
+                        PremiumInstanceConfig.INSTANCE_IDENTIFIER
+                    )
                     response = ec2.run_instances(
                         LaunchTemplate={
-                            "LaunchTemplateId": (launch_template_id),
+                            "LaunchTemplateId": launch_template_id,
                             "Version": "$Latest",
                         },
                         InstanceType=instance_type,
@@ -1608,30 +1619,32 @@ def create_and_stop_standby_instance():
                                 "Tags": [
                                     {
                                         "Key": "Name",
-                                        "Value": "{}-{}-standby".format(
-                                            PremiumInstanceConfig.get_env_prefix(),
-                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER,
+                                        "Value": (
+                                            f"{env_prefix}-"
+                                            f"{inst_id}-standby"
                                         ),
                                     },
                                     {
                                         "Key": "Type",
                                         "Value": (
-                                            PremiumInstanceConfig.INSTANCE_TYPE_TAG
+                                            PremiumInstanceConfig
+                                            .INSTANCE_TYPE_TAG
                                         ),
                                     },
                                     {
                                         "Key": "Tier",
-                                        "Value": (
-                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER
-                                        ),
+                                        "Value": inst_id,
                                     },
                                     {
                                         "Key": "Service",
-                                        "Value": PremiumInstanceConfig.SERVICE_TAG,
+                                        "Value": (
+                                            PremiumInstanceConfig
+                                            .SERVICE_TAG
+                                        ),
                                     },
                                     {
                                         "Key": "Environment",
-                                        "Value": PremiumInstanceConfig.get_environment_label(),
+                                        "Value": env_label,
                                     },
                                 ],
                             },
@@ -1640,14 +1653,14 @@ def create_and_stop_standby_instance():
                                 "Tags": [
                                     {
                                         "Key": "Name",
-                                        "Value": "{}-{}-standby-vol".format(
-                                            PremiumInstanceConfig.get_env_prefix(),
-                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER,
+                                        "Value": (
+                                            f"{env_prefix}-"
+                                            f"{inst_id}-standby-vol"
                                         ),
                                     },
                                     {
                                         "Key": "Environment",
-                                        "Value": PremiumInstanceConfig.get_environment_label(),
+                                        "Value": env_label,
                                     },
                                 ],
                             },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1349,8 +1349,25 @@ def create_running_instance():
                                     "Key": "Service",
                                     "Value": PremiumInstanceConfig.SERVICE_TAG,
                                 },
+                                {
+                                    "Key": "Environment",
+                                    "Value": PremiumInstanceConfig.get_environment_label(),
+                                },
                             ],
-                        }
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Name",
+                                    "Value": f"{PremiumInstanceConfig.get_instance_name()}-vol",
+                                },
+                                {
+                                    "Key": "Environment",
+                                    "Value": PremiumInstanceConfig.get_environment_label(),
+                                },
+                            ],
+                        },
                     ],
                 )
 
@@ -1612,8 +1629,28 @@ def create_and_stop_standby_instance():
                                         "Key": "Service",
                                         "Value": PremiumInstanceConfig.SERVICE_TAG,
                                     },
+                                    {
+                                        "Key": "Environment",
+                                        "Value": PremiumInstanceConfig.get_environment_label(),
+                                    },
                                 ],
-                            }
+                            },
+                            {
+                                "ResourceType": "volume",
+                                "Tags": [
+                                    {
+                                        "Key": "Name",
+                                        "Value": "{}-{}-standby-vol".format(
+                                            PremiumInstanceConfig.get_env_prefix(),
+                                            PremiumInstanceConfig.INSTANCE_IDENTIFIER,
+                                        ),
+                                    },
+                                    {
+                                        "Key": "Environment",
+                                        "Value": PremiumInstanceConfig.get_environment_label(),
+                                    },
+                                ],
+                            },
                         ],
                     )
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -50,6 +50,7 @@ import pymysql
 from aws_constants import (
     DatabaseConfig,
     ECSTaskStatus,
+    EnvironmentConfig,
     InstanceState,
     PremiumAssignment,
     PremiumInstanceConfig,
@@ -862,7 +863,7 @@ def get_all_premium_instances_with_states():
     contamination (e.g., development Lambda discovering production instances).
     """
     ec2: "EC2Client" = boto3.client("ec2")
-    env_prefix = PremiumInstanceConfig.get_env_prefix()
+    env_prefix = EnvironmentConfig.get_env_prefix()
     try:
         # Get instances with premium tags (use multiple filters for robust discovery)
         response = ec2.describe_instances(
@@ -1320,7 +1321,7 @@ def create_running_instance():
                 )
 
                 # Launch instance using the premium launch template
-                env_label = PremiumInstanceConfig.get_environment_label()
+                env_label = EnvironmentConfig.get_environment_label()
                 inst_name = PremiumInstanceConfig.get_instance_name()
                 response = ec2.run_instances(
                     LaunchTemplate={
@@ -1596,10 +1597,10 @@ def create_and_stop_standby_instance():
                     )
 
                     env_label = (
-                        PremiumInstanceConfig.get_environment_label()
+                        EnvironmentConfig.get_environment_label()
                     )
                     env_prefix = (
-                        PremiumInstanceConfig.get_env_prefix()
+                        EnvironmentConfig.get_env_prefix()
                     )
                     inst_id = (
                         PremiumInstanceConfig.INSTANCE_IDENTIFIER
@@ -4916,7 +4917,7 @@ def terminate_aged_stopped_instances():
         response = ec2.describe_instances(InstanceIds=instance_ids)
         now = datetime.now(timezone.utc).replace(tzinfo=None)
         cutoff = timedelta(hours=max_age_hours)
-        env_prefix = PremiumInstanceConfig.get_env_prefix()
+        env_prefix = EnvironmentConfig.get_env_prefix()
         aged_instances = []
 
         for reservation in response["Reservations"]:


### PR DESCRIPTION
# Add Environment tag to dynamically-created resources

## Summary

- Add `Environment` tag to dynamically-created premium EC2 instances and their EBS volumes
- Add `Environment` tag to launch templates (premium + ASG) so Terraform-managed instances and volumes are also tagged
- Add `get_environment_label()` helper to `PremiumInstanceConfig` for consistent tag values

## Context

Production (`subscr`) and development (`development`) share the same AWS account. An audit found that **dynamically-created premium instances and their EBS volumes** were missing the `Environment` tag, causing ~$40/5 days (~$242/month projected) in unattributable costs in AWS Cost Explorer.

Three untagged EC2 instances and five untagged EBS volumes were identified — all created by the premium manager Lambda or launched from templates that lacked the tag.

Full audit: `infrastructure/documentation/UNTAGGED_RESOURCES_REPORT.md`

## Changes

### `infrastructure/aws_constants.py`
- Added `get_environment_label()` to `PremiumInstanceConfig` — returns `"Production"` for `subscr`, `"Development"` otherwise. Matches Terraform's `local.environment_label` convention.

### `infrastructure/terraform/premium_manager_package/premium_manager.py`
- `create_running_instance()` — added `Environment` tag to instance `TagSpecifications`, added `volume` resource type with `Name` and `Environment` tags
- `create_and_stop_standby_instance()` — same changes for standby instances

### `infrastructure/terraform/compute.tf`
- **ASG launch template** (`aws_launch_template.ecs`) — added `Environment = local.environment_label` to instance tags, added new `volume` tag specification block
- **Premium launch template** (`aws_launch_template.premium`) — same changes

## Note

Existing untagged instances will not be retroactively tagged by this change. Only newly-created instances and volumes will receive the tag. To tag existing resources, run:

```bash
# Tag existing untagged instances
aws ec2 create-tags --resources i-0a0288bbc9b390158 i-074ef11ba77b7a141 \
  --tags Key=Environment,Value=Development --region ap-northeast-1

aws ec2 create-tags --resources i-0fbf3a6290189c6bb \
  --tags Key=Environment,Value=Production --region ap-northeast-1
```

## Test Plan

- [x] Deploy to development — verify new premium instances get `Environment: Development` tag
- [x] Verify EBS volumes attached to new instances get `Environment` tag
- [x] Check AWS Cost Explorer after 24h — new instances appear under the correct environment
- [x] Existing functionality unaffected (instance creation, standby pool, ASG scaling)
