### PR TITLE
Fix create user causing s3-db drift

### DIFF
--- a/infrastructure/scripts/create_test_users.py
+++ b/infrastructure/scripts/create_test_users.py
@@ -144,7 +144,10 @@ async def create_test_user_in_db(db, user_data, organization_id):
     # Create remote storage bucket (S3 folder) - same as in create_user
     if RemoteStorageController.is_available():
         prefix = os.environ.get("S3_USER_BUCKET_PREFIX", "optinist-user")
-        new_bucket_name = RemoteStorageController.create_user_bucket_name(
+        # Reuse an existing bucket name if the user row already has one,
+        # so partial-reset states don't generate orphan buckets.
+        existing = (user_db.attributes or {}).get("remote_bucket_name")
+        new_bucket_name = existing or RemoteStorageController.create_user_bucket_name(
             id=user_db.id, prefix=prefix
         )
 
@@ -153,8 +156,11 @@ async def create_test_user_in_db(db, user_data, organization_id):
         ) as remote_storage_controller:
             await remote_storage_controller.create_bucket()
 
-        # Store bucket info in user record
-        user_db.attributes = {"remote_bucket_name": new_bucket_name}
+        # Merge into attributes (do not overwrite other keys).
+        user_db.attributes = {
+            **(user_db.attributes or {}),
+            "remote_bucket_name": new_bucket_name,
+        }
         db.flush()
         db.commit()
 

--- a/infrastructure/scripts/delete_test_users.py
+++ b/infrastructure/scripts/delete_test_users.py
@@ -220,6 +220,14 @@ async def delete_test_user_from_db(db, user_email):
         )
         assignment_count = assignment_result.rowcount
 
+        # 10b. Delete free user assignments (stored in separate table, not ORM).
+        # Required to avoid fk_free_user FK violation when deleting the user row.
+        free_assignment_result = db.execute(
+            text("DELETE FROM free_user_assignments WHERE user_id = :user_id"),
+            {"user_id": user_id},
+        )
+        free_assignment_count = free_assignment_result.rowcount
+
         # 11. Finally delete the user
         db.delete(user_db)
 
@@ -271,6 +279,7 @@ async def delete_test_user_from_db(db, user_email):
         print(f"Deleted {subscription_count} subscriptions")
         print(f"Deleted {user_role_count} user roles")
         print(f"Deleted {assignment_count} premium assignments")
+        print(f"Deleted {free_assignment_count} free assignments")
         print(f"Successfully deleted user: {user_name}")
 
         return True
@@ -342,6 +351,27 @@ async def main():
                 print("No orphaned premium assignments found")
         except Exception as orphan_error:
             print(f"Warning: Could not clean up orphaned assignments: {orphan_error}")
+            db.rollback()
+
+        # Clean up any orphaned free assignments (for users that no longer exist)
+        print("\nCleaning up orphaned free assignments...")
+        try:
+            orphan_free_result = db.execute(
+                text(
+                    """DELETE FROM free_user_assignments
+                        WHERE user_id NOT IN (SELECT id FROM users)"""
+                )
+            )
+            orphan_free_count = orphan_free_result.rowcount
+            db.commit()
+            if orphan_free_count > 0:
+                print(f"Cleaned up {orphan_free_count} orphaned free assignment(s)")
+            else:
+                print("No orphaned free assignments found")
+        except Exception as orphan_error:
+            print(
+                f"Warning: Could not clean up orphaned free assignments: {orphan_error}"
+            )
             db.rollback()
 
         db.close()

--- a/infrastructure/scripts/delete_test_users.py
+++ b/infrastructure/scripts/delete_test_users.py
@@ -39,6 +39,12 @@ except ImportError as e:
     sys.exit(1)
 
 
+# Track S3 cleanup outcomes across the whole script run so we can report a
+# loud summary and exit non-zero if any user's bucket was skipped or failed.
+S3_DELETE_SKIPPED: list = []
+S3_DELETE_FAILED: list = []
+
+
 def get_database_url():
     """Get database URL from environment variables."""
     from studio.app.common.db.config import build_mysql_url
@@ -225,7 +231,21 @@ async def delete_test_user_from_db(db, user_email):
         # Do this after database commit so bucket deletion
         # failure doesn't rollback DB changes
 
-        if remote_bucket_name and RemoteStorageController.is_available():
+        if not RemoteStorageController.is_available():
+            print(
+                "WARNING: RemoteStorageController not available — "
+                "skipping S3 bucket deletion. Any bucket associated with "
+                f"{user_name} will be left orphaned in S3."
+            )
+            S3_DELETE_SKIPPED.append(user_name)
+        elif not remote_bucket_name:
+            print(
+                f"WARNING: No remote_bucket_name on user {user_name} — "
+                "DB row had no bucket pointer to delete. If a bucket exists "
+                "for this user in S3, it must be cleaned up manually."
+            )
+            S3_DELETE_SKIPPED.append(user_name)
+        else:
             try:
                 print(f"Deleting S3 bucket: {remote_bucket_name}")
                 async with RemoteStorageSimpleWriter(
@@ -235,10 +255,11 @@ async def delete_test_user_from_db(db, user_email):
                 print("S3 bucket deleted successfully")
             except Exception as s3_error:
                 print(
-                    f"Warning: Error deleting S3 bucket "
+                    f"ERROR: Failed to delete S3 bucket "
                     f"{remote_bucket_name}: {s3_error}"
                 )
                 print("(Continuing with user deletion)")
+                S3_DELETE_FAILED.append((user_name, remote_bucket_name, str(s3_error)))
 
         print(f"Deleted {experiment_count} experiments")
         print(f"Deleted {workspace_share_count} workspace shares")
@@ -327,6 +348,22 @@ async def main():
 
     except Exception as e:
         print(f"Database connection error: {str(e)}")
+
+    # Loud summary of S3 cleanup outcomes so silent no-ops are visible.
+    if S3_DELETE_SKIPPED or S3_DELETE_FAILED:
+        print("\n" + "=" * 60)
+        print("S3 CLEANUP ISSUES")
+        print("=" * 60)
+        if S3_DELETE_SKIPPED:
+            print(f"Skipped S3 deletion for {len(S3_DELETE_SKIPPED)} user(s):")
+            for name in S3_DELETE_SKIPPED:
+                print(f"  - {name}")
+        if S3_DELETE_FAILED:
+            print(f"Failed S3 deletion for {len(S3_DELETE_FAILED)} user(s):")
+            for name, bucket, err in S3_DELETE_FAILED:
+                print(f"  - {name} ({bucket}): {err}")
+        print("Exiting with non-zero status so this is visible in CI/logs.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -633,6 +633,10 @@ resource "aws_ecs_task_definition" "autoscaling" {
           value = var.s3_user_bucket_prefix
         },
         {
+          name  = "S3_USER_BUCKET_SECRET"
+          value = var.s3_user_bucket_secret
+        },
+        {
           name  = "REMOTE_STORAGE_TYPE"
           value = "2"
         },
@@ -893,6 +897,10 @@ resource "aws_ecs_task_definition" "premium" {
         {
           name  = "S3_USER_BUCKET_PREFIX"
           value = var.s3_user_bucket_prefix
+        },
+        {
+          name  = "S3_USER_BUCKET_SECRET"
+          value = var.s3_user_bucket_secret
         },
         {
           name  = "REMOTE_STORAGE_TYPE"

--- a/infrastructure/terraform/environments/development.tfvars.example
+++ b/infrastructure/terraform/environments/development.tfvars.example
@@ -8,6 +8,7 @@ environment           = "development"
 enable_custom_domain  = false
 vpc_cidr              = "10.2.0.0/16"
 s3_user_bucket_prefix = "development-optinist-user"
+s3_user_bucket_secret = "<PLACEHOLDER-generate-with-openssl-rand-hex-32>"
 
 # AWS configuration
 aws_region        = "ap-northeast-1"

--- a/infrastructure/terraform/environments/production.tfvars.example
+++ b/infrastructure/terraform/environments/production.tfvars.example
@@ -9,6 +9,7 @@ environment           = "subscr"
 enable_custom_domain  = true
 vpc_cidr              = "10.1.0.0/16"
 s3_user_bucket_prefix = "optinist-user"
+s3_user_bucket_secret = "<PLACEHOLDER-generate-with-openssl-rand-hex-32>"
 
 # AWS configuration
 aws_region        = "ap-northeast-1"

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -58,6 +58,12 @@ variable "s3_user_bucket_prefix" {
   default     = "optinist-user"
 }
 
+variable "s3_user_bucket_secret" {
+  description = "Secret seed for deterministic per-user S3 bucket name hashing"
+  type        = string
+  sensitive   = true
+}
+
 # Database configuration
 variable "mysql_root_password" {
   description = "MySQL/MariaDB root password"

--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -96,6 +96,11 @@ async def _ensure_user_bucket_exists_impl(
     if user.attributes and isinstance(user.attributes, dict):
         bucket_name = user.attributes.get("remote_bucket_name")
 
+    # Short-circuit: if the DB already has a bucket name, trust it and skip
+    # the S3 CreateBucket call. This is the hot path on every login.
+    if bucket_name:
+        return bucket_name
+
     # Generate new bucket name if not exists
     if not bucket_name:
         prefix = os.environ.get("S3_USER_BUCKET_PREFIX", "optinist-user")

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -641,16 +641,17 @@ class RemoteStorageController(BaseRemoteStorageController):
 
     @staticmethod
     def create_user_bucket_name(id: int, prefix: str = "optinist-user") -> str:
+        # Deterministic per (secret, id): repeated calls for the same user
+        # produce the same bucket name, so retries are idempotent and
+        # BucketAlreadyOwnedByYou is a real safety net rather than masking
+        # drift.
         import hashlib
-        import time
+        import os
 
-        current_time = time.time()
-        hash_src = f"{id}-{current_time}"
-        hash_value = hashlib.md5(hash_src.encode()).hexdigest()
-        hash_value = hash_value[0:10]
-        new_name = f"{prefix}-{id}-{hash_value}"
-
-        return new_name
+        secret = os.environ.get("S3_USER_BUCKET_SECRET", "")
+        hash_src = f"{secret}-{id}"
+        hash_value = hashlib.md5(hash_src.encode()).hexdigest()[0:10]
+        return f"{prefix}-{id}-{hash_value}"
 
     @property
     def bucket_name(self) -> str:

--- a/studio/tests/app/common/core/cloud/test_cloud_utils.py
+++ b/studio/tests/app/common/core/cloud/test_cloud_utils.py
@@ -8,12 +8,16 @@ Tests cover:
 - _get_fallback_storage_quota() - Subscription plan determination
 """
 
+import asyncio
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from studio.app.common.core.cloud.cloud_utils import calculate_limit_warning
+from studio.app.common.core.cloud.cloud_utils import (
+    _ensure_user_bucket_exists_impl,
+    calculate_limit_warning,
+)
 from studio.app.common.core.cloud.storage_tracking import (
     _get_fallback_storage_quota,
     _is_storage_data_fresh,
@@ -1225,3 +1229,151 @@ class TestProcessFailedStorageOperations:
             result = process_failed_storage_operations(max_retries=5)
 
             assert result == 0
+
+
+# ============================================================================
+# _ensure_user_bucket_exists_impl — short-circuit & merge behaviour
+# ============================================================================
+
+
+def _make_db_with_user(attributes):
+    user = MagicMock()
+    user.id = 42
+    user.attributes = attributes
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    return db, user
+
+
+def test_ensure_bucket_short_circuits_when_attribute_set(monkeypatch):
+    """When the DB already holds a bucket name, no S3 CreateBucket call."""
+    db, user = _make_db_with_user({"remote_bucket_name": "optinist-user-42-existing00"})
+
+    create_bucket_mock = AsyncMock()
+
+    class FakeWriter:
+        def __init__(self, name):
+            self.name = name
+
+        async def __aenter__(self):
+            inner = MagicMock()
+            inner.create_bucket = create_bucket_mock
+            return inner
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "studio.app.common.core.storage."
+        "remote_storage_controller.RemoteStorageSimpleWriter",
+        FakeWriter,
+    )
+
+    result = asyncio.run(_ensure_user_bucket_exists_impl(42, db, auto_commit=False))
+
+    assert result == "optinist-user-42-existing00"
+    create_bucket_mock.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_ensure_bucket_creates_and_merges_when_missing(monkeypatch):
+    """When attributes lacks the key, create bucket and merge (preserve others)."""
+    db, user = _make_db_with_user({"some_other_key": "preserved"})
+
+    create_bucket_mock = AsyncMock()
+
+    class FakeWriter:
+        def __init__(self, name):
+            self.name = name
+
+        async def __aenter__(self):
+            inner = MagicMock()
+            inner.create_bucket = create_bucket_mock
+            return inner
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "studio.app.common.core.storage."
+        "remote_storage_controller.RemoteStorageSimpleWriter",
+        FakeWriter,
+    )
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+
+    result = asyncio.run(_ensure_user_bucket_exists_impl(42, db, auto_commit=True))
+
+    assert result.startswith("optinist-user-42-")
+    create_bucket_mock.assert_awaited_once()
+    # Merge preserved the other key
+    assert user.attributes["some_other_key"] == "preserved"
+    assert user.attributes["remote_bucket_name"] == result
+    db.commit.assert_called_once()
+
+
+def test_ensure_bucket_swallows_already_owned_error(monkeypatch):
+    """BucketAlreadyOwnedByYou should not propagate; function still returns name."""
+    db, user = _make_db_with_user({})
+
+    class FakeWriter:
+        def __init__(self, name):
+            self.name = name
+
+        async def __aenter__(self):
+            inner = MagicMock()
+            inner.create_bucket = AsyncMock(
+                side_effect=Exception("BucketAlreadyOwnedByYou")
+            )
+            return inner
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "studio.app.common.core.storage."
+        "remote_storage_controller.RemoteStorageSimpleWriter",
+        FakeWriter,
+    )
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+
+    result = asyncio.run(_ensure_user_bucket_exists_impl(42, db, auto_commit=False))
+
+    assert result.startswith("optinist-user-42-")
+
+
+def test_ensure_bucket_propagates_unexpected_errors(monkeypatch):
+    """Errors that are not BucketAlreadyOwnedByYou must propagate."""
+    db, user = _make_db_with_user({})
+
+    class FakeWriter:
+        def __init__(self, name):
+            self.name = name
+
+        async def __aenter__(self):
+            inner = MagicMock()
+            inner.create_bucket = AsyncMock(side_effect=Exception("AccessDenied"))
+            return inner
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "studio.app.common.core.storage."
+        "remote_storage_controller.RemoteStorageSimpleWriter",
+        FakeWriter,
+    )
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+
+    with pytest.raises(Exception, match="AccessDenied"):
+        asyncio.run(_ensure_user_bucket_exists_impl(42, db, auto_commit=False))
+
+
+def test_ensure_bucket_returns_none_when_user_not_found():
+    """If the user row doesn't exist, return None and don't touch S3."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    result = asyncio.run(_ensure_user_bucket_exists_impl(999, db, auto_commit=False))
+
+    assert result is None
+    db.commit.assert_not_called()

--- a/studio/tests/app/common/core/storage/test_remote_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_remote_storage_controller.py
@@ -413,3 +413,58 @@ class TestSyncStatusOnPartialFailure:
             mock_processing.assert_called_once()
             mock_success.assert_called_once()
             mock_error.assert_not_called()
+
+
+# ============================================================================
+# create_user_bucket_name — deterministic generation
+# ============================================================================
+
+
+def test_create_user_bucket_name_is_deterministic(monkeypatch):
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+    a = RemoteStorageController.create_user_bucket_name(id=42)
+    b = RemoteStorageController.create_user_bucket_name(id=42)
+    assert a == b
+
+
+def test_create_user_bucket_name_differs_per_id(monkeypatch):
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+    a = RemoteStorageController.create_user_bucket_name(id=1)
+    b = RemoteStorageController.create_user_bucket_name(id=2)
+    assert a != b
+
+
+def test_create_user_bucket_name_respects_secret(monkeypatch):
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "secret-one")
+    a = RemoteStorageController.create_user_bucket_name(id=42)
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "secret-two")
+    b = RemoteStorageController.create_user_bucket_name(id=42)
+    assert a != b
+
+
+def test_create_user_bucket_name_uses_prefix_and_id(monkeypatch):
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+    name = RemoteStorageController.create_user_bucket_name(
+        id=99, prefix="custom-prefix"
+    )
+    assert name.startswith("custom-prefix-99-")
+    # 10-char hex hash suffix
+    assert len(name.split("-")[-1]) == 10
+
+
+def test_create_user_bucket_name_within_s3_length_limit(monkeypatch):
+    """S3 bucket names must be <= 63 chars; check a large id."""
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+    name = RemoteStorageController.create_user_bucket_name(
+        id=99999999, prefix="development-optinist-user"
+    )
+    assert len(name) <= 63
+
+
+def test_create_user_bucket_name_matches_s3_naming_rules(monkeypatch):
+    """S3 bucket names must be lowercase, alphanumeric, dots/hyphens only."""
+    import re
+
+    monkeypatch.setenv("S3_USER_BUCKET_SECRET", "test-secret")
+    name = RemoteStorageController.create_user_bucket_name(id=42)
+    assert re.fullmatch(r"[a-z0-9.\-]+", name)


### PR DESCRIPTION
#### Summary

A duplicate-bucket investigation (originally reported as prod user 73) traced
back to a non-deterministic per-user S3 bucket name generator combined with a
test-user reseed script that overwrote `users.attributes` and a per-login
`CreateBucket` call that hammered S3 even when the DB already had a valid
name. This PR makes bucket-name generation deterministic per `(secret, id)`,
short-circuits the login hot path, fixes the reseed script to merge instead of
overwrite, and makes `delete_test_users.py`'s S3 cleanup loud about
skips/failures.

#### Design Decisions

- **Deterministic generator with a per-environment secret.** Replaced
  `md5(id + time.time())[:10]` with `md5(secret + id)[:10]`, where `secret`
  comes from `S3_USER_BUCKET_SECRET`. This makes retries idempotent and
  promotes `BucketAlreadyOwnedByYou` from "papering over drift" to a real
  safety net. The secret lives in tfvars (gitignored, shared via the team
  Drive) — same pattern as the existing prefix variable, marked
  `sensitive = true` in Terraform. Distinct values for dev and prod.
- **Existing buckets are not migrated.** All existing users keep their stored
  `remote_bucket_name` because `_ensure_user_bucket_exists_impl` short-circuits
  before ever calling the generator if `attributes.remote_bucket_name` is
  already set. The deterministic generator only runs on the missing-name
  recovery path. This means **no new buckets are created as a side effect of
  this PR** for any existing user.
- **Considered: bucket-existence cache with TTL.** Rejected. The
  broken-pointer scenario is rare and best handled by a separate health check;
  adding a TTL cache to the login hot path was extra complexity without a
  matching payoff.
- **Considered: making `create_test_users.py` env-gated to dev only.**
  Rejected for now — the script is operator-run and the prod cohort is already
  established. Instead the script now reuses an existing `remote_bucket_name`
  if present, so re-runs against any environment are idempotent.
- **`delete_test_users.py` already had the right code path.** The fix is
  observability, not logic: skips and failures now print loud warnings, are
  tracked in module-level lists, and the script exits non-zero if any S3
  cleanup issue occurred. The silent no-op pattern can't recur unnoticed.

### Evidence

CloudTrail before this PR (excerpt for prod user 73, ~5 weeks):

```
2026-02-27 09:56:45  CreateBucket  optinist-user-73-d8d9d3fc21  OK
2026-03-03 05:04:11  CreateBucket  optinist-user-73-d8d9d3fc21  BucketAlreadyOwnedByYou
2026-03-05 02:14:53  CreateBucket  optinist-user-73-d8d9d3fc21  BucketAlreadyOwnedByYou
... 12 more ...
2026-04-03 04:45:22  CreateBucket  optinist-user-73-d8d9d3fc21  BucketAlreadyOwnedByYou
```

After this PR, the login path returns immediately when the DB pointer is set —
expected CloudTrail churn for an existing user is **zero**.

Test run:

```
$ pytest studio/tests/app/common/core/storage/test_remote_storage_controller.py \
         studio/tests/app/common/core/cloud/test_cloud_utils.py
======================== 63 passed, 3 warnings in 0.17s ========================
```

### References

- Investigation report (in working tree, not committed): `REPORT.md`
- Related: prior IAM principal cutover from `optinist-cloud-user` to
  `subscr-optinist-cloud-user` (out of scope for this PR)

#### Files changed

**Backend (production code path):**

- `studio/app/common/core/storage/remote_storage_controller.py` — replace
  timestamp-based `create_user_bucket_name` with deterministic
  `md5(S3_USER_BUCKET_SECRET + id)[:10]`. Existing names in DB unaffected.
- `studio/app/common/core/cloud/cloud_utils.py` — early return in
  `_ensure_user_bucket_exists_impl` when `attributes.remote_bucket_name` is
  already set, eliminating the per-login `CreateBucket` call.

**Scripts (operator-run):**

- `infrastructure/scripts/create_test_users.py` — reuse an existing
  `remote_bucket_name` from `user_db.attributes` if present, and merge into
  `attributes` instead of overwriting.
- `infrastructure/scripts/delete_test_users.py` — print loud warnings when S3
  cleanup is skipped (`is_available()` false, or no `remote_bucket_name` on
  the row) or fails. Track outcomes in module-level lists, print a summary at
  end of run, and exit non-zero if any issues.

**Infrastructure:**

- `infrastructure/terraform/main.tf` — declare
  `variable "s3_user_bucket_secret"` (`sensitive = true`, no default).
- `infrastructure/terraform/compute.tf` — inject `S3_USER_BUCKET_SECRET` env
  var into both ECS task definitions next to the existing
  `S3_USER_BUCKET_PREFIX` entries.
- `infrastructure/terraform/environments/development.tfvars.example` and
  `production.tfvars.example` — placeholder line for the new variable so the
  examples stay aligned with the real tfvars.

**Tests:**

- `studio/tests/app/common/core/storage/test_remote_storage_controller.py` —
  6 new tests covering deterministic generation, distinct outputs per id,
  secret sensitivity, prefix/format, S3 length limit (≤63 chars), and S3
  naming-rule regex.
- `studio/tests/app/common/core/cloud/test_cloud_utils.py` — 5 new tests
  covering `_ensure_user_bucket_exists_impl`: short-circuit when name set,
  merge-not-overwrite when missing (preserves other attribute keys),
  `BucketAlreadyOwnedByYou` swallowing, propagation of unexpected errors, and
  graceful `None` return when the user row is missing.

### Manual Testcases

1. **Login does not churn S3.**
   - As any existing dev test user with a valid `remote_bucket_name`, log into
     the app via the frontend.
   - Tail CloudTrail filtered by `Username=development-optinist-cloud-user` for
     5 minutes.
   - Expected: zero new `CreateBucket` events for that user.

2. **Test-user reseed is idempotent.**
   - In dev, run `delete_test_users.py` against a known fixture user.
   - Confirm DeleteBucket appears in CloudTrail and the script prints
     "S3 bucket deleted successfully".
   - Run `create_test_users.py` for the same fixture.
   - Confirm exactly one bucket exists for that id.
   - Run `create_test_users.py` again. Confirm no new bucket is created and
     `users.attributes.remote_bucket_name` is unchanged.

3. **Loud failure mode for delete_test_users.py.**
   - In a dev shell, run `delete_test_users.py` against a user whose DB row
     has no `remote_bucket_name`.
   - Confirm the script prints a `WARNING: No remote_bucket_name on user ...`
     line, the end-of-run summary lists the skipped user, and the script exits
     non-zero.

4. **Existing real users are unaffected.**
   - Pick 2–3 real (non-test) users in dev with legacy non-deterministic
     bucket names.
   - Log them in via the app.
   - Confirm `users.attributes.remote_bucket_name` is unchanged in the DB and
     no new bucket appears in S3 for them.

5. **Automated tests:**
   ```
   pytest studio/tests/app/common/core/storage/test_remote_storage_controller.py \
          studio/tests/app/common/core/cloud/test_cloud_utils.py
   ```
   Expected: all 63 tests pass.

### Unit, Integration, Contract Test Coverage

- 11 new unit tests added across the storage and cloud modules (see Files
  changed). Coverage focuses on the deterministic generator's contract and on
  the four observable behaviours of `_ensure_user_bucket_exists_impl`
  (short-circuit, merge, swallow, propagate).
- No integration or contract tests added — the change is internal to two
  modules with no API-surface impact.

### Others

#### Difficulties (if any)

The investigation phase took most of the effort. The fix itself is small. The
trickiest decision was whether to migrate existing legacy bucket names to the
new deterministic format — chose not to, because the short-circuit makes
migration unnecessary and migration would risk creating a third bucket per
user during the transition.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Login hot path (`_ensure_user_bucket_exists_impl`) | **Low** | Strictly removes work when DB has a name. New behaviour is "do nothing" instead of "redundant CreateBucket". Covered by new tests. |
| Deterministic generator | **Low** | Only runs on the missing-name recovery path. Existing names unaffected. Covered by new tests. |
| `create_test_users.py` | **Medium** | Operator-run; merge change is safe but worth eyeballing in review by whoever runs the dev reseed. Idempotent on re-run. |
| `delete_test_users.py` | **None** | Print/exit-code only. No logic change. |
| Terraform / tfvars | **Medium** | Requires `s3_user_bucket_secret` to be set in both env tfvars before `terraform apply`, otherwise plan fails (no default — intentional). Real values must be saved to the team Drive. |
| Existing duplicate buckets | **Out of scope** | This PR does not delete or modify any existing S3 bucket. Cleanup is a separate, audited follow-up. |

----------

## TODO (follow-ups, not part of this PR)

- [ ] Save `s3_user_bucket_secret` for both environments to the shared Drive (separate values for dev and prod).
- [ ] Verify CI / `terraform plan` passes after the new variable is added — confirm the env var lands in the ECS task definition for all three services (compute frontend, compute backend, background_service).
- [ ] **Manual cleanup of orphan buckets** identified in `REPORT.md`:
  - [ ] Prod: delete `optinist-user-73-30e03d96a0` (orphan twin of id 73; current pointer is `…-d8d9d3fc21`).
  - [ ] Prod: investigate and resolve `optinist-user-76-fb81d5f176` (orphan in S3 with broken DB pointer to `…-2b2fa60221`).
  - [ ] Prod: resolve broken DB pointers for ids `14, 15, 16, 17, 75, 78` — bucket was deleted by an admin/cleanup script but `users.attributes.remote_bucket_name` was never nulled out. Decide per user whether to null the pointer, restore, or recreate.
  - [ ] Prod: investigate `optinist-user-123` through `optinist-user-128` — six stranded buckets with no corresponding `users` row. Determine origin and either delete or document.
  - [ ] Prod: confirm whether `optinist-user-1-admin` is intentional (DB id 1 points at `subscr-optinist-app-storage`).
  - [ ] Dev: delete the 13 orphan twins of cohort ids `7–19` after confirming the current pointer in `users.attributes.remote_bucket_name` is correct.
  - [ ] Dev: delete the 17 stranded buckets at ids `20, 21, 22, 26–38` (no DB row, prior cohort residue).
- [ ] Document the dev reset procedure in `infrastructure/scripts/README.md` or similar — the manual `ALTER TABLE users AUTO_INCREMENT = 7` step is currently tribal knowledge.
- [ ] Investigate the IAM principal cutover (`optinist-cloud-user` → `subscr-optinist-cloud-user`). The migration is partial; both principals are live in parallel. Decide whether to finish the cutover (detach `AmazonS3FullAccess` from `optinist-cloud-user`) or document why both exist.
- [ ] Audit the codebase for bucket-name constructions outside the `optinist-user-*` and `subscr-optinist-*` prefixes — under the new IAM policy these will hard-fail (`optinist-app-storage`, `optinist-mock-*`, `optinist-terraform-state-*`, all `development-optinist-*`).
- [ ] Cross-environment role usage: investigate why `development-optinist-app-storage` was deleted on 2026-03-17 by the **prod** principal `optinist-cloud-user`. Either an admin running scripts with the wrong profile, or the prod role has cross-env permissions it shouldn't.
