### PR TITLE
Docs: Premium manager assign flow, log flow, update

### DIFF
--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -1,12 +1,12 @@
-# Premium Manager Refactoring: Separation of Concerns
+# Premium Manager: Scaling, Cleanup, and Frontend Lifecycle
 
 ## Executive Summary
 
-- **Premium Manager** handles all compute and capacity decisions (scaling, instance management), plus infrastructure cleanup (ghost ECS registrations, orphaned EC2 instances)
-- **Premium Cleanup** handles data and resource hygiene (stale records, orphaned ALB resources, instance state reconciliation)
-- **Scheduled coordination** via staggered EventBridge rules: Manager every 15 minutes, Cleanup every 60 minutes, with no direct inter-Lambda communication
-- **Conservative scaling** keeps `active_users + 1` instances running and requires 2 idle instances before scaling down
-- **Frontend integration** provides auto-assignment on login, inactivity monitoring (1h warning, 2h release), and heartbeat-based activity tracking
+- **Premium Manager Lambda** handles compute and capacity decisions (scaling, instance start/stop), plus infrastructure cleanup (ghost ECS registrations, orphaned EC2 instances) on a 15-minute schedule, and serves real-time user assign/release/heartbeat APIs
+- **Premium Cleanup Lambda** handles data and resource hygiene (stale assignments, orphaned ALB resources, instance state reconciliation, standby-pool capacity) on a 60-minute schedule
+- **Separation of concerns**: only Manager starts or stops instances; only Cleanup mutates assignment rows and ALB resources. No direct inter-Lambda communication — coordination is through clean DB state
+- **Conservative scaling** keeps `max(1, active_users + 1)` instances running and requires `idle_instances >= 2` before stopping any
+- **Frontend integration** provides auto-assignment on login, inactivity monitoring (1h warning, 2h release), heartbeat-based activity tracking, and leader-tab polling while on a shared instance
 
 ---
 
@@ -99,6 +99,317 @@ graph TB
 
 ---
 
+## Premium User Lifecycle
+
+This section is the end-to-end view of what a single user sees and what the system does across one session, from login to release. It is the UX counterpart to the backend-heavy sections that follow -- the box-level flows under "Implementation Details" and the deep dive in "Premium Frontend Architecture" are the reference versions of the individual pieces called out here.
+
+Premium state is mounted for **all authenticated users** (`PremiumAssignmentProvider` wraps `AuthedLayout`), but every effect inside it gates on `isPremiumUser` before doing anything. Non-premium users therefore take the "inert provider" path with no API calls, no timers, and no toasts.
+
+`isPremiumUser` resolves to true when:
+
+```
+currentUser.subscription_plan_name === PlanName.PREMIUM
+  AND (subscription_status === PREMIUM OR subscription_status === LIMIT_GRACE)
+```
+
+### Sequence Overview
+
+High-level flow between the user's browser, the leader tab's background polling, and the premium Lambda:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Tab as Browser Tab
+    participant Leader as Leader Tab (poll loop)
+    participant API as Premium Manager Lambda
+
+    User->>Tab: Log in
+    Tab->>Tab: Resolve isPremiumUser
+    alt Not premium
+        Tab-->>User: No premium effects run
+    else Premium
+        Tab->>API: GET /users/me/premium/status
+        alt Already assigned
+            API-->>Tab: existing assignment
+        else Not assigned
+            Tab->>API: POST /users/me/premium/assign
+            API-->>Tab: { assigned, is_shared, scaling_in_progress?, retry_after? }
+        end
+        Tab->>API: GET /users/me/premium/beacon-token
+        alt Dedicated
+            Tab-->>User: "Premium instance assigned" (success, 5s)
+        else Shared / scaling / retry
+            Tab-->>User: "Please wait..." (info, persistent)
+            loop Until dedicated, max 40 attempts (leader tab only)
+                Leader->>API: POST /assign (backoff 30s -> 60s, x1.5)
+                API-->>Leader: assignment or still shared
+            end
+            Leader-->>User: "Premium instance assigned" (success) on promotion
+        end
+
+        loop Every 30s while assigned
+            Tab->>Tab: Check idle time (this tab + cross-tab activity)
+        end
+        Tab-->>User: After 1h idle: InactivityWarning snackbar (60-min countdown)
+        alt "Stay Active" clicked
+            Tab->>API: POST /users/me/premium/heartbeat (up to 3 tries: 1s, 2s)
+            API-->>Tab: 200 -> dismiss warning
+        else Heartbeat returns 401
+            Tab-->>User: "Session Expired" (error), logout in 2s
+        else 2h idle reached
+            Tab->>API: DELETE /users/me/premium/assign
+        end
+
+        Note over Tab,API: On beforeunload: navigator.sendBeacon -> /premium/release-beacon
+    end
+```
+
+### Detailed ASCII Flow
+
+The authoritative reference. Branches are explicit; toast text matches the strings emitted by `PremiumNotificationManager`.
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ 1. User logs in; AuthedLayout mounts PremiumAssignmentProvider         │
+│    - Provider mounts for EVERY authenticated user                      │
+│    - All internal effects gate on isPremiumUser before running         │
+└────────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+                ┌──────────────────────────────────┐
+                │ isPremiumUser ?                  │
+                │  (plan=PREMIUM AND status in     │
+                │   {PREMIUM, LIMIT_GRACE})        │
+                └──────────────────────────────────┘
+                        │                   │
+                     NO │                   │ YES
+                        ▼                   ▼
+         ┌──────────────────────┐   ┌──────────────────────────────────┐
+         │ Inert path:          │   │ 2. Leader election starts        │
+         │  - no API calls      │   │    (localStorage-backed,         │
+         │  - no timers         │   │     2s heartbeat, 5s timeout)    │
+         │  - no toasts         │   │ 3. useEffect fires:              │
+         │  Provider is mounted │   │    autoAssignOnLogin()           │
+         │  but does nothing    │   └──────────────────────────────────┘
+         └──────────────────────┘                   │
+                                                    ▼
+                ┌───────────────────────────────────────────────────────┐
+                │ 4. hasAttemptedAutoAssignment flag check              │
+                │    (useRef backed by sessionStorage:                  │
+                │     "premium_hasAttempted")                           │
+                │    - Set immediately to prevent re-entry              │
+                │    - Cleared only on user-id change or logout         │
+                └───────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+                ┌───────────────────────────────────────────────────────┐
+                │ 5. GET /users/me/premium/status                       │
+                └───────────────────────────────────────────────────────┘
+                        │                                     │
+             assignment exists                        no assignment
+                        │                                     │
+                        ▼                                     ▼
+     ┌─────────────────────────────────┐   ┌─────────────────────────────────┐
+     │ 6a. Adopt existing assignment   │   │ 6b. POST /users/me/premium/     │
+     │     - convert PremiumAssignment │   │       assign                    │
+     │       -> PremiumAssignmentResult│   │     Lambda returns one of:      │
+     │     - set assignmentResult      │   │      - dedicated (is_shared=F)  │
+     │     - GET beacon-token          │   │      - shared    (is_shared=T)  │
+     │     - persist attempted flag    │   │      - not assigned +           │
+     │                                 │   │        scaling_in_progress      │
+     │                                 │   │      - not assigned +           │
+     │                                 │   │        retry_after              │
+     │                                 │   │      - hard error               │
+     │                                 │   │     Then GET beacon-token       │
+     │                                 │   │       (stored in ref for        │
+     │                                 │   │        sendBeacon on unload)    │
+     └─────────────────────────────────┘   └─────────────────────────────────┘
+                        │                                     │
+                        └──────────────────┬──────────────────┘
+                                           ▼
+                ┌───────────────────────────────────────────────────────┐
+                │ 7. Branch on result                                   │
+                └───────────────────────────────────────────────────────┘
+        ┌──────────────────┬───────────────────┬──────────────────────┐
+        │                  │                   │                      │
+     DEDICATED          SHARED           RETRYABLE ERROR         HARD ERROR
+  (assigned=true,   (assigned=true,      (assigned=false,      (assigned=false,
+   is_shared=false)  is_shared=true)      retry_after          no retry_after,
+                                          OR scaling_in_        no scaling_in_
+                                          progress)             progress)
+        │                  │                   │                      │
+        ▼                  ▼                   ▼                      ▼
+┌──────────────┐   ┌──────────────┐   ┌──────────────────┐   ┌──────────────────┐
+│ success toast│   │ info toast   │   │ info toast       │   │ warning toast    │
+│ "Premium     │   │ "Please wait │   │ (same "Please    │   │ "Premium         │
+│  instance    │   │  while your  │   │  wait..." copy   │   │  assignment      │
+│  assigned    │   │  dedicated   │   │  -- suppressed   │   │  issue: {err}.   │
+│  successfully│   │  premium     │   │  error path via  │   │  Falling back to │
+│  You now have│   │  resource is │   │  isRetryableError│   │  shared          │
+│  dedicated   │   │  being       │   │  flag; NO        │   │  resources."     │
+│  compute     │   │  prepared."  │   │  warning toast   │   │                  │
+│  resources." │   │              │   │  is shown)       │   │ auto-dismiss 10s │
+│              │   │ persist:true │   │                  │   │                  │
+│ 5s dismiss   │   │              │   │ persist:true     │   │ assignmentResult │
+└──────────────┘   └──────────────┘   └──────────────────┘   │ stays null;      │
+        │                  │                   │             │ polling does NOT │
+        │                  └─────────┬─────────┘             │ start            │
+        │                            │                       └──────────────────┘
+        │                            ▼
+        │               ┌─────────────────────────────────────┐
+        │               │ 8. Leader tab begins polling loop   │
+        │               │    (non-leader tabs skip step 8)    │
+        │               │                                     │
+        │               │    POST /premium/assign repeatedly  │
+        │               │    - initial delay: 30 000 ms       │
+        │               │    - backoff multiplier: 1.5        │
+        │               │    - error backoff: 2.0             │
+        │               │    - cap: 60 000 ms                 │
+        │               │    - max attempts: 40               │
+        │               │                                     │
+        │               │    On response:                     │
+        │               │     - dedicated -> go to step 9     │
+        │               │     - still shared/retry -> loop    │
+        │               │     - attempts >= 40 -> stop and    │
+        │               │       set error: "No premium        │
+        │               │       instance available after      │
+        │               │       extended wait. Please try     │
+        │               │       again later or contact        │
+        │               │       support."                     │
+        │               └─────────────────────────────────────┘
+        │                                │
+        │                                ▼
+        │               ┌─────────────────────────────────────┐
+        │               │ 9. Promotion shared -> dedicated    │
+        │               │    - update assignmentResult        │
+        │               │    - reset poll state (attempts=0,  │
+        │               │      interval=30s)                  │
+        │               │    - notification manager fires     │
+        │               │      success toast (same copy as    │
+        │               │      step 7 dedicated branch)       │
+        │               └─────────────────────────────────────┘
+        │                                │
+        └────────────────┬───────────────┘
+                         ▼
+   ┌──────────────────────────────────────────────────────────────────────┐
+   │ 10. Steady state: inactivity monitor running                         │
+   │     - setInterval 30 000 ms                                          │
+   │     - idle = now - max(local lastActivity,                           │
+   │                        localStorage "premium_last_activity")         │
+   │     - recordActivity() writes both and sends heartbeat to server     │
+   │     - heartbeat retries up to 3 total attempts with 1s then 2s       │
+   │       delays between attempts (no 3rd delay; final failure surfaces) │
+   │     - any activity in any tab dismisses an open InactivityWarning    │
+   └──────────────────────────────────────────────────────────────────────┘
+                         │
+              ┌──────────┼───────────┐
+              ▼          ▼           ▼
+         < 1h idle    >= 1h      >= 2h idle
+              │          │           │
+              │          ▼           ▼
+              │  ┌───────────────┐  ┌─────────────────────────────────┐
+              │  │ InactivityWar │  │ autoReleaseOnLogout()           │
+              │  │ ning snackbar │  │  - if beacon token present:     │
+              │  │ (top/center,  │  │      navigator.sendBeacon to    │
+              │  │  severity=    │  │      /premium/release-beacon    │
+              │  │  warning)     │  │  - else:                        │
+              │  │ 60-min        │  │      DELETE /premium/assign     │
+              │  │ countdown,    │  │  - clear assignmentResult,      │
+              │  │ 1-min updates │  │    warning, beacon token        │
+              │  │               │  └─────────────────────────────────┘
+              │  │ "Stay Active":│
+              │  │  recordActiv- │
+              │  │  ity() then   │
+              │  │  dismiss      │
+              │  │               │
+              │  │ 401 from      │
+              │  │ heartbeat ->  │
+              │  │ severity=     │
+              │  │ error,        │
+              │  │ "Session      │
+              │  │  Expired",    │
+              │  │ performLogout │
+              │  │ after 2s      │
+              │  └───────────────┘
+              │
+              ▼
+   (loop continues)
+
+   ───────────────────────────────────────────────────────────────────────
+   Cross-cutting: browser close (window 'beforeunload')
+   ───────────────────────────────────────────────────────────────────────
+     If isPremiumUser && currentUser && beacon token is cached:
+        navigator.sendBeacon(
+          BASE_URL + "/users/me/premium/release-beacon",
+          Blob({ token }, "text/plain"))
+     - Fire-and-forget; survives tab close
+     - Backend path differs from the authed DELETE: no session required,
+       token is the authorization material
+```
+
+### What Each Step Maps To
+
+| Step | Code reference |
+|------|----------------|
+| `isPremiumUser` resolution | `PremiumAssignmentContext.tsx` -- subscription_plan_name + subscription_status check |
+| Auto-assign trigger | `PremiumAssignmentContext.tsx` -- `useEffect` on `isPremiumUser && currentUser` |
+| `hasAttemptedAutoAssignment` | `useRef` seeded from `sessionStorage["premium_hasAttempted"]`; cleared on user-id change or logoutGeneration change |
+| Status then assign then beacon-token | `autoAssignOnLogin()` in `PremiumAssignmentContext.tsx` |
+| Shared vs dedicated branch | `is_shared` field on `PremiumAssignmentResult` |
+| Retryable vs hard error | `isRetryableError = !result.assigned && (result.scaling_in_progress || result.retry_after != null)` |
+| Toast strings and variants | `PremiumNotificationManager.tsx` |
+| Leader-tab election | `frontend/src/utils/crossTabSync.ts` -- localStorage key `"premium_poll_leader"`, 2s heartbeat, 5s timeout |
+| Poll config | constants in `PremiumAssignmentContext.tsx`: `INITIAL_POLL_INTERVAL_MS=30000`, `MAX_POLL_INTERVAL_MS=60000`, `MAX_POLL_ATTEMPTS=40`, `BACKOFF_MULTIPLIER=1.5`, `ERROR_BACKOFF_MULTIPLIER=2` |
+| Inactivity thresholds | 1h/2h hardcoded in context; countdown length `INACTIVITY_WARNING_DURATION_MINUTES=60` and `WARNING_UPDATE_INTERVAL_MS=60000` from `frontend/src/const/Subscription.ts` |
+| Heartbeat retry | `HEARTBEAT_MAX_RETRIES=3`, `HEARTBEAT_RETRY_DELAY_MS=1000`; delay between attempts is `DELAY * (attempt + 1)` |
+| 401 session-expired UI | `InactivityWarning.tsx` -- AxiosError + status 401 path, 2 s setTimeout then `performLogout()` |
+| beforeunload beacon | `PremiumAssignmentContext.tsx` beforeunload effect; endpoint `/users/me/premium/release-beacon` |
+| Cross-tab activity sync | `frontend/src/utils/crossTabSync.ts` -- localStorage key `"premium_last_activity"` |
+
+### Reverse Reference: Symptom -> State -> Cause
+
+The flows above read top-to-bottom: login in, state out. When debugging, developers usually start from the other end -- a user is seeing X right now, so what state must the system be in, and what conditions put it there? This subsection is that reverse index.
+
+**First, clarify what "shared" means.** A premium user can occupy one of four distinct states. The toast copy collapses the last three into a single "please wait" message, but they are different at the data layer and worth keeping separate when debugging.
+
+| State (DB `premium_user_assignments` row) | What the user sees | What it means |
+|---|---|---|
+| `instance_id = i-xxxx, is_shared = false` | Dedicated success toast | Normal dedicated: the user is the sole premium assignment on that EC2 instance |
+| `instance_id = i-xxxx, is_shared = true` | Persistent "please wait..." info toast; leader tab polling | Routed to a **real premium EC2 instance that is already hosting at least one other premium user** (the Lambda picked the least-loaded running instance). Not the non-premium ASG. Uniqueness is per-user, not per-instance -- multiple users can share the same premium EC2 |
+| `instance_id = "autoscaling-pool"` (sentinel) | Persistent "please wait..." info toast; leader tab polling | Fallback marker used when no running premium instance was available at assign time and scaling has been triggered. Routes via a shared ALB target group; will be migrated to a real instance once one comes up |
+| No row | Either (a) no premium effects at all (inert provider path), or (b) a transient `warning` toast "Premium assignment issue: {err}. Falling back to shared resources." that auto-dismisses after 10s, then nothing; `assignmentResult` stays null either way | (a) user is not premium, so the assignment flow never ran; (b) `/assign` returned a hard error (no `retry_after`, no `scaling_in_progress`), so `isRetryableError` is false and polling does not start |
+
+Two premium users **can** share the same dedicated-class EC2 -- the uniqueness constraint is `(user_id)`, not `(instance_id)`. The `is_shared` flag records whether that happened at assign time; it does not guarantee exclusivity once set to false.
+
+**Symptom -> state -> cause table.** Read left to right when debugging. "Implied state" is what you can conclude from the symptom alone; "upstream cause" is what put the system there.
+
+| Observed symptom | Implied state | Upstream cause |
+|---|---|---|
+| No toasts, no premium effects, no network calls to `/premium/*` | Inert provider path | `isPremiumUser` is false -- either `subscription_plan_name != PREMIUM`, or `subscription_status` is neither `PREMIUM` nor `LIMIT_GRACE` |
+| Console warn "Conditions not met for auto-assignment" | Provider mounted but gate failed | `currentUser` null at mount time, or `isPremiumUser` flipped false between mount and the useEffect firing |
+| Success toast "Premium instance assigned successfully..." at login | `/assign` returned `assigned=true, is_shared=false` on first call, OR `/status` found an existing dedicated assignment | A dedicated instance had zero active assignments at assign time and was picked up; or the user already had a live assignment from a prior session that survived in DB (cleanup hadn't run) |
+| Persistent info toast "Please wait while your dedicated premium resource is being prepared." from login, no success toast follows | `assignmentResult.assigned=true && is_shared=true`, OR response was 202 with `retry_after`, OR `/assign` returned an `autoscaling-pool` assignment | No premium instance had spare capacity at assign time: either (a) all running instances already have users so the least-loaded was picked (is_shared=true on a real instance), (b) scaling was initiated and the Lambda returned 202+retry_after, or (c) launching instances exist and response is 202 |
+| Info toast is showing AND the tab is the leader AND poll attempts are incrementing | Leader-tab polling loop is live: re-POSTing `/assign` on exponential backoff | User is on shared / autoscaling-pool / retry state; poll will promote to dedicated once any premium instance frees up or finishes launching |
+| Info toast is showing AND no polling is happening in any tab | Shared state with polling suppressed | Either (a) `assignmentResult` is null so the `state.assignmentResult != null` gate blocks polling -- this is the hard-error path, or (b) no tab has won leader election (storage unavailable / all tabs closed simultaneously) |
+| Info toast persists for more than ~30 minutes with no promotion | Polling capped out, or backend has no capacity to give | `MAX_POLL_ATTEMPTS=40` at capped 60s interval is roughly 30-40 minutes of wall time. Upstream: premium ASG cannot scale further (instance quota, scaling lock stuck, ghost ECS registrations consuming slots) |
+| Error toast "No premium instance available after extended wait..." | Polling loop stopped after exceeding 40 attempts | Same as above, but the loop has now given up; user will not auto-retry without a new login or re-mount |
+| Warning toast "Premium assignment issue: {err}. Falling back to shared resources." | `/assign` returned `assigned=false` with **no** `retry_after` and no `scaling_in_progress` | Hard error from Lambda: scaling lock held + no launching instances, or an exception inside `assign_premium_user()`. `isRetryableError` is false so `assignmentResult` stays null and polling never starts |
+| Two users on the same EC2 instance (DB shows same `instance_id`) with different `is_shared` values | Expected. One user was assigned first and became the dedicated owner (`is_shared=false`); a later user found no idle instance and was placed on the same one with `is_shared=true` | Premium ASG was at capacity when the second user logged in; Manager's 15-min monitor will scale up if `running < active_users + 1` |
+| User row has `instance_id = "autoscaling-pool"` | User is routed via the shared ALB target group, not a per-user target group | Lambda saw `running_instances == 0 && launching_instances == 0` (or a migration-retry scenario). Scaling was triggered; a follow-up `/assign` (either from polling or from the migration path) will move them to a real instance |
+| InactivityWarning snackbar appears | `now - max(local lastActivity, cross-tab lastActivity) >= 1h` inside the 30s-tick inactivity monitor | User has been idle for at least one hour **in every tab**; cross-tab sync would have cleared the warning otherwise |
+| InactivityWarning appears even though the user was typing | Cross-tab activity sync failed | `localStorage["premium_last_activity"]` not being written (storage disabled / quota / private-mode). Record-activity path does run locally, so only the *multi-tab* case is vulnerable |
+| "Session Expired" error snackbar with 2s auto-logout | Heartbeat hit 401 inside `recordActivity()` path | Server session expired (cookie gone / revoked / backend logout). Frontend state catches the AxiosError, switches Alert to error, and calls `performLogout()` |
+| Heartbeat retries visible in network tab (1s then 2s gaps) then final 5xx | Final heartbeat failure | Premium Lambda `/heartbeat` unavailable or ALB is routing the user to a dead instance; `heartbeatFailing` state is set |
+| User is released but never saw a toast | `autoReleaseOnLogout()` fired silently -- either 2h-idle trigger or `beforeunload` beacon | Frontend inactivity monitor hit 2h threshold, or user closed the tab (sendBeacon is fire-and-forget, no UI). If neither, the backend cleanup Lambda (3h `PREMIUM_IDLE_TIMEOUT_HOURS`) removed a stale row |
+| User logs back in after a crash and immediately gets dedicated | `/status` returned an existing assignment on the fresh tab | Assignment survived in DB because no release path ran (sendBeacon missed / 2h not reached / cleanup 3h window not elapsed). `hasAttemptedAutoAssignment` was in sessionStorage on the old tab only, so the new tab re-runs status and adopts the row |
+| On a fresh tab `hasAttemptedAutoAssignment` is false but no re-assign fires on refresh | Flag survived via `sessionStorage` within the same tab | Refresh preserves sessionStorage; re-open in a new tab resets it. If you want to force re-attempt, change user id or bump logoutGeneration |
+| Both tabs appear to poll simultaneously | Leader-election race or stale leader token | `localStorage` events dropped (rare); or system clock skew made the 5s timeout misfire. Each tab re-elects every `storage` event -- the losing tab will drop within 2s |
+
+A small caveat on one field: `scaling_in_progress` exists on the frontend `PremiumAssignmentResponse` type and is checked inside `isRetryableError`, but the backend `/assign` endpoint does not populate it in the JSON body today -- it is an internal CloudWatch-metric-backed lock used by the scheduled monitor (`is_premium_scaling_in_progress()` in `premium_manager.py`). In practice, `retry_after` is what drives the retryable branch for `/assign` callers.
+
+---
+
 ## Implementation Details
 
 ### 1. Premium Manager
@@ -111,8 +422,9 @@ The `handler()` function routes events based on type:
 
 | Event Type | Route | Description |
 |---|---|---|
-| `{"action": "migrate_shared_users"}` | `_handle_migrate_shared_users()` | Async migration under distributed lock |
+| `{"action": "migrate_shared_users"}` | `_handle_migrate_shared_users()` | Async migration under MySQL `GET_LOCK` |
 | `{"action": "fix_shared_flags"}` | `fix_incorrect_is_shared_flags()` | One-time data cleanup |
+| `{"action": "cleanup_all_dynamic"}` | `cleanup_all_dynamic_instances()` | Tear down all dynamically-provisioned premium instances (dev scheduler before environment stop) |
 | CloudWatch Scheduled Event | `handle_scheduled_monitoring()` | 15-min monitoring cycle |
 | `GET` (API Gateway) | `get_premium_user_status()` | Status check |
 | `POST action=assign` | `assign_premium_user()` | User assignment |
@@ -121,22 +433,27 @@ The `handler()` function routes events based on type:
 
 #### Scheduled Monitoring: `handle_scheduled_monitoring()`
 
-Runs every 15 minutes. Performs these operations in order:
+Runs every 15 minutes. Step numbering matches the comments in the source. Some step numbers (8, 10) bundle related sub-operations:
 
 ```
-1.  Check scaling lock (prevent concurrent operations)
-2.  Set scaling lock
-3.  Get current state (active users, running instances, idle instances)
-4.  Publish CloudWatch metrics
-5.  scale_down_if_possible() - Stop idle instances
-6.  update_premium_service_desired_count() - Sync ECS desired count
-7.  cleanup_failed_standby_instances() - Remove DB entries for terminated instances
-8.  cleanup_ghost_ecs_registrations() - Deregister orphaned ECS container instances
-9.  cleanup_orphaned_ec2_instances() - Stop EC2 instances not in ECS cluster
-10. process_shared_instance_optimization() - Migrate shared users to dedicated instances
+1.   Check scaling lock (skip run if another operation in progress)
+2.   Set scaling lock
+3.   Get current state (active users, total users, running + idle instance counts)
+4.   Publish CloudWatch metrics
+5.   scale_down_if_possible()              - Stop idle instances
+6.   update_premium_service_desired_count() - Sync ECS desired count to running count
+7.   cleanup_failed_standby_instances()    - Remove DB rows for terminated standbys
+8a.  register_orphaned_stopped_instances() - Re-register stopped instances missing from DB
+8b.  terminate_aged_stopped_instances()    - Terminate standbys stopped longer than PREMIUM_STOPPED_MAX_AGE_HOURS
+9.   cleanup_excess_standby_instances()    - Trim standby pool to PREMIUM_STANDBY_POOL_SIZE
+10a. finalize_expired_pending_releases()   - Tear down ALB resources for assignments past soft-release grace
+10b. cleanup_ghost_ecs_registrations()     - Deregister ECS container instances whose EC2 is gone
+11.  cleanup_orphaned_ec2_instances()      - Stop premium-tagged EC2 not in the ECS cluster (15-min grace)
+12.  fix_incorrect_is_shared_flags() then
+     process_shared_instance_optimization() - Promote shared users to dedicated, or fire invoke_migration_async() if none free
 ```
 
-Always clears scaling lock in `finally` block, even on error.
+The scaling lock is always cleared in the `finally` block, even on error.
 
 #### scale_down_if_possible()
 
@@ -185,7 +502,8 @@ The `handler()` function supports both scheduled and manual invocations:
 | `{"action": "get_user_assignment", "user_email": "..."}` | `get_user_assignment()` | Look up user assignment |
 | `{"action": "migrate_user", "user_email": "...", "target_instance_id": "..."}` | `migrate_user()` | Migrate user to different instance |
 | `{"action": "get_instance_users", "instance_id": "..."}` | `get_assigned_users_for_instance()` | List users on a specific instance |
-| `{"action": "reconcile"}` | `reconcile_instance_states()` | Manual reconciliation trigger |
+| `{"action": "reconcile"}` | `reconcile_instance_states()` | Manual full-fleet reconciliation |
+| `{"action": "reconcile_instance", "instance_id": "..."}` | `reconcile_single_instance()` | Targeted reconciliation for one instance (invoked from the EC2 state-change EventBridge rule) |
 | Scheduled (default) | Normal cleanup flow | 5-step cleanup process |
 
 #### Scheduled Cleanup Flow
@@ -303,42 +621,42 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 ┌──────────────────────────────────────────────────────────┐
 │ 3-4. Get State & Publish Metrics                         │
 │    → Count active users, running instances, idle         │
-│    → Publish to CloudWatch OptiNiSt/PremiumManager      │
+│    → Publish to OptiNiSt/PremiumManager/{env_prefix}     │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 5. scale_down_if_possible()                              │
-│    → Stop idle instances if conditions are met           │
-│    → Deregister from ECS before stopping                 │
+│ 5-6. Scaling                                             │
+│    → scale_down_if_possible() (deregisters ECS first)    │
+│    → update_premium_service_desired_count()              │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 6. update_premium_service_desired_count()                │
-│    → Sync ECS desired count with running instances       │
+│ 7-9. Standby pool hygiene                                │
+│    → cleanup_failed_standby_instances()                  │
+│    → register_orphaned_stopped_instances()               │
+│    → terminate_aged_stopped_instances()                  │
+│    → cleanup_excess_standby_instances()                  │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 7. cleanup_failed_standby_instances()                    │
-│    → Remove DB entries for terminated standby instances  │
+│ 10. Pending-release + ghost ECS cleanup                  │
+│    → finalize_expired_pending_releases()                 │
+│      tears down ALB resources for soft-released users    │
+│    → cleanup_ghost_ecs_registrations()                   │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 8. cleanup_ghost_ecs_registrations()                     │
-│    → Deregister ECS container instances where agent is   │
-│       disconnected or EC2 is stopped/terminated          │
-└──────────────────────────────────────────────────────────┘
-                         ↓
-┌──────────────────────────────────────────────────────────┐
-│ 9. cleanup_orphaned_ec2_instances()                      │
-│    → Stop premium-tagged EC2 instances not in ECS        │
+│ 11. cleanup_orphaned_ec2_instances()                     │
+│    → Stop premium-tagged EC2 not in ECS                  │
 │    → 15-minute grace period for booting instances        │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
-│ 10. process_shared_instance_optimization()               │
-│    → Find users on shared instances                      │
-│    → Migrate to dedicated if instances available         │
-│    → Trigger async migration if no instances ready       │
+│ 12. Shared-instance optimization                         │
+│    → fix_incorrect_is_shared_flags() (safety net)        │
+│    → process_shared_instance_optimization() promotes     │
+│      users to dedicated when instances are ready         │
+│    → invoke_migration_async() if none ready              │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
@@ -461,16 +779,16 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 | `IdleInstances` | Running instances with 0 assignments | Count |
 | `ScalingInProgress` | Lock to prevent concurrent operations | None (0 or 1) |
 
-**Namespace:** `OptiNiSt/PremiumManager`
+**Namespace:** `OptiNiSt/PremiumManager/{env_prefix}` where `env_prefix` is the Terraform `environment` variable (e.g. `staging`, `prod`).
 
 ### CloudWatch Logs
 
 **Premium Manager:**
-- `/aws/lambda/subscr-premium-manager`
+- `/aws/lambda/{env_prefix}-premium-manager`
 - Retention: 30 days
 
 **Premium Cleanup:**
-- `/aws/lambda/subscr-premium-cleanup`
+- `/aws/lambda/{env_prefix}-premium-cleanup`
 - Retention: 30 days
 
 ---
@@ -481,84 +799,100 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 **Premium Manager:**
 ```bash
+# Environment
+ENV_PREFIX                    # Prefix applied to dynamic resource names and metric namespace
+
 # Network / ALB
-VPC_ID                       # VPC ID for target group creation
-SUBNET_IDS                   # Comma-separated subnet IDs
-SECURITY_GROUP_ID            # ECS security group
-ALB_ARN                      # Application Load Balancer ARN
-ALB_LISTENER_ARN             # ALB HTTPS listener ARN
-ALB_DNS_NAME                 # ALB DNS name
-AUTOSCALING_TARGET_GROUP_ARN # Shared autoscaling target group ARN
+VPC_ID                        # VPC ID for target group creation
+SUBNET_IDS                    # Comma-separated subnet IDs
+SECURITY_GROUP_ID             # ECS security group
+ALB_ARN                       # Application Load Balancer ARN
+ALB_LISTENER_ARN              # ALB HTTPS listener ARN
+ALB_DNS_NAME                  # ALB DNS name (used for internal API callbacks)
+AUTOSCALING_TARGET_GROUP_ARN  # Shared autoscaling target group ARN
 
 # Compute
-PREMIUM_INSTANCE_IDS         # Comma-separated EC2 instance IDs
-PREMIUM_LAUNCH_TEMPLATE_ID   # Launch template for creating instances
-CLUSTER_NAME                 # ECS cluster name
-PREMIUM_SERVICE_NAME         # ECS service name for premium tier
+PREMIUM_INSTANCE_IDS          # Comma-separated base EC2 instance IDs
+PREMIUM_LAUNCH_TEMPLATE_ID    # Launch template for creating dynamic instances
+PREMIUM_INSTANCE_TYPE         # EC2 instance type for dynamically-created premium instances
+CLUSTER_NAME                  # ECS cluster name
+PREMIUM_SERVICE_NAME          # ECS service name for premium tier
 
 # Database
-RDS_HOST                     # Database endpoint (via RDS Proxy)
-RDS_USER                     # Database username
-RDS_PASSWORD                 # Database password
-RDS_DATABASE                 # Database name
+RDS_HOST                      # Database endpoint (via RDS Proxy)
+RDS_USER                      # Database username
+RDS_PASSWORD                  # Database password
+RDS_DATABASE                  # Database name
 
 # Security
-ROUTING_SECRET_KEY           # HMAC secret for generating routing IDs
-INTERNAL_API_SECRET          # Secret for internal API authentication
+ROUTING_SECRET_KEY            # HMAC secret for generating routing IDs
+INTERNAL_API_SECRET           # Secret for internal API authentication
 
 # Capacity tuning
-PREMIUM_STANDBY_POOL_SIZE    # Standby instances to maintain (default: 1)
-PREMIUM_EXTRA_CAPACITY       # Extra capacity buffer for scaling (default: 2, Terraform: 1)
+PREMIUM_STANDBY_POOL_SIZE     # Standby instances to maintain (Terraform: 1)
+PREMIUM_EXTRA_CAPACITY        # Extra capacity buffer for scaling (Terraform: 1)
+PREMIUM_STOPPED_MAX_AGE_HOURS # Terminate stopped standby instances older than this (Terraform: 4)
 
 # Set in Terraform but only read by Cleanup Lambda:
-# PREMIUM_IDLE_TIMEOUT_HOURS # (Terraform: 3, not read by Manager code)
+# PREMIUM_IDLE_TIMEOUT_HOURS  # (Terraform: 3, not read by Manager code)
 ```
 
 **Premium Cleanup:**
 ```bash
+# Environment
+ENV_PREFIX                    # Prefix applied to dynamic resource names
+
 # Network / ALB
-VPC_ID                       # VPC ID
-SUBNET_IDS                   # Comma-separated subnet IDs
-SECURITY_GROUP_ID            # ECS security group
-ALB_ARN                      # Application Load Balancer ARN
-ALB_LISTENER_ARN             # ALB HTTPS listener ARN
+VPC_ID                        # VPC ID
+SUBNET_IDS                    # Comma-separated subnet IDs
+SECURITY_GROUP_ID             # ECS security group
+ALB_ARN                       # Application Load Balancer ARN
+ALB_LISTENER_ARN              # ALB HTTPS listener ARN
 
 # Compute
-PREMIUM_INSTANCE_IDS         # Comma-separated EC2 instance IDs
-PREMIUM_LAUNCH_TEMPLATE_ID   # Launch template ID
-CLUSTER_NAME                 # ECS cluster name
-PREMIUM_SERVICE_NAME         # ECS service name
+PREMIUM_INSTANCE_IDS          # Comma-separated base EC2 instance IDs
+PREMIUM_LAUNCH_TEMPLATE_ID    # Launch template ID
+CLUSTER_NAME                  # ECS cluster name
+PREMIUM_SERVICE_NAME          # ECS service name
 
 # Database
-RDS_HOST                     # Database endpoint (via RDS Proxy)
-RDS_USER                     # Database username
-RDS_PASSWORD                 # Database password
-RDS_DATABASE                 # Database name
+RDS_HOST                      # Database endpoint (via RDS Proxy)
+RDS_USER                      # Database username
+RDS_PASSWORD                  # Database password
+RDS_DATABASE                  # Database name
 
 # Cleanup tuning
-PREMIUM_IDLE_TIMEOUT_HOURS   # Hours before stale assignment cleanup (code default: 2, Terraform: 3)
+PREMIUM_IDLE_TIMEOUT_HOURS    # Hours before stale assignment cleanup (code default: 2, Terraform: 3)
 ```
 
 ### Triggers
 
-| Lambda          | Trigger              | Frequency        | EventBridge Rule                  |
-|-----------------|----------------------|------------------|-----------------------------------|
-| Premium Manager | Scheduled monitoring | Every 15 minutes | `subscr-premium-manager-schedule` |
-| Premium Manager | User assign/release  | On-demand (API)  | N/A                               |
-| Premium Cleanup | Scheduled cleanup    | Every 60 minutes | `subscr-premium-cleanup-schedule` |
+| Lambda          | Trigger              | Frequency        | EventBridge Rule                       |
+|-----------------|----------------------|------------------|----------------------------------------|
+| Premium Manager | Scheduled monitoring | Every 15 minutes | `{env_prefix}-premium-manager-schedule` |
+| Premium Manager | User assign/release  | On-demand (API)  | N/A                                    |
+| Premium Cleanup | Scheduled cleanup    | Every 60 minutes | `{env_prefix}-premium-cleanup-schedule` |
+| Premium Cleanup | EC2 state change     | On EC2 terminate | `{env_prefix}-premium-ec2-state-change` |
 
-### AWS Resources
+---
 
-- **Premium Manager Lambda:** `subscr-premium-manager` (timeout: 600s)
-- **Premium Cleanup Lambda:** `subscr-premium-cleanup` (timeout: 300s)
+## AWS Resources
+
+All resource names are prefixed with the Terraform `environment` variable (shown here as `{env_prefix}`, e.g. `staging-premium-manager`).
+
+- **Premium Manager Lambda:** `{env_prefix}-premium-manager` (timeout: 600s)
+- **Premium Cleanup Lambda:** `{env_prefix}-premium-cleanup` (timeout: 300s)
 - **EventBridge Rules:**
-  - `subscr-premium-manager-schedule` (15 min)
-  - `subscr-premium-cleanup-schedule` (60 min)
+  - `{env_prefix}-premium-manager-schedule` (rate(15 minutes))
+  - `{env_prefix}-premium-cleanup-schedule` (rate(1 hour))
+  - `{env_prefix}-premium-ec2-state-change` (EC2 terminate events targeting Cleanup with `action=reconcile_instance`)
 - **CloudWatch Log Groups:**
-  - `/aws/lambda/subscr-premium-manager` (30 day retention)
-  - `/aws/lambda/subscr-premium-cleanup` (30 day retention)
+  - `/aws/lambda/{env_prefix}-premium-manager` (30 day retention)
+  - `/aws/lambda/{env_prefix}-premium-cleanup` (30 day retention)
 
-### Key Functions Reference
+---
+
+## Key Functions Reference
 
 **In Premium Manager:**
 
@@ -689,7 +1023,7 @@ Note: `autoAssignOnLogin()` is internal only -- triggered by a `useEffect` when 
 | **Inactivity monitoring** | Checks every 30 seconds for user activity |
 | **Warning at 1 hour** | Shows InactivityWarning component |
 | **Auto-release at 2 hours** | Releases instance after extended inactivity |
-| **Heartbeat with retry** | `recordActivity()` retries up to 3 times with linear backoff (1s, 2s, 3s) |
+| **Heartbeat with retry** | `recordActivity()` makes up to 3 attempts with linear backoff between them (1s after attempt 1, 2s after attempt 2; a 3rd failure surfaces without a further delay) |
 | **Browser close handling** | Uses `navigator.sendBeacon` on `beforeunload` event |
 | **Polling with backoff** | If on shared instance, polls for dedicated with exponential backoff (1.5x multiplier, 30s initial, 60s max, 40 attempts max, leader tab only) |
 
@@ -759,7 +1093,7 @@ Handles user notifications for premium assignment events using notistack.
 | Assignment error (non-scaling) | `warning` | "Premium assignment issue: {error}" | Auto-dismiss |
 | Scaling/retry errors | (suppressed) | N/A | Silently ignored |
 
-Note: Errors containing "scaling" or "retry" substrings are suppressed to avoid noisy notifications during normal scaling operations.
+Note: Scaling/retry errors are not filtered by substring. The manager sets an `isRetryableError` flag when the `/assign` response has `!assigned && (scaling_in_progress || retry_after != null)`; when that flag is true the warning toast is skipped entirely and the persistent "Please wait..." info toast covers the state instead.
 
 ### InactivityWarning
 
@@ -787,6 +1121,9 @@ Displays a warning when premium users have been inactive for 1 hour.
 | `getPremiumStatus()` | GET /users/me/premium/status | Get current assignment status |
 | `sendPremiumHeartbeat()` | POST /users/me/premium/heartbeat | Update activity timestamp |
 | `getBeaconTokenApi()` | GET /users/me/premium/beacon-token | Get token for sendBeacon release |
+| `logPremiumUiEvent()` | POST /users/me/premium/ui-event | Fire-and-forget UI event log (CloudWatch timing correlation); errors swallowed |
+
+The browser-close path also calls `POST /users/me/premium/release-beacon` directly via `navigator.sendBeacon` -- it has no wrapper function since it must run without axios during `beforeunload`.
 
 ### Frontend Files Summary
 
@@ -796,7 +1133,283 @@ Displays a warning when premium users have been inactive for 1 hour.
 | `frontend/src/components/Premium/PremiumAssignmentManager.tsx` | Cleanup on unmount, debug logging |
 | `frontend/src/components/Premium/PremiumNotificationManager.tsx` | User notifications via notistack |
 | `frontend/src/components/Premium/InactivityWarning.tsx` | Inactivity warning UI with countdown |
-| `frontend/src/api/premium/PremiumAssignmentApi.ts` | API client functions (6 endpoints) |
+| `frontend/src/api/premium/PremiumAssignmentApi.ts` | API client functions (7 endpoints; `release-beacon` is called directly via `navigator.sendBeacon`) |
 | `frontend/src/contexts/__tests__/PremiumHeartbeatRetry.test.ts` | Tests for heartbeat retry logic |
 | `frontend/src/contexts/__tests__/PremiumPollingBackoff.test.ts` | Tests for polling backoff behavior |
 | `frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts` | Tests for sleep/wake detection |
+
+---
+
+## Appendix A: Log Playbook
+
+This appendix is written for an AI agent (or on-call engineer) reading logs to answer "did this premium flow work, and if not, where did it break." It lists the **expected log sequence** for each common scenario and the **specific strings that signal a problem**. Every string is quoted from source; placeholders are shown as `${...}`.
+
+Two log sources matter:
+
+- **Browser console** -- emitted by `PremiumAssignmentContext.tsx`, `PremiumAssignmentManager.tsx`, `InactivityWarning.tsx`, `RoutingService.ts`. Visible via DevTools or exported session recordings.
+- **CloudWatch Logs** -- `/aws/lambda/{env_prefix}-premium-manager` and `/aws/lambda/{env_prefix}-premium-cleanup` log groups. Emitted via `print()` from Python. (Below, the groups are referred to as `premium_manager` and `premium_cleanup` for brevity.)
+
+Every table below uses this 4-level classification:
+
+- **Healthy** -- expected in the happy path, do not flag.
+- **Noisy-but-fine** -- shows up in normal operation due to benign races (reservation loss, lock contention, localStorage unavailable). A single occurrence is not a signal.
+- **Watch** -- one occurrence is fine; pattern or frequency matters. Repeated for the same user/instance/minute = investigate.
+- **Problem** -- indicates a real fault. One occurrence should be triaged.
+
+### A.1 Healthy Sequences (what a correct flow looks like)
+
+#### A.1.1 Premium user logs in, dedicated instance available
+
+Backend (`premium_manager` log group), in order:
+
+```
+Premium manager received event: ${event_json}
+=== PREMIUM USER ASSIGNMENT START ===
+Target user: ${user_id}
+Assignment context: Running instances: ${N} ...
+=== STARTING ASSIGNMENT LOGIC ===
+[1/${N}] Evaluating instance ${i-xxx}
+Checking readiness for instance ${i-xxx}...
+Readiness result: True
+Checking assigned users for instance ${i-xxx}...
+Found 0 assigned users: []
+Found available instance ${i-xxx}, attempting reservation...
+Reserved dedicated instance: ${i-xxx}
+Using dedicated running instance ${i-xxx} for user ${user_id}
+```
+
+Frontend (browser console): `PremiumAssignmentManager.tsx` emits
+
+```
+Premium instance assigned successfully: ${instance_id}
+```
+
+as an `info` log whenever `assignmentResult.assigned` is true. Note: this fires for **both** dedicated and shared assignments (the log does not discriminate on `is_shared`). Use the presence of the leader-tab polling logs (see A.1.2) to tell the two apart.
+
+**Verdict:** if you see this sequence end-to-end with no error lines between `Reserved dedicated instance` and the assignment manager's success log, the flow worked.
+
+#### A.1.2 Premium user logs in, no dedicated instance available (sharing path)
+
+Backend:
+
+```
+=== PREMIUM USER ASSIGNMENT START ===
+...
+[1/${N}] Evaluating instance ${i-xxx}
+Found ${K} assigned users: [...]
+Tracking as least loaded: ${i-xxx} (${K} users)
+...
+Dedicated instance search results: Available dedicated: None, Least loaded: ${i-xxx}
+No dedicated instances available
+```
+
+Followed by either a shared assignment or a scaling trigger (both are healthy). Frontend behaviour:
+
+- **Shared assignment** (`assigned=true, is_shared=true`): same success log as A.1.1 (`Premium instance assigned successfully: ${instance_id}`) — the assignment manager does not differentiate shared vs dedicated in its log.
+- **Retryable (202 with `retry_after`)**: no dedicated log fires by default. `PremiumAssignmentManager.tsx` *does* have a branch that emits `Premium capacity scaling in progress, will retry automatically`, but it only fires when `assignmentResult.scaling_in_progress` is true in the response body — and the backend `/assign` endpoint does not populate that flag today (see the caveat at the end of the Lifecycle section). In practice you will not see this line; the retryable state is recognised from `retry_after` alone.
+
+Regardless of which branch, the leader tab will begin polling. Per-poll browser logs:
+
+```
+Still on temporary instance, will retry with backoff...
+```
+
+And on eventual promotion:
+
+```
+Premium instance now available: ${instance_id}
+```
+
+**Verdict:** the "Still on temporary instance..." line can appear up to `MAX_POLL_ATTEMPTS = 40` times per user session and is healthy until it stops. Absence of a terminating "Premium instance now available" or "Max poll attempts reached" means the loop is still in flight.
+
+#### A.1.3 Scheduled monitoring cycle (every 15 min)
+
+Expected baseline:
+
+```
+Premium monitoring triggered by event: ${event_json}
+Monitoring: ${X} active users, ${Y} total users, ${Z} running instances, ${W} idle instances
+Scale-down analysis: ${total} total, ${occupied} occupied, ${idle} idle, ${active_users} active users, ${total_premium_users} total premium users (max capacity: ${max})
+Published metrics: active_users=${X}, idle_users=${Y}, running_instances=${Z}, idle_instances=${W}
+```
+
+Plus at least one of:
+
+- `No idle instances found to stop` -- nothing to scale down
+- `No scale-down: running=${Z}, min_needed=${M}, idle=${W}` -- constraints prevent action
+- `Stopping ${K} idle instances: ${ids} (min running needed: ${M})` -- active scale-down
+
+**Verdict:** each monitoring invocation must log `Premium monitoring triggered by event:` followed by the metrics line. If the metrics line is missing, something threw between them.
+
+#### A.1.4 Cleanup Lambda run (hourly, `premium_cleanup` log group)
+
+```
+Starting cleanup of assignments idle for >${N}h
+[either] No stale assignments found
+[or]     Found ${K} stale assignments to clean
+         Cleaning stale assignment for user ${user_id}     (xK)
+         Cleaned assignment for user ${user_id}            (xK)
+         Cleanup complete: ${K}/${K} assignments cleaned
+Scanning for orphaned ALB resources...
+Found ${P} premium user ALB rules
+Found ${Q} active assignments in database
+[either] No orphaned ALB resources found
+[or]     Found ${R} orphaned ALB rules to clean up
+         Deleting orphaned rule (priority ${prio}): ${arn}  (xR)
+         Orphaned resource cleanup complete: ${rules_deleted} rules, ${tgs_deleted} target groups deleted
+Scanning for duplicate ALB rules by routing_id...
+Duplicate cleanup complete: ${duplicates_deleted} rules, ${target_groups_deleted} target groups deleted
+```
+
+**Verdict:** `${K}/${K}` equality (cleaned == found) is the healthy signal. `${K}/${K-n}` means some per-user deletions failed -- scan for `Error cleaning assignment for user ${user_id}:` lines above the summary.
+
+#### A.1.5 Release: user logs out (soft release grace path)
+
+```
+Soft-released user ${user_id} from instance ${i-xxx} (grace period ${N}s)
+```
+
+Or, if the user had already released / is in `pending_release`:
+
+```
+No active assignment to release for user ${user_id} (may already be pending_release or removed)
+```
+
+Followed, when the last user of an instance leaves:
+
+```
+No premium users remaining, converting idle instances to standby immediately
+Immediately converted ${K} idle instances to standby after user logout
+```
+
+#### A.1.6 Release: browser close (sendBeacon path)
+
+No frontend log (beacon is fire-and-forget before the tab unloads). Backend logs look identical to A.1.5 but via the `/release-beacon` endpoint rather than `DELETE /assign`.
+
+### A.2 Heartbeat Retry: Is `Attempt 3/3` a Problem?
+
+This is the most-asked question and deserves its own subsection.
+
+**The retry mechanism.** `recordActivity()` in `PremiumAssignmentContext.tsx` makes **up to 3 attempts** to `POST /users/me/premium/heartbeat`. Between attempts it waits `HEARTBEAT_RETRY_DELAY_MS * (attempt + 1)` = **1s after attempt 1, 2s after attempt 2, no delay after attempt 3** (the third failure surfaces the error). Constants: `HEARTBEAT_MAX_RETRIES=3`, `HEARTBEAT_RETRY_DELAY_MS=1000`.
+
+**What actually gets logged** (browser console):
+
+| Outcome | Log emitted |
+|---|---|
+| Attempt 1 succeeds | *(no log)* |
+| Attempt 1 fails, attempt 2 succeeds | `Heartbeat attempt 1 failed, retrying...` (once) |
+| Attempts 1+2 fail, attempt 3 succeeds | `Heartbeat attempt 1 failed, retrying...` then `Heartbeat attempt 2 failed, retrying...` |
+| All 3 attempts fail | Both retrying lines above **plus** `Heartbeat failed after retries: ${error}`; `heartbeatFailing` state set |
+
+Note the log template is literal: it says `attempt N failed, retrying...`, not `Attempt N/3`. There is no log with the exact phrase "Attempt 3/3" -- the final failure is announced by the `Heartbeat failed after retries:` string.
+
+**Why 3 attempts.** The heartbeat flies over the ALB into the per-user premium target group, which can briefly deregister during scaling, cold-start, or target health transitions. Empirically those blips resolve within 1-2 seconds. Three attempts with 1s/2s linear backoff covers ~3 seconds of transient failure before declaring the session broken -- long enough to survive the common flakes, short enough that the user's "Stay Active" click still feels responsive. Single-attempt heartbeats were tried first and produced false-positive session expirations during routine scaling; five-plus attempts introduced user-visible latency on the warning snackbar.
+
+**Triage rules.**
+
+| Pattern | Verdict |
+|---|---|
+| `Heartbeat attempt 1 failed, retrying...` for a user, no follow-up error | **Healthy.** Transient recovered on attempt 2. Ignore. |
+| `Heartbeat attempt 2 failed, retrying...` followed by no error | **Noisy-but-fine.** Recovered on attempt 3. Single occurrence is expected during ALB reroutes. |
+| `Heartbeat failed after retries:` **once** for a user | **Watch.** All three failed. Check backend for coincident 5xx / target group health event. If isolated, treat as transient. |
+| `Heartbeat failed after retries:` **repeatedly** for the same user over minutes | **Problem.** Likely the per-user target group is gone, the instance is dead, or the session is revoked. Expect the user to eventually see `Session Expired` (401 path) or be auto-released at 2h idle. |
+| `Heartbeat failed after retries:` for **many different users** at the same time | **Problem.** Backend/ALB incident. Check `premium_manager` CloudWatch for 5xx and `Error in scheduled monitoring:` concurrent with the failures. |
+
+### A.3 Noisy-but-Fine Strings (do not alert on these)
+
+| Log | Source | Why it's fine |
+|---|---|---|
+| `Heartbeat attempt ${N} failed, retrying...` (N in {1,2}) | `PremiumAssignmentContext.tsx` | See A.2 |
+| `Failed to reserve ${i-xxx} (another user claimed it)` | `premium_manager.py` | Concurrent assign race; the other user won, this call falls through to next instance |
+| `Scaling already in progress, skipping this run` | `premium_manager.py` scheduled monitor | Concurrency guard; the previous run is still finishing |
+| `Failed to acquire lock '${lock_name}' (held by another session)` | `premium_manager.py` | Advisory-lock contention; retried on next run |
+| `No assignment found for user ${user_id}: ${error}` (on hard release) | `premium_manager.py` | User already had no assignment; idempotent release |
+| `No active assignment to release for user ${user_id} (may already be pending_release or removed)` | `premium_manager.py` | Same as above for the soft-release path |
+| `Failed to (load\|save\|clear) ${x} from localStorage: ...` | `RoutingService.ts` | Private mode / quota / SSR; routing headers still work from memory |
+| `Agent disconnected on ${i-xxx}, starting grace period` and its "within grace period" follow-up | `premium_manager.py` ghost ECS cleanup | 5-min grace before deregistering ECS container instance |
+| `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 15-min grace before stopping orphan EC2 |
+| `Warning: Error closing database connection: ${e}` | both lambdas | Cleanup-path warning on teardown; does not affect the work already done |
+| `Transaction rolled back due to error: ${e}` | `premium_manager.py` | Expected when a `@with_transaction` path encounters an exception and rolls back cleanly |
+| `Conditions not met for auto-assignment: { isPremiumUser: false, ... }` | `PremiumAssignmentContext.tsx` | Non-premium user; the provider correctly short-circuits |
+
+### A.4 Problem Strings (treat as signals)
+
+Grouped by subsystem so you can scan quickly.
+
+**Assignment / release path:**
+
+| Log | Meaning |
+|---|---|
+| `Auto-assignment failed: ${error}` (browser) | Frontend threw inside `autoAssignOnLogin`. User will not retry until next login |
+| `Error assigning premium user: ${error}` | Backend `/assign` threw. Response will be 5xx; frontend goes to hard-error warning toast |
+| `Assignment failed - environment configuration error: ${error}` | Required env var (e.g. `VPC_ID`, `ALB_LISTENER_ARN`) missing. Deploy-time regression |
+| `WARNING: Instance ${i-xxx} started but ECS not ready after 120s, cleaning up stale assignment` | Restart succeeded at EC2 level but the ECS task never reached running. Likely image pull / ENI issue on that instance |
+| `Error: Failed to check existing assignment: ${error}` | DB query failed during assign; user will get hard error |
+
+**Scheduled monitor:**
+
+| Log | Meaning |
+|---|---|
+| `Error in scheduled monitoring: ${error}` | Monitor crashed mid-cycle. Scale-down / ghost cleanup skipped for this interval |
+| `Error in removing lock: ${error}` | Scaling lock may still be set, which will cause the next run to print `Scaling already in progress, skipping this run` for 15-min windows indefinitely. Manually clear the CloudWatch metric if repeated |
+| `WARNING: finalize_expired_pending_releases() failed` | Grace-period finalizer threw. Pending-release assignments pile up until next successful run |
+| `WARNING: fix_incorrect_is_shared_flags() failed` | `is_shared` flag reconciliation failed. Affects scale-down accuracy |
+| `Shared optimization error: ${error}` | Async migration of shared users failed |
+| `Error scaling down premium instances: ${error}` | `scale_down_if_possible()` crashed. Cost will drift until next successful run |
+
+**Polling / client-side loops:**
+
+| Log | Meaning |
+|---|---|
+| `Max poll attempts (40) reached. Stopping polling.` | Leader tab gave up after ~30-40 minutes. Means the premium ASG could not free/launch a dedicated instance in that window. Check ASG quota, ghost registrations, scaling lock |
+| `Error polling for premium instance: ${error}` | Single poll iteration threw. Loop continues with 2x error backoff; repeated means the API path is failing, not just capacity |
+
+**Database & AWS:**
+
+| Log | Meaning |
+|---|---|
+| `Database connection failed - environment configuration error: ${error}` | RDS env vars misconfigured (deploy regression) |
+| `Database connection failed - connection error: ${error}` | RDS unreachable (security group, DNS, credentials, or instance down) |
+| `All database queries failed, using development fallback` | Capacity-count code took its safety-net default. Scaling decisions this cycle are using a hardcoded number -- investigate before relying on scale outcomes |
+| `Error publishing metrics: ${error}` | CloudWatch PutMetricData failed. Monitoring dashboards will have a gap |
+
+**Ghost / orphan cleanup:**
+
+| Log | Meaning |
+|---|---|
+| `Failed to deregister ghost container instance ${arn}: ${error}` | ECS deregister API failed for a specific ghost. Slot remains consumed. Single instance = investigate; repeats = cluster-wide issue |
+| `Error cleaning up ghost ECS registrations: ${error}` | Whole cleanup routine crashed; no ghosts removed this cycle |
+| `Error cleaning up orphaned EC2 instances: ${error}` | Orphan sweep crashed; stranded instances will keep billing until next successful run |
+
+**Session / activity:**
+
+| Log | Meaning |
+|---|---|
+| `Heartbeat failed after retries: ${error}` (browser) | See A.2. Problem if repeated for same user or many users |
+| `Failed to record activity: ${error}` (browser, `InactivityWarning.tsx`) | The "Stay Active" click's heartbeat failed after all retries. User is about to see Session Expired (if 401) or is stranded on the warning (if network) |
+| `Error updating activity for user ${user_id}: ${error}` | Backend heartbeat handler threw. Still returns 200 to keep the client happy; investigate if frequent |
+
+### A.5 Watchlist Patterns (single = ok, frequency matters)
+
+These strings are individually benign but tell you something when they accumulate.
+
+| Pattern | Interpretation when repeating |
+|---|---|
+| `Inline migration not possible for user ${user_id}, falling back to async migration` for the same user across multiple 15-min runs | No empty instance ever becomes available -- capacity starvation, or the candidate-discovery query is missing results |
+| `Shared users found but no instances ready, triggering async migration...` on every scheduled monitor run | Migration worker is not keeping up; users stuck on shared |
+| `Teardown warnings for user ${user_id}: ${errors}` (ALB cleanup during finalize) repeatedly | ALB API throttling or specific rule-deletion permissions issue |
+| `Reserved dedicated instance: ${i-xxx}` without a matching `Using dedicated running instance ${i-xxx} for user ${user_id}` shortly after | Reservation acquired but the code threw before converting to assignment -- leaks a slot |
+| `Failed to register standby for ${i-xxx}: ${error}` | Standby-pool accounting drifting from reality; standby count metric will be wrong |
+| `Fixed ${N} stale is_shared flags` with N > 0 on repeated cycles | Something upstream is setting `is_shared=true` on rows that should be `false` -- investigate the shared→dedicated promotion code path |
+
+### A.6 "How to read a premium incident" checklist
+
+When asked to diagnose a premium issue, walk this list in order:
+
+1. **What is the user's actual assignment row?** Query `premium_user_assignments` for `user_id`. Record `instance_id`, `is_shared`, `status`, `last_activity_at`. Compare with the four states in the Symptom→State→Cause table.
+2. **What did `/assign` return?** Grep `premium_manager` for `Target user: ${user_id}` within the suspected window. The surrounding `=== PREMIUM USER ASSIGNMENT START ===` block tells you whether the Lambda even ran, and which branch it took.
+3. **Is the scheduled monitor alive?** Check that `Premium monitoring triggered by event:` appears every ~15 minutes. A gap means the EventBridge rule or the Lambda is broken; a presence-but-no-metrics-line means it's crashing mid-cycle.
+4. **Is the scaling lock stuck?** If you see `Scaling already in progress, skipping this run` in every monitor invocation for more than two cycles in a row, the lock was not cleared by a previous run (look for `Error in removing lock:` upstream).
+5. **For user-facing heartbeat issues**, apply the A.2 matrix: single retry log = ignore; repeated "failed after retries" for one user = check per-user ALB target; "failed after retries" across many users = backend incident.
+6. **For "user keeps getting shared instance"**, look for (a) `No dedicated instances available` on each assign, (b) `Inline migration not possible for user ${user_id}`, and (c) whether the hourly cleanup is running -- a stuck standby row can make the monitor think capacity is taken.
+

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -2,9 +2,9 @@
 
 ## Executive Summary
 - **Premium Manager** handles all instance provisioning and user assignment
-- **5-tier prioritization** system optimizes user experience and cost
+- **5-tier prioritization** (with a 3.5 sub-tier fallback) optimizes user experience and cost
 - **Standby pool** ensures fast cold starts via stopped instances
-- **Automatic migration** moves users from shared to dedicated instances
+- **Automatic migration** moves users from shared to dedicated instances, inline when possible and async otherwise
 - **Workflow safety** prevents migration of users with active workflows
 
 ## Key Architectural Principles
@@ -85,8 +85,22 @@ graph TB
 | 2 | Shared Instance | 0s | Good (shared) | Medium | Burst capacity |
 | 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning / re-login |
 | 3.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Last-resort fallback (no standby) |
-| 4 | AWS Stopped | 60-90s | Acceptable | Low | Fallback recovery |
+| 4 | AWS Stopped | 60s-6min | Acceptable | Low | Fallback recovery |
 | 5 | New Instance | 4-8 min | Poor (scaling) | Highest | Last resort |
+
+### Responsibility Matrix
+
+This document covers one Lambda -- the Premium Manager -- acting across several subsystems. The table below maps each concern to the function family that owns it, to make it clear where to look for a given behavior.
+
+| Concern                              | Owning subsystem                              | Key functions                                                                           |
+|--------------------------------------|-----------------------------------------------|-----------------------------------------------------------------------------------------|
+| Real-time user assignment            | Assignment handler                            | `assign_premium_user()`, `try_reserve_instance()`, `store_user_assignment()`            |
+| Standby pool lifecycle               | Standby pool management                       | `create_and_stop_standby_instance()`, `start_standby_instance()`, `register_orphaned_stopped_instances()` |
+| Capacity scaling (up)                | Scaling system                                | `scale_premium_instances_if_needed()`, `_create_running_instances_locked()`             |
+| Shared-to-dedicated migration        | Background migration                          | `process_shared_instance_optimization()`, `migrate_user_to_dedicated_instance()`, `invoke_migration_async()` |
+| Concurrency / race prevention        | Locking                                       | `distributed_lock()` (MySQL `GET_LOCK`), `try_reserve_instance_transaction()` (`SELECT FOR UPDATE`), `is_creation_lock_held()` |
+| Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see `PREMIUM_MANAGER_ARCHITECTURE.md`) | `handle_scheduled_monitoring()`, `scale_down_if_possible()`                             |
+| Stale assignment + ALB rule hygiene  | Premium Cleanup Lambda (separate)             | See `PREMIUM_MANAGER_ARCHITECTURE.md`                                                   |
 
 ## Provisioning Flow Diagrams
 
@@ -150,9 +164,9 @@ sequenceDiagram
     alt Tier 4: AWS Stopped Instance
         DB-->>PM: Found stopped instance (not standby)
         PM->>EC2: Start Instance
-        EC2-->>PM: Instance running (60-90s)
+        EC2-->>PM: Instance running (typically 60-90s; waiter caps at 6 min)
         PM->>PM: Create Target Group + Rule
-        PM-->>User: Assigned (60-90s wait)
+        PM-->>User: Assigned (60s-6min wait)
     else Tier 5: Scale New Instance
         DB-->>PM: No instances available
         PM->>PM: Check launching instances + creation locks
@@ -216,13 +230,18 @@ graph TB
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Assign a premium instance using 5-tier priority fallback
 **Input:** user_id (int), event (API Gateway dict), optional user_uid (str)
-**Output:** Dict with statusCode, instance_id, routing headers; or 202 retry
-**Calls:** register_orphaned_stopped_instances() -> check_instance_readiness_with_retry() -> try_reserve_instance() -> create_or_get_target_group() -> store_user_assignment()
+**Output:** Dict with `statusCode` and a body containing `instance_id`, `target_group_arn`, `rule_arn`, `is_shared`, `assignment_source`; or `statusCode: 202` when scaling is in progress
+**Calls:** restore_pending_release() -> get_existing_user_assignment() -> register_orphaned_stopped_instances() -> check_instance_readiness_with_retry() -> try_reserve_instance() -> create_or_get_target_group() -> store_user_assignment()
 
 **Pre-assignment Steps:**
-1. Check for existing assignment (return it if found; trigger migration if shared/autoscaling)
-2. Register orphaned stopped instances as standby
-3. Get comprehensive instance state (running, launching, stopped, standby)
+1. Restore any `pending_release` assignment (beacon fired but the user is back) -- returns with `assignment_source: "restored_from_pending_release"`
+2. Check for existing assignment:
+   - If the EC2 is `stopped`/`stopping`, restart it, clear the ECS checkpoint, wait up to 120s for ECS readiness, and return `assignment_source: "restarted_instance"`
+   - If the EC2 is `terminated`/`shutting-down`/gone, remove the stale DB entry and fall through to fresh assignment
+   - If the assignment is on `autoscaling-pool` or a shared instance, attempt an **inline migration** to a ready dedicated instance first (`assignment_source: "inline_migration"`); fall back to `invoke_migration_async()` if no instance is ready
+   - Otherwise return the existing assignment (`assignment_source: "existing"`)
+3. Register orphaned stopped instances as standby
+4. Get comprehensive instance state (running, launching, stopped, standby)
 
 **Priority Evaluation:**
 
@@ -238,7 +257,7 @@ graph TB
   temporary fallback only when no standby instances exist, always
   trigger scaling
 - **Tier 4 (AWS Stopped):** Start non-standby stopped instance,
-  wait up to 6 minutes for running state
+  wait up to 6 minutes for running state (typical cold start is 60-90s)
 - **Tier 5 (Scale New):** If launching instances exist, return 202;
   otherwise call `scale_premium_instances_if_needed()` and return 202
 
@@ -378,7 +397,7 @@ subscribers.
 
 **Key behaviors:**
 - Blocked if launching instances exist or `CREATE_RUNNING_LOCK` held
-- No-op if `running_count >= active_users` (sufficient capacity)
+- No-op if `running_count >= active_users` (sufficient capacity). Note this is distinct from `scale_down_if_possible()`, which keeps `max(1, active_users + 1)` -- scale-up has no `+ 1` safety margin, so the scale-down headroom only exists after a full monitor cycle runs
 - Prefers starting stopped instances (fastest) over creating new
 - Clears ECS agent checkpoints after starting stopped instances
 - Falls back to `_create_running_instances_locked()` under
@@ -480,7 +499,7 @@ retried on the next attempt.
 The single table that tracks all premium instance assignments,
 including standby pool entries.
 
-**Source:** `studio/alembic/versions/e701e7250019_create_premium_management_system.py`
+**Sources:** Created in `studio/alembic/versions/e701e7250019_create_premium_management_system.py`; the conditional `idx_unique_user_assignment` index and nullable `user_id` were added by `h901h9270022_add_standby_sentinel_user.py`; `heartbeat_failures` was added by `j901j9290024_add_alert_fix_tables_and_columns.py`.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -490,7 +509,7 @@ including standby pool entries.
 | `target_group_arn` | VARCHAR(512) | ALB target group ARN or "standby"/"reserving" |
 | `alb_rule_arn` | VARCHAR(512) | ALB rule ARN or "standby"/"reserving" |
 | `assigned_at` | TIMESTAMP | Assignment creation time |
-| `status` | ENUM | 'active', 'migrating', 'terminating' |
+| `status` | ENUM | `'active'`, `'migrating'`, `'terminating'`. The soft-release "pending_release" state reuses `'terminating'` rather than being a distinct ENUM value -- the code-level `PremiumAssignment.PENDING_RELEASE` constant resolves to the string `"terminating"` (see `infrastructure/aws_constants.py`) |
 | `last_activity` | TIMESTAMP | Last user activity (auto-updates) |
 | `instance_state` | ENUM | 'launching', 'running', 'stopping', 'stopped', 'terminating' |
 | `is_shared` | BOOLEAN | Whether instance is shared with other users |
@@ -520,7 +539,7 @@ including standby pool entries.
 
 ### CloudWatch Metrics Published
 
-**By Premium Manager** (every 15 minutes via `publish_premium_metrics()`):
+**By Premium Manager** (published every 15 minutes by `publish_premium_metrics()`, invoked inside `handle_scheduled_monitoring()`):
 
 | Metric Name | Description | Unit |
 |-------------|-------------|------|
@@ -530,11 +549,11 @@ including standby pool entries.
 | `IdleInstances` | Running instances with 0 users | Count |
 | `ScalingInProgress` | Lock to prevent concurrent operations | None (0 or 1) |
 
-**Namespace:** `OptiNiSt/PremiumManager`
+**Namespace:** `OptiNiSt/PremiumManager/{env_prefix}` where `env_prefix` is the Terraform `environment` variable (e.g. `staging`, `prod`).
 
 ### Key Log Events
 
-**Premium Manager Logs** (`/aws/lambda/subscr-premium-manager`):
+**Premium Manager Logs** (`/aws/lambda/{env_prefix}-premium-manager`):
 
 ```
 === PREMIUM USER ASSIGNMENT START ===
@@ -563,14 +582,14 @@ PRIORITY 1 SUCCESS: Using dedicated running instance i-abc123
 **Standby Creation Logs:**
 
 ```
-Acquired distributed lock for standby creation
+Acquired distributed lock '${lock_name}'
 Standby pool has capacity (0/1), proceeding with creation
-Attempting to launch standby instance in subnet-abc (attempt 1/2)
-Successfully created standby instance i-def456
+Attempting to launch standby instance in subnet ${subnet_id} (attempt 1/2)
+Successfully created standby instance ${instance_id}...
 Waiting for instance to start...
 Instance running, stopping for standby...
 Instance stopped successfully
-Registered instance i-def456 as standby
+Registered instance ${instance_id} as standby
 ```
 
 **Migration Logs:**
@@ -595,6 +614,7 @@ Shared instance optimization complete: 1 users migrated
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
+| `ENV_PREFIX` | Terraform `environment` value; used for resource naming and the CloudWatch metric namespace | Required |
 | `RDS_HOST` | Database endpoint (via RDS Proxy, format: host:port) | Required |
 | `RDS_USER` | Database username | Required |
 | `RDS_PASSWORD` | Database password | Required |
@@ -603,23 +623,29 @@ Shared instance optimization complete: 1 users migrated
 | `PREMIUM_SERVICE_NAME` | ECS service name for premium tier | Required |
 | `VPC_ID` | VPC ID for target groups | Required |
 | `SUBNET_IDS` | Comma-separated subnet IDs (for multi-AZ) | Required |
+| `SECURITY_GROUP_ID` | ECS security group | Required |
+| `ALB_ARN` | Application Load Balancer ARN | Required |
 | `ALB_LISTENER_ARN` | ALB HTTPS listener for routing rules | Required |
 | `ALB_DNS_NAME` | ALB DNS name (for experiment sync) | Required |
 | `AUTOSCALING_TARGET_GROUP_ARN` | Shared pool target group | Required |
-| `PREMIUM_LAUNCH_TEMPLATE_ID` | EC2 launch template for premium instances | Required |
+| `PREMIUM_INSTANCE_IDS` | Comma-separated base EC2 instance IDs | Required |
+| `PREMIUM_LAUNCH_TEMPLATE_ID` | EC2 launch template for dynamic premium instances | Required |
+| `PREMIUM_INSTANCE_TYPE` | EC2 instance type for dynamically-created premium instances | Required |
 | `PREMIUM_STANDBY_POOL_SIZE` | Desired standby pool size | `1` |
 | `PREMIUM_EXTRA_CAPACITY` | Extra capacity buffer for scaling decisions | `1` |
-| `PREMIUM_IDLE_TIMEOUT_HOURS` | Hours before idle timeout | `3` |
+| `PREMIUM_STOPPED_MAX_AGE_HOURS` | Terminate stopped standby instances older than this | `4` |
 | `ROUTING_SECRET_KEY` | HMAC secret for generating routing IDs | Required |
 | `INTERNAL_API_SECRET` | Secret for internal API authentication | Required |
 
+`PREMIUM_IDLE_TIMEOUT_HOURS` is set in the Manager's Terraform block but is only read by the Cleanup Lambda; it does not influence Manager behavior.
+
 ### Triggers
 
-| Lambda          | Trigger              | Frequency        | EventBridge Rule                  |
-|-----------------|----------------------|------------------|-----------------------------------|
-| Premium Manager | User assign/release  | On-demand (API)  | N/A                               |
-| Premium Manager | Scheduled monitoring | Every 15 minutes | `subscr-premium-manager-schedule` |
-| Premium Manager | Migration check      | After assignment | N/A (async self-invocation)       |
+| Lambda          | Trigger              | Frequency        | EventBridge Rule                       |
+|-----------------|----------------------|------------------|----------------------------------------|
+| Premium Manager | User assign/release  | On-demand (API)  | N/A                                    |
+| Premium Manager | Scheduled monitoring | Every 15 minutes | `{env_prefix}-premium-manager-schedule` |
+| Premium Manager | Migration check      | After assignment | N/A (async self-invocation)            |
 
 ---
 
@@ -682,15 +708,17 @@ Shared instance optimization complete: 1 users migrated
 | `cleanup_failed_standby_instances()` | Remove DB entries for terminated instances |
 | `cleanup_ghost_ecs_registrations()` | Deregister orphaned ECS container instances |
 | `cleanup_orphaned_ec2_instances()` | Stop premium EC2 not in ECS cluster |
-| `handle_scheduled_monitoring()` | 15-minute monitoring loop (10 operations) |
+| `handle_scheduled_monitoring()` | 15-minute monitoring loop (12 steps: scale-down, ECS sync, standby-pool hygiene, pending-release finalization, ghost/orphan cleanup, shared-instance optimization -- see `PREMIUM_MANAGER_ARCHITECTURE.md`) |
 
 ---
 
 ## AWS Resources
 
-- **Premium Manager Lambda:** `subscr-premium-manager` (timeout: 600s)
+All resource names are prefixed with the Terraform `environment` variable (shown here as `{env_prefix}`, e.g. `staging-premium-manager`).
+
+- **Premium Manager Lambda:** `{env_prefix}-premium-manager` (timeout: 600s)
 - **EventBridge Rules:**
-  - `subscr-premium-manager-schedule` (15 min monitoring)
-- **CloudWatch Log Group:** `/aws/lambda/subscr-premium-manager` (14 day retention)
+  - `{env_prefix}-premium-manager-schedule` (rate(15 minutes) monitoring)
+- **CloudWatch Log Group:** `/aws/lambda/{env_prefix}-premium-manager` (30 day retention)
 - **Launch Template:** Defined by `PREMIUM_LAUNCH_TEMPLATE_ID`
 - **RDS Table:** `premium_user_assignments` (assignments + standby pool)


### PR DESCRIPTION
### Content

#### Summary
- `PREMIUM_MANAGER_ARCHITECTURE.md` was missing the end-to-end user lifecycle view, had a stale scheduled-monitoring step list (10 steps; code now has 12), and used hardcoded `subscr-` prefixes for resource names that are actually `${var.environment}-` in Terraform.
- This PR adds two major reference sections -- **Premium User Lifecycle** (login through release, frontend+backend, with a symptom→state→cause debugging index) and **Appendix A: Log Playbook** (healthy/noisy/problem CloudWatch + browser-console string classifications for incident response) -- and corrects the accuracy drift that had accumulated since the original refactor doc.
- Also corrects accuracy drift in `PREMIUM_USER_ASSIGNMENT.md`: `assign_premium_user()` pre-assignment steps now cover `restore_pending_release`, existing-instance restart, and inline migration; Tier 4 wait range, DB schema migration sources, and CloudWatch metric wording are fixed.
- Docs-only change. No code, no Terraform, no behavior.

#### Design Decisions

##### One consolidated doc vs. splitting into three files

The doc is now ~1400 lines covering backend (Manager + Cleanup Lambdas), frontend (assignment context, polling, inactivity), and operations (log playbook). Considered splitting into `PREMIUM_MANAGER_ARCHITECTURE.md`, `PREMIUM_FRONTEND_ARCHITECTURE.md`, and `PREMIUM_LOG_PLAYBOOK.md`.

Chose one file because the sections are genuinely intertwined: the Symptom→State→Cause table references both DB rows and toast copy; the Log Playbook's A.1.2 "sharing path" pulls from both backend log strings and frontend polling logs; the Manager's scheduled cycle is only intelligible once you know what user-facing state it's protecting. Splitting forces cross-file jumps for anyone debugging a real incident.

The `Appendix A: Log Playbook` prefix and the top-level anchor in the TOC mean a reader uninterested in the lifecycle can skip straight to it; the cost of one long file is accepted for the single-source-of-truth benefit.

##### Function documentation: docstring blocks, not pseudocode

The style guide (`DOCUMENTATION_STYLE_GUIDE.md`) explicitly forbids pseudocode in function documentation because it drifts from the implementation. Followed that: every documented function uses the File/Purpose/Input/Output/Calls block, not reproduced logic. The one SQL snippet (`WHERE active_workflow_count = 0`) is flagged as a **constraint**, not a full query, matching the style guide's guidance on SQL.

##### Scheduled monitoring step list: match the code's own numbering, not a tidy round number

The code has comments numbered 1, 2, 3, 4, 5, 6, 7, 8a, 8b, 9, 10a, 10b, 11, 12 inside `handle_scheduled_monitoring()`. The old doc collapsed these into a clean 10-item list, which is what made the drift hard to spot. New list preserves the code's exact numbering (including the `a/b` sub-steps) so a reader can grep-to-match between doc and source.

##### `{env_prefix}` placeholder instead of a specific environment name

Resource names in Terraform are `${var.environment}-premium-manager`, etc. The doc previously hardcoded `subscr-` which worked for one environment but misled anyone reading from staging/prod. Used the literal placeholder `{env_prefix}` with a one-line explanation at the top of the AWS Resources section rather than picking one environment's names as canonical.

##### Keep the Executive Summary at 5 bullets, not 6+

The style guide caps the Executive Summary at 4-6 bullets. Resisted the pull to add a 6th "Log Playbook included" bullet -- the appendix is a reference, not a headline capability. Anyone who needs it will find it via the TOC or a grep for a specific error string.

### Evidence
- Scheduled monitoring sequence verified against `premium_manager.py` `handle_scheduled_monitoring()` (steps 1-12 inclusive, with 8a/8b, 10a/10b sub-steps).
- Handler routing tables verified against both `premium_manager.py handler()` and `premium_cleanup.py handler()`; the previously-undocumented actions (`cleanup_all_dynamic` on Manager, `reconcile_instance` on Cleanup) are now listed.
- Frontend constants (`INITIAL_POLL_INTERVAL_MS=30000`, `MAX_POLL_ATTEMPTS=40`, `HEARTBEAT_MAX_RETRIES=3`, etc.) cross-checked against `PremiumAssignmentContext.tsx` and `frontend/src/const/Subscription.ts`.
- CloudWatch metric namespace verified as `OptiNiSt/PremiumManager/{env_prefix}` (was documented as `OptiNiSt/PremiumManager`).
- Log Playbook strings are all quoted directly from `print(...)` calls in the two Python modules and `console.warn/info/error` calls in the frontend context; no paraphrasing.

### References
- `infrastructure/documentation/DOCUMENTATION_STYLE_GUIDE.md` -- template, tables, diagram conventions, function-doc format.
- Prior PR #503 (stale-agent recovery) and #522 (free-tier orphan gating) motivated extending the log playbook with agent-disconnect strings and standby-instance hygiene entries.
- `PREMIUM_USER_ASSIGNMENT.md`, `FREE_MANAGER_ARCHITECTURE.md`, `ALB_ROUTING_ARCHITECTURE.md` -- style-guide reference documents used as format templates.

### Files changed
- `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md` -- +706 / -93. Title retitled from "Refactoring: Separation of Concerns" to describe the system; executive summary and principles clarified; added `Premium User Lifecycle` section (Mermaid sequence + ASCII flow + code-mapping table + Symptom→State→Cause index); rewrote scheduled-monitoring step list to match the 12-step code reality; added `cleanup_all_dynamic` and `reconcile_instance` to handler routing tables; replaced hardcoded `subscr-` prefixes with `{env_prefix}-`; corrected CloudWatch namespace; added missing env vars (`ENV_PREFIX`, `PREMIUM_INSTANCE_TYPE`, `PREMIUM_STOPPED_MAX_AGE_HOURS`); added `ui-event` endpoint to API table; promoted `AWS Resources` and `Key Functions Reference` from `###` subsections to `##` top-level sections to match the style guide; added `Appendix A: Log Playbook` (healthy/noisy/watch/problem classifications across both Lambdas and the frontend).
- `infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md` -- accuracy pass against current `premium_manager.py`:
  - **Executive Summary**: clarified "5-tier (with 3.5 sub-tier fallback)"; noted that migration runs inline when a dedicated instance is ready and async otherwise.
  - **`assign_premium_user()` docstring block**: corrected the `Output` field (was "routing headers" -- the body actually contains `instance_id`, `target_group_arn`, `rule_arn`, `is_shared`, `assignment_source`); extended the `Calls` chain to include `restore_pending_release()` and `get_existing_user_assignment()`; rewrote the **Pre-assignment Steps** list to document the three code paths that were previously missing: (1) `restore_pending_release()` beacon-refresh recovery, (2) existing-assignment instance-restart with 120s ECS readiness wait, (3) inline synchronous migration for `autoscaling-pool`/shared users before falling back to `invoke_migration_async()`.
  - **Tier 4 wait range**: updated from "60-90s" to "60s-6min" in the priority matrix, Tier 4 sequence diagram, and Implementation Details, with a note that typical cold starts land at 60-90s but the EC2 waiter caps at 6 minutes.
  - **Database Schema source attribution**: expanded from a single migration reference to list all three relevant migrations (base `e701e7250019`, nullable-user_id `h901h9270022`, `heartbeat_failures` column `j901j9290024`) since the column table covers additions from multiple migrations.
  - **Monitoring and Metrics**: reworded the `publish_premium_metrics()` trigger line to make it clear it's called from inside `handle_scheduled_monitoring()`, not directly scheduled by EventBridge.

### Manual Testcases
- [ ] Render the doc in GitHub's Markdown preview and confirm the Mermaid sequence diagram and `graph TB` architecture diagram both render (GitHub renders Mermaid natively; syntax errors will show as raw text).
- [ ] Spot-check three random function references in the doc (e.g. `finalize_expired_pending_releases()`, `cleanup_excess_standby_instances()`, `reconcile_single_instance()`) by grepping the corresponding Python file for the function name -- all three should exist.
- [ ] Search the doc for `subscr-` -- should return zero matches outside intentional historical context.
- [ ] Search the doc for `OptiNiSt/PremiumManager` -- every occurrence should be followed by `/{env_prefix}`.
- [ ] Follow the Symptom→State→Cause table for one row (e.g. "Two users on the same EC2 instance with different `is_shared` values"): read the claimed "implied state" and "upstream cause" and confirm they are consistent with the code in `assign_premium_user()` and `process_shared_instance_optimization()`.
- [ ] From the Log Playbook A.1.1 sequence, grep `premium_manager.py` for each of the quoted log strings (`=== PREMIUM USER ASSIGNMENT START ===`, `Reserved dedicated instance:`, `Using dedicated running instance`) -- all should match source exactly.

### Unit, Integration, Contract Test Coverage
No automated tests. This is a documentation change; accuracy was verified by cross-reading the source (`premium_manager.py`, `premium_cleanup.py`, `PremiumAssignmentContext.tsx`, `premium_manager.tf`) and by the manual grep testcases above.

### Others

#### Difficulties (if any)
- The `scaling_in_progress` field drift between frontend type and backend response body: the frontend `PremiumAssignmentResponse` type has it and `isRetryableError` reads it, but `/assign` does not populate it today. Chose to document the discrepancy explicitly (with the "small caveat" paragraph at the end of the Lifecycle section) rather than silently omit it -- anyone reading the frontend code will otherwise wonder why the branch appears unreachable.
- The `PREMIUM_IDLE_TIMEOUT_HOURS` env var is set in Terraform for both Lambdas but only read by Cleanup. Documented the discrepancy in the env var list with an explicit "set in Terraform but only read by Cleanup Lambda" comment so future environment-var cleanup knows it can be removed from Manager's Terraform block.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Documentation accuracy | Low | Every log string, function name, constant, and resource name was verified against current source. If anything drifts going forward, the style guide says doc updates belong in the same PR as the code change. |
| Doc length (~1400 lines) | Low | Single file is intentional (see Design Decisions). TOC and anchors let readers jump. No build/CI impact since the file is not parsed. |
| Mermaid rendering | Low | Two Mermaid diagrams (sequence + graph). GitHub renders natively; local Markdown readers vary. If a reader's tool cannot render Mermaid they still get the ASCII flow diagrams as authoritative fallback. |
| Log Playbook strings going stale | Medium | The string-literal log entries are only accurate as of this commit. If someone edits a `print(...)` call in `premium_manager.py` without updating the playbook, the A.2-A.5 tables will mismatch reality. Mitigation: the style guide already requires doc updates in code PRs; this is a process concern, not a code concern. |
