### PR TITLE
Fix issue where agent-recovery scripts cause problem with asg scaling

### DIFF
--- a/infrastructure/scripts/agent-recovery/watchdog.sh
+++ b/infrastructure/scripts/agent-recovery/watchdog.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Stale ECS agent watchdog — see AGENT_RECOVERY_ARCHITECTURE.md.
+# Premium: detects stale agent and runs in-place recovery (agent.db wipe).
+# Free/background: detection + heartbeat only; health probe triggers ASG replacement.
 #
 # Greps /var/log/ecs/ecs-agent.log* for known stale-agent error strings
 # within the last 5 minutes. On match, runs the documented manual
@@ -33,6 +35,7 @@ imds_get() {
 
 INSTANCE_ID=$(imds_get instance-id); INSTANCE_ID="${INSTANCE_ID:-unknown}"
 REGION="${AWS_REGION:-$(imds_get placement/region)}"
+TIER="${INSTANCE_TIER:-free}"
 SENTINEL=/var/run/agent-recovery/last-recovery
 # Probe-armed sentinel: written by health-probe.sh once it's seen
 # AgentConnected=true at least once on this boot. Used here to debounce the
@@ -147,32 +150,38 @@ if [ -z "$MATCH" ]; then
   exit 0
 fi
 
-# Rate-limit: max 1 recovery per hour per instance.
-if [ -f "$SENTINEL" ]; then
-  LAST=$(stat -c %Y "$SENTINEL" 2>/dev/null || echo 0)
-  NOW=$(date -u +%s)
-  if [ $((NOW - LAST)) -lt $RATE_LIMIT_SECONDS ]; then
-    emit_log "rate-limited match=\"$MATCH\""
-    exit 0
+# Premium: in-place recovery (agent.db wipe + restart). premium_manager
+# deregisters the old container instance, so no orphan is created.
+# Free/background: log only; health probe will mark Unhealthy for ASG replacement.
+if [ "$TIER" = "premium" ]; then
+  # Rate-limit: max 1 recovery per hour per instance.
+  if [ -f "$SENTINEL" ]; then
+    LAST=$(stat -c %Y "$SENTINEL" 2>/dev/null || echo 0)
+    NOW=$(date -u +%s)
+    if [ $((NOW - LAST)) -lt $RATE_LIMIT_SECONDS ]; then
+      emit_log "rate-limited match=\"$MATCH\""
+      exit 0
+    fi
   fi
-fi
 
-emit_log "match=\"$MATCH\" — running recovery sequence"
-
-# Documented manual recovery sequence — order matters.
-systemctl stop ecs || true
-docker rm -f ecs-agent 2>/dev/null || true
-rm -f /var/lib/ecs/data/agent.db
-# Clear the probe-armed sentinel: the restarted agent will go through its
+  emit_log "match=\"$MATCH\" — running recovery sequence"
+  # Documented manual recovery sequence — order matters.
+  systemctl stop ecs || true
+  docker rm -f ecs-agent 2>/dev/null || true
+  rm -f /var/lib/ecs/data/agent.db
+  # Clear the probe-armed sentinel: the restarted agent will go through its
 # own warmup, and the probe should re-arm only after observing it healthy.
-rm -f "$ARMED_FILE"
+  rm -f "$ARMED_FILE"
 
-# Only mark recovery successful if `systemctl start ecs` actually succeeded;
+  # Only mark recovery successful if `systemctl start ecs` actually succeeded;
 # otherwise the rate-limit sentinel would block retries for an hour.
-if systemctl start ecs; then
-  touch "$SENTINEL"
-  emit_log "recovery complete instance=$INSTANCE_ID"
+  if systemctl start ecs; then
+    touch "$SENTINEL"
+    emit_log "recovery complete instance=$INSTANCE_ID"
+  else
+    emit_log "recovery failed: systemctl start ecs returned $? — instance left without agent"
+    exit 1
+  fi
 else
-  emit_log "recovery failed: systemctl start ecs returned $? — instance left without agent"
-  exit 1
+  emit_log "stale-agent detected match=\"$MATCH\" — health probe will trigger ASG replacement"
 fi

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -12,7 +12,10 @@ echo ECS_INSTANCE_ATTRIBUTES='{"tier":"${tier}"}' >> /etc/ecs/ecs.config
 # Must be >= task-level stopTimeout (see compute.tf).
 echo ECS_CONTAINER_STOP_TIMEOUT=120s >> /etc/ecs/ecs.config
 
-# Systemd service to clear stale ECS agent checkpoint on every boot.
+# Premium: clear agent.db on boot so restarted instances re-register cleanly.
+# premium_manager handles deregistering the old container instance before stop.
+# Free/background: skip — ASG replacement is the recovery path.
+if [ "${tier}" = "premium" ]; then
 cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
 [Unit]
 Description=Clear stale ECS agent checkpoint before startup
@@ -30,6 +33,7 @@ UNIT_EOF
 
 systemctl daemon-reload
 systemctl enable ecs-clear-checkpoint.service
+fi
 
 # =====================================================================
 # Stale ECS agent watchdog + on-instance health probe
@@ -69,6 +73,7 @@ mkdir -p /opt/agent-recovery /var/run/agent-recovery /etc/agent-recovery
 # Region pinned from Terraform; sourced by the agent-recovery scripts.
 cat > /etc/agent-recovery/env << ENV_EOF
 AWS_REGION=${aws_region}
+INSTANCE_TIER=${tier}
 ENV_EOF
 chmod 0644 /etc/agent-recovery/env
 


### PR DESCRIPTION
#### Summary
- The v1.1.3 agent-recovery scripts (PR #503) applied the same `agent.db` wipe to all tiers. On free/background instances this creates orphaned container instance registrations (the old registration persists with `agentConnected=false`), which causes the `subscr-ecs-agent-disconnected` alarm to flap.
- Free/background instances are ASG-managed and fungible -- the correct recovery path is health-probe -> mark Unhealthy -> ASG replacement, not in-place agent.db wipe.
- This PR gates the destructive recovery actions (boot-time systemd unit and watchdog recovery sequence) to premium-only, where in-place recovery is necessary because instances carry user-specific state.

#### Design Decisions

##### Tier-gating in shared scripts vs. separate scripts per tier

The `ecs-user-data.sh` template and `watchdog.sh` are shared across all three tiers (free, premium, background) via Terraform `templatefile()`. Two options:

1. **Tier-gating in shared scripts** (chosen) -- single source of truth, conditional logic at the right layer. `ecs-user-data.sh` uses the Terraform `${tier}` variable (resolved at template render time). `watchdog.sh` reads `INSTANCE_TIER` from `/etc/agent-recovery/env` at runtime.
2. **Separate scripts per tier** -- eliminates conditionals but duplicates all shared logic (heartbeat, health probe setup, CloudWatch agent config). Any future change must be made in multiple places.

Option 1 is the clear winner. The conditionals are small and well-commented.

##### Safe default for INSTANCE_TIER

`watchdog.sh` defaults `TIER` to `free` when `INSTANCE_TIER` is unset (`${INSTANCE_TIER:-free}`). This means if the env file is missing or malformed, the watchdog will never attempt destructive recovery -- fail-safe by design.

##### Free/background watchdog still detects and logs

The watchdog on free/background instances still parses logs and emits a detection line on stale-agent match. This preserves the CloudWatch alarm signal. The only thing removed is the destructive action (stop ECS, wipe agent.db, restart). The health probe handles the actual recovery via ASG.

### Evidence
- Alarm flapping timeline (UTC, 2026-04-13): ALARM 07:01 -> OK 07:05 -> ALARM 07:14 -> OK 07:15 -> ALARM 07:16 -> OK 07:18
- Root cause: two container instances registered to the same EC2 host (`i-0d0463095ae10e599`) -- one stale (registered Apr 9, `agentConnected=false`), one healthy (registered Apr 13, `agentConnected=true`). The stale one was created by an `agent.db` wipe that orphaned the original registration.

### References
- arayabrain/araya-optinist#503 -- PR that introduced agent-recovery scripts (v1.1.3)
- `PLAN_free_orphan.md` -- full root-cause analysis and investigation notes

#### Files changed
- `infrastructure/scripts/ecs-user-data.sh` -- wrap `ecs-clear-checkpoint.service` (boot-time agent.db wipe) in `if [ "${tier}" = "premium" ]`; pass `INSTANCE_TIER=${tier}` to `/etc/agent-recovery/env`
- `infrastructure/scripts/agent-recovery/watchdog.sh` -- add tier-awareness via `INSTANCE_TIER` env var; gate destructive recovery sequence behind `if [ "$TIER" = "premium" ]`; free/background instances log detection only

### Manual Testcases
- [ ] On a free-tier instance: confirm `ecs-clear-checkpoint.service` does not exist (`systemctl status ecs-clear-checkpoint`)
- [ ] On a free-tier instance: confirm `/etc/agent-recovery/env` contains `INSTANCE_TIER=free`
- [ ] On a free-tier instance: simulate stale agent (`sudo systemctl stop ecs`, wait 6 min), confirm watchdog emits detection log but does NOT run recovery sequence
- [ ] On a free-tier instance: confirm health probe marks instance Unhealthy and ASG replaces it, leaving no orphaned container instance
- [ ] On a premium-tier instance: confirm `ecs-clear-checkpoint.service` is enabled and active
- [ ] On a premium-tier instance: confirm `/etc/agent-recovery/env` contains `INSTANCE_TIER=premium`
- [ ] On a premium-tier instance: confirm watchdog recovery sequence still runs (stop ECS, wipe agent.db, restart)

### Unit, Integration, Contract Test Coverage
No automated tests -- these are EC2 user-data scripts that run on instance boot. Verified by manual testcases above.

### Others

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Free/background tier | Low | Removes destructive action that was causing orphans; detection + health probe path is unchanged and was already working before v1.1.3 |
| Premium tier | Low | No behavioral change -- premium instances still get the full recovery sequence |
| Watchdog env file | Low | Safe default (`free`) means missing env gracefully degrades to no-op recovery |
