### PR TITLE
Fix scheduler permissions

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -146,6 +146,11 @@ class PremiumInstanceConfig:
     INSTANCE_NAME_SUFFIX = "premium-running"
 
     @classmethod
+    def get_env_prefix(cls) -> str:
+        """Delegate to EnvironmentConfig.get_env_prefix for convenience."""
+        return EnvironmentConfig.get_env_prefix()
+
+    @classmethod
     def get_instance_name_pattern(cls) -> str:
         """Get the EC2 Name tag wildcard pattern for this environment.
 

--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -199,8 +199,7 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
         Resource = [
           aws_db_instance.main.arn,
           aws_db_proxy.main.arn,
-          # RestoreDBInstanceFromDBSnapshot requires access to the
-          # parameter group, subnet group, security group, and snapshot
+          aws_db_proxy_default_target_group.main.arn,
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:pg:${aws_db_parameter_group.main.name}",
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:subgrp:${aws_db_subnet_group.main.name}",
           "arn:aws:rds:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secgrp:${aws_security_group.rds.id}",


### PR DESCRIPTION
### Content

The development-dev-scheduler lambda is missing the rds:DescribeDBProxyTargets IAM permission, which causes ensure_rds_proxy_target to fail all 3 retries → the handler raises RuntimeError at the end of start_environment even though
everything else succeeded. 

 The IAM statement lists rds:DescribeDBProxyTargets / RegisterDBProxyTargets, but the Resource block only has
 aws_db_proxy.main.arn — those two actions act on the proxy target group ARN (...:target-group:prx-tg-...), not the proxy itself, so AWS denies them.

Fix: Add `aws_db_proxy_default_target_group.main.arn`
