### PR TITLE
Added functionality to display the Backend unavailable screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,18 @@
-import { FC, useEffect } from "react"
+import { FC, useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 
+import { isAxiosError } from "axios"
 import { SnackbarProvider, SnackbarKey, useSnackbar } from "notistack"
 
 import Close from "@mui/icons-material/Close"
 import IconButton from "@mui/material/IconButton"
 
+import BackendUnavailable from "components/common/BackendUnavailable"
 import ErrorBoundary from "components/common/ErrorBoundary"
 import Loading from "components/common/Loading"
 import Layout from "components/Layout"
-import { RETRY_WAIT } from "const/Mode"
+import { RETRY_MAX_COUNT, RETRY_WAIT, RETRY_WAIT_LONG } from "const/Mode"
 import Account from "pages/Account"
 import AccountDelete from "pages/AccountDelete"
 import AccountManager from "pages/AccountManager"
@@ -34,24 +36,74 @@ import {
 } from "store/slice/Standalone/StandaloneSeclector"
 import { AppDispatch } from "store/store"
 
+/**
+ * Returns whether the error from getModeStandalone should be retried.
+ *
+ * - Treat as "backend down" (retry): network/timeout errors and HTTP 5xx.
+ * - Treat as terminal (no retry): HTTP 4xx. Non-axios errors are retried for safety.
+ */
+const isRetryableBackendError = (error: unknown): boolean => {
+  if (!isAxiosError(error)) return true
+  if (!error.response) return true
+  const status = error.response.status
+  return status >= 500 && status < 600
+}
+
 const App: FC = () => {
   const dispatch = useDispatch<AppDispatch>()
   const isStandalone = useSelector(selectModeStandalone)
   const loading = useSelector(selectLoading)
-  const getMode = () => {
-    dispatch(getModeStandalone())
-      .unwrap()
-      .catch(() => {
-        new Promise((resolve) => setTimeout(resolve, RETRY_WAIT)).then(() => {
-          getMode()
-        })
-      })
-  }
+  // Show the "backend unavailable" screen instead of the normal layout.
+  const [showBackendError, setShowBackendError] = useState(false)
+  // false = background polling has stopped (4xx); user must reload manually.
+  const [isRetrying, setIsRetrying] = useState(true)
 
   useEffect(() => {
+    let cancelled = false
+    let timerId: ReturnType<typeof setTimeout> | undefined
+    let retryCount = 0
+
+    const getMode = () => {
+      dispatch(getModeStandalone())
+        .unwrap()
+        .then(() => {
+          if (cancelled) return
+          // Recovered: hide the error screen.
+          setShowBackendError(false)
+          setIsRetrying(true)
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return
+          if (!isRetryableBackendError(error)) {
+            // Terminal error (4xx): stop polling, require manual reload.
+            setShowBackendError(true)
+            setIsRetrying(false)
+            return
+          }
+          retryCount += 1
+          const reachedMax = retryCount >= RETRY_MAX_COUNT
+          if (reachedMax) {
+            setShowBackendError(true)
+          }
+          const wait = reachedMax ? RETRY_WAIT_LONG : RETRY_WAIT
+          timerId = setTimeout(() => {
+            getMode()
+          }, wait)
+        })
+    }
+
     getMode()
+
+    return () => {
+      cancelled = true
+      if (timerId !== undefined) clearTimeout(timerId)
+    }
     //eslint-disable-next-line
   }, [])
+
+  if (showBackendError) {
+    return <BackendUnavailable isRetrying={isRetrying} />
+  }
 
   return loading ? (
     <Loading loading={true} />

--- a/frontend/src/components/common/BackendUnavailable.tsx
+++ b/frontend/src/components/common/BackendUnavailable.tsx
@@ -1,0 +1,65 @@
+import { FC } from "react"
+
+import { Box, Stack, styled, Typography } from "@mui/material"
+
+type Props = {
+  // true: background retries are running and the page will auto-recover.
+  // false: polling has stopped and the user must reload manually.
+  isRetrying: boolean
+}
+
+const BackendUnavailable: FC<Props> = ({ isRetrying }) => {
+  return (
+    <Wrapper>
+      <Content>
+        <Title>Cannot connect to the OptiNiSt server</Title>
+        <Message>
+          The server is currently unavailable. Please try again after a while.
+        </Message>
+        {isRetrying ? (
+          <SubMessage>
+            This page will automatically recover once the connection is
+            restored.
+          </SubMessage>
+        ) : (
+          <SubMessage>Please reload this page to retry.</SubMessage>
+        )}
+      </Content>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Box)({
+  width: "100vw",
+  height: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+})
+
+const Content = styled(Stack)({
+  padding: 32,
+  boxShadow: "2px 1px 3px 1px rgba(0,0,0,0.1)",
+  borderRadius: 4,
+  maxWidth: 480,
+  textAlign: "center",
+  gap: 12,
+})
+
+const Title = styled(Typography)({
+  fontSize: 18,
+  fontWeight: 600,
+})
+
+const Message = styled(Typography)({
+  fontSize: 14,
+  color: "rgba(0, 0, 0, 0.75)",
+})
+
+const SubMessage = styled(Typography)({
+  fontSize: 12,
+  color: "rgba(0, 0, 0, 0.55)",
+})
+
+export default BackendUnavailable

--- a/frontend/src/const/Mode.ts
+++ b/frontend/src/const/Mode.ts
@@ -1,2 +1,6 @@
 export const RETRY_WAIT = 5000
+// Max retries at RETRY_WAIT before showing the backend-unavailable screen.
+export const RETRY_MAX_COUNT = 5
+// Retry interval used while the backend-unavailable screen is shown.
+export const RETRY_WAIT_LONG = 30000
 export const STANDALONE_WORKSPACE_ID = 1


### PR DESCRIPTION
## Summary

When the backend is down, the app used to spin forever on a blank loading
screen because `getModeStandaloneApi` (`/is_standalone`) was retried in an
unbounded recursive loop and the loading flag in the standalone slice was
never cleared. This PR replaces that loop with a bounded retry strategy
backed by a dedicated "backend unavailable" screen.

## Background / Problem

- On initial render, `App.tsx` dispatches `getModeStandalone()` which calls `getModeStandaloneApi` (`GET /is_standalone`).
- If the request failed (e.g. backend is down), the previous implementation recursively re-invoked itself every `RETRY_WAIT` (5s) with no upper bound.
- The standalone slice did not handle the `rejected` action, so `loading` stayed `true` forever and the user was stuck on a blank loading screen with no feedback.

## Changes

### 1. Bounded retry with classification of errors

`isRetryableBackendError(error)` in `frontend/src/App.tsx` classifies errors
into two groups:

| Category | Detection | Behavior |
| --- | --- | --- |
| Retryable ("backend down") | No HTTP response received (network error / timeout / `ECONNABORTED`) **or** HTTP status `5xx` | Retried with the bounded retry strategy described below |
| Terminal | HTTP status `4xx` | Not retried; the error screen is shown immediately and background polling stops |
| Unknown (non-axios) | Anything else | Treated as retryable to stay on the safe side |

Note: 4xx is intentionally excluded from retries because it indicates a
client-side / configuration issue (e.g. endpoint not deployed) that will not
recover by retrying. 401 is already handled separately by the existing axios
interceptor (token refresh).

### 2. Bounded retry strategy

- The first `RETRY_MAX_COUNT` (= 5) failures are retried at the existing `RETRY_WAIT` (= 5s) interval. The user keeps seeing the loading spinner during this phase.
- Once the retry count reaches `RETRY_MAX_COUNT`, the dedicated `BackendUnavailable` screen is shown.
- The app continues background polling at the longer `RETRY_WAIT_LONG` (= 30s) interval so that the screen automatically recovers as soon as the backend becomes reachable again. The longer interval is intentional so we do not hammer a server we already know is unreachable.
- For terminal (4xx) errors background polling is stopped, and the error screen instructs the user to reload the page manually.

### 3. New `BackendUnavailable` screen component

A new presentational component
(`frontend/src/components/common/BackendUnavailable.tsx`) renders the error
screen using existing MUI primitives. It takes an `isRetrying` prop:

- `true`: shows "This page will automatically recover once the connection is restored."
- `false`: shows "Please reload this page to retry." (used after a terminal 4xx error).

<img width="565" height="218" alt="image" src="https://github.com/user-attachments/assets/06b0d0ac-e97a-4255-b7d6-8c4beef95967" />

### 4. Effect lifecycle / cleanup

The retry loop is now contained inside a single `useEffect`. A `cancelled`
flag plus `clearTimeout` cleanup prevent leaking timers or stale state
updates after unmount or React StrictMode double-invocation.

## Why the standalone slice was intentionally left unchanged

The standalone slice still does not handle `rejected`, leaving `loading`
truthy between attempts. This is intentional: it prevents a brief flash of
the unauthenticated/standalone routes (with `mode === undefined`) between
retries during the initial polling phase. The error screen visibility is
managed in `App.tsx` via local state instead.

## Files

- `frontend/src/App.tsx` — bounded retry loop, error classification, error screen branching, effect cleanup.
- `frontend/src/components/common/BackendUnavailable.tsx` — new component.
- `frontend/src/const/Mode.ts` — new `RETRY_MAX_COUNT` and `RETRY_WAIT_LONG` constants.

## Behavior matrix

| Scenario | What the user sees |
| --- | --- |
| First request succeeds | Normal app, no change |
| 1–4 failures (network / timeout / 5xx) | Existing `<Loading />` spinner, retried every 5s |
| 5 failures (network / timeout / 5xx) | `<BackendUnavailable isRetrying={true} />`; background polling continues every 30s |
| Background poll succeeds while error screen is shown | App automatically returns to normal screen |
| 4xx error (any time) | `<BackendUnavailable isRetrying={false} />`; background polling stops; user reloads manually |
| Component unmounts mid-retry | Pending timer is cleared and pending state updates are dropped |

## Test plan

- [x] Start the frontend with the backend stopped and confirm:
  - The loading spinner is shown for up to ~25s (5 retries × 5s).
  - The `BackendUnavailable` screen then appears with the "automatically recover" message.
    <img width="565" height="218" alt="image" src="https://github.com/user-attachments/assets/06b0d0ac-e97a-4255-b7d6-8c4beef95967" />
  - Background requests to `/is_standalone` continue every ~30s in DevTools.
- [x] While the error screen is displayed, start the backend and confirm the app automatically transitions to the normal screen on the next poll.
- [x] Force a 5xx response from `/is_standalone` (e.g. by stopping the backend or returning 500 from a stub) and confirm the spinner is shown for ~25s, then the `BackendUnavailable` screen appears with the "automatically recover" message and background polling continues at ~30s.
- [x] Force a 4xx response from `/is_standalone` (e.g. via DevTools request blocking with a custom rule) and confirm the error screen is shown immediately with the "Please reload" message and that polling stops.
- [x] Navigate away (or hot-reload) during the initial retry phase and confirm no console warnings about state updates on unmounted components.
- [x] Run `yarn lint` / `tsc --noEmit` on the changed files and confirm no new warnings or errors are introduced.
