### PR TITLE
Patch for long time migrate users lock branch

### DIFF
--- a/infrastructure/documentation/AGENT_RECOVERY_ARCHITECTURE.md
+++ b/infrastructure/documentation/AGENT_RECOVERY_ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Executive Summary
 
 - **On-host watchdog** detects the stale-ECS-agent failure mode by grepping the ECS agent log for `InvalidInstanceException` / `Missing container instance arn` and re-running the documented manual recovery sequence
-- **On-host health probe** flips the instance to `Unhealthy` in the ASG when the ECS agent introspection endpoint reports `AgentConnected=false` for >5 minutes, so the ASG terminates and replaces it
+- **On-host health probe** reacts to prolonged (`>5 min`) ECS agent disconnect by tier: ASG-managed free-tier hosts are flipped to `Unhealthy` so the ASG replaces them; premium hosts (no ASG) self-terminate via `ec2:TerminateInstances`, and `cleanup_ghost_ecs_registrations()` in the premium Lambda is the backstop
 - **Out-of-band alarms** (EventBridge `agentConnected=false`, watchdog heartbeat silence, ASG↔ECS reconciliation Lambda) page humans when the on-host watchdog itself is broken
 - **ASG health-check type is `EC2`** because dynamic-port ECS targets never register with the ALB target group, so ELB health checks would silently treat stranded hosts as healthy
 - **AMI is pinned** because the watchdog parses the ECS agent log line format, which is AMI-version-specific — bumping the AMI requires the smoke test in this document
@@ -22,10 +22,10 @@
    - Plus a reconciliation Lambda that compares ASG `InService` instances against `ListContainerInstances` every 5 min
    - Any single path can fail without the system going blind
 
-3. **Alarm-only Lambda, never destructive**
+3. **Alarm-only reconciliation Lambda, never destructive**
    - The reconciliation Lambda emits a count metric and that's it
-   - The only resource that *terminates* an instance is the ASG itself, in response to the on-host probe flipping health to `Unhealthy`
-   - Centralises destructive authority on the host, where the lifecycle guard via IMDS prevents racing the capacity provider
+   - Destructive actions are tier-specific and live on the host: free-tier uses `autoscaling:SetInstanceHealth` so the ASG replaces the instance; premium (no ASG) calls `ec2:TerminateInstances` on itself, with `cleanup_ghost_ecs_registrations()` in `premium_manager.py` as the Lambda-side backstop
+   - Centralises destructive authority on the host, where the lifecycle guard via IMDS prevents racing the capacity provider; premium terminate is IAM-scoped to `Service=premium-tier`-tagged instances to contain blast radius
 
 4. **AMI pinning over `most_recent = true`**
    - Watchdog log parsing depends on the agent log format, which has shifted between AMI releases
@@ -47,11 +47,13 @@
 │  │ greps ecs-agent.log*   │   │ curls localhost:51678      │   │
 │  │ for known stale-agent  │   │ /v1/metadata; if           │   │
 │  │ error strings within   │   │ AgentConnected=false       │   │
-│  │ last 5 min; if found:  │   │ for >5 min:                │   │
-│  │   stop ecs             │   │   set-instance-health      │   │
-│  │   docker rm ecs-agent  │   │   --status Unhealthy       │   │
-│  │   rm agent.db          │   │   (ASG terminates host)    │   │
-│  │   start ecs            │   │                            │   │
+│  │ last 5 min; if found:  │   │ for >5 min, branch by      │   │
+│  │   stop ecs             │   │ INSTANCE_TIER:             │   │
+│  │   docker rm ecs-agent  │   │   free → set-instance-     │   │
+│  │   rm agent.db          │   │     health Unhealthy       │   │
+│  │   start ecs            │   │     (ASG replaces host)    │   │
+│  │                        │   │   premium → ec2:Terminate  │   │
+│  │                        │   │     Instances (no ASG)     │   │
 │  └─────────┬──────────────┘   └─────────────┬──────────────┘   │
 │            │                                │                  │
 │            ↓ PutLogEvents (heartbeat + actions)                 │
@@ -77,7 +79,8 @@
 | Detect stale-agent error in agent log   | Yes — exclusive  | No            | No                    | No               |
 | Detect prolonged AgentConnected=false   | No               | Yes — primary | Yes — secondary       | Yes — primary    |
 | Run recovery sequence (stop/rm/start)   | Yes — exclusive  | No            | No                    | No               |
-| Mark instance Unhealthy in ASG          | No               | Yes — exclusive | No                  | No               |
+| Mark instance Unhealthy in ASG (free)   | No               | Yes — exclusive | No                  | No               |
+| Self-terminate EC2 (premium, no ASG)    | No               | Yes — primary; `cleanup_ghost_ecs_registrations()` in premium Lambda is the backstop | No | No |
 | Page humans                             | No               | No            | Yes (via alarm)       | Yes (via alarm)  |
 
 ---
@@ -101,10 +104,14 @@ The watchdog (`infrastructure/scripts/ecs-user-data.sh`, embedded as a heredoc t
 The probe (`/opt/agent-recovery/health-probe.sh`, also written by user-data) runs every 5 minutes via `agent-health-probe.timer`:
 
 1. Honour the same lifecycle guard as the watchdog
-2. `curl http://localhost:51678/v1/metadata` and look for `"AgentConnected": true`
-3. If connected, clear the disconnect-since state file and exit
-4. If disconnected, write the current epoch to the state file (or read the existing one)
-5. If `now - since >= 300` seconds, call `aws autoscaling set-instance-health --health-status Unhealthy` so the ASG replaces the host
+2. Read `INSTANCE_TIER` from `/etc/agent-recovery/env` (fail-closed default `free` — a missing or unreadable env file takes the non-destructive ASG path)
+3. `curl http://localhost:51678/v1/metadata`; a non-empty `ContainerInstanceArn` counts as connected
+4. If connected, clear the disconnect-since state file, touch `$ARMED_FILE` (the "agent was connected at least once this boot" flag), and exit
+5. If disconnected and `$ARMED_FILE` does not exist, exit — we are still in first-boot agent warmup, not stranded
+6. Otherwise, write the current epoch to the state file (or read the existing one)
+7. If `now - since >= 300` seconds, branch on `INSTANCE_TIER`:
+   - `free` → `aws autoscaling set-instance-health --health-status Unhealthy` so the ASG replaces the host
+   - `premium` → `aws ec2 terminate-instances --instance-ids $INSTANCE_ID` (premium has no ASG, so `set-instance-health` is a no-op; termination is IAM-scoped to `Service=premium-tier` so the host cannot terminate a free-tier peer). The Lambda-side `cleanup_ghost_ecs_registrations()` is the backstop if this call is rate-limited or IAM-denied
 
 ### Reconciliation Lambda
 
@@ -187,7 +194,8 @@ The heartbeat-missing alarm aggregates across the whole fleet (no instance dimen
 | `CLUSTERS`                     | Comma-separated ECS cluster names for the reconciliation Lambda | `aws_ecs_cluster.main.name`                   |
 | `ASG_NAMES`                    | Comma-separated ASG names for the reconciliation Lambda         | `aws_autoscaling_group.main.name`             |
 | `RATE_LIMIT_SECONDS`           | Min seconds between watchdog recoveries per instance            | `3600` (in `watchdog.sh`)                     |
-| `DISCONNECT_THRESHOLD_SECONDS` | Seconds of `AgentConnected=false` before probe marks Unhealthy  | `300` (in `health-probe.sh`)                  |
+| `DISCONNECT_THRESHOLD_SECONDS` | Seconds of `AgentConnected=false` before probe acts             | `300` (in `health-probe.sh`)                  |
+| `INSTANCE_TIER`                | `free` or `premium`; selects the probe's disconnect action      | `free` fail-closed default (set via `/etc/agent-recovery/env` from ecs-user-data) |
 
 ---
 
@@ -247,7 +255,7 @@ If any step fails, do **not** promote the AMI to production. Revert the pin and 
 | Function / script                          | Purpose                                                                                    |
 |--------------------------------------------|--------------------------------------------------------------------------------------------|
 | `/opt/agent-recovery/watchdog.sh`          | Detects stale-agent log entries and runs the documented manual recovery sequence           |
-| `/opt/agent-recovery/health-probe.sh`      | Marks the instance Unhealthy in the ASG when the agent is disconnected for 5+ minutes      |
+| `/opt/agent-recovery/health-probe.sh`      | Acts on 5+ min agent disconnect: free-tier → mark Unhealthy in ASG; premium → self-terminate |
 | `/opt/agent-recovery/lifecycle-state.sh`   | Reads ASG target lifecycle state via IMDS; shared by watchdog and probe                    |
 | `handler()` (Lambda)                       | Counts ASG-vs-ECS reconciliation gaps and emits a CloudWatch metric                        |
 | `_registered_ec2_ids()`                    | Returns the set of EC2 IDs registered as container instances with `agentConnected=true`    |
@@ -267,4 +275,5 @@ If any step fails, do **not** promote the AMI to production. Revert the pin and 
 | `aws_cloudwatch_metric_alarm`       | `${env}-agent-recovery-heartbeat-missing`             | Pages when on-host watchdog has gone silent          |
 | `aws_cloudwatch_metric_alarm`       | `${env}-ecs-asg-instance-unregistered`                | Pages when reconciliation finds gaps                 |
 | `aws_lambda_function`               | `${env}-agent-recovery-reconciliation`                | ASG vs ECS reconciliation, alarm-only                |
-| `aws_iam_role_policy` addition      | `autoscaling:SetInstanceHealth` on ECS instance role  | Lets the on-host probe mark itself Unhealthy         |
+| `aws_iam_role_policy` addition      | `autoscaling:SetInstanceHealth` on ECS instance role  | Lets free-tier on-host probe mark itself Unhealthy   |
+| `aws_iam_role_policy` addition      | `ec2:TerminateInstances` on ECS instance role, scoped by tag `Service=premium-tier` | Lets premium on-host probe self-terminate (no ASG path available) |

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -407,12 +407,11 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 ### 4. Ghost ECS Container Instances
 
-**Problem:** EC2 instances stopped/terminated outside normal flow leave orphaned ECS registrations that confuse the ECS scheduler.
+**Problem:** Premium EC2s can land `running` with the ECS agent never (re-)registering — e.g. a `start_instances()` + `clear_ecs_agent_checkpoint()` cycle that fails to reconnect. With no ASG, nothing replaces the host, and the stale tag-match inflates `running_count` in `scale_premium_instances_if_needed()`, suppressing legitimate scale-up.
 
-**Solution:** Premium Manager's `cleanup_ghost_ecs_registrations()`:
-- Finds container instances with disconnected agents or stopped/terminated EC2
-- Force-deregisters them from the ECS cluster
-- Runs every 15 minutes as part of scheduled monitoring
+**Solution:** `cleanup_ghost_ecs_registrations()`, on the 15-min monitoring cycle, force-deregisters ghosts from ECS and — on the "EC2 `running` + agent disconnected past `_AGENT_DISCONNECT_GRACE_SECONDS` (300s)" branch — also calls `ec2.terminate_instances()`. **Terminate, not stop:** a stopped ghost is picked up by `register_orphaned_stopped_instances()` and the next `start_premium_instance()` re-runs `clear_ecs_agent_checkpoint()` on the same bad host, reproducing the failure. The on-host probe (`health-probe.sh`, premium branch — see `AGENT_RECOVERY_ARCHITECTURE.md`) is the faster independent path.
+
+**IAM:** `ec2:TerminateInstances` on the Lambda role is tag-scoped to `Service=premium-tier` (premium_manager.tf); the launch template's `Service` tag is aligned to match so direct `RunInstances` without the usual override doesn't silently hit `AccessDenied`.
 
 
 ### 5. Orphaned EC2 Instances

--- a/infrastructure/scripts/agent-recovery/health-probe.sh
+++ b/infrastructure/scripts/agent-recovery/health-probe.sh
@@ -30,6 +30,8 @@ imds_get() {
 
 INSTANCE_ID=$(imds_get instance-id); INSTANCE_ID="${INSTANCE_ID:-unknown}"
 REGION="${AWS_REGION:-$(imds_get placement/region)}"
+# Safe default: unknown tier falls through to the non-destructive ASG path.
+TIER="${INSTANCE_TIER:-free}"
 STATE_FILE=/var/run/agent-recovery/agent-disconnect-since
 ARMED_FILE=/var/run/agent-recovery/probe-armed
 DISCONNECT_THRESHOLD_SECONDS=300
@@ -82,10 +84,19 @@ fi
 
 SINCE=$(cat "$STATE_FILE" 2>/dev/null || echo "$NOW")
 if [ $((NOW - SINCE)) -ge $DISCONNECT_THRESHOLD_SECONDS ]; then
-  logger -t agent-recovery "agent disconnected for >=${DISCONNECT_THRESHOLD_SECONDS}s — marking instance Unhealthy"
-  aws autoscaling set-instance-health \
-    --instance-id "$INSTANCE_ID" \
-    --health-status Unhealthy \
-    --region "$REGION" || true
+  # Premium has no ASG, so set-instance-health is a no-op; self-terminate
+  # instead. cleanup_ghost_ecs_registrations is the Lambda-side backstop.
+  if [ "$TIER" = "premium" ]; then
+    logger -t agent-recovery "agent disconnected for >=${DISCONNECT_THRESHOLD_SECONDS}s — terminating instance"
+    aws ec2 terminate-instances \
+      --instance-ids "$INSTANCE_ID" \
+      --region "$REGION" || true
+  else
+    logger -t agent-recovery "agent disconnected for >=${DISCONNECT_THRESHOLD_SECONDS}s — marking instance Unhealthy"
+    aws autoscaling set-instance-health \
+      --instance-id "$INSTANCE_ID" \
+      --health-status Unhealthy \
+      --region "$REGION" || true
+  fi
   rm -f "$STATE_FILE"
 fi

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -425,7 +425,7 @@ resource "aws_launch_template" "premium" {
       Name        = "${local.env_prefix}-premium-instance"
       Type        = "ECS-Premium"
       Tier        = "premium"
-      Service     = "premium-spot-fleet"
+      Service     = "premium-tier"
       Environment = local.environment_label
     }
   }

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -376,9 +376,7 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Effect = "Allow"
         Action = [
           "ec2:DescribeInstances",
-          "ec2:DescribeInstanceStatus",
-          "ec2:DescribeSpotFleetInstances",
-          "ec2:DescribeSpotFleetRequests"
+          "ec2:DescribeInstanceStatus"
         ]
         Resource = "*"
       },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -5503,6 +5503,9 @@ def cleanup_ghost_ecs_registrations():
                                     f"{_AGENT_DISCONNECT_GRACE_SECONDS}s)"
                                 ),
                                 "status": status,
+                                # Terminate — stop would re-enter standby and
+                                # ghost again on next start.
+                                "terminate_ec2": True,
                             }
                         )
                         continue
@@ -5559,6 +5562,21 @@ def cleanup_ghost_ecs_registrations():
                         )
                     except Exception:
                         pass
+                if ghost.get("terminate_ec2") and ghost["ec2_instance_id"]:
+                    try:
+                        print(
+                            f"Terminating ghost EC2 "
+                            f"{ghost['ec2_instance_id']} "
+                            f"after ECS deregistration"
+                        )
+                        ec2.terminate_instances(
+                            InstanceIds=[ghost["ec2_instance_id"]],
+                        )
+                    except Exception as term_err:
+                        print(
+                            f"Failed to terminate ghost EC2 "
+                            f"{ghost['ec2_instance_id']}: {str(term_err)}"
+                        )
                 cleanup_count += 1
             except Exception as e:
                 print(

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -912,9 +912,7 @@ def get_all_premium_instances_with_states():
             # Name tag at all (tagless instances cannot be verified as belonging
             # to this environment).
             if is_premium:
-                if not name_tag or not name_tag.lower().startswith(
-                    env_prefix.lower()
-                ):
+                if not name_tag or not name_tag.lower().startswith(env_prefix.lower()):
                     print(
                         f"Skipping instance {instance_id}: "
                         f"Name '{name_tag}' does not match "
@@ -1601,15 +1599,9 @@ def create_and_stop_standby_instance():
                         f"/{len(subnet_ids)})"
                     )
 
-                    env_label = (
-                        EnvironmentConfig.get_environment_label()
-                    )
-                    env_prefix = (
-                        EnvironmentConfig.get_env_prefix()
-                    )
-                    inst_id = (
-                        PremiumInstanceConfig.INSTANCE_IDENTIFIER
-                    )
+                    env_label = EnvironmentConfig.get_environment_label()
+                    env_prefix = EnvironmentConfig.get_env_prefix()
+                    inst_id = PremiumInstanceConfig.INSTANCE_IDENTIFIER
                     response = ec2.run_instances(
                         LaunchTemplate={
                             "LaunchTemplateId": launch_template_id,
@@ -1626,15 +1618,13 @@ def create_and_stop_standby_instance():
                                     {
                                         "Key": "Name",
                                         "Value": (
-                                            f"{env_prefix}-"
-                                            f"{inst_id}-standby"
+                                            f"{env_prefix}-" f"{inst_id}-standby"
                                         ),
                                     },
                                     {
                                         "Key": "Type",
                                         "Value": (
-                                            PremiumInstanceConfig
-                                            .INSTANCE_TYPE_TAG
+                                            PremiumInstanceConfig.INSTANCE_TYPE_TAG
                                         ),
                                     },
                                     {
@@ -1643,10 +1633,7 @@ def create_and_stop_standby_instance():
                                     },
                                     {
                                         "Key": "Service",
-                                        "Value": (
-                                            PremiumInstanceConfig
-                                            .SERVICE_TAG
-                                        ),
+                                        "Value": (PremiumInstanceConfig.SERVICE_TAG),
                                     },
                                     {
                                         "Key": "Environment",
@@ -1660,8 +1647,7 @@ def create_and_stop_standby_instance():
                                     {
                                         "Key": "Name",
                                         "Value": (
-                                            f"{env_prefix}-"
-                                            f"{inst_id}-standby-vol"
+                                            f"{env_prefix}-" f"{inst_id}-standby-vol"
                                         ),
                                     },
                                     {
@@ -2367,19 +2353,8 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
         }
 
 
-def _handle_migrate_shared_users(event, context=None):
-    """Run migration loop under a distributed lock.
-
-    Uses ``context.get_remaining_time_in_millis()`` (when available)
-    to guarantee the loop exits with enough time for RELEASE_LOCK to
-    run, preventing a permanently stuck advisory lock on Lambda
-    timeout.
-    """
-    # Safety margin: exit the loop this many ms before Lambda
-    # timeout so the finally block in distributed_lock() can run
-    # RELEASE_LOCK and close the connection.
-    SAFETY_MARGIN_MS = 60_000
-
+def _handle_migrate_shared_users(event):
+    """Run migration loop under a distributed lock."""
     with distributed_lock(MIGRATE_USERS_LOCK) as acquired:
         if not acquired:
             print("Another Lambda is already running " "migrations, skipping")
@@ -2388,7 +2363,7 @@ def _handle_migrate_shared_users(event, context=None):
                 "body": json.dumps({"message": "Migration skipped - lock held"}),
             }
 
-        max_wait_seconds = event.get("max_wait_seconds", 480)
+        max_wait_seconds = event.get("max_wait_seconds", 600)
         retry_interval = event.get("retry_interval", 10)
 
         print(
@@ -2408,23 +2383,7 @@ def _handle_migrate_shared_users(event, context=None):
         time.sleep(MIGRATION_INITIAL_DELAY_SECONDS)
         elapsed += MIGRATION_INITIAL_DELAY_SECONDS
 
-        def _should_continue():
-            """Check both elapsed-time budget and Lambda remaining time."""
-            if elapsed >= max_wait_seconds:
-                return False
-            if context and hasattr(context, "get_remaining_time_in_millis"):
-                remaining = context.get_remaining_time_in_millis()
-                if remaining < SAFETY_MARGIN_MS:
-                    print(
-                        f"Approaching Lambda timeout "
-                        f"({remaining}ms remaining < "
-                        f"{SAFETY_MARGIN_MS}ms margin), "
-                        f"exiting migration loop gracefully"
-                    )
-                    return False
-            return True
-
-        while _should_continue():
+        while elapsed < max_wait_seconds:
             update_premium_service_desired_count()
 
             migration_result = process_shared_instance_optimization()
@@ -2487,7 +2446,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         # Handle async migration invocation
         if event.get("action") == "migrate_shared_users":
-            return _handle_migrate_shared_users(event, context)
+            return _handle_migrate_shared_users(event)
 
         # Handle fix_shared_flags action (one-time data cleanup)
         if event.get("action") == "fix_shared_flags":
@@ -3214,9 +3173,7 @@ def assign_premium_user(
                                 "instance_id": refreshed["instance_id"],
                                 "target_group_arn": refreshed["target_group_arn"],
                                 "rule_arn": refreshed["alb_rule_arn"],
-                                "is_shared": bool(
-                                    refreshed.get("is_shared", False)
-                                ),
+                                "is_shared": bool(refreshed.get("is_shared", False)),
                                 "assignment_source": "concurrent_migration",
                             }
                         ),
@@ -3927,14 +3884,12 @@ def invoke_migration_async():
             )
             return
 
-        # Invoke this function with a special event to trigger migration.
-        # max_wait_seconds + MIGRATION_INITIAL_DELAY_SECONDS (60) must
-        # stay well within the Lambda timeout (600s) to ensure
-        # RELEASE_LOCK runs before the process is killed.
+        # Invoke this function with a special event to trigger migration
+        # Retry every 10s for up to 180s waiting for instances to be ready
         payload = json.dumps(
             {
                 "action": "migrate_shared_users",
-                "max_wait_seconds": 480,
+                "max_wait_seconds": 600,
                 "retry_interval": 10,
             }
         )
@@ -3976,24 +3931,7 @@ def scale_premium_instances_if_needed():
             if i["state"] in [InstanceState.PENDING, InstanceState.LAUNCHING]
         ]
 
-        # Filter out ghost instances: EC2 running but no ECS tasks.
-        # These inflate the "running" count and suppress scale-up.
-        ready_running_instances = []
-        ghost_instances = []
-        for inst in running_instances:
-            if check_instance_readiness(inst["instance_id"]):
-                ready_running_instances.append(inst)
-            else:
-                ghost_instances.append(inst)
-        if ghost_instances:
-            ghost_ids = [g["instance_id"] for g in ghost_instances]
-            print(
-                f"WARNING: {len(ghost_instances)} ghost instance(s) detected "
-                f"(EC2 running, 0 ECS tasks): {ghost_ids}. "
-                f"Excluded from capacity calculation."
-            )
-
-        running_count = len(ready_running_instances)
+        running_count = len(running_instances)
         launching_count = len(launching_instances)
         total_instances = len(all_instances)
 
@@ -4007,8 +3945,7 @@ def scale_premium_instances_if_needed():
         effective_capacity = running_count + launching_count
 
         print("Enhanced premium instance analysis:")
-        print(f"- Running instances (ready): {running_count}")
-        print(f"- Ghost instances (running, no ECS tasks): {len(ghost_instances)}")
+        print(f"- Running instances: {running_count}")
         print(f"- Launching instances: {launching_count}")
         print(f"- Standby creation in progress: {standby_creating}")
         print(f"- Running creation in progress: {running_creating}")

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2353,8 +2353,17 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
         }
 
 
-def _handle_migrate_shared_users(event):
-    """Run migration loop under a distributed lock."""
+def _handle_migrate_shared_users(event, context=None):
+    """Run migration loop under a distributed lock.
+
+    Exits the loop with a 60 s safety margin before the Lambda
+    timeout so the ``finally`` in ``distributed_lock`` can run
+    ``RELEASE_LOCK``. Without this the Lambda is SIGKILLed
+    mid-loop and the lock releases only after RDS Proxy tears
+    down the pinned backend connection (~30-60 s).
+    """
+    SAFETY_MARGIN_MS = 60_000
+
     with distributed_lock(MIGRATE_USERS_LOCK) as acquired:
         if not acquired:
             print("Another Lambda is already running " "migrations, skipping")
@@ -2383,7 +2392,21 @@ def _handle_migrate_shared_users(event):
         time.sleep(MIGRATION_INITIAL_DELAY_SECONDS)
         elapsed += MIGRATION_INITIAL_DELAY_SECONDS
 
-        while elapsed < max_wait_seconds:
+        def _should_continue():
+            if elapsed >= max_wait_seconds:
+                return False
+            if context and hasattr(context, "get_remaining_time_in_millis"):
+                remaining = context.get_remaining_time_in_millis()
+                if remaining < SAFETY_MARGIN_MS:
+                    print(
+                        f"Approaching Lambda timeout ({remaining}ms "
+                        f"remaining < {SAFETY_MARGIN_MS}ms margin), "
+                        f"exiting migration loop gracefully"
+                    )
+                    return False
+            return True
+
+        while _should_continue():
             update_premium_service_desired_count()
 
             migration_result = process_shared_instance_optimization()
@@ -2446,7 +2469,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         # Handle async migration invocation
         if event.get("action") == "migrate_shared_users":
-            return _handle_migrate_shared_users(event)
+            return _handle_migrate_shared_users(event, context)
 
         # Handle fix_shared_flags action (one-time data cleanup)
         if event.get("action") == "fix_shared_flags":

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -239,6 +239,18 @@ resource "aws_iam_role_policy" "ecs_instance_enhanced_monitoring" {
         Effect   = "Allow"
         Action   = "autoscaling:SetInstanceHealth"
         Resource = aws_autoscaling_group.main.arn
+      },
+      {
+        # Premium has no ASG: the probe self-terminates instead. Tag-scoped
+        # so only premium instances can be targets.
+        Effect   = "Allow"
+        Action   = "ec2:TerminateInstances"
+        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+        Condition = {
+          StringEquals = {
+            "ec2:ResourceTag/Service" = "premium-tier"
+          }
+        }
       }
     ]
   })

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aws_constants import ECSTaskStatus, PremiumInstanceConfig
+from aws_constants import ECSTaskStatus, PremiumAssignment, PremiumInstanceConfig
 from conftest import MockRow, setup_db_mock
 
 TEST_USER_ID = "test_user_12345"
@@ -2922,6 +2922,42 @@ class TestCleanupGhostECSRegistrations:
                 containerInstance=ci_arn,
                 force=True,
             )
+            mock_ec2.terminate_instances.assert_called_once_with(
+                InstanceIds=["i-expired1"],
+            )
+
+    def test_does_not_terminate_already_stopped_ec2(self, mock_env_vars_premium):
+        """Stopped EC2 is deregistered but not re-terminated."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/stopped1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-stopped1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {"Instances": [{"State": {"Name": "stopped"}, "Tags": []}]}
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once()
+            mock_ec2.terminate_instances.assert_not_called()
 
     def test_clears_tag_on_reconnect(self, mock_env_vars_premium):
         """Connected agent triggers delete_tags to clear disconnect tag."""
@@ -3039,6 +3075,193 @@ class TestCleanupGhostECSRegistrations:
             )
             # No EC2 calls should be made
             mock_ec2.describe_instances.assert_not_called()
+
+
+class TestAssignPremiumUserConcurrentMigration:
+    """When inline migration has no candidate but a concurrent Lambda has
+    already migrated the user, assign_premium_user must re-check and return
+    the updated dedicated assignment instead of falling back to async."""
+
+    def _pool_assignment(self):
+        return {
+            "instance_id": PremiumAssignment.AUTOSCALING_POOL,
+            "target_group_arn": "tg-pool",
+            "alb_rule_arn": "rule-pool",
+            "is_shared": False,
+        }
+
+    def _dedicated_assignment(self, instance_id):
+        return {
+            "instance_id": instance_id,
+            "target_group_arn": f"tg-{instance_id}",
+            "alb_rule_arn": f"rule-{instance_id}",
+            "is_shared": False,
+        }
+
+    def test_concurrent_migration_returns_refreshed_assignment(
+        self, mock_env_vars_premium
+    ):
+        """Second get_existing_user_assignment sees a new dedicated
+        instance → response reflects it, async migration is not invoked."""
+        new_id = "i-dedicated-new"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_assignment, patch(
+            "premium_manager.get_all_premium_instances_with_states",
+            return_value=[],
+        ), patch(
+            "premium_manager.invoke_migration_async"
+        ) as mock_invoke_async, patch(
+            "boto3.client"
+        ):
+            mock_get_assignment.side_effect = [
+                self._pool_assignment(),
+                self._dedicated_assignment(new_id),
+            ]
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(user_id=42, event={}, user_uid="uid-42")
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert body["assignment_source"] == "concurrent_migration"
+            assert body["instance_id"] == new_id
+            assert body["is_shared"] is False
+            mock_invoke_async.assert_not_called()
+            assert mock_get_assignment.call_count == 2
+
+    def test_no_concurrent_migration_falls_back_to_async(self, mock_env_vars_premium):
+        """If the re-check still returns the pool assignment,
+        invoke_migration_async must run."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment"
+        ) as mock_get_assignment, patch(
+            "premium_manager.get_all_premium_instances_with_states",
+            return_value=[],
+        ), patch(
+            "premium_manager.invoke_migration_async"
+        ) as mock_invoke_async, patch(
+            "boto3.client"
+        ):
+            mock_get_assignment.side_effect = [
+                self._pool_assignment(),
+                self._pool_assignment(),
+            ]
+
+            from premium_manager import assign_premium_user
+
+            result = assign_premium_user(user_id=42, event={}, user_uid="uid-42")
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert body.get("assignment_source") != "concurrent_migration"
+            mock_invoke_async.assert_called_once()
+
+
+class TestHandleMigrateSharedUsersTimeout:
+    """Migration loop must exit before the Lambda is SIGKILLed, so the
+    ``finally`` in ``distributed_lock`` can release the MySQL advisory
+    lock synchronously (as opposed to relying on RDS Proxy to tear down
+    the pinned backend connection ~30-60 s later)."""
+
+    def _common_patches(self, mock_env_vars_premium):
+        """Patch out everything the migration loop touches except the
+        pieces under test (loop condition + ``context`` handling)."""
+        lock_cm = MagicMock()
+        lock_cm.__enter__.return_value = True
+        lock_cm.__exit__.return_value = None
+
+        return [
+            patch.dict("os.environ", mock_env_vars_premium),
+            patch("premium_manager.distributed_lock", return_value=lock_cm),
+            patch("premium_manager.time.sleep"),
+            patch("premium_manager.update_premium_service_desired_count"),
+            patch("premium_manager.get_assigned_users_for_instance", return_value=[]),
+        ]
+
+    def test_exits_early_when_lambda_time_low(self, mock_env_vars_premium):
+        """When ``context.get_remaining_time_in_millis()`` drops below the
+        60 s safety margin, the loop must exit *without* starting another
+        iteration, even if ``elapsed < max_wait_seconds`` is still true."""
+        mock_process = MagicMock(
+            return_value={"migrations_performed": 0, "shared_instances_found": 1}
+        )
+        mock_context = MagicMock()
+        # 30 s remaining — below the 60 s safety margin on the very first
+        # check, so the loop should never enter an iteration.
+        mock_context.get_remaining_time_in_millis.return_value = 30_000
+
+        patches = self._common_patches(mock_env_vars_premium) + [
+            patch("premium_manager.process_shared_instance_optimization", mock_process),
+        ]
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            from premium_manager import _handle_migrate_shared_users
+
+            result = _handle_migrate_shared_users(
+                {"max_wait_seconds": 600, "retry_interval": 10},
+                context=mock_context,
+            )
+
+        assert result["statusCode"] == 200
+        # Zero iterations: the loop short-circuits on the context check
+        # before the first call to process_shared_instance_optimization.
+        mock_process.assert_not_called()
+
+    def test_runs_at_least_one_iteration_when_time_plentiful(
+        self, mock_env_vars_premium
+    ):
+        """With plenty of remaining time and a completed migration, the
+        loop runs a normal iteration and exits via the success path."""
+        # First call: migrates a user. Second call (if it happens): none.
+        # The happy-path branch in _handle_migrate_shared_users exits the
+        # loop once migrations_performed>0 and no shared instances remain.
+        mock_process = MagicMock(
+            side_effect=[
+                {"migrations_performed": 1, "shared_instances_found": 0},
+            ]
+        )
+        mock_context = MagicMock()
+        mock_context.get_remaining_time_in_millis.return_value = 500_000  # 500 s
+
+        patches = self._common_patches(mock_env_vars_premium) + [
+            patch("premium_manager.process_shared_instance_optimization", mock_process),
+        ]
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            from premium_manager import _handle_migrate_shared_users
+
+            _handle_migrate_shared_users(
+                {"max_wait_seconds": 600, "retry_interval": 10},
+                context=mock_context,
+            )
+
+        assert mock_process.call_count >= 1
+
+    def test_works_without_context(self, mock_env_vars_premium):
+        """``context=None`` (local invocation / older callers) must still
+        be accepted; the loop falls back to the elapsed-time budget."""
+        mock_process = MagicMock(
+            return_value={"migrations_performed": 1, "shared_instances_found": 0}
+        )
+
+        patches = self._common_patches(mock_env_vars_premium) + [
+            patch("premium_manager.process_shared_instance_optimization", mock_process),
+        ]
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            from premium_manager import _handle_migrate_shared_users
+
+            result = _handle_migrate_shared_users(
+                {"max_wait_seconds": 600, "retry_interval": 10},
+                # No context kwarg — use the default.
+            )
+
+        assert result["statusCode"] == 200
+        mock_process.assert_called()
 
 
 class TestGetHostPortForInstance:

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -729,7 +729,8 @@ class TestEarlyCheckAndCleanup:
                 assert response_body.get("instance_id") == "autoscaling-pool"
                 assert response_body.get("assignment_source") == "existing"
                 assert mock_invoke_migration.called
-                mock_get_existing.assert_called_once_with(test_user_id)
+                mock_get_existing.assert_called_with(test_user_id)
+                assert mock_get_existing.call_count == 2
                 assert not mock_elbv2.create_rule.called
 
     def test_restore_pending_release_returns_alb_fields(self, mock_env_vars_premium):


### PR DESCRIPTION
## Content

#### Summary
- Builds on the migration-lock fix in the target branch. Keeps the post-inline-migration re-check (so a user migrated by a concurrent Lambda is reflected in the response), keeps the Lambda-timeout safety-margin helper (`_should_continue` exits the loop 60 s before Lambda timeout so `RELEASE_LOCK` runs synchronously rather than waiting on RDS Proxy to tear down the pinned connection), and drops the ghost-exclusion in `scale_premium_instances_if_needed` — that one added complexity without closing the root cause.
- Gives the system a real way to evict ghost premium instances: the on-host health probe now self-terminates (premium has no ASG, so `set-instance-health` was a no-op) and `cleanup_ghost_ecs_registrations` now terminates the EC2 after deregistering ECS.
- Adds the matching IAM grant (`ec2:TerminateInstances` scoped by `Service=premium-tier`), aligns the premium launch-template `Service` tag to `premium-tier` so it matches the condition, and drops two vestigial `ec2:DescribeSpotFleet*` actions (we have no spot fleet).
- Expands unit test coverage for the three behaviors above: concurrent-migration re-check, migration-loop timeout guard (including the `context=None` fallback), and ghost cleanup skipping already-stopped EC2.

#### Design Decisions
- **Keep re-check and timeout guard; drop ghost exclusion.** The re-check plugs a real user-visible race (two assign requests, one migrates, the other must not bounce back to the shared pool). The `get_remaining_time_in_millis` safety margin prevents a SIGKILL from stranding the MySQL advisory lock on the pinned RDS Proxy backend — `distributed_lock()`'s `finally` only runs `RELEASE_LOCK` if the loop exits cleanly, and the reaper session only fires after RDS Proxy tears down the pinned connection (~30-60 s later), during which a follow-up migration invocation will skip. 60 s of head-room is cheap insurance. `max_wait_seconds` stays at 600s (the full Lambda window); the helper short-circuits before we hit it. The ghost-exclusion in `scale_premium_instances_if_needed` is the one piece we drop — ghosts are now force-terminated by the probe + Lambda sweep, so filtering them out of capacity math is redundant.
- **Terminate, not stop, for ghosts.** A stopped premium EC2 gets restarted by the Lambda for a new user session; if the underlying cause (agent bricked, network partition) persists, the instance ghosts again on next boot. Terminate forces a fresh launch.
- **Probe self-terminates only on `TIER=premium`.** `TIER="${INSTANCE_TIER:-free}"` fails closed — a missing env var takes the non-destructive ASG path. Free-tier behavior is unchanged.
- **Lambda-side terminate is the backstop.** If the probe's terminate is rate-limited or IAM-denied, `cleanup_ghost_ecs_registrations` still removes the ghost within its grace period.
- **Launch-template tag fix is a footgun removal.** `aws_instance.premium` and the Lambda `RunInstances` call both override `Service` to `premium-tier`, so the launch-template's `premium-spot-fleet` label was invisible in practice — but a future RunInstances that forgets the override would silently fail the IAM condition. Aligning the template closes that.

### Evidence
- Before: premium ghost → probe logs `marking instance Unhealthy` → ASG API returns success but the instance isn't in an ASG, so nothing happens → instance stays stranded until `cleanup_orphaned_ec2_instances` runs.
- After: premium ghost → probe logs `terminating instance` → `ec2:TerminateInstances` succeeds (IAM condition matches `Service=premium-tier`) → ECS registration cleaned up by Lambda on next run.
- Lambda-side ghost termination logs: `Terminating ghost EC2 <id> after ECS deregistration`.

### References
- Target branch PR: migration-lock fix (`2d8b41517`) that this one patches.
- `AGENT_RECOVERY_ARCHITECTURE.md` — agent-recovery timer semantics.
- Existing IAM-scoped terminate policy in `premium_manager.tf` (Lambda role) — same shape reused on the ECS instance role.

#### Files changed
- `infrastructure/scripts/agent-recovery/health-probe.sh` — branch on `INSTANCE_TIER`; premium self-terminates via `ec2:TerminateInstances`, free-tier keeps the ASG `set-instance-health` path.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — ghost-instance cleanup flags `terminate_ec2: True` on the running-EC2+past-grace branch and calls `ec2.terminate_instances` after `deregister_container_instance`; reverts the `scale_premium_instances_if_needed` ghost filter; `max_wait_seconds` stays 600s; keeps the inline-migration re-check; `_handle_migrate_shared_users` accepts an optional `context` and uses a `_should_continue` helper with a 60 s `SAFETY_MARGIN_MS` to exit the migration loop before the Lambda is SIGKILLed (fall-back to elapsed-time budget when `context` is `None`).
- `infrastructure/terraform/security.tf` — grants the ECS instance role `ec2:TerminateInstances` scoped by tag `Service=premium-tier`, so the probe can act.
- `infrastructure/terraform/compute.tf` — fixes premium launch-template tag `Service` from `premium-spot-fleet` → `premium-tier` so instances launched from the template directly still satisfy the IAM condition.
- `infrastructure/terraform/premium_manager.tf` — removes unused `ec2:DescribeSpotFleetInstances` / `ec2:DescribeSpotFleetRequests` from the Lambda role; there is no spot fleet in this stack.

### Manual Testcases

- [x] **1. Premium ghost → probe self-terminates.** Dry-run + real `ec2:TerminateInstances` from the ECS instance profile succeeded; instance transitioned `running → terminated` in ~30 s.

- [x] **2. Free-tier ghost → ASG path unchanged.** `INSTANCE_TIER=free` confirmed. `ec2:TerminateInstances` against a `Service=autoscaling` target returned `UnauthorizedOperation` (tag condition denies); `autoscaling:DescribeAutoScalingInstances` still works.

- [x] **3. Lambda-side ghost sweep terminates a stranded EC2.** Induced a ghost and invoked scheduled monitoring. Lambda logged the expected `Terminating ghost EC2 <id> after ECS deregistration` sequence; EC2 ended `terminated`, container instance `INACTIVE`.

- [x] **4. Concurrent assignment re-check still works** — live-partial + unit-test-covered. The re-check code path executed on every concurrent-assign fallback (`Inline migration not possible ... falling back to async migration`). The `assignment_source: "concurrent_migration"` branch requires a committed migration mid-race, which is pinned by `TestAssignPremiumUserConcurrentMigration`.

- [x] **5. Migration loop exits before Lambda SIGKILL.** `Approaching Lambda timeout (<60000ms margin), exiting migration loop gracefully` fired twice in live traffic, each followed by `Released lock 'migrate_users_lock'` within ~10 ms. Zero `Task timed out` entries in the same window.

- [x] **Automated:** `pytest studio/tests/infrastructure/test_premium_manager.py studio/tests/infrastructure/test_premium_cleanup.py -v` → **111 passed, 3 warnings in 37.12 s**. All PR-specific tests pass.

### Unit, Integration, Contract Test Coverage
- `studio/tests/infrastructure/test_premium_manager.py`
  - `TestCleanupGhostECSRegistrations.test_does_not_terminate_already_stopped_ec2` — deregister still runs, but `ec2.terminate_instances` is skipped when the EC2 is already `stopped`.
  - `TestAssignPremiumUserConcurrentMigration` — re-check path returns `assignment_source: "concurrent_migration"` with the refreshed `instance_id` when a concurrent Lambda has migrated the user, and falls back to `invoke_migration_async` otherwise.
  - `TestHandleMigrateSharedUsersTimeout` — loop exits with zero iterations when `context.get_remaining_time_in_millis()` is below the 60 s safety margin, runs at least one iteration when time is plentiful, and accepts `context=None` (falls back to the elapsed-time budget).
- `studio/tests/infrastructure/test_premium_cleanup.py` — existing ghost cleanup path (already asserts `terminate_ec2: True` and the `ec2.terminate_instances` call on the past-grace branch).

### Others

#### Difficulties (if any)
- Two overlapping ghost-eviction mechanisms (on-host probe + Lambda sweep) mean a terminated instance can briefly race a describe — both sides swallow `InvalidInstanceID` so the loser is harmless.
- The launch-template tag had drifted from the `aws_instance` tag (`premium-spot-fleet` vs `premium-tier`); not active today but would have been a silent IAM denial if anything ever ran from the template without the override.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Premium health probe (`health-probe.sh`) | Medium | First time the probe takes a destructive action. Gated on `TIER=premium` + ≥5 min disconnect + `ARMED_FILE` (agent was connected at least once this boot); IAM is tag-scoped. Fail-closed default (`TIER=free`) protects against a missing env file. |
| Ghost cleanup Lambda (`premium_manager.py`) | Medium | Adds terminate to an existing deregister path. Only runs on the past-grace-period branch; stopped/terminated EC2 are skipped. Terminate errors are logged but don't block `cleanup_count`. |
| IAM (`security.tf`) | Medium | New `TerminateInstances` on the shared ECS instance role. Tag-scoped to `Service=premium-tier`, region- and account-scoped. Free-tier hosts inherit the permission but can only target premium-tier instances. |
| Launch-template tag (`compute.tf`) | Low | Alignment only — the actual running tag was already `premium-tier` via the `aws_instance` override. |
| Lambda role (`premium_manager.tf`) | Low | Removes two unused Describe actions; no functional impact (no spot fleet exists). |
| Migration loop timeout guard (`_should_continue`) | Low | Loop now exits 60 s before Lambda timeout so `RELEASE_LOCK` runs in `finally`. `context=None` path is covered and falls back to the elapsed-time budget. `max_wait_seconds` stays 600s (unchanged from `2d8b41517`). |
