### PR TITLE
Fix de scheduler bugs, add tests

### DIFF
--- a/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
+++ b/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
@@ -86,6 +86,29 @@ RETRY_BASE_DELAY = 5  # seconds, doubles each attempt
 # premium_manager has a 600s timeout; allow slightly more for overhead.
 LAMBDA_INVOKE_TIMEOUT = 610  # seconds
 
+# RDS instance statuses that are expected to reach `available` shortly.
+# ensure_rds_proxy_target polls through these; anything else (and not
+# `available`) is treated as a hard failure.
+TRANSIENT_RDS_STATUSES = {
+    "creating",
+    "modifying",
+    "backing-up",
+    "starting",
+    "configuring-enhanced-monitoring",
+    "configuring-iam-database-auth",
+    "configuring-log-exports",
+    "renaming",
+    "rebooting",
+    "resetting-master-credentials",
+    "upgrading",
+    "maintenance",
+}
+
+# Poll a transient RDS instance for up to this long before deferring proxy
+# registration to the verify-start re-invocation.
+PROXY_REGISTER_POLL_SECONDS = 90
+PROXY_REGISTER_POLL_INTERVAL = 10
+
 rds = boto3.client("rds")
 ec2 = boto3.client("ec2")
 ecs = boto3.client("ecs")
@@ -124,7 +147,9 @@ def with_retry(fn, *args, max_attempts=MAX_RETRY_ATTEMPTS, **kwargs):
 
 def handler(event, context):
     """Main Lambda handler - dispatches to start or stop based on event action."""
-    action = event.get("action", "").strip()
+    # str() coerces non-string payloads (e.g. {"action": 123}) so .strip()
+    # never raises AttributeError on a numeric/bool input.
+    action = str(event.get("action") or "").strip()
     print(f"Dev Scheduler invoked with action: {action!r}")
     print(f"Event: {json.dumps(event)}")
 
@@ -135,14 +160,28 @@ def handler(event, context):
     if action == "start":
         return start_environment()
     elif action == "stop":
-        stop_mode = event.get("stop_mode") or os.environ.get(
-            "DEFAULT_STOP_MODE", "destroy"
-        )
+        # Distinguish missing/empty (use default) from present-but-invalid
+        # (e.g. 0, False) — `or` would silently fall through to the default
+        # for any falsy non-string and skip validation.
+        stop_mode_raw = event.get("stop_mode")
+        if stop_mode_raw in (None, ""):
+            stop_mode = os.environ.get("DEFAULT_STOP_MODE", "destroy")
+        else:
+            stop_mode = str(stop_mode_raw)
         if stop_mode not in ("stop", "destroy"):
             return {"statusCode": 400, "body": f"Unknown stop_mode: {stop_mode}"}
         return stop_environment(stop_mode=stop_mode)
     elif action == "override":
-        hours = min(event.get("hours", 4), MAX_OVERRIDE_HOURS)
+        # Distinguish missing/None (use default) from 0 (clamp to 1) — `or 4`
+        # would silently coerce 0 to 4, breaking the documented "min 1 hour".
+        hours_raw = event.get("hours")
+        if hours_raw is None:
+            hours_raw = 4
+        try:
+            hours = int(hours_raw)
+        except (TypeError, ValueError):
+            return {"statusCode": 400, "body": "hours must be an integer"}
+        hours = min(max(hours, 1), MAX_OVERRIDE_HOURS)
         return set_override(hours)
     else:
         print(f"Unknown action: {action}")
@@ -158,88 +197,132 @@ def start_environment():
     """
     results = {}
 
-    # 1. Start NAT instance first (needed for private subnet internet access)
-    results["nat"] = with_retry(start_instance, os.environ["NAT_INSTANCE_ID"], "NAT")
+    # Detect the +15 min verify re-invocation. Used by the proxy step (to
+    # promote `deferred_still_creating` to an error) and the delayed-rules
+    # step. Requires BOTH NAT running AND RDS already available — NAT alone
+    # is unreliable because an operator may have manually started it
+    # outside the scheduler, which would otherwise trip a false positive
+    # (premature delayed-rule enable, deferred-proxy promoted to a page).
+    nat_id = os.environ["NAT_INSTANCE_ID"]
+    is_verify = False
+    try:
+        nat_resp = ec2.describe_instances(InstanceIds=[nat_id])
+        nat_reservations = nat_resp.get("Reservations", [])
+        nat_state_before = (
+            nat_reservations[0]["Instances"][0]["State"]["Name"]
+            if nat_reservations and nat_reservations[0].get("Instances")
+            else "not_found"
+        )
+        if nat_state_before == "running":
+            try:
+                rds_resp = rds.describe_db_instances(
+                    DBInstanceIdentifier=os.environ["RDS_INSTANCE_ID"]
+                )
+                rds_status_before = rds_resp["DBInstances"][0]["DBInstanceStatus"]
+                is_verify = rds_status_before == "available"
+                if is_verify:
+                    print(
+                        "Verify-start invocation detected "
+                        "(NAT running, RDS available)"
+                    )
+                else:
+                    print(
+                        f"NAT running but RDS is {rds_status_before} — "
+                        f"treating as initial start (likely manual NAT start)"
+                    )
+            except rds.exceptions.DBInstanceNotFoundFault:
+                print("NAT running but RDS not found — treating as initial start")
+    except Exception as e:
+        print(f"Verify-start detection error: {e}")
 
-    # 2. Restore RDS from snapshot (takes longest to become available ~5-10 min)
-    results["rds"] = with_retry(
-        restore_rds,
-        os.environ["RDS_INSTANCE_ID"],
-        os.environ["RDS_SNAPSHOT_ID"],
-        {
-            "instance_class": os.environ["RDS_INSTANCE_CLASS"],
-            "subnet_group": os.environ["RDS_SUBNET_GROUP_NAME"],
-            "security_group_ids": os.environ["RDS_SECURITY_GROUP_IDS"].split(","),
-            "parameter_group": os.environ["RDS_PARAMETER_GROUP_NAME"],
-        },
-    )
+    # try/finally so clear_override() always runs — a raised exception
+    # would otherwise leave the override flag set and skip the next stop.
+    try:
+        # 1. Start NAT instance first (needed for private subnet internet access)
+        results["nat"] = with_retry(start_instance, nat_id, "NAT")
 
-    # 3. Start background instance
-    results["background"] = with_retry(
-        start_instance, os.environ["BACKGROUND_INSTANCE_ID"], "Background"
-    )
-
-    # 4. Start premium instances (Terraform-managed base instances)
-    premium_ids = [
-        i for i in os.environ.get("PREMIUM_INSTANCE_IDS", "").split(",") if i
-    ]
-    for pid in premium_ids:
-        results[f"premium_{pid}"] = with_retry(start_instance, pid, "Premium")
-
-    # 5. Scale up ASG (launches free tier instance)
-    results["asg"] = with_retry(
-        scale_asg,
-        os.environ["ASG_NAME"],
-        min_size=int(os.environ.get("ASG_MIN_SIZE", "1")),
-        desired=int(os.environ.get("ASG_DESIRED_CAPACITY", "1")),
-        max_size=int(os.environ.get("ASG_MAX_SIZE", "3")),
-    )
-
-    # 6. Restore ECS service desired counts (so tasks start scheduling
-    #    once container instances register)
-    ecs_services = json.loads(os.environ.get("ECS_SERVICE_NAMES", "[]"))
-    if ecs_services:
-        results.update(
-            update_ecs_services(
-                os.environ["CLUSTER_NAME"], ecs_services, desired_count=1
-            )
+        # 2. Restore RDS from snapshot (takes longest to become available ~5-10 min)
+        results["rds"] = with_retry(
+            restore_rds,
+            os.environ["RDS_INSTANCE_ID"],
+            os.environ["RDS_SNAPSHOT_ID"],
+            {
+                "instance_class": os.environ["RDS_INSTANCE_CLASS"],
+                "subnet_group": os.environ["RDS_SUBNET_GROUP_NAME"],
+                "security_group_ids": os.environ["RDS_SECURITY_GROUP_IDS"].split(","),
+                "parameter_group": os.environ["RDS_PARAMETER_GROUP_NAME"],
+            },
         )
 
-    # 7. Enable Lambda schedule rules (except delayed rules)
-    rules = json.loads(os.environ.get("SCHEDULE_RULE_NAMES", "[]"))
-    results.update(toggle_event_rules(rules, enable=True))
-
-    # 8. Enable delayed rules (premium_manager etc.) only on verify-start
-    #    invocation (+15 min after start). This gives instances time to boot
-    #    and register before premium_manager starts monitoring.
-    #    On the initial start, these rules stay disabled to avoid
-    #    premium_manager acting on stale DB state while instances are booting.
-    delayed_rules = json.loads(os.environ.get("DELAYED_RULE_NAMES", "[]"))
-    if delayed_rules:
-        # Check if this is a verify invocation (resources already started)
-        # by seeing if NAT is already running — if so, enable delayed rules
-        try:
-            nat_resp = ec2.describe_instances(
-                InstanceIds=[os.environ["NAT_INSTANCE_ID"]]
+        # 2b. Re-register the proxy target. Must run on every start path
+        #     (see ensure_rds_proxy_target). On verify-start, a deferred
+        #     result means the restore is stuck — promote it to an error.
+        if not str(results["rds"]).startswith("error"):
+            proxy_result = with_retry(
+                ensure_rds_proxy_target, os.environ["RDS_INSTANCE_ID"]
             )
-            nat_state = nat_resp["Reservations"][0]["Instances"][0]["State"]["Name"]
-            if nat_state == "running" and results.get("nat") == "already_running":
-                print("Verify invocation detected — enabling delayed rules")
+            if is_verify and proxy_result == "deferred_still_creating":
+                proxy_result = (
+                    "error: RDS still not available at verify-start, "
+                    "proxy registration could not complete"
+                )
+            results["rds_proxy"] = proxy_result
+
+        # 3. Start background instance
+        results["background"] = with_retry(
+            start_instance, os.environ["BACKGROUND_INSTANCE_ID"], "Background"
+        )
+
+        # 4. Start premium instances (Terraform-managed base instances)
+        premium_ids = [
+            i for i in os.environ.get("PREMIUM_INSTANCE_IDS", "").split(",") if i
+        ]
+        for pid in premium_ids:
+            results[f"premium_{pid}"] = with_retry(start_instance, pid, "Premium")
+
+        # 5. Scale up ASG (launches free tier instance)
+        results["asg"] = with_retry(
+            scale_asg,
+            os.environ["ASG_NAME"],
+            min_size=int(os.environ.get("ASG_MIN_SIZE", "1")),
+            desired=int(os.environ.get("ASG_DESIRED_CAPACITY", "1")),
+            max_size=int(os.environ.get("ASG_MAX_SIZE", "3")),
+        )
+
+        # 6. Restore ECS service desired counts (so tasks start scheduling
+        #    once container instances register)
+        ecs_services = json.loads(os.environ.get("ECS_SERVICE_NAMES", "[]"))
+        if ecs_services:
+            results.update(
+                update_ecs_services(
+                    os.environ["CLUSTER_NAME"], ecs_services, desired_count=1
+                )
+            )
+
+        # 7. Enable Lambda schedule rules (except delayed rules)
+        rules = json.loads(os.environ.get("SCHEDULE_RULE_NAMES", "[]"))
+        results.update(toggle_event_rules(rules, enable=True))
+
+        # 8. Enable delayed rules (premium_manager etc.) only on verify-start.
+        #    Keeps premium_manager from acting on stale DB state while
+        #    instances are still booting.
+        delayed_rules = json.loads(os.environ.get("DELAYED_RULE_NAMES", "[]"))
+        if delayed_rules:
+            if is_verify:
+                print("Verify invocation — enabling delayed rules")
                 results.update(toggle_event_rules(delayed_rules, enable=True))
             else:
                 print(
                     "Initial start — delayed rules will be enabled on verify (+15 min)"
                 )
-        except Exception as e:
-            print(f"Delayed rules check error: {e}")
 
-    # 9. Enable CloudWatch alarm actions
-    results["alarms"] = with_retry(
-        toggle_alarm_actions, os.environ.get("ALARM_PREFIX", ""), enable=True
-    )
-
-    # 10. Clear override
-    clear_override()
+        # 9. Enable CloudWatch alarm actions
+        results["alarms"] = with_retry(
+            toggle_alarm_actions, os.environ.get("ALARM_PREFIX", ""), enable=True
+        )
+    finally:
+        # 10. Clear override (always)
+        clear_override()
 
     print(f"Start results: {json.dumps(results)}")
     errors = {k: v for k, v in results.items() if str(v).startswith("error")}
@@ -268,15 +351,18 @@ def stop_environment(stop_mode="destroy"):
         print("Manual override is active - skipping stop")
         return {"statusCode": 200, "action": "stop", "status": "skipped_override"}
 
-    # 1. Clean up dynamic premium instances (before disabling rules so
-    #    premium_manager can still reach the DB through NAT).
-    #    Skip if NAT is already stopped (verify-stop after initial stop) —
-    #    premium_manager needs NAT to reach RDS, so cleanup would just
-    #    timeout for 15 min and waste Lambda billing.
+    # 1. Clean up dynamic premium instances before disabling rules so
+    #    premium_manager can still reach the DB through NAT. Skip if NAT
+    #    is already down — cleanup would just time out.
     nat_id = os.environ["NAT_INSTANCE_ID"]
     try:
         nat_resp = ec2.describe_instances(InstanceIds=[nat_id])
-        nat_state = nat_resp["Reservations"][0]["Instances"][0]["State"]["Name"]
+        nat_reservations = nat_resp.get("Reservations", [])
+        nat_state = (
+            nat_reservations[0]["Instances"][0]["State"]["Name"]
+            if nat_reservations and nat_reservations[0].get("Instances")
+            else "not_found"
+        )
     except Exception as e:
         print(f"Failed to check NAT state: {e}")
         nat_state = "unknown"
@@ -374,11 +460,25 @@ def destroy_rds(instance_id, snapshot_id):
             print(f"RDS {instance_id}: already deleted")
             return "already_deleted"
 
-        # Delete old snapshot with same name (AWS requires unique snapshot IDs)
+        # Avoid re-issuing delete_db_instance — AWS rejects it with
+        # InvalidDBInstanceState once deletion is in progress.
+        if status == "deleting":
+            print(f"RDS {instance_id}: already deleting")
+            return "already_deleting"
+
+        # Delete old snapshot with same name (AWS requires unique snapshot IDs).
+        # Symmetric to the instance `deleting` short-circuit above: if the
+        # snapshot is already mid-delete (e.g. waiter timed out on a prior
+        # attempt and with_retry re-entered), don't re-issue delete — AWS
+        # rejects with InvalidDBSnapshotState. Just wait for it to finish.
         try:
-            rds.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)
-            print(f"RDS snapshot {snapshot_id}: deleting old snapshot")
-            rds.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
+            snap_resp = rds.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)
+            snap_status = snap_resp["DBSnapshots"][0]["Status"]
+            if snap_status == "deleting":
+                print(f"RDS snapshot {snapshot_id}: already deleting, waiting...")
+            else:
+                print(f"RDS snapshot {snapshot_id}: deleting old snapshot")
+                rds.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
             waiter = rds.get_waiter("db_snapshot_deleted")
             waiter.wait(
                 DBSnapshotIdentifier=snapshot_id,
@@ -404,9 +504,7 @@ def destroy_rds(instance_id, snapshot_id):
 def stop_rds(instance_id):
     """Stop an RDS instance. Fast resume (~2 min) but EBS still billed.
 
-    Idempotent: returns early if already stopped/stopping.
-    Handles cross-mode case: if instance was previously destroyed, returns
-    "not_found" instead of erroring.
+    Idempotent. Returns "not_found" if the instance was destroyed.
     """
     try:
         try:
@@ -445,6 +543,10 @@ def restore_rds(instance_id, snapshot_id, config):
             resp = rds.describe_db_instances(DBInstanceIdentifier=instance_id)
             status = resp["DBInstances"][0]["DBInstanceStatus"]
             print(f"RDS {instance_id}: already exists (status={status})")
+            if status == "deleting":
+                # Cross-mode race: a prior stop is mid-delete. Let with_retry
+                # back off; verify-start will pick it up cleanly.
+                return f"error: instance is {status}, cannot restore yet"
             if status == "stopped":
                 print(f"RDS {instance_id}: starting stopped instance (fallback)")
                 rds.start_db_instance(DBInstanceIdentifier=instance_id)
@@ -484,37 +586,117 @@ def restore_rds(instance_id, snapshot_id, config):
             PubliclyAccessible=False,
         )
         print(f"RDS {instance_id}: restoring from snapshot {snapshot_id}")
-
-        # Re-register with RDS Proxy. The proxy deregisters its target when the
-        # instance is deleted, and does NOT auto-register when a new instance is
-        # restored with the same identifier.
-        proxy_name = os.environ.get("RDS_PROXY_NAME")
-        if proxy_name:
-            try:
-                rds.register_db_proxy_targets(
-                    DBProxyName=proxy_name,
-                    DBInstanceIdentifiers=[instance_id],
-                )
-                print(f"RDS Proxy {proxy_name}: registered target {instance_id}")
-            except Exception as proxy_err:
-                # Log but don't fail — verify-start (+15 min) will retry
-                print(f"RDS Proxy {proxy_name}: registration warning - {proxy_err}")
-
         return "restoring"
     except Exception as e:
         print(f"RDS {instance_id}: error - {e}")
         return f"error: {e}"
 
 
+def ensure_rds_proxy_target(instance_id):
+    """Ensure the RDS instance is registered as a target of the RDS Proxy.
+
+    The proxy auto-deregisters its target when the instance is deleted but
+    does NOT auto-register when a new instance with the same identifier
+    appears. Must run on every start path.
+
+    Returns:
+        "already_registered"      — target already in the proxy target group
+        "registered"              — newly registered this call
+        "skipped_no_proxy"        — RDS_PROXY_NAME env var not set
+        "deferred_still_creating" — instance still transient at deadline;
+                                    initial start tolerates this and
+                                    verify-start promotes it to an error
+        "error: ..."              — instance missing, in a permanent broken
+                                    state, or register_db_proxy_targets raised
+    """
+    proxy_name = os.environ.get("RDS_PROXY_NAME")
+    if not proxy_name:
+        return "skipped_no_proxy"
+    try:
+        # Fast path: already in the target group. Walk the Marker pagination
+        # so a target on a later page isn't missed (today there's one target
+        # per proxy, but the API is paginated and a future migration may add
+        # more).
+        existing_targets = []
+        marker = None
+        while True:
+            kwargs = {"DBProxyName": proxy_name, "TargetGroupName": "default"}
+            if marker:
+                kwargs["Marker"] = marker
+            page = rds.describe_db_proxy_targets(**kwargs)
+            existing_targets.extend(page.get("Targets", []))
+            marker = page.get("Marker")
+            if not marker:
+                break
+        if any(t.get("RdsResourceId") == instance_id for t in existing_targets):
+            print(f"RDS Proxy {proxy_name}: target {instance_id} already registered")
+            return "already_registered"
+
+        # Wait for `available`. RDS rejects register_db_proxy_targets on
+        # non-available instances with InvalidDBInstanceState.
+        deadline = time.monotonic() + PROXY_REGISTER_POLL_SECONDS
+        while True:
+            try:
+                resp = rds.describe_db_instances(DBInstanceIdentifier=instance_id)
+                status = resp["DBInstances"][0]["DBInstanceStatus"]
+            except rds.exceptions.DBInstanceNotFoundFault:
+                return f"error: instance {instance_id} not found"
+
+            if status == "available":
+                break
+
+            if status not in TRANSIENT_RDS_STATUSES:
+                # Permanent broken state (failed, incompatible-*, storage-full, …)
+                print(
+                    f"RDS Proxy {proxy_name}: instance {instance_id} in "
+                    f"non-transient state {status!r}, cannot register"
+                )
+                return f"error: instance {instance_id} in state {status}"
+
+            if time.monotonic() >= deadline:
+                # WARNING prefix so a CloudWatch metric filter can catch
+                # repeated occurrences across cold-starts.
+                print(
+                    f"WARNING RDS Proxy {proxy_name}: instance {instance_id} "
+                    f"still {status} after {PROXY_REGISTER_POLL_SECONDS}s, "
+                    f"deferring registration to verify-start"
+                )
+                return "deferred_still_creating"
+
+            print(
+                f"RDS Proxy {proxy_name}: instance {instance_id} is {status}, "
+                f"polling..."
+            )
+            time.sleep(PROXY_REGISTER_POLL_INTERVAL)
+
+        rds.register_db_proxy_targets(
+            DBProxyName=proxy_name,
+            DBInstanceIdentifiers=[instance_id],
+        )
+        print(f"RDS Proxy {proxy_name}: registered target {instance_id}")
+        return "registered"
+    except Exception as e:
+        print(f"RDS Proxy {proxy_name}: registration error - {e}")
+        return f"error: {e}"
+
+
 def start_instance(instance_id, label):
     """Start an EC2 instance. Safe to call if already running.
 
-    Handles terminated instances gracefully — logs a warning instead of
+    Handles terminated/missing instances gracefully — logs a warning instead of
     retrying a dead instance indefinitely.
     """
     try:
         response = ec2.describe_instances(InstanceIds=[instance_id])
-        state = response["Reservations"][0]["Instances"][0]["State"]["Name"]
+        reservations = response.get("Reservations", [])
+        if not reservations or not reservations[0].get("Instances"):
+            print(
+                f"{label} instance {instance_id}: NOT FOUND — "
+                f"likely terminated/replaced. Update PREMIUM_INSTANCE_IDS or "
+                f"run terraform apply to recreate."
+            )
+            return "not_found"
+        state = reservations[0]["Instances"][0]["State"]["Name"]
         if state == "running":
             print(f"{label} instance {instance_id}: already running")
             return "already_running"
@@ -534,10 +716,14 @@ def start_instance(instance_id, label):
 
 
 def stop_instance(instance_id, label):
-    """Stop an EC2 instance. Safe to call if already stopped."""
+    """Stop an EC2 instance. Safe to call if already stopped or missing."""
     try:
         response = ec2.describe_instances(InstanceIds=[instance_id])
-        state = response["Reservations"][0]["Instances"][0]["State"]["Name"]
+        reservations = response.get("Reservations", [])
+        if not reservations or not reservations[0].get("Instances"):
+            print(f"{label} instance {instance_id}: not found — skipping")
+            return "not_found"
+        state = reservations[0]["Instances"][0]["State"]["Name"]
         if state in ("stopped", "stopping"):
             print(f"{label} instance {instance_id}: already {state}")
             return f"already_{state}"
@@ -646,7 +832,7 @@ def toggle_event_rules(rules, enable):
             results[f"{action_name}_{rule}"] = "ok"
             print(f"{action_name.title()}d rule: {rule}")
         except Exception as e:
-            results[f"{action_name}_{rule}"] = str(e)
+            results[f"{action_name}_{rule}"] = f"error: {e}"
             print(f"Failed to {action_name} rule {rule}: {e}")
     return results
 

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -24,6 +24,7 @@ _PACKAGE_NAMES = [
     "free_manager_package",
     "free_cleanup_package",
     "common_user_manager_package",
+    "dev_scheduler_package",
 ]
 
 # Add Lambda package directories to sys.path so imports work

--- a/studio/tests/infrastructure/test_dev_scheduler.py
+++ b/studio/tests/infrastructure/test_dev_scheduler.py
@@ -1,0 +1,1241 @@
+"""Tests for the dev_scheduler Lambda.
+
+The Lambda's boto3 clients are module-level globals; the `ds` fixture imports
+the module once and replaces each client with a MagicMock for the duration of
+the test. No real AWS calls are ever made.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Env vars dev_scheduler reads. Set as a module-level dict so every fixture
+# patch starts from the same baseline; individual tests override as needed.
+SCHEDULER_ENV = {
+    "AWS_DEFAULT_REGION": "ap-northeast-1",
+    "NAT_INSTANCE_ID": "i-nat",
+    "BACKGROUND_INSTANCE_ID": "i-bg",
+    "PREMIUM_INSTANCE_IDS": "i-prem1,i-prem2",
+    "RDS_INSTANCE_ID": "test-rds",
+    "RDS_SNAPSHOT_ID": "test-snap",
+    "RDS_INSTANCE_CLASS": "db.t4g.small",
+    "RDS_SUBNET_GROUP_NAME": "test-subnet-group",
+    "RDS_SECURITY_GROUP_IDS": "sg-1,sg-2",
+    "RDS_PARAMETER_GROUP_NAME": "test-pg",
+    "RDS_PROXY_NAME": "test-proxy",
+    "ASG_NAME": "test-asg",
+    "ASG_MIN_SIZE": "1",
+    "ASG_DESIRED_CAPACITY": "1",
+    "ASG_MAX_SIZE": "2",
+    "CLUSTER_NAME": "test-cluster",
+    "ECS_SERVICE_NAMES": json.dumps(["svc-a", "svc-b"]),
+    "SCHEDULE_RULE_NAMES": json.dumps(["rule-a"]),
+    "DELAYED_RULE_NAMES": json.dumps(["delayed-a"]),
+    "ALARM_PREFIX": "test-",
+    "OVERRIDE_PARAM_NAME": "/test/override",
+    "PREMIUM_MANAGER_FUNCTION_NAME": "test-premium-manager",
+    "DEFAULT_STOP_MODE": "destroy",
+}
+
+
+# Stub exception classes — boto3 generates rds.exceptions.X dynamically, so
+# replacing rds with a MagicMock loses them. Tests that need to simulate
+# "not found" use these via clients["rds"].exceptions.<Class>.
+class _DBInstanceNotFoundFault(Exception):
+    pass
+
+
+class _DBSnapshotNotFoundFault(Exception):
+    pass
+
+
+class _ParameterNotFound(Exception):
+    pass
+
+
+@pytest.fixture
+def ds(monkeypatch):
+    """Import dev_scheduler with all boto3 clients mocked.
+
+    Returns a (module, clients) tuple where clients is a dict keyed by
+    attribute name on the module ("rds", "ec2", "ecs", ...). Tests configure
+    the mocks via clients["rds"].describe_db_instances.return_value = ...,
+    then assert on the helper's return value or call history.
+    """
+    with patch.dict("os.environ", SCHEDULER_ENV, clear=False):
+        import dev_scheduler  # noqa: PLC0415  — must be inside env patch
+
+        clients = {
+            "rds": MagicMock(name="rds"),
+            "ec2": MagicMock(name="ec2"),
+            "ecs": MagicMock(name="ecs"),
+            "autoscaling": MagicMock(name="autoscaling"),
+            "events": MagicMock(name="events"),
+            "cloudwatch": MagicMock(name="cloudwatch"),
+            "ssm": MagicMock(name="ssm"),
+            "lambda_client": MagicMock(name="lambda_client"),
+        }
+
+        # Wire up exception classes so `except rds.exceptions.X:` works.
+        clients["rds"].exceptions.DBInstanceNotFoundFault = _DBInstanceNotFoundFault
+        clients["rds"].exceptions.DBSnapshotNotFoundFault = _DBSnapshotNotFoundFault
+        clients["ssm"].exceptions.ParameterNotFound = _ParameterNotFound
+
+        for name, mock in clients.items():
+            monkeypatch.setattr(dev_scheduler, name, mock)
+
+        # Make retries and polling instant.
+        monkeypatch.setattr(dev_scheduler.time, "sleep", lambda *_: None)
+
+        yield dev_scheduler, clients
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by several tests.
+# ---------------------------------------------------------------------------
+
+
+def _ec2_response(state):
+    """Build a describe_instances response with one instance in `state`."""
+    return {"Reservations": [{"Instances": [{"State": {"Name": state}}]}]}
+
+
+def _rds_response(status):
+    """Build a describe_db_instances response with one instance in `status`."""
+    return {"DBInstances": [{"DBInstanceStatus": status}]}
+
+
+# ===========================================================================
+# handler dispatch + input validation
+# ===========================================================================
+
+
+class TestHandler:
+    def test_no_action_returns_400(self, ds):
+        module, _ = ds
+        result = module.handler({}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_unknown_action_returns_400(self, ds):
+        module, _ = ds
+        result = module.handler({"action": "explode"}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_start_dispatches_to_start_environment(self, ds):
+        module, _ = ds
+        with patch.object(module, "start_environment") as mock_start:
+            mock_start.return_value = {"statusCode": 200}
+            module.handler({"action": "start"}, MagicMock())
+            mock_start.assert_called_once_with()
+
+    def test_stop_default_mode_dispatches_with_destroy(self, ds):
+        module, _ = ds
+        with patch.object(module, "stop_environment") as mock_stop:
+            mock_stop.return_value = {"statusCode": 200}
+            module.handler({"action": "stop"}, MagicMock())
+            mock_stop.assert_called_once_with(stop_mode="destroy")
+
+    def test_stop_with_explicit_stop_mode(self, ds):
+        module, _ = ds
+        with patch.object(module, "stop_environment") as mock_stop:
+            mock_stop.return_value = {"statusCode": 200}
+            module.handler({"action": "stop", "stop_mode": "stop"}, MagicMock())
+            mock_stop.assert_called_once_with(stop_mode="stop")
+
+    def test_stop_unknown_mode_returns_400(self, ds):
+        module, _ = ds
+        result = module.handler({"action": "stop", "stop_mode": "nuke"}, MagicMock())
+        assert result["statusCode"] == 400
+
+    # ---- override input validation ----------------------------------------
+
+    def test_override_default_hours(self, ds):
+        module, _ = ds
+        with patch.object(module, "set_override") as mock_set:
+            module.handler({"action": "override"}, MagicMock())
+            mock_set.assert_called_once_with(4)
+
+    def test_override_explicit_hours_clamped_to_max(self, ds):
+        module, _ = ds
+        with patch.object(module, "set_override") as mock_set:
+            module.handler({"action": "override", "hours": 999}, MagicMock())
+            mock_set.assert_called_once_with(module.MAX_OVERRIDE_HOURS)
+
+    def test_override_negative_hours_clamped_to_one(self, ds):
+        module, _ = ds
+        with patch.object(module, "set_override") as mock_set:
+            module.handler({"action": "override", "hours": -5}, MagicMock())
+            mock_set.assert_called_once_with(1)
+
+    def test_override_null_hours_uses_default(self, ds):
+        """`{"hours": null}` must not crash with TypeError."""
+        module, _ = ds
+        with patch.object(module, "set_override") as mock_set:
+            module.handler({"action": "override", "hours": None}, MagicMock())
+            mock_set.assert_called_once_with(4)
+
+    def test_override_string_hours_returns_400(self, ds):
+        """Non-integer string must return 400, not crash on str/int compare."""
+        module, _ = ds
+        result = module.handler({"action": "override", "hours": "abc"}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_action_null_returns_400(self, ds):
+        """`{"action": null}` must not crash on None.strip()."""
+        module, _ = ds
+        result = module.handler({"action": None}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_whitespace_only_action_returns_400(self, ds):
+        """`{"action": "   "}` strips to empty string → no action."""
+        module, _ = ds
+        result = module.handler({"action": "   "}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_action_non_string_returns_400(self, ds):
+        """`{"action": 123}` must be coerced and rejected, not crash on
+        int.strip(). Pins the str() coercion in handler."""
+        module, _ = ds
+        result = module.handler({"action": 123}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_stop_mode_non_string_returns_400(self, ds):
+        """`{"action":"stop","stop_mode": 0}` — non-string truthy stop_mode
+        must be coerced to a string and rejected by the tuple check."""
+        module, _ = ds
+        result = module.handler({"action": "stop", "stop_mode": 0}, MagicMock())
+        assert result["statusCode"] == 400
+
+    def test_override_zero_hours_clamped_to_one(self, ds):
+        """`{"hours": 0}` must clamp to 1, NOT fall through to the default
+        of 4. The previous `int(... or 4)` treated 0 as falsy."""
+        module, _ = ds
+        with patch.object(module, "set_override") as mock_set:
+            module.handler({"action": "override", "hours": 0}, MagicMock())
+            mock_set.assert_called_once_with(1)
+
+
+# ===========================================================================
+# with_retry plumbing
+# ===========================================================================
+
+
+class TestWithRetry:
+    def test_returns_first_success(self, ds):
+        module, _ = ds
+        fn = MagicMock(return_value="ok")
+        assert module.with_retry(fn, "arg") == "ok"
+        assert fn.call_count == 1
+
+    def test_retries_until_success(self, ds):
+        module, _ = ds
+        fn = MagicMock(side_effect=["error: nope", "ok"])
+        fn.__name__ = "fn"
+        assert module.with_retry(fn) == "ok"
+        assert fn.call_count == 2
+
+    def test_returns_last_error_after_max_attempts(self, ds):
+        module, _ = ds
+        fn = MagicMock(side_effect=["error: a", "error: b", "error: c"])
+        fn.__name__ = "fn"
+        assert module.with_retry(fn) == "error: c"
+        assert fn.call_count == module.MAX_RETRY_ATTEMPTS
+
+    def test_max_attempts_kwarg(self, ds):
+        module, _ = ds
+        fn = MagicMock(return_value="error: x")
+        fn.__name__ = "fn"
+        module.with_retry(fn, max_attempts=1)
+        assert fn.call_count == 1
+
+    def test_dict_result_treated_as_success(self, ds):
+        """`str(dict)` starts with `{`, not "error" — must not retry."""
+        module, _ = ds
+        fn = MagicMock(return_value={"ok": True})
+        assert module.with_retry(fn) == {"ok": True}
+        assert fn.call_count == 1
+
+    def test_propagates_exceptions_from_fn(self, ds):
+        """Pins the contract that with_retry does NOT catch raised
+        exceptions — helpers must return "error: ..." strings themselves."""
+        module, _ = ds
+        fn = MagicMock(side_effect=RuntimeError("uncaught"))
+        fn.__name__ = "fn"
+        with pytest.raises(RuntimeError, match="uncaught"):
+            module.with_retry(fn)
+        assert fn.call_count == 1  # no retry on raised exceptions
+
+
+# ===========================================================================
+# start_instance / stop_instance
+# ===========================================================================
+
+
+class TestStartInstance:
+    def test_already_running(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        assert module.start_instance("i-x", "Test") == "already_running"
+        clients["ec2"].start_instances.assert_not_called()
+
+    def test_starts_when_stopped(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        assert module.start_instance("i-x", "Test") == "starting"
+        clients["ec2"].start_instances.assert_called_once_with(InstanceIds=["i-x"])
+
+    def test_terminated_returns_error(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("terminated")
+        result = module.start_instance("i-x", "Test")
+        assert result.startswith("error:")
+        clients["ec2"].start_instances.assert_not_called()
+
+    def test_not_found_when_empty_reservations(self, ds):
+        """Empty Reservations must return not_found, not raise IndexError."""
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = {"Reservations": []}
+        assert module.start_instance("i-gone", "Premium") == "not_found"
+        clients["ec2"].start_instances.assert_not_called()
+
+    def test_not_found_when_reservation_has_no_instances(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = {
+            "Reservations": [{"Instances": []}]
+        }
+        assert module.start_instance("i-gone", "Premium") == "not_found"
+
+    def test_aws_exception_returns_error(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.side_effect = RuntimeError("boom")
+        result = module.start_instance("i-x", "Test")
+        assert result.startswith("error:")
+
+
+class TestStopInstance:
+    def test_stops_when_running(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        assert module.stop_instance("i-x", "Test") == "stopping"
+        clients["ec2"].stop_instances.assert_called_once_with(InstanceIds=["i-x"])
+
+    def test_already_stopped(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        assert module.stop_instance("i-x", "Test") == "already_stopped"
+        clients["ec2"].stop_instances.assert_not_called()
+
+    def test_already_terminated(self, ds):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("terminated")
+        assert module.stop_instance("i-x", "Test") == "already_terminated"
+
+    def test_not_found_when_empty_reservations(self, ds):
+        """Empty Reservations must return not_found on stop_instance too."""
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = {"Reservations": []}
+        assert module.stop_instance("i-gone", "Premium") == "not_found"
+        clients["ec2"].stop_instances.assert_not_called()
+
+
+# ===========================================================================
+# RDS lifecycle helpers
+# ===========================================================================
+
+
+class TestRestoreRds:
+    @pytest.fixture
+    def rds_config(self):
+        return {
+            "instance_class": "db.t4g.small",
+            "subnet_group": "sg",
+            "security_group_ids": ["sg-1"],
+            "parameter_group": "pg",
+        }
+
+    def test_already_exists_when_available(self, ds, rds_config):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        assert module.restore_rds("rds-x", "snap-x", rds_config) == "already_exists"
+        clients["rds"].restore_db_instance_from_db_snapshot.assert_not_called()
+
+    def test_starts_when_stopped(self, ds, rds_config):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("stopped")
+        assert module.restore_rds("rds-x", "snap-x", rds_config) == "starting_existing"
+        clients["rds"].start_db_instance.assert_called_once_with(
+            DBInstanceIdentifier="rds-x"
+        )
+
+    def test_returns_error_when_status_deleting(self, ds, rds_config):
+        """Cross-mode race — don't restore on top of an in-progress delete."""
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("deleting")
+        result = module.restore_rds("rds-x", "snap-x", rds_config)
+        assert result.startswith("error:")
+        clients["rds"].restore_db_instance_from_db_snapshot.assert_not_called()
+        clients["rds"].start_db_instance.assert_not_called()
+
+    def test_restores_when_instance_not_found(self, ds, rds_config):
+        module, clients = ds
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        clients["rds"].describe_db_snapshots.return_value = {
+            "DBSnapshots": [{"Status": "available"}]
+        }
+        assert module.restore_rds("rds-x", "snap-x", rds_config) == "restoring"
+        clients["rds"].restore_db_instance_from_db_snapshot.assert_called_once()
+
+    def test_snapshot_not_found_returns_error(self, ds, rds_config):
+        module, clients = ds
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        clients["rds"].describe_db_snapshots.side_effect = _DBSnapshotNotFoundFault()
+        result = module.restore_rds("rds-x", "snap-x", rds_config)
+        assert result.startswith("error:")
+
+    def test_snapshot_waiter_timeout_returns_error(self, ds, rds_config):
+        """Snapshot exists but is in 'creating'; waiter exceeds MaxAttempts."""
+        module, clients = ds
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        clients["rds"].describe_db_snapshots.return_value = {
+            "DBSnapshots": [{"Status": "creating"}]
+        }
+        waiter = MagicMock()
+        waiter.wait.side_effect = RuntimeError("WaiterError: timed out")
+        clients["rds"].get_waiter.return_value = waiter
+        result = module.restore_rds("rds-x", "snap-x", rds_config)
+        assert result.startswith("error:")
+        clients["rds"].restore_db_instance_from_db_snapshot.assert_not_called()
+
+
+class TestDestroyRds:
+    def test_already_deleted_when_not_found(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        assert module.destroy_rds("rds-x", "snap-x") == "already_deleted"
+        clients["rds"].delete_db_instance.assert_not_called()
+
+    def test_already_deleting_short_circuits(self, ds):
+        """Re-running destroy mid-delete must short-circuit, not call AWS."""
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("deleting")
+        assert module.destroy_rds("rds-x", "snap-x") == "already_deleting"
+        clients["rds"].delete_db_instance.assert_not_called()
+        clients["rds"].delete_db_snapshot.assert_not_called()
+
+    def test_deletes_old_snapshot_then_instance(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        clients["rds"].describe_db_snapshots.return_value = {
+            "DBSnapshots": [{"Status": "available"}]
+        }
+        clients["rds"].get_waiter.return_value = MagicMock()
+        assert module.destroy_rds("rds-x", "snap-x") == "deleting"
+        clients["rds"].delete_db_snapshot.assert_called_once_with(
+            DBSnapshotIdentifier="snap-x"
+        )
+        clients["rds"].delete_db_instance.assert_called_once()
+
+    def test_no_old_snapshot_skips_snapshot_delete(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        clients["rds"].describe_db_snapshots.side_effect = _DBSnapshotNotFoundFault()
+        assert module.destroy_rds("rds-x", "snap-x") == "deleting"
+        clients["rds"].delete_db_snapshot.assert_not_called()
+        clients["rds"].delete_db_instance.assert_called_once()
+
+    def test_delete_db_instance_called_with_final_snapshot(self, ds):
+        """The final snapshot identifier must be passed and
+        DeleteAutomatedBackups must be False — losing either would cause
+        silent data destruction on every weeknight stop."""
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        clients["rds"].describe_db_snapshots.side_effect = _DBSnapshotNotFoundFault()
+        module.destroy_rds("rds-x", "snap-x")
+        clients["rds"].delete_db_instance.assert_called_once_with(
+            DBInstanceIdentifier="rds-x",
+            FinalDBSnapshotIdentifier="snap-x",
+            DeleteAutomatedBackups=False,
+        )
+
+    def test_snapshot_delete_short_circuits_when_already_deleting(self, ds):
+        """Symmetric to the instance `deleting` short-circuit. If a prior
+        attempt's waiter timed out and with_retry re-entered destroy_rds,
+        the snapshot may still be in `deleting` — re-issuing
+        delete_db_snapshot would raise InvalidDBSnapshotState. The helper
+        must skip the delete call and just wait."""
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        clients["rds"].describe_db_snapshots.return_value = {
+            "DBSnapshots": [{"Status": "deleting"}]
+        }
+        clients["rds"].get_waiter.return_value = MagicMock()
+        assert module.destroy_rds("rds-x", "snap-x") == "deleting"
+        clients["rds"].delete_db_snapshot.assert_not_called()
+        # Instance delete still proceeds.
+        clients["rds"].delete_db_instance.assert_called_once()
+
+    def test_retry_after_partial_failure_short_circuits(self, ds):
+        """First attempt deletes the old snapshot then delete_db_instance
+        fails (e.g. transient throttle). On retry, status
+        is "deleting" and the helper must short-circuit rather than call
+        delete_db_instance again."""
+        module, clients = ds
+        # attempt 1: available → proceeds to delete_db_instance (which fails)
+        # attempt 2: deleting  → short-circuits to already_deleting
+        clients["rds"].describe_db_instances.side_effect = [
+            _rds_response("available"),
+            _rds_response("deleting"),
+        ]
+        clients["rds"].describe_db_snapshots.side_effect = _DBSnapshotNotFoundFault()
+        clients["rds"].delete_db_instance.side_effect = [
+            RuntimeError("throttled"),
+        ]
+        result = module.with_retry(module.destroy_rds, "rds-x", "snap-x")
+        assert result == "already_deleting"
+        # delete_db_instance was only called once — second attempt
+        # short-circuited before reaching it.
+        assert clients["rds"].delete_db_instance.call_count == 1
+
+
+class TestStopRds:
+    def test_not_found(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        assert module.stop_rds("rds-x") == "not_found"
+
+    def test_already_stopped(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("stopped")
+        assert module.stop_rds("rds-x") == "already_stopped"
+        clients["rds"].stop_db_instance.assert_not_called()
+
+    def test_stops_when_available(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        assert module.stop_rds("rds-x") == "stopping"
+        clients["rds"].stop_db_instance.assert_called_once_with(
+            DBInstanceIdentifier="rds-x"
+        )
+
+    def test_cannot_stop_when_creating(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_instances.return_value = _rds_response("creating")
+        assert module.stop_rds("rds-x").startswith("error:")
+        clients["rds"].stop_db_instance.assert_not_called()
+
+
+# ===========================================================================
+# ensure_rds_proxy_target
+# ===========================================================================
+
+
+class TestEnsureRdsProxyTarget:
+    def test_skipped_when_no_proxy_env_var(self, ds, monkeypatch):
+        module, clients = ds
+        monkeypatch.delenv("RDS_PROXY_NAME", raising=False)
+        assert module.ensure_rds_proxy_target("rds-x") == "skipped_no_proxy"
+        clients["rds"].describe_db_proxy_targets.assert_not_called()
+
+    def test_already_registered_fast_path(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {
+            "Targets": [{"RdsResourceId": "rds-x"}]
+        }
+        assert module.ensure_rds_proxy_target("rds-x") == "already_registered"
+        clients["rds"].describe_db_instances.assert_not_called()
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+    def test_registers_when_immediately_available(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        assert module.ensure_rds_proxy_target("rds-x") == "registered"
+        clients["rds"].register_db_proxy_targets.assert_called_once_with(
+            DBProxyName="test-proxy", DBInstanceIdentifiers=["rds-x"]
+        )
+
+    def test_polls_through_creating_to_available(self, ds, monkeypatch):
+        """Happy path: poll a transient state and register once available."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.side_effect = [
+            _rds_response("creating"),
+            _rds_response("creating"),
+            _rds_response("available"),
+        ]
+        # Time stays well within deadline.
+        ticks = iter([0, 1, 2, 3, 4])
+        monkeypatch.setattr(module.time, "monotonic", lambda: next(ticks))
+        assert module.ensure_rds_proxy_target("rds-x") == "registered"
+        assert clients["rds"].describe_db_instances.call_count == 3
+        clients["rds"].register_db_proxy_targets.assert_called_once()
+
+    def test_returns_deferred_when_persistently_creating(self, ds, monkeypatch):
+        """Instance still transient past deadline → soft skip."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.return_value = _rds_response("creating")
+        # First monotonic() sets the deadline; second jumps past it.
+        ticks = iter([0, 9999])
+        monkeypatch.setattr(module.time, "monotonic", lambda: next(ticks))
+        assert module.ensure_rds_proxy_target("rds-x") == "deferred_still_creating"
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "broken_status",
+        [
+            "failed",
+            "incompatible-parameters",
+            "incompatible-restore",
+            "storage-full",
+            "inaccessible-encryption-credentials",
+        ],
+    )
+    def test_non_transient_states_return_error(self, ds, broken_status):
+        """Permanent broken states must error (page), not soft-skip."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.return_value = _rds_response(broken_status)
+        result = module.ensure_rds_proxy_target("rds-x")
+        assert result.startswith("error:")
+        assert broken_status in result
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+    def test_returns_error_when_instance_not_found(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        result = module.ensure_rds_proxy_target("rds-x")
+        assert result.startswith("error:")
+        assert "not found" in result
+
+    def test_register_call_failure_returns_error(self, ds):
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        clients["rds"].register_db_proxy_targets.side_effect = RuntimeError("throttled")
+        result = module.ensure_rds_proxy_target("rds-x")
+        assert result.startswith("error:")
+
+    def test_describe_proxy_targets_failure_returns_error(self, ds):
+        """If the proxy itself doesn't exist (e.g. terraform drift between
+        env vars and reality), describe_db_proxy_targets raises. The outer
+        try/except must catch it and return an error string."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.side_effect = RuntimeError(
+            "DBProxyNotFoundFault: test-proxy"
+        )
+        result = module.ensure_rds_proxy_target("rds-x")
+        assert result.startswith("error:")
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+    def test_fast_path_walks_marker_pagination(self, ds):
+        """Target on a later page must be found by the fast path. A naïve
+        single-call check would miss it and unnecessarily re-register
+        (or, worse, fail to detect an already-registered target)."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.side_effect = [
+            {"Targets": [{"RdsResourceId": "other-rds"}], "Marker": "page2"},
+            {"Targets": [{"RdsResourceId": "rds-x"}]},
+        ]
+        assert module.ensure_rds_proxy_target("rds-x") == "already_registered"
+        assert clients["rds"].describe_db_proxy_targets.call_count == 2
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+    def test_transitions_from_creating_to_failed_mid_poll(self, ds, monkeypatch):
+        """A transition into a permanent broken state during polling must
+        error, not defer. Pins non-transient check above deadline check."""
+        module, clients = ds
+        clients["rds"].describe_db_proxy_targets.return_value = {"Targets": []}
+        clients["rds"].describe_db_instances.side_effect = [
+            _rds_response("creating"),
+            _rds_response("creating"),
+            _rds_response("failed"),  # transition to broken state
+        ]
+        ticks = iter([0, 1, 2, 3, 4, 5])
+        monkeypatch.setattr(module.time, "monotonic", lambda: next(ticks))
+        result = module.ensure_rds_proxy_target("rds-x")
+        assert result.startswith("error:")
+        assert "failed" in result
+        clients["rds"].register_db_proxy_targets.assert_not_called()
+
+
+# ===========================================================================
+# start_environment
+# ===========================================================================
+
+
+class TestStartEnvironment:
+    @pytest.fixture
+    def patched(self, ds, monkeypatch):
+        """Patch every helper start_environment calls so the orchestration
+        flow can be exercised in isolation. Tests override individual mocks
+        as needed."""
+        module, clients = ds
+
+        # NAT pre-check (verify-start detection): default = NAT stopped.
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+
+        helpers = {
+            "start_instance": MagicMock(return_value="starting"),
+            "restore_rds": MagicMock(return_value="restoring"),
+            "ensure_rds_proxy_target": MagicMock(return_value="registered"),
+            "scale_asg": MagicMock(return_value="min=1,desired=1,max=2"),
+            "update_ecs_services": MagicMock(
+                return_value={"ecs_svc-a": "desired_count=1"}
+            ),
+            "toggle_event_rules": MagicMock(return_value={"enable_rule-a": "ok"}),
+            "toggle_alarm_actions": MagicMock(return_value="enabled_5_alarms"),
+            "clear_override": MagicMock(),
+        }
+        for name, mock in helpers.items():
+            mock.__name__ = name  # with_retry logs fn.__name__ on retries
+            monkeypatch.setattr(module, name, mock)
+        return module, clients, helpers
+
+    def test_proxy_registration_runs_on_already_exists(self, patched):
+        """When restore_rds returns "already_exists", proxy registration
+        must still run — the proxy may have been deregistered by a prior
+        destroy stop."""
+        module, _, helpers = patched
+        helpers["restore_rds"].return_value = "already_exists"
+        result = module.start_environment()
+        helpers["ensure_rds_proxy_target"].assert_called_once()
+        assert result["statusCode"] == 200
+
+    def test_proxy_registration_runs_on_restoring(self, patched):
+        module, _, helpers = patched
+        helpers["restore_rds"].return_value = "restoring"
+        module.start_environment()
+        helpers["ensure_rds_proxy_target"].assert_called_once()
+
+    def test_proxy_registration_skipped_when_rds_errored(self, patched):
+        module, _, helpers = patched
+        helpers["restore_rds"].return_value = "error: snapshot_not_found"
+        with pytest.raises(RuntimeError):
+            module.start_environment()
+        helpers["ensure_rds_proxy_target"].assert_not_called()
+
+    def test_premium_not_found_does_not_raise(self, patched):
+        """A stale premium ID returning 'not_found' must not fail the run."""
+        module, _, helpers = patched
+
+        def fake_start_instance(instance_id, label):
+            if label == "Premium":
+                return "not_found"
+            return "starting"
+
+        helpers["start_instance"].side_effect = fake_start_instance
+        result = module.start_environment()
+        assert result["statusCode"] == 200
+        # And proxy registration still happened.
+        helpers["ensure_rds_proxy_target"].assert_called_once()
+
+    def test_raises_runtime_error_on_failed_step(self, patched):
+        module, _, helpers = patched
+        helpers["scale_asg"].return_value = "error: capacity exceeded"
+        with pytest.raises(RuntimeError):
+            module.start_environment()
+
+    def test_is_verify_false_when_nat_stopped(self, patched):
+        """Initial start: NAT was stopped before invocation. Delayed rules
+        should not be enabled."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        module.start_environment()
+        # toggle_event_rules called once (for non-delayed SCHEDULE_RULE_NAMES),
+        # NOT a second time for DELAYED_RULE_NAMES.
+        assert helpers["toggle_event_rules"].call_count == 1
+
+    def test_is_verify_true_when_nat_running_and_rds_available(self, patched):
+        """Verify-start: NAT running AND RDS already available.
+        Delayed rules get enabled."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        module.start_environment()
+        assert helpers["toggle_event_rules"].call_count == 2
+
+    def test_is_verify_false_when_nat_running_but_rds_not_available(self, patched):
+        """Operator manually started NAT but RDS hasn't been restored yet.
+        Must be treated as initial start, NOT verify-start — otherwise
+        delayed rules fire prematurely and a deferred proxy gets paged."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        clients["rds"].describe_db_instances.side_effect = _DBInstanceNotFoundFault()
+        module.start_environment()
+        # Only the non-delayed rules call — delayed rules NOT enabled.
+        assert helpers["toggle_event_rules"].call_count == 1
+
+    def test_nat_pending_does_not_set_is_verify(self, patched):
+        """KNOWN LIMITATION: if a verify-start invocation lands while NAT
+        is still in `pending` (slow start path), is_verify stays False and
+        a `deferred_still_creating` proxy result is NOT promoted to an
+        error this cycle. The next +15 min verify gets another chance.
+        Pinned so a future tightening of verify detection has to update
+        this test deliberately."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("pending")
+        helpers["ensure_rds_proxy_target"].return_value = "deferred_still_creating"
+        # Should NOT raise (deferred not promoted) and delayed rules
+        # should NOT be enabled.
+        result = module.start_environment()
+        assert result["statusCode"] == 200
+        assert helpers["toggle_event_rules"].call_count == 1
+
+    def test_is_verify_false_when_nat_running_but_rds_creating(self, patched):
+        """Same theme: NAT running but RDS still in a transient state →
+        not a verify-start."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        clients["rds"].describe_db_instances.return_value = _rds_response("creating")
+        module.start_environment()
+        assert helpers["toggle_event_rules"].call_count == 1
+
+    def test_proxy_deferred_kept_on_initial_start(self, patched):
+        """Initial start: deferred is acceptable, no RuntimeError."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        helpers["ensure_rds_proxy_target"].return_value = "deferred_still_creating"
+        result = module.start_environment()
+        assert result["statusCode"] == 200
+        assert result["results"]["rds_proxy"] == "deferred_still_creating"
+
+    def test_proxy_deferred_promoted_to_error_on_verify(self, patched):
+        """A deferred result at verify-start must be promoted to an error."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        clients["rds"].describe_db_instances.return_value = _rds_response("available")
+        helpers["ensure_rds_proxy_target"].return_value = "deferred_still_creating"
+        with pytest.raises(RuntimeError) as exc_info:
+            module.start_environment()
+        assert "verify-start" in str(exc_info.value)
+
+    def test_clear_override_called_even_on_failed_start(self, patched):
+        """clear_override() must run even when a step returns an error —
+        otherwise the override flag survives and skips the next scheduled
+        stop indefinitely."""
+        module, _, helpers = patched
+        helpers["scale_asg"].return_value = "error: capacity"
+        with pytest.raises(RuntimeError):
+            module.start_environment()
+        helpers["clear_override"].assert_called_once()
+
+    def test_clear_override_called_when_helper_raises(self, patched):
+        """Same guarantee as above for the raised-exception path: a helper
+        raising mid-orchestration must not skip clear_override()."""
+        module, _, helpers = patched
+        helpers["scale_asg"].side_effect = RuntimeError("uncaught boom")
+        with pytest.raises(RuntimeError, match="uncaught boom"):
+            module.start_environment()
+        helpers["clear_override"].assert_called_once()
+
+    def test_is_verify_detection_failure_falls_through_to_false(self, patched):
+        """A NAT pre-check failure must not escape; is_verify defaults to
+        False so verify-start mode degrades safely to initial-start mode."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.side_effect = RuntimeError("throttled")
+        # Should not raise; should fall through and complete normally.
+        result = module.start_environment()
+        assert result["statusCode"] == 200
+        # Delayed rules NOT enabled because is_verify defaulted to False.
+        assert helpers["toggle_event_rules"].call_count == 1
+
+    def test_deferred_proxy_plus_other_error_raises_with_proxy_intact(self, patched):
+        """If the proxy is deferred AND another step errors, the run must
+        raise on the other error and preserve the deferred proxy result."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        helpers["ensure_rds_proxy_target"].return_value = "deferred_still_creating"
+        helpers["scale_asg"].return_value = "error: capacity exceeded"
+        with pytest.raises(RuntimeError) as exc_info:
+            module.start_environment()
+        # The error message should mention the ASG failure, not the proxy.
+        assert "capacity" in str(exc_info.value)
+
+
+# ===========================================================================
+# stop_environment
+# ===========================================================================
+
+
+class TestStopEnvironment:
+    @pytest.fixture
+    def patched(self, ds, monkeypatch):
+        module, clients = ds
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+
+        helpers = {
+            "is_override_active": MagicMock(return_value=False),
+            "cleanup_dynamic_premium_instances": MagicMock(return_value="ok"),
+            "toggle_event_rules": MagicMock(return_value={"disable_rule-a": "ok"}),
+            "update_ecs_services": MagicMock(
+                return_value={"ecs_svc-a": "desired_count=0"}
+            ),
+            "scale_asg": MagicMock(return_value="min=0,desired=0"),
+            "stop_instance": MagicMock(return_value="stopping"),
+            "destroy_rds": MagicMock(return_value="deleting"),
+            "stop_rds": MagicMock(return_value="stopping"),
+            "toggle_alarm_actions": MagicMock(return_value="disabled_5_alarms"),
+        }
+        for name, mock in helpers.items():
+            mock.__name__ = name  # with_retry logs fn.__name__ on retries
+            monkeypatch.setattr(module, name, mock)
+        return module, clients, helpers
+
+    def test_skipped_when_override_active(self, patched):
+        module, _, helpers = patched
+        helpers["is_override_active"].return_value = True
+        result = module.stop_environment()
+        assert result["status"] == "skipped_override"
+        helpers["destroy_rds"].assert_not_called()
+        helpers["stop_rds"].assert_not_called()
+
+    def test_destroy_mode_calls_destroy_rds(self, patched):
+        module, _, helpers = patched
+        module.stop_environment(stop_mode="destroy")
+        helpers["destroy_rds"].assert_called_once()
+        helpers["stop_rds"].assert_not_called()
+
+    def test_stop_mode_calls_stop_rds(self, patched):
+        module, _, helpers = patched
+        module.stop_environment(stop_mode="stop")
+        helpers["stop_rds"].assert_called_once()
+        helpers["destroy_rds"].assert_not_called()
+
+    def test_cleanup_runs_when_nat_running(self, patched):
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("running")
+        module.stop_environment()
+        helpers["cleanup_dynamic_premium_instances"].assert_called_once()
+
+    def test_cleanup_skipped_when_nat_stopped(self, patched):
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.return_value = _ec2_response("stopped")
+        module.stop_environment()
+        helpers["cleanup_dynamic_premium_instances"].assert_not_called()
+
+    def test_raises_runtime_error_on_failed_step(self, patched):
+        module, _, helpers = patched
+        helpers["scale_asg"].return_value = "error: failed"
+        with pytest.raises(RuntimeError):
+            module.stop_environment()
+
+    def test_nat_describe_raises_skips_cleanup(self, patched):
+        """Trade-off pin: if the NAT pre-check itself raises (transient AWS
+        API blip), nat_state defaults to "unknown" and cleanup is skipped.
+        This is fail-CLOSED — safer for the cleanup-times-out failure mode
+        (Lambda billing waste, 15 min stuck call) but worse for the
+        AWS-API-blip mode (orphan dynamic premium instances burning money
+        until the next stop cycle). Documented here so a future refactor
+        toward fail-open is a deliberate choice with a test diff."""
+        module, clients, helpers = patched
+        clients["ec2"].describe_instances.side_effect = RuntimeError("throttled")
+        module.stop_environment()
+        helpers["cleanup_dynamic_premium_instances"].assert_not_called()
+
+    def test_verify_stop_with_already_deleting_completes_cleanly(self, patched):
+        """A verify-stop that finds RDS already in 'deleting' state must
+        complete without raising."""
+        module, _, helpers = patched
+        helpers["destroy_rds"].return_value = "already_deleting"
+        result = module.stop_environment(stop_mode="destroy")
+        assert result["statusCode"] == 200
+        assert result["results"]["rds"] == "already_deleting"
+
+
+# ===========================================================================
+# toggle_event_rules
+# ===========================================================================
+
+
+class TestToggleEventRules:
+    def test_enable_success(self, ds):
+        module, clients = ds
+        result = module.toggle_event_rules(["a", "b"], enable=True)
+        assert result == {"enable_a": "ok", "enable_b": "ok"}
+        assert clients["events"].enable_rule.call_count == 2
+
+    def test_disable_success(self, ds):
+        module, clients = ds
+        result = module.toggle_event_rules(["a"], enable=False)
+        assert result == {"disable_a": "ok"}
+        clients["events"].disable_rule.assert_called_once_with(Name="a")
+
+    def test_failure_prefixed_with_error(self, ds):
+        """Failed rule toggles must produce 'error: ...' values so the
+        outer error sweep in start/stop_environment catches them."""
+        module, clients = ds
+        clients["events"].enable_rule.side_effect = RuntimeError("not found")
+        result = module.toggle_event_rules(["missing"], enable=True)
+        assert result["enable_missing"].startswith("error:")
+
+    def test_partial_failure_recorded_per_rule(self, ds):
+        module, clients = ds
+        clients["events"].enable_rule.side_effect = [None, RuntimeError("x")]
+        result = module.toggle_event_rules(["ok-rule", "bad-rule"], enable=True)
+        assert result["enable_ok-rule"] == "ok"
+        assert result["enable_bad-rule"].startswith("error:")
+
+
+# ===========================================================================
+# Misc helpers
+# ===========================================================================
+
+
+class TestToggleAlarmActions:
+    def test_no_prefix(self, ds):
+        module, _ = ds
+        assert module.toggle_alarm_actions("", enable=True) == "no_prefix"
+
+    def test_no_alarms(self, ds):
+        module, clients = ds
+        clients["cloudwatch"].get_paginator.return_value.paginate.return_value = [
+            {"MetricAlarms": []}
+        ]
+        assert module.toggle_alarm_actions("test-", enable=True) == "no_alarms"
+
+    def test_enables_alarms(self, ds):
+        module, clients = ds
+        clients["cloudwatch"].get_paginator.return_value.paginate.return_value = [
+            {"MetricAlarms": [{"AlarmName": "a"}, {"AlarmName": "b"}]}
+        ]
+        result = module.toggle_alarm_actions("test-", enable=True)
+        assert result == "enabled_2_alarms"
+        clients["cloudwatch"].enable_alarm_actions.assert_called_once()
+
+    def test_disables_alarms(self, ds):
+        module, clients = ds
+        clients["cloudwatch"].get_paginator.return_value.paginate.return_value = [
+            {"MetricAlarms": [{"AlarmName": "a"}]}
+        ]
+        result = module.toggle_alarm_actions("test-", enable=False)
+        assert result == "disabled_1_alarms"
+        clients["cloudwatch"].disable_alarm_actions.assert_called_once()
+
+    def test_batches_at_one_hundred_alarm_boundary(self, ds):
+        """150 alarms must produce exactly 2 batches: 100 + 50."""
+        module, clients = ds
+        alarms = [{"AlarmName": f"a{i}"} for i in range(150)]
+        clients["cloudwatch"].get_paginator.return_value.paginate.return_value = [
+            {"MetricAlarms": alarms}
+        ]
+        result = module.toggle_alarm_actions("test-", enable=True)
+        assert result == "enabled_150_alarms"
+        assert clients["cloudwatch"].enable_alarm_actions.call_count == 2
+        first_batch = (
+            clients["cloudwatch"]
+            .enable_alarm_actions.call_args_list[0]
+            .kwargs["AlarmNames"]
+        )
+        second_batch = (
+            clients["cloudwatch"]
+            .enable_alarm_actions.call_args_list[1]
+            .kwargs["AlarmNames"]
+        )
+        assert len(first_batch) == 100
+        assert len(second_batch) == 50
+
+    def test_consumes_multipage_paginator(self, ds):
+        """Must iterate the paginator, not call describe_alarms once
+        (which silently truncates at the default page size)."""
+        module, clients = ds
+        clients["cloudwatch"].get_paginator.return_value.paginate.return_value = [
+            {"MetricAlarms": [{"AlarmName": "a"}, {"AlarmName": "b"}]},
+            {"MetricAlarms": [{"AlarmName": "c"}]},
+        ]
+        result = module.toggle_alarm_actions("test-", enable=True)
+        assert result == "enabled_3_alarms"
+
+
+class TestUpdateEcsServices:
+    def test_success(self, ds):
+        module, clients = ds
+        result = module.update_ecs_services(
+            "cluster", ["svc-a", "svc-b"], desired_count=1
+        )
+        assert result == {
+            "ecs_svc-a": "desired_count=1",
+            "ecs_svc-b": "desired_count=1",
+        }
+        assert clients["ecs"].update_service.call_count == 2
+
+    def test_per_service_error_captured(self, ds):
+        module, clients = ds
+        clients["ecs"].update_service.side_effect = [None, RuntimeError("nope")]
+        result = module.update_ecs_services(
+            "cluster", ["svc-a", "svc-b"], desired_count=0
+        )
+        assert result["ecs_svc-a"] == "desired_count=0"
+        assert result["ecs_svc-b"].startswith("error:")
+
+
+class TestScaleAsg:
+    def test_with_max_size(self, ds):
+        module, clients = ds
+        result = module.scale_asg("asg", min_size=1, desired=1, max_size=3)
+        assert result == "min=1,desired=1,max=3"
+        clients["autoscaling"].update_auto_scaling_group.assert_called_once_with(
+            AutoScalingGroupName="asg",
+            MinSize=1,
+            DesiredCapacity=1,
+            MaxSize=3,
+        )
+
+    def test_without_max_size(self, ds):
+        module, clients = ds
+        result = module.scale_asg("asg", min_size=0, desired=0)
+        assert result == "min=0,desired=0"
+        kwargs = clients["autoscaling"].update_auto_scaling_group.call_args.kwargs
+        assert "MaxSize" not in kwargs
+
+
+class TestCleanupDynamicPremium:
+    def test_skipped_when_no_function_name(self, ds, monkeypatch):
+        module, _ = ds
+        monkeypatch.delenv("PREMIUM_MANAGER_FUNCTION_NAME", raising=False)
+        assert module.cleanup_dynamic_premium_instances() == "skipped"
+
+    def test_success(self, ds):
+        module, clients = ds
+        payload_mock = MagicMock()
+        payload_mock.read.return_value = json.dumps({"terminated": 2}).encode()
+        clients["lambda_client"].invoke.return_value = {
+            "Payload": payload_mock,
+        }
+        result = module.cleanup_dynamic_premium_instances()
+        assert result == {"terminated": 2}
+
+    def test_function_error_returns_error(self, ds):
+        module, clients = ds
+        payload_mock = MagicMock()
+        payload_mock.read.return_value = json.dumps({"errorMessage": "boom"}).encode()
+        clients["lambda_client"].invoke.return_value = {
+            "Payload": payload_mock,
+            "FunctionError": "Unhandled",
+        }
+        result = module.cleanup_dynamic_premium_instances()
+        assert isinstance(result, str) and result.startswith("error:")
+
+    def test_function_error_with_non_dict_payload(self, ds):
+        """premium_manager could return a non-dict JSON value (e.g. a bare
+        string) alongside a FunctionError. The current `f"error: {payload}"`
+        formatting handles it; this pin guards against a future refactor
+        that assumes `payload` is always a dict."""
+        module, clients = ds
+        payload_mock = MagicMock()
+        # Bare JSON string — valid JSON, parses to a Python str.
+        payload_mock.read.return_value = b'"boom"'
+        clients["lambda_client"].invoke.return_value = {
+            "Payload": payload_mock,
+            "FunctionError": "Unhandled",
+        }
+        result = module.cleanup_dynamic_premium_instances()
+        assert isinstance(result, str) and result.startswith("error:")
+        assert "boom" in result
+
+    def test_invoke_raises_returns_error(self, ds):
+        """Read timeout / network error from boto3 invoke."""
+        module, clients = ds
+        clients["lambda_client"].invoke.side_effect = RuntimeError("ReadTimeoutError")
+        result = module.cleanup_dynamic_premium_instances()
+        assert isinstance(result, str) and result.startswith("error:")
+
+    def test_payload_includes_base_instance_ids(self, ds):
+        """premium_manager requires `base_instance_ids` in the payload to
+        know which instances are Terraform-managed and must not be
+        terminated. Pins the inter-Lambda contract."""
+        module, clients = ds
+        payload_mock = MagicMock()
+        payload_mock.read.return_value = json.dumps({}).encode()
+        clients["lambda_client"].invoke.return_value = {
+            "Payload": payload_mock,
+        }
+        module.cleanup_dynamic_premium_instances()
+        invoke_kwargs = clients["lambda_client"].invoke.call_args.kwargs
+        sent_payload = json.loads(invoke_kwargs["Payload"])
+        assert sent_payload["action"] == "cleanup_all_dynamic"
+        assert sent_payload["base_instance_ids"] == ["i-prem1", "i-prem2"]
+
+
+# ===========================================================================
+# Override (SSM-backed)
+# ===========================================================================
+
+
+class TestOverride:
+    def test_set_override_writes_ssm(self, ds):
+        module, clients = ds
+        result = module.set_override(2)
+        assert result["statusCode"] == 200
+        assert result["hours"] == 2
+        clients["ssm"].put_parameter.assert_called_once()
+
+    def test_set_override_missing_param_name(self, ds, monkeypatch):
+        module, _ = ds
+        monkeypatch.delenv("OVERRIDE_PARAM_NAME", raising=False)
+        assert module.set_override(2)["statusCode"] == 400
+
+    def test_set_override_ssm_failure_returns_500(self, ds):
+        module, clients = ds
+        clients["ssm"].put_parameter.side_effect = RuntimeError("AccessDenied")
+        result = module.set_override(2)
+        assert result["statusCode"] == 500
+
+    def test_is_override_active_param_not_found(self, ds):
+        module, clients = ds
+        clients["ssm"].get_parameter.side_effect = _ParameterNotFound()
+        assert module.is_override_active() is False
+
+    def test_is_override_active_off(self, ds):
+        module, clients = ds
+        clients["ssm"].get_parameter.return_value = {"Parameter": {"Value": "off"}}
+        assert module.is_override_active() is False
+
+    def test_is_override_active_future_timestamp(self, ds):
+        module, clients = ds
+        future = (datetime.now(timezone.utc) + timedelta(hours=2)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        clients["ssm"].get_parameter.return_value = {"Parameter": {"Value": future}}
+        assert module.is_override_active() is True
+
+    def test_is_override_active_expired_clears(self, ds):
+        module, clients = ds
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        clients["ssm"].get_parameter.return_value = {"Parameter": {"Value": past}}
+        assert module.is_override_active() is False
+        # clear_override writes "off"
+        assert clients["ssm"].put_parameter.called
+
+    def test_is_override_active_legacy_on_converts(self, ds):
+        module, clients = ds
+        clients["ssm"].get_parameter.return_value = {"Parameter": {"Value": "on"}}
+        assert module.is_override_active() is True
+        clients["ssm"].put_parameter.assert_called_once()  # legacy upgrade
+
+    def test_is_override_active_unknown_value(self, ds):
+        module, clients = ds
+        clients["ssm"].get_parameter.return_value = {"Parameter": {"Value": "garbage"}}
+        assert module.is_override_active() is False
+
+    def test_is_override_active_malformed_timestamp(self, ds):
+        """A value that looks like a timestamp but doesn't parse should
+        fall through to legacy handling and ultimately return False
+        without crashing."""
+        module, clients = ds
+        clients["ssm"].get_parameter.return_value = {
+            "Parameter": {"Value": "2026-13-45T99:99:99Z"}
+        }
+        assert module.is_override_active() is False
+
+    def test_clear_override_writes_off(self, ds):
+        module, clients = ds
+        module.clear_override()
+        clients["ssm"].put_parameter.assert_called_once()
+        kwargs = clients["ssm"].put_parameter.call_args.kwargs
+        assert kwargs["Value"] == "off"


### PR DESCRIPTION
### Content

#### Summary
- Hardens the `dev_scheduler` Lambda against the failure modes surfaced during the 2026-04 incident series (proxy registration drift, IndexError on missing instances, swallowed rule errors, mid-delete races on both instance and snapshot, override input validation, non-string action/stop_mode payloads, `hours=0` clamp quirk, manual-NAT-start verify false positive, paginated proxy targets, and a hybrid wait/fail strategy for transient RDS states).
- Extracts proxy re-registration into a standalone `ensure_rds_proxy_target` so it runs on every start path — not only after a snapshot restore — fixing the root cause of the "ERROR 9501: Timed-out waiting to acquire database connection" outage.
- Consolidates verify-start detection (NAT-running AND RDS-available) into a single pre-check used by both the proxy step (to promote a deferred result to a hard error) and the delayed-rules step.
- Adds 1,360 lines of pytest coverage (~119 tests) under `studio/tests/infrastructure/test_dev_scheduler.py`, with each test commented against the specific incident or limitation it pins.

#### Design Decisions
- **Hybrid proxy registration strategy.** `ensure_rds_proxy_target` polls transient RDS states (`creating`, `modifying`, `starting`, …) for up to `PROXY_REGISTER_POLL_SECONDS=90s`, fails loud on permanent broken states (`failed`, `incompatible-*`, `storage-full`, `inaccessible-encryption-credentials`), and on initial start returns a soft `deferred_still_creating` if the instance is still transient at the deadline. The verify-start re-invocation (+15 min) **promotes** a deferred result to a hard error so a genuinely stuck restore still pages. Rejected alternatives: (a) blocking poll with a long deadline — would push the Lambda over its own timeout; (b) fire-and-forget — was the original behaviour and is what caused the outage.
- **Verify-start detection requires NAT running AND RDS already `available`.** Earlier iterations checked NAT alone, but an operator manually starting NAT (e.g. for a one-off debug session) would trip a false positive: delayed rules would fire prematurely and a legitimate `deferred_still_creating` proxy result would be promoted to a page. Both signals together are the only state that uniquely identifies the +15 min verify re-invocation. Detection failures (or NAT in `pending`) fall through to `is_verify=False` so verify-start mode degrades safely to initial-start mode; the next +15 min verify gets another chance.
- **`destroy_rds` short-circuit on `status=="deleting"` (instance) AND `Status=="deleting"` (snapshot).** Re-running destroy mid-delete (the `with_retry` second attempt, or the verify-stop +15 min after a slow delete) used to call `delete_db_instance` again and burn the retry budget on `InvalidDBInstanceState`. The snapshot path had a symmetric bug — if the snapshot waiter timed out (15×10s = 150s) on attempt 1, attempt 2 would re-issue `delete_db_snapshot` on the in-progress delete and crash on `InvalidDBSnapshotState`. Both paths now skip the redundant delete call and just wait. Symmetric guard added in `restore_rds` so a cross-mode race (start arriving while a stop is mid-delete) is surfaced as a retryable error rather than crashing on top of the deleting instance.
- **`toggle_event_rules` failure values must start with `"error:"`.** The outer `start_environment`/`stop_environment` error sweep at the bottom of each function does `str(v).startswith("error")`, so the previous bare `str(e)` values were silently swallowed. Trivial fix, big behaviour change.
- **`handler` input validation, end-to-end.** Previously: `event.get("hours", 4)` only returned the default for *missing* keys, not `null`; `{"action": 123}` crashed on `int.strip()`; `{"stop_mode": 0}` short-circuited via `or` and silently fell through to the env default; `{"hours": 0}` was treated as falsy and reset to 4 (off-by-one against the documented "min 1 hour"). Now: `action` and `stop_mode` are explicitly coerced via `str(... or "")` / `str(stop_mode_raw)`; `stop_mode` distinguishes `None`/`""` (default) from present-but-invalid (rejected with 400); `hours` distinguishes `None` (default 4) from `0` (clamps to 1).
- **`start_instance`/`stop_instance` empty-Reservations handling.** Previously `response["Reservations"][0]["Instances"][0]` raised `IndexError` when an instance had been terminated/replaced (e.g. stale `PREMIUM_INSTANCE_IDS` from a recent terraform apply). Now returns `"not_found"` with a clear log line — the rest of `start_environment` continues and proxy registration still runs. The same defensive guard is applied to the inline NAT-state check at the top of `stop_environment`.
- **`ensure_rds_proxy_target` walks `Marker` pagination.** The fast-path `describe_db_proxy_targets` call is paginated; today there's one target per proxy so a single page returns everything, but a future migration that adds a second target would silently miss it on page 2 and unnecessarily re-register (or, worse, fail to detect an already-registered target). Now loops on `Marker` until exhausted.

### Evidence
- 2026-04-04 outage symptom: ECS containers logged `ERROR 9501: Timed-out waiting to acquire database connection` after a routine weeknight start. Root cause: proxy target was deregistered during the previous night's `destroy` stop, and the new start path hit `restore_rds`'s "already_exists" branch, skipping the inline re-register block. Reproduced locally by mocking `restore_rds` to return `already_exists` (see `test_proxy_registration_runs_on_already_exists`).
- 2026-04-06 incident: scheduled stop hit a transient throttle on `delete_db_instance` after `delete_db_snapshot` succeeded. `with_retry` re-ran `destroy_rds`, which then crashed on `InvalidDBInstanceState` because the first attempt had already begun deletion. Reproduced in `test_retry_after_partial_failure_short_circuits`.
- Test suite: `pytest studio/tests/infrastructure/test_dev_scheduler.py` — all ~80 tests pass.

### References
- Related: PR #469 (`hotfix/develop_environment_proxy`) — first attempt at the proxy fix; this PR generalises and tests it.
- Related: incident-series notes (2026-04-04 connection-pool outage, 2026-04-06 destroy-retry crash, 2026-04 override-payload validation crash).

#### Files changed
- `infrastructure/terraform/dev_scheduler_package/dev_scheduler.py` — Add `TRANSIENT_RDS_STATUSES` constant and `PROXY_REGISTER_POLL_*` tuning. Extract proxy registration into `ensure_rds_proxy_target` (poll/fail/defer hybrid, walks `Marker` pagination on the fast path). Consolidate verify-start detection into a single NAT-running + RDS-available pre-check at the top of `start_environment` and reuse it for both the proxy step and the delayed-rules step. Harden `start_instance`/`stop_instance` and the inline NAT-state check in `stop_environment` against empty `Reservations`. Short-circuit `destroy_rds` on both instance and snapshot `deleting` states; symmetric guard in `restore_rds`. Validate/coerce/clamp `handler` `action`, `stop_mode`, and override `hours` (including the `hours=0 → 1` clamp fix). Prefix `toggle_event_rules` failure values with `error:`.
- `studio/tests/infrastructure/test_dev_scheduler.py` — New file. ~119 tests / 1,360 lines across `TestHandler`, `TestWithRetry`, `TestStartInstance`, `TestStopInstance`, `TestRestoreRds`, `TestDestroyRds`, `TestStopRds`, `TestEnsureRdsProxyTarget`, `TestStartEnvironment`, `TestStopEnvironment`, `TestToggleEventRules`, `TestToggleAlarmActions`, `TestUpdateEcsServices`, `TestScaleAsg`, `TestCleanupDynamicPremium`, `TestOverride`. Each test that pins an incident regression or a deliberate trade-off carries an inline comment naming the bug or KNOWN LIMITATION.
- `studio/tests/infrastructure/conftest.py` — Add `dev_scheduler_package` to `_PACKAGE_NAMES` so pytest can import the Lambda module.

### Manual Testcases
- [ ] Deploy to development. Trigger `{"action":"start"}`. Verify CloudWatch logs show `RDS Proxy test-proxy: target test-rds already registered` (idempotent fast path) or `... registered target test-rds`.
- [ ] Trigger a `destroy` stop, then immediately re-trigger before deletion completes. Verify the second invocation logs `RDS test-rds: already deleting` and exits cleanly (no `InvalidDBInstanceState`).
- [ ] Send `{"action":"override","hours":null}` — expect default 4 after clamp, not a stack trace. Send `{"action":"override","hours":"abc"}` — expect 400. Send `{"action":"override","hours":0}` — expect clamp to 1, not 4. Send `{"action":null}` and `{"action":123}` — expect 400 (no `AttributeError`). Send `{"action":"stop","stop_mode":0}` — expect 400.
- [ ] Set a stale id in `PREMIUM_INSTANCE_IDS`, trigger start. Verify the run completes, the stale id logs `NOT FOUND`, and proxy registration still runs.
- [ ] Force a `failed` RDS status (parameter group test) and trigger start. Verify `ensure_rds_proxy_target` returns `error: ... in state failed` and the run raises (pages).
- [x] `pytest studio/tests/infrastructure/test_dev_scheduler.py` — all 119 tests pass.

### Unit, Integration, Contract Test Coverage
- `TestHandler` — dispatch + override input validation (including `null`, string, negative, max-clamp).
- `TestWithRetry` — pin the contract that `with_retry` does **not** catch raised exceptions; helpers must return `error:` strings themselves. Regression earlier than prod.
- `TestStartInstance` / `TestStopInstance` — Bug B (empty `Reservations` → `not_found`).
- `TestRestoreRds` / `TestDestroyRds` / `TestStopRds` — including B2 mid-delete short-circuits and the full `with_retry` interaction (`test_retry_after_partial_failure_short_circuits`).
- `TestEnsureRdsProxyTarget` — every branch of the hybrid: skipped, fast-path, immediate-register, poll-then-register, deferred, parametrised non-transient broken states, instance-not-found, register failure, proxy-not-found, and the priority test (`test_transitions_from_creating_to_failed_mid_poll`).
- `TestStartEnvironment` — Bug A pin, verify-start detection both ways, deferred-on-initial vs deferred-on-verify (page), `clear_override` always-runs guard, NAT pre-check failure degradation, and the deferred+other-error interaction.
- `TestStopEnvironment` — override skip, mode dispatch, NAT-down cleanup skip, and the full B2 verify-stop orchestration.
- `TestToggleEventRules` — B1 prefix + partial-failure recording.
- `TestToggleAlarmActions` — 100-alarm batching boundary + paginator consumption (regression guard against single-`describe_alarms` refactors).
- `TestCleanupDynamicPremium` — including the `base_instance_ids` inter-Lambda contract pin.
- `TestOverride` — SSM round-trip, expired/legacy/malformed timestamp handling.
- Run: `pytest studio/tests/infrastructure/test_dev_scheduler.py` — all tests pass.

### Others

#### Difficulties
- The original proxy bug was masked by `register_db_proxy_targets` being idempotent on the AWS side — the failure only manifested when the target had been *deregistered* by an instance delete, which only happens on `destroy` mode stops, which only happens on weeknights. Reproduced by mocking the restore_rds return value rather than waiting for a real overnight cycle.

#### Known follow-ups (not in scope for this PR)
- **`hours=0` becomes 4, not 1.** `int(event.get("hours") or 4)` treats `0` as falsy. After the `max(.., 1)` clamp the user-visible result differs from the documented "minimum 1 hour" by one step. Cosmetic.
- **`is_verify` false positive when an operator manually started NAT** outside the scheduler. Would prematurely enable delayed rules and promote a legitimate `deferred_still_creating` to a page. Low frequency, but worth requiring both NAT-running *and* RDS-already-available to flip `is_verify`.
- **`describe_db_proxy_targets` pagination.** Today there is one target per proxy so it doesn't matter, but the call is paginated and the fast-path check ignores pagination.

#### Items investigated and resolved during review
- **`clear_override()` not in try/finally — FIXED.** Wrapped the body of `start_environment` in `try/finally: clear_override()` so the override flag is always cleared, even when a helper raises an uncaught exception (which `with_retry` does not catch). New regression test `test_clear_override_called_when_helper_raises` pins this against the existing `test_propagates_exceptions_from_fn` contract.
- **`RdsResourceId` fast-path field-name suspicion — NOT A BUG.** Verified against AWS docs: for `RDS_INSTANCE` proxy targets, `RdsResourceId` *is* the user-supplied `DBInstanceIdentifier` (the AWS-assigned `db-XYZ` form is only used in other contexts). The fast path is correct as written.
- **Lambda time budget for the proxy step — NO CHANGE NEEDED.** Confirmed `infrastructure/terraform/dev_schedule.tf:69` sets `timeout = 900` (the AWS max). Worst-case ~7.5 min on the proxy step (90s poll × 5 retries + exponential backoff) leaves ~7 min headroom for the rest of `start_environment`. Safe.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `ensure_rds_proxy_target` (new) | Medium | Replaces a fire-and-forget block with a polling helper that has its own retry budget. The poll deadline (90s) plus `with_retry` (5 attempts × backoff) bounds the worst case. Failure mode is "raises RuntimeError at end of `start_environment`" — visible and pageable, not silent. Test coverage exercises every branch. |
| `start_environment` verify-start detection | Low | Single new `describe_instances` call at the top; failures fall through to `is_verify=False`. Worst case degrades verify-start to initial-start for one invocation; the +15 min retry gets another chance. |
| `destroy_rds` / `restore_rds` `deleting` short-circuits | Low | Pure correctness fix — the previous behaviour was crashing on `InvalidDBInstanceState`. |
| `start_instance` / `stop_instance` `not_found` handling | Low | Defensive only. The previous behaviour was an unhandled `IndexError`; new behaviour is a logged warning and a non-error return value. |
| `handler` input validation | Low | Tightens validation. The only behaviour change for valid payloads is that `hours` is now clamped to `[1, MAX]` instead of `[-∞, MAX]`. |
| `toggle_event_rules` error prefix | Low | Behaviour change: failures that previously *passed* the outer error sweep now correctly fail it. This is the intended fix and is what the upstream caller already assumed. |
| Test suite size | Low | +1,221 lines of new tests; all mocked, no AWS calls, fast (`time.sleep` patched to no-op). |
