### PR TITLE
Fix CloudWatch alarm to reduce startup alerts

### DIFF
--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -285,13 +285,15 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
 resource "aws_cloudwatch_metric_alarm" "alb_response_time_high" {
   alarm_name          = "${local.env_prefix}-alb-response-time-high"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  # p95 over 3×5-min: Average is tripped by one slow request on sparse traffic.
+  evaluation_periods  = "3"
+  datapoints_to_alarm = "3"
   metric_name         = "TargetResponseTime"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
-  statistic           = "Average"
+  extended_statistic  = "p95"
   threshold           = "5"
-  alarm_description   = "ALB response time is too high"
+  alarm_description   = "ALB p95 response time exceeded 5s across 3×5-min windows."
   alarm_actions       = local.critical_alerts_actions
   ok_actions          = local.critical_alerts_actions
 

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -845,6 +845,8 @@ resource "aws_cloudwatch_metric_alarm" "premium_cpu_high" {
   alarm_description   = "Premium ECS service CPU utilization is high"
   alarm_actions       = local.critical_alerts_actions
   ok_actions          = local.critical_alerts_actions
+  # Scale-to-zero leaves no datapoints; avoid OK emails on every warm-up.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     ServiceName = aws_ecs_service.premium.name
@@ -869,6 +871,8 @@ resource "aws_cloudwatch_metric_alarm" "premium_memory_high" {
   alarm_description   = "Premium ECS service memory utilization is high"
   alarm_actions       = local.critical_alerts_actions
   ok_actions          = local.critical_alerts_actions
+  # Scale-to-zero leaves no datapoints; avoid OK emails on every warm-up.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     ServiceName = aws_ecs_service.premium.name


### PR DESCRIPTION

#### Summary
- Two small CloudWatch alarm changes to stop `optinist-support@araya.org` from receiving cosmetic alerts.
- `subscr-optinist-alb-response-time-high` switches from `Average > 5s over 2×5-min` to `p95 > 5s over 3×5-min`. The Average statistic is dominated by a single slow request when traffic is <20 req/5-min, which is why the alarm flapped ALARM↔OK four times in 11 minutes on 2026-04-13 even though the service had almost no 5XX responses.
- `subscr-premium-cpu-high` and `subscr-premium-memory-high` add `treat_missing_data = "notBreaching"`. When the premium ECS service scales to zero, the CPU/memory metrics stop reporting and the alarm cycles `OK → INSUFFICIENT_DATA → OK`, firing an OK email on every transition even though the alarm never reached ALARM.

#### Design Decisions
- **`extended_statistic = "p95"` over metric-math with SampleCount gate.** Metric math (`IF(sampleCount > N, average, 0)`) would also work but is harder to read and reason about. p95 is a first-class ALB statistic, is resistant to a single tail outlier, and is the right semantic for "is the service slow for most users?" A single slow workflow request still bumps p99 but no longer trips p95.
- **`evaluation_periods = 3`, `datapoints_to_alarm = 3`.** 15 min of sustained slow p95 before paging. The ALB has legitimate long-running endpoints (Caiman workflows, file uploads), so a one-off slow 5-min window should not fire; genuine degradation persists across multiple windows.
- **`treat_missing_data = "notBreaching"` rather than `"ignore"`.** `"ignore"` keeps the previous state forever, meaning if the service scales to zero while the alarm is in ALARM, it would stay in ALARM indefinitely. `"notBreaching"` explicitly treats a scale-to-zero window as healthy, which matches what we actually mean: no tasks running = no CPU/memory pressure to worry about. Once metrics resume the alarm re-evaluates normally.
- **Applied to both `premium_cpu_high` and `premium_memory_high`.** `aws cloudwatch describe-alarm-history` on the memory alarm confirms the same INSUFFICIENT_DATA ↔ OK churn pattern on the same dates, so the same fix is warranted.
- **Out of scope:** the ALB threshold value (5s) is left unchanged. Raising it could mask real slowness; the noise was structural (statistic choice + sparse traffic), not threshold choice. If 5s is still too aggressive after this PR, a follow-up can raise it.

### Evidence
- **ALB alarm — state transitions received today/yesterday on `optinist-support@araya.org` (from the alert inbox thread):**
  - `ALARM` 2026-04-13 10:35:15 UTC — "2 datapoints [6.97 (10:28), 6.28 (10:23)] > 5.0".
  - `OK`    2026-04-13 10:38:15 UTC — one datapoint 4.17s.
  - `ALARM` 2026-04-13 10:39:15 UTC — 5.31s, 7.31s.
  - `OK`    2026-04-13 10:43:15 UTC — 4.17s.
  - `ALARM` 2026-04-13 10:44:15 UTC — 6.91s, 5.31s.
  - `OK`    2026-04-13 10:45:15 UTC — 4.85s.
  - `ALARM` 2026-04-13 10:46:15 UTC — 6.46s, 5.88s.
  - `OK`    2026-04-13 10:48:15 UTC — 0.36s.
  - `OK`    2026-04-13 14:29:15 UTC — INSUFFICIENT_DATA → OK (metric gap when traffic stopped).
  - `OK`    2026-04-14 02:34:15 UTC (today) — INSUFFICIENT_DATA → OK, 0.003s.
  - `OK`    2026-04-14 03:07:15 UTC (today) — INSUFFICIENT_DATA → OK, 0.002s.
- During that 10:20–10:45 UTC window, `RequestCount` per 5-min dropped from 48 → 16 → 10 → 16 → 11 → 0 → 10. With that few requests a single slow response (Max seen: 81.7s at 10:15, 16.3s at 10:20, 19.4s at 10:30) drives the 5-min Average above 5s. Only 2 `HTTPCode_Target_5XX_Count` events in the whole period — the service itself was not failing.
- **Premium CPU alarm — OK transition received yesterday:**
  - `OK` 2026-04-13 11:07:40 UTC — "INSUFFICIENT_DATA → OK", datapoint 53.6% (threshold 80%). Never reached ALARM; the OK email was just the transition out of INSUFFICIENT_DATA.
- **Premium memory alarm history** (`aws cloudwatch describe-alarm-history --alarm-name subscr-premium-memory-high`) shows the same INSUFFICIENT_DATA ↔ OK cycling pattern on 2026-04-06, 2026-04-03, and 2026-04-01.
- `terraform validate` passes after the edits.

### References
- PR `fix/alarm-agent-disconnected-scope` — scoped the agent-disconnected alarm to production only
- AWS docs: CloudWatch extended statistics, `TreatMissingData` behaviour

#### Files changed
- `infrastructure/terraform/monitoring.tf` -- `alb_response_time_high` switched from `statistic = "Average"` to `extended_statistic = "p95"`; `evaluation_periods` 2 → 3; new `datapoints_to_alarm = 3`; alarm description updated.
- `infrastructure/terraform/premium_manager.tf` -- `treat_missing_data = "notBreaching"` added to both `premium_cpu_high` and `premium_memory_high`, with inline comments explaining the scale-to-zero gap.

### Manual Testcases

1. **Operator, verify ALB alarm config post-apply:**
   - `aws cloudwatch describe-alarms --alarm-names subscr-optinist-alb-response-time-high --region ap-northeast-1 --query 'MetricAlarms[0].{ExtStat:ExtendedStatistic,Stat:Statistic,EvalPeriods:EvaluationPeriods,DatapointsToAlarm:DatapointsToAlarm,Threshold:Threshold}'`
   - Expected: `ExtendedStatistic = "p95"`, `Statistic = null`, `EvaluationPeriods = 3`, `DatapointsToAlarm = 3`, `Threshold = 5.0`.

2. **Operator, verify premium alarms no longer enter INSUFFICIENT_DATA:**
   - `aws cloudwatch describe-alarms --alarm-names subscr-premium-cpu-high subscr-premium-memory-high --region ap-northeast-1 --query 'MetricAlarms[].{Name:AlarmName,TMD:TreatMissingData,State:StateValue}'`
   - Expected: both alarms show `TreatMissingData = "notBreaching"` and `StateValue = "OK"`.
   - Scale the premium service to zero (or wait for a natural scale-to-zero window). After ≥15 min of missing metric datapoints, rerun `describe-alarms`. Expected: alarms remain `OK`, never enter `INSUFFICIENT_DATA`.

3. **Operator, confirm inbox silence:**
   - Over the 24 h after apply, check `optinist-support@araya.org`. Expected: zero OK notifications for `subscr-premium-cpu-high` or `subscr-premium-memory-high`; zero ALARM→OK flapping emails for `subscr-optinist-alb-response-time-high` during sparse-traffic windows.

### Unit, Integration, Contract Test Coverage
- No unit tests. Alarm-only Terraform resources; no test harness in this repo covers them.
- Terraform statically validated via `terraform validate`.

### Others

#### Difficulties (if any)

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| ALB alarm semantics (Average → p95) | Low | Alarm is email-only; no auto-remediation depends on it. Worst case the alarm is less sensitive than before — a follow-up can tighten the threshold or widen evaluation if needed. |
| Premium alarm TreatMissingData | Low | `notBreaching` is strictly quieter than the default `missing` behaviour for this resource. Cannot introduce new false positives; at most delays detection if the metric never resumes (but in that case the ECS service-level alarms would fire instead). |
| Terraform update kind | Low | Both changes are in-place updates on existing alarm resources (no replacement). Rollback = revert the PR and `terraform apply`. |
| SNS / paging scope | Low | `critical_alerts_actions` is still gated on `var.environment == "subscr"` via `monitoring.tf:42`, so non-production environments remain email-free regardless of this PR. |