### PR TITLE
fix potential crash based on docker error and port jam

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -146,6 +146,11 @@ class PremiumInstanceConfig:
     INSTANCE_NAME_SUFFIX = "premium-running"
 
     @classmethod
+    def get_env_prefix(cls) -> str:
+        """Delegate to EnvironmentConfig.get_env_prefix for convenience."""
+        return EnvironmentConfig.get_env_prefix()
+
+    @classmethod
     def get_instance_name_pattern(cls) -> str:
         """Get the EC2 Name tag wildcard pattern for this environment.
 

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -9,6 +9,8 @@ echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
 echo ECS_INSTANCE_ATTRIBUTES='{"tier":"${tier}"}' >> /etc/ecs/ecs.config
+# Must be >= task-level stopTimeout (see compute.tf).
+echo ECS_CONTAINER_STOP_TIMEOUT=120s >> /etc/ecs/ecs.config
 
 # Systemd service to clear stale ECS agent checkpoint on every boot.
 cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -529,6 +529,8 @@ resource "aws_ecs_task_definition" "autoscaling" {
       entryPoint        = ["/bin/sh", "-c"]
       command           = ["./cloud-startup.sh"]
 
+      stopTimeout = 120 # see ECS_CONTAINER_STOP_TIMEOUT in ecs-user-data.sh
+
       linuxParameters = {
         maxSwap    = 32768 # Max swap in MiB (matches 32GB host swap on EBS)
         swappiness = 20    # Only swap under memory pressure (host also set to 20)
@@ -538,7 +540,7 @@ resource "aws_ecs_task_definition" "autoscaling" {
         {
           name          = "${local.env_prefix}-cloud-container-port-8000"
           containerPort = 8000
-          hostPort      = 8000
+          hostPort      = 0 # ephemeral
           protocol      = "tcp"
         }
       ]
@@ -790,6 +792,8 @@ resource "aws_ecs_task_definition" "premium" {
       entryPoint        = ["/bin/sh", "-c"]
       command           = ["./cloud-startup.sh"]
 
+      stopTimeout = 120 # see ECS_CONTAINER_STOP_TIMEOUT in ecs-user-data.sh
+
       # linuxParameters = {
       #   maxSwap    = 32768  # Max swap in MiB (matches 32GB host swap on EBS)
       #   swappiness = 20     # Only swap under memory pressure (host also set to 20)
@@ -800,7 +804,7 @@ resource "aws_ecs_task_definition" "premium" {
         {
           name          = "${var.environment}-premium-optinist-cloud-container-port-8000"
           containerPort = 8000
-          hostPort      = 8000
+          hostPort      = 0 # ephemeral; resolved by premium_manager Lambda
           protocol      = "tcp"
         }
       ]
@@ -1021,6 +1025,11 @@ resource "aws_ecs_service" "autoscaling" {
   desired_count                      = 1
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 0
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.main.name

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -397,11 +397,14 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           }
         }
       },
-      # EC2 CreateTags (unrestricted — needed by RunInstances TagSpecifications)
+      # EC2 CreateTags (needed by RunInstances TagSpecifications on instances and volumes)
       {
         Effect   = "Allow"
         Action   = "ec2:CreateTags"
-        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+        Resource = [
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
+        ]
       },
       # EC2 DeleteTags (scoped to ghost cleanup grace period tag only)
       {

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -705,7 +705,9 @@ def _restore_pending_release_transaction(connection, user_id: int):
                 rule_arn = (assignment.get("alb_rule_arn") or "").strip() or None
                 if target_group_arn or rule_arn:
                     try:
-                        _teardown_alb_resources(user_id, rule_arn, target_group_arn)
+                        _teardown_alb_resources(
+                            user_id, rule_arn, target_group_arn, instance_id
+                        )
                     except Exception as alb_err:
                         print(
                             f"ALB cleanup warning for stale user {user_id}: "
@@ -2212,7 +2214,10 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                             assignment.get("target_group_arn") or ""
                         ).strip() or None
                         teardown_errors = _teardown_alb_resources(
-                            assignment["user_id"], rule_arn, tg_arn
+                            assignment["user_id"],
+                            rule_arn,
+                            tg_arn,
+                            assignment.get("instance_id"),
                         )
                         if teardown_errors:
                             print(
@@ -2627,6 +2632,103 @@ def _enable_sticky_sessions(
         print(f"WARNING: Failed to enable sticky sessions on {target_group_arn}: {e}")
 
 
+# Container port the studio backend always binds inside the task. The host port
+# is now ephemeral (hostPort=0 in the task definition), so all register /
+# deregister calls must look up the actual mapped host port instead of assuming
+# the container port equals the host port.
+CONTAINER_PORT = 8000
+
+
+def get_host_port_for_instance(
+    instance_id: str, max_attempts: int = 10, delay: float = 3.0
+) -> int:
+    """Look up the ephemeral host port that the studio container is bound to
+    on the given EC2 instance.
+
+    The premium task def uses ``hostPort = 0``, so ECS picks a port from the
+    OS ephemeral range at task start. We resolve it via:
+        EC2 instance -> ECS container instance -> running task -> networkBindings
+
+    ``networkBindings`` is empty during a window where ``lastStatus == RUNNING``
+    but the container has not yet bound its port — poll instead of one-shot.
+    Filter explicitly by ``containerPort`` so a future second port mapping
+    (metrics/debug) cannot silently return the wrong entry.
+    """
+    cluster_name = get_required_env_var("CLUSTER_NAME")
+    ecs_client: "ECSClient" = boto3.client("ecs")
+
+    last_err: Optional[str] = None
+    for _ in range(max_attempts):
+        try:
+            ecs_container_instance_id = get_ecs_container_instance_id(
+                instance_id, cluster_name
+            )
+            if not ecs_container_instance_id:
+                last_err = "no ECS container instance mapping yet"
+                time.sleep(delay)
+                continue
+
+            tasks_response = ecs_client.list_tasks(
+                cluster=cluster_name, containerInstance=ecs_container_instance_id
+            )
+            task_arns = tasks_response.get("taskArns", [])
+            if not task_arns:
+                last_err = "no tasks on container instance yet"
+                time.sleep(delay)
+                continue
+
+            task_details = ecs_client.describe_tasks(
+                cluster=cluster_name, tasks=task_arns
+            )
+            for task in task_details.get("tasks", []):
+                if task.get("lastStatus") != ECSTaskStatus.RUNNING:
+                    continue
+                for container in task.get("containers", []):
+                    bindings = container.get("networkBindings") or []
+                    match = next(
+                        (
+                            b
+                            for b in bindings
+                            if b.get("containerPort") == CONTAINER_PORT
+                        ),
+                        None,
+                    )
+                    if match and match.get("hostPort"):
+                        host_port = int(match["hostPort"])
+                        print(
+                            f"Resolved host port {host_port} for instance "
+                            f"{instance_id} (container port {CONTAINER_PORT})"
+                        )
+                        return host_port
+            last_err = "task running but networkBindings still empty"
+        except Exception as e:
+            last_err = str(e)
+        time.sleep(delay)
+
+    raise RuntimeError(
+        f"Could not resolve host port for instance {instance_id} after "
+        f"{max_attempts} attempts: {last_err}"
+    )
+
+
+def get_registered_port_for_instance(target_group_arn: str, instance_id: str) -> int:
+    """Look up the port currently registered in a target group for an instance.
+
+    Used in deregister paths because the task may already be stopped — we
+    cannot rely on ``describe_tasks`` to recover the host port. Reads the
+    target group's live registrations via ``describe_target_health`` instead.
+    """
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+    response = elbv2.describe_target_health(TargetGroupArn=target_group_arn)
+    for desc in response.get("TargetHealthDescriptions", []):
+        target = desc.get("Target", {}) or {}
+        if target.get("Id") == instance_id and target.get("Port"):
+            return int(target["Port"])
+    raise RuntimeError(
+        f"Instance {instance_id} not found in target group {target_group_arn}"
+    )
+
+
 def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
     """
     Create a new target group for a premium user, or return existing one if
@@ -2649,7 +2751,11 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
         response = elbv2.create_target_group(
             Name=target_group_name,
             Protocol="HTTP",
-            Port=8000,
+            # TG-level Port is only a default for unported registrations; we
+            # always register with the actual ephemeral host port via
+            # get_host_port_for_instance(). Kept aligned with CONTAINER_PORT
+            # for clarity rather than functional reasons.
+            Port=CONTAINER_PORT,
             VpcId=vpc_id,
             HealthCheckPath="/health",
             HealthCheckProtocol="HTTP",
@@ -3497,7 +3603,9 @@ def assign_premium_user(
             target_group_response = elbv2.create_target_group(
                 Name=tg_name,
                 Protocol="HTTP",
-                Port=8000,
+                # TG-level Port is only a default; we always register with the
+                # actual ephemeral host port via get_host_port_for_instance().
+                Port=CONTAINER_PORT,
                 VpcId=vpc_id,
                 HealthCheckPath="/health",
                 HealthCheckProtocol="HTTP",
@@ -3518,10 +3626,11 @@ def assign_premium_user(
             ]
             _enable_sticky_sessions(elbv2, target_group_arn)
 
-            # 8. Register instance to target group
+            # 8. Register instance to target group on its ephemeral host port
+            host_port = get_host_port_for_instance(instance_id)
             elbv2.register_targets(
                 TargetGroupArn=target_group_arn,
-                Targets=[{"Id": instance_id, "Port": 8000}],
+                Targets=[{"Id": instance_id, "Port": host_port}],
             )
 
         # Create ALB listener rule for user routing
@@ -4313,10 +4422,11 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                     vpc_id = get_required_env_var("VPC_ID")
                     new_target_group_arn = create_or_get_target_group(user_id, vpc_id)
 
-                    # Register new instance to new target group
+                    # Register new instance to new target group on its ephemeral port
+                    new_host_port = get_host_port_for_instance(new_instance_id)
                     elbv2.register_targets(
                         TargetGroupArn=new_target_group_arn,
-                        Targets=[{"Id": new_instance_id, "Port": 8000}],
+                        Targets=[{"Id": new_instance_id, "Port": new_host_port}],
                     )
 
                     # Check if old ALB rule exists, create new one if not
@@ -4417,15 +4527,29 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                             user_id, vpc_id
                         )
 
-                    elbv2.deregister_targets(
-                        TargetGroupArn=old_target_group_arn,
-                        Targets=[{"Id": old_instance_id, "Port": 8000}],
-                    )
+                    # Look up the actual registered port for the old instance
+                    # — the task may already be stopping so we cannot rely on
+                    # describe_tasks. Fall back to skipping deregister if the
+                    # entry is already gone (e.g. cleaned up by EC2 state event).
+                    try:
+                        old_host_port = get_registered_port_for_instance(
+                            old_target_group_arn, old_instance_id
+                        )
+                        elbv2.deregister_targets(
+                            TargetGroupArn=old_target_group_arn,
+                            Targets=[{"Id": old_instance_id, "Port": old_host_port}],
+                        )
+                    except RuntimeError as lookup_err:
+                        print(
+                            f"Skipping deregister for {old_instance_id} from "
+                            f"{old_target_group_arn}: {lookup_err}"
+                        )
 
-                    # Register to new instance (same target group)
+                    # Register new instance on its ephemeral host port
+                    new_host_port = get_host_port_for_instance(new_instance_id)
                     elbv2.register_targets(
                         TargetGroupArn=old_target_group_arn,
-                        Targets=[{"Id": new_instance_id, "Port": 8000}],
+                        Targets=[{"Id": new_instance_id, "Port": new_host_port}],
                     )
 
                     # Update RDS assignment
@@ -4458,8 +4582,16 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
         return False
 
 
-def _teardown_alb_resources(user_id, rule_arn, target_group_arn):
-    """Delete ALB rule and target group for a released user."""
+def _teardown_alb_resources(user_id, rule_arn, target_group_arn, instance_id=None):
+    """Delete ALB rule and target group for a released user.
+
+    For per-user target groups the TG is deleted outright. For the shared
+    autoscaling target group we cannot delete it (other users still depend on
+    it), but we *must* deregister this user's instance from it — otherwise the
+    instance:port entry leaks. With ephemeral host ports a leak is untraceable
+    (no stable port to match on after the next task replacement), so the
+    deregister is now load-bearing rather than just hygiene.
+    """
     elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
     errors = []
 
@@ -4486,6 +4618,39 @@ def _teardown_alb_resources(user_id, rule_arn, target_group_arn):
             print(error_msg)
             errors.append(error_msg)
     elif target_group_arn == autoscaling_tg_arn:
+        # Shared TG: do not delete, but deregister this user's instance so the
+        # ephemeral instance:port entry does not leak.
+        if instance_id and instance_id != PremiumAssignment.AUTOSCALING_POOL:
+            try:
+                old_host_port = get_registered_port_for_instance(
+                    autoscaling_tg_arn, instance_id
+                )
+                elbv2.deregister_targets(
+                    TargetGroupArn=autoscaling_tg_arn,
+                    Targets=[{"Id": instance_id, "Port": old_host_port}],
+                )
+                print(
+                    f"Deregistered {instance_id}:{old_host_port} from shared "
+                    f"autoscaling target group"
+                )
+            except RuntimeError as lookup_err:
+                # Already gone — fine, nothing to leak
+                print(
+                    f"No registration to deregister for {instance_id} in "
+                    f"shared autoscaling TG: {lookup_err}"
+                )
+            except Exception as dereg_err:
+                error_msg = (
+                    f"Error deregistering {instance_id} from shared "
+                    f"autoscaling TG: {str(dereg_err)}"
+                )
+                print(error_msg)
+                errors.append(error_msg)
+        else:
+            print(
+                f"Skipping deregister from shared autoscaling TG "
+                f"(instance_id={instance_id})"
+            )
         print(
             f"Skipping deletion of shared autoscaling "
             f"target group: {target_group_arn}"
@@ -4519,6 +4684,7 @@ def release_premium_user(user_id: int, hard: bool = False) -> Dict[str, Any]:
                 ).strip() or None
                 rule_arn = (assignment["alb_rule_arn"] or "").strip() or None
                 print(f"Hard-released user {user_id} from instance {instance_id}")
+                instance_id_for_teardown = instance_id
             except Exception as assignment_error:
                 print(
                     f"No assignment found for user {user_id}: "
@@ -4526,8 +4692,11 @@ def release_premium_user(user_id: int, hard: bool = False) -> Dict[str, Any]:
                 )
                 target_group_arn = None
                 rule_arn = None
+                instance_id_for_teardown = None
 
-            errors = _teardown_alb_resources(user_id, rule_arn, target_group_arn)
+            errors = _teardown_alb_resources(
+                user_id, rule_arn, target_group_arn, instance_id_for_teardown
+            )
         else:
             # Soft release: mark as pending_release, keep ALB/TG intact
             assignment = soft_release_user_assignment(user_id)

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1803,6 +1803,9 @@ class TestRoutingIdContract:
                 return_value=200,
             ), patch(
                 "premium_manager." "trigger_experiment_sync"
+            ), patch(
+                "premium_manager.get_host_port_for_instance",
+                return_value=49153,
             ):
                 mock_connection = setup_db_mock(
                     fetchone_values=[
@@ -1884,6 +1887,7 @@ class TestRoutingIdContract:
             "premium_manager.try_reserve_instance": True,
             "premium_manager." "cleanup_duplicate_rules_for_routing_id": 0,
             "premium_manager." "get_next_available_priority": 100,
+            "premium_manager.get_host_port_for_instance": 49153,
         }
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
@@ -2961,3 +2965,298 @@ class TestCleanupGhostECSRegistrations:
             )
             # No EC2 calls should be made
             mock_ec2.describe_instances.assert_not_called()
+
+
+class TestGetHostPortForInstance:
+    """Tests for ephemeral host port resolution.
+
+    Premium task def now uses hostPort=0, so the Lambda must look up the
+    actual host port via networkBindings instead of assuming 8000.
+    """
+
+    def _make_task(self, status, bindings):
+        return {
+            "lastStatus": status,
+            "containers": [{"networkBindings": bindings}],
+        }
+
+    def test_happy_path_returns_host_port(self, mock_env_vars_premium):
+        """Walks EC2 -> ECS container instance -> task -> networkBindings."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id"
+        ) as mock_get_ci:
+            mock_get_ci.return_value = "ci-arn-123"
+            mock_ecs = MagicMock()
+            mock_ecs.list_tasks.return_value = {"taskArns": ["task-arn-1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    self._make_task(
+                        "RUNNING",
+                        [{"containerPort": 8000, "hostPort": 49153}],
+                    )
+                ]
+            }
+            mock_boto3.return_value = mock_ecs
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-abc") == 49153
+            mock_get_ci.assert_called_with("i-abc", "test-cluster")
+
+    def test_polls_when_bindings_initially_empty(self, mock_env_vars_premium):
+        """networkBindings is empty for a window after lastStatus=RUNNING.
+
+        The plan explicitly warns against one-shot lookups here — there's a
+        race where the task is RUNNING but the container has not yet bound
+        its port.
+        """
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id"
+        ) as mock_get_ci, patch(
+            "premium_manager.time.sleep"
+        ) as mock_sleep:
+            mock_get_ci.return_value = "ci-arn-123"
+            mock_ecs = MagicMock()
+            mock_ecs.list_tasks.return_value = {"taskArns": ["task-arn-1"]}
+            mock_ecs.describe_tasks.side_effect = [
+                {"tasks": [self._make_task("RUNNING", [])]},
+                {
+                    "tasks": [
+                        self._make_task(
+                            "RUNNING",
+                            [{"containerPort": 8000, "hostPort": 49200}],
+                        )
+                    ]
+                },
+            ]
+            mock_boto3.return_value = mock_ecs
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-abc") == 49200
+            assert mock_ecs.describe_tasks.call_count == 2
+            assert mock_sleep.called
+
+    def test_filters_by_container_port_not_index(self, mock_env_vars_premium):
+        """Multiple bindings must be filtered by containerPort==8000.
+
+        Plan warning: do NOT use bindings[0] — a future second port
+        mapping (metrics/debug) would silently return the wrong entry.
+        """
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id"
+        ) as mock_get_ci:
+            mock_get_ci.return_value = "ci-arn-123"
+            mock_ecs = MagicMock()
+            mock_ecs.list_tasks.return_value = {"taskArns": ["task-arn-1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    self._make_task(
+                        "RUNNING",
+                        [
+                            {"containerPort": 9000, "hostPort": 49100},
+                            {"containerPort": 8000, "hostPort": 49153},
+                        ],
+                    )
+                ]
+            }
+            mock_boto3.return_value = mock_ecs
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-abc") == 49153
+
+    def test_raises_after_max_attempts(self, mock_env_vars_premium):
+        """Give up loudly rather than silently fall back to a wrong port."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id"
+        ) as mock_get_ci, patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_get_ci.return_value = "ci-arn-123"
+            mock_ecs = MagicMock()
+            mock_ecs.list_tasks.return_value = {"taskArns": ["task-arn-1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [self._make_task("RUNNING", [])]
+            }
+            mock_boto3.return_value = mock_ecs
+
+            from premium_manager import get_host_port_for_instance
+
+            with pytest.raises(RuntimeError, match="Could not resolve host port"):
+                get_host_port_for_instance("i-abc", max_attempts=3, delay=0)
+
+
+class TestGetRegisteredPortForInstance:
+    """Tests for the deregister-path lookup.
+
+    Used in teardown paths where the task is already gone, so we can't
+    rely on describe_tasks to recover the host port.
+    """
+
+    def test_finds_registered_port(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": [
+                    {"Target": {"Id": "i-abc", "Port": 49153}},
+                    {"Target": {"Id": "i-xyz", "Port": 49200}},
+                ]
+            }
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import get_registered_port_for_instance
+
+            assert get_registered_port_for_instance("tg-arn", "i-abc") == 49153
+            assert get_registered_port_for_instance("tg-arn", "i-xyz") == 49200
+
+    def test_raises_when_not_registered(self, mock_env_vars_premium):
+        """Required so _teardown_alb_resources can gracefully skip deregister
+        when the entry is already gone (e.g. cleaned up by an EC2 state
+        change event)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": []
+            }
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import get_registered_port_for_instance
+
+            with pytest.raises(RuntimeError, match="not found in target group"):
+                get_registered_port_for_instance("tg-arn", "i-abc")
+
+
+class TestTeardownAlbResources:
+    """Tests for _teardown_alb_resources, especially the leak fix.
+
+    The shared autoscaling target group is never deleted (other users
+    depend on it) but this user's instance:port entry MUST be deregistered
+    — with ephemeral ports a leak is untraceable after the next task
+    replacement.
+    """
+
+    def test_per_user_tg_deletes_and_does_not_deregister(self, mock_env_vars_premium):
+        """Pinning test: per-user TG path is unchanged."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import _teardown_alb_resources
+
+            errors = _teardown_alb_resources(
+                user_id=42,
+                rule_arn="arn:aws:rule/r-1",
+                target_group_arn="arn:aws:tg/premium-42-tg",
+                instance_id="i-abc",
+            )
+
+            assert errors == []
+            mock_elbv2.delete_rule.assert_called_once_with(RuleArn="arn:aws:rule/r-1")
+            mock_elbv2.delete_target_group.assert_called_once_with(
+                TargetGroupArn="arn:aws:tg/premium-42-tg"
+            )
+            mock_elbv2.deregister_targets.assert_not_called()
+
+    def test_shared_tg_deregisters_with_looked_up_port(self, mock_env_vars_premium):
+        """Load-bearing leak fix: shared TG must deregister this instance."""
+        asg_tg_arn = mock_env_vars_premium["AUTOSCALING_TARGET_GROUP_ARN"]
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": [
+                    {"Target": {"Id": "i-abc", "Port": 49153}},
+                ]
+            }
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import _teardown_alb_resources
+
+            errors = _teardown_alb_resources(
+                user_id=42,
+                rule_arn=None,
+                target_group_arn=asg_tg_arn,
+                instance_id="i-abc",
+            )
+
+            assert errors == []
+            mock_elbv2.delete_target_group.assert_not_called()
+            mock_elbv2.deregister_targets.assert_called_once_with(
+                TargetGroupArn=asg_tg_arn,
+                Targets=[{"Id": "i-abc", "Port": 49153}],
+            )
+
+    def test_shared_tg_skips_gracefully_when_not_registered(
+        self, mock_env_vars_premium
+    ):
+        """Already-gone case must not raise — release/finalize paths must
+        not break when an EC2 state-change event has already cleaned up."""
+        asg_tg_arn = mock_env_vars_premium["AUTOSCALING_TARGET_GROUP_ARN"]
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": []
+            }
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import _teardown_alb_resources
+
+            errors = _teardown_alb_resources(
+                user_id=42,
+                rule_arn=None,
+                target_group_arn=asg_tg_arn,
+                instance_id="i-abc",
+            )
+
+            assert errors == []
+            mock_elbv2.delete_target_group.assert_not_called()
+            mock_elbv2.deregister_targets.assert_not_called()
+
+    def test_shared_tg_skips_when_instance_id_is_pool_marker(
+        self, mock_env_vars_premium
+    ):
+        """AUTOSCALING_POOL marker is not a real instance id — don't try
+        to deregister it."""
+        from aws_constants import PremiumAssignment
+
+        asg_tg_arn = mock_env_vars_premium["AUTOSCALING_TARGET_GROUP_ARN"]
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import _teardown_alb_resources
+
+            errors = _teardown_alb_resources(
+                user_id=42,
+                rule_arn=None,
+                target_group_arn=asg_tg_arn,
+                instance_id=PremiumAssignment.AUTOSCALING_POOL,
+            )
+
+            assert errors == []
+            mock_elbv2.describe_target_health.assert_not_called()
+            mock_elbv2.deregister_targets.assert_not_called()
+            mock_elbv2.delete_target_group.assert_not_called()


### PR DESCRIPTION
### Content

#### Summary
- Preventative hardening, not an incident response. ECS premium and autoscaling task definitions hard-code `hostPort = 8000`, which leaves the cluster fragile to a documented Docker bridge-mode failure: a SIGKILLed container can leave a `docker-proxy` process bound to `0.0.0.0:8000`, after which any subsequent task on the same host fails with `Bind for 0.0.0.0:8000 failed: port is already allocated`. We have not observed this in prod (the 2026-04-08 outage was a stale ECS agent checkpoint, tracked separately in #501), but the configuration makes recovery from such an event catastrophic.
- Switches both task definitions to `hostPort = 0` (ephemeral) and teaches the `premium_manager` Lambda to look up the actual mapped host port for every ALB register/deregister call.
- Adds a matching `stopTimeout = 120` on the task and `ECS_CONTAINER_STOP_TIMEOUT=120s` on the host so containers get a real SIGTERM grace period before Docker SIGKILLs (the primary trigger for the orphan-`docker-proxy` bug), and turns on a deployment circuit breaker for the autoscaling service so failed deploys surface instead of looping silently.

#### Design Decisions
- **Ephemeral host port instead of unique-per-deploy fixed ports.** Fixed ports would require coordinated state between Terraform and the Lambda; ephemeral ports let ECS arbitrate and we just resolve at register time. The cost is that every register/deregister site has to look up the real port — accepted because all such sites live in one Lambda.
- **Two distinct lookup helpers, not one.**
  - `get_host_port_for_instance` walks `EC2 → ECS container instance → task → networkBindings`. It polls because there is a window where `lastStatus == RUNNING` but `networkBindings` is still empty, and it filters bindings by `containerPort == 8000` (not by index) so a future second port mapping can't silently return the wrong entry.
  - `get_registered_port_for_instance` reads `describe_target_health` instead, because deregister paths run after the task is already gone — `describe_tasks` is no longer authoritative there.
- **Single-task-per-instance assumption is safe by construction.** Premium tasks are sized to consume essentially the whole instance, so there is never more than one studio task per host. "First RUNNING match" in the lookup is therefore unambiguous; no `startedAt` / family disambiguation needed.
- **Deregister in `_teardown_alb_resources` is now load-bearing, not hygiene.** With fixed ports a leaked target entry was at least traceable; with ephemeral ports a leak becomes untraceable after the next task replacement. The shared autoscaling target group (which we cannot delete) must therefore deregister this user's `instance:port` on release. The function gains an `instance_id` parameter and all three call sites pass it through.
- **Skip-on-not-found for deregister.** EC2 state-change events can race ahead and clean up the registration before the Lambda gets there. `get_registered_port_for_instance` raises `RuntimeError`, and the migrate / teardown paths catch it and log-and-skip rather than failing the whole release.
- **`stopTimeout = 120` paired with `ECS_CONTAINER_STOP_TIMEOUT=120s`.** ECS caps task-level `stopTimeout` to the host-level value, so both must move together or the task value is silently clamped. Cross-referenced both directions in comments.
- **Deployment circuit breaker on `autoscaling` only, not `premium`.** The premium service is pinned to dedicated instances and the `premium_manager` Lambda owns its lifecycle (instance assignment, ALB rules, target group state). An ECS-side rollback would fight the Lambda's view of state and risk leaving them out of sync. The autoscaling service is a standard rolling-deploy fleet where circuit breaker is exactly the right safety net.
- **Target-group `Port = CONTAINER_PORT`** is kept for clarity even though it is now only a default for unported registrations — every real registration passes the resolved ephemeral port.

### Evidence
- New unit test suite covers the happy path, the polling race, the multi-binding filter, max-attempts failure, the per-user vs shared TG teardown branches, the already-gone case, and the `AUTOSCALING_POOL` marker guard.

### References
- Related: rolling deploy failures observed when premium task replacement collided on host port 8000.

#### Files changed
- `infrastructure/scripts/ecs-user-data.sh` — set `ECS_CONTAINER_STOP_TIMEOUT=120s` on the host with a comment pointing back to the task-level value.
- `infrastructure/terraform/compute.tf` — switch premium and autoscaling task `hostPort` to `0`, add `stopTimeout = 120` to both task defs, and enable `deployment_circuit_breaker` on the autoscaling service.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — add `CONTAINER_PORT`, `get_host_port_for_instance`, and `get_registered_port_for_instance`; update every register/deregister call to resolve the real host port; extend `_teardown_alb_resources` with an `instance_id` parameter so the shared autoscaling target group can be deregistered cleanly.
- `studio/tests/infrastructure/test_premium_manager.py` — new `TestGetHostPortForInstance`, `TestGetRegisteredPortForInstance`, and `TestTeardownAlbResources` suites; patch `get_host_port_for_instance` in the existing `TestRoutingIdContract` fixtures so they continue to pass.

### Manual Testcases
- Operator: deploy the new task definition to a premium environment, then trigger a rolling task replacement. Expected: new task starts, old task drains within `stopTimeout`, no host-port collision in CloudWatch, ALB target group shows the new `instance:port` and the old entry is removed.
- Operator: assign a premium user via the Lambda. Expected: user's target group has exactly one healthy target on an ephemeral port (49152–65535), not 8000.
- Operator: release a premium user assigned to the shared autoscaling pool. Expected: the user's `instance:port` entry is removed from the shared autoscaling target group; the shared TG itself is preserved.
- Operator: simulate an EC2 state-change race by manually deregistering the target before calling release. Expected: release path logs "No registration to deregister..." and completes without error.
- `pytest studio/tests/infrastructure/test_premium_manager.py -- all tests pass`

### Unit, Integration, Contract Test Coverage
- Unit: ephemeral port resolution (happy path, polling race, multi-binding filter, max-attempts failure).
- Unit: registered port lookup (found, not found).
- Unit / contract: `_teardown_alb_resources` per-user TG branch, shared TG deregister branch, already-gone branch, `AUTOSCALING_POOL` marker branch.
- Existing routing-id contract suite patched to inject the new lookup so it continues to exercise the assign path end-to-end.

### Others

#### Difficulties (if any)
- The `networkBindings`-empty-while-`RUNNING` window is invisible from a one-shot `describe_tasks` call and only shows up under load; confirmed by the polling test.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Premium ALB register/deregister | Medium | All call sites updated and covered, but the lookup adds latency on assign and a new failure mode (`RuntimeError` after max attempts). Failure is loud, not silent. |
| Shared autoscaling target group cleanup | Medium | New deregister is load-bearing — a regression here would leak `instance:port` entries that are untraceable after the next task replacement. Covered by tests, but worth watching the shared TG target count after release. |
| Rolling deploy on premium tier | Low | This is the path the change is designed to fix. |
| Premium service (no circuit breaker) | Low | Intentional — premium lifecycle is Lambda-owned. |
| Host `ECS_CONTAINER_STOP_TIMEOUT` change | Low | Applied via user-data, takes effect on instance replacement. Must roll instances for the new value to apply. |
