### PR TITLE
premium manager permission issue

### DIFF
--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -397,11 +397,14 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           }
         }
       },
-      # EC2 CreateTags (unrestricted — needed by RunInstances TagSpecifications)
+      # EC2 CreateTags (needed by RunInstances TagSpecifications on instances and volumes)
       {
         Effect   = "Allow"
         Action   = "ec2:CreateTags"
-        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+        Resource = [
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
+        ]
       },
       # EC2 DeleteTags (scoped to ghost cleanup grace period tag only)
       {


### PR DESCRIPTION
### Content

Permission issue causing premium_manager assignment to fail. Found while testing #504 . See https://github.com/arayabrain/araya-optinist/pull/504#issuecomment-4222247984 for details. 