### PR TITLE
Adjusted the display of Platform service info

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/service.ts
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/service.ts
@@ -23,6 +23,7 @@ export type TParamQueryLogs = TParams & { reverse?: boolean; offset: number }
 export type TPlatformInfo = {
   service_name: string
   task_id: string
+  instance_id: string
 }
 
 export const fetchAvailableLogLevels = async (): Promise<TLevelsLog[]> => {

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
@@ -366,7 +366,8 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
         {platform ? (
           <PlatformInfoBox>
             <span>
-              Platform service name: {platform.service_name}
+              Service: {platform.service_name}, Task: {platform.task_id} (
+              {platform.instance_id})
               {platform.service_name.includes("-premium-") ? (
                 <WorkspacePremiumIcon
                   sx={{ ...serviceNameIconSx, color: "#fffb00" }}
@@ -376,9 +377,6 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
                   sx={{ ...serviceNameIconSx, color: "#ffffff" }}
                 />
               )}
-            </span>
-            <span>
-              task id: {platform.task_id} ({platform.instance_id})
             </span>
           </PlatformInfoBox>
         ) : null}

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
@@ -12,6 +12,7 @@ import styled from "@emotion/styled"
 import AdbIcon from "@mui/icons-material/Adb"
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos"
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos"
+import CheckCircleIcon from "@mui/icons-material/CheckCircle"
 import CloseIcon from "@mui/icons-material/Close"
 import ComputerIcon from "@mui/icons-material/Computer"
 import ErrorIcon from "@mui/icons-material/Error"
@@ -22,6 +23,7 @@ import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrow
 import MenuIcon from "@mui/icons-material/Menu"
 import SearchIcon from "@mui/icons-material/Search"
 import WarningIcon from "@mui/icons-material/Warning"
+import WorkspacePremiumIcon from "@mui/icons-material/WorkspacePremium"
 import { Badge, Box, Modal, Tooltip } from "@mui/material"
 
 import {
@@ -40,6 +42,12 @@ type Props = {
 }
 
 const SPACE_CHECK_SCROLL = 50
+
+const serviceNameIconSx = {
+  fontSize: 18,
+  verticalAlign: "-4px",
+  ml: 0.5,
+} as const
 
 const ModalLogs = ({ isOpen = false, onClose }: Props) => {
   const [levels, setLevels] = useState<TLevelsLog[]>([])
@@ -357,7 +365,18 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
         ) : null}
         {platform ? (
           <PlatformInfoBox>
-            <span>Platform service name: {platform.service_name}</span>
+            <span>
+              Platform service name: {platform.service_name}
+              {platform.service_name.includes("-premium-") ? (
+                <WorkspacePremiumIcon
+                  sx={{ ...serviceNameIconSx, color: "#FFD700" }}
+                />
+              ) : (
+                <CheckCircleIcon
+                  sx={{ ...serviceNameIconSx, color: "#ffffff" }}
+                />
+              )}
+            </span>
             <span>task id: {platform.task_id}</span>
           </PlatformInfoBox>
         ) : null}

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
@@ -12,7 +12,7 @@ import styled from "@emotion/styled"
 import AdbIcon from "@mui/icons-material/Adb"
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos"
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos"
-import CheckCircleIcon from "@mui/icons-material/CheckCircle"
+import CheckCircleOutline from "@mui/icons-material/CheckCircleOutline"
 import CloseIcon from "@mui/icons-material/Close"
 import ComputerIcon from "@mui/icons-material/Computer"
 import ErrorIcon from "@mui/icons-material/Error"
@@ -369,15 +369,17 @@ const ModalLogs = ({ isOpen = false, onClose }: Props) => {
               Platform service name: {platform.service_name}
               {platform.service_name.includes("-premium-") ? (
                 <WorkspacePremiumIcon
-                  sx={{ ...serviceNameIconSx, color: "#FFD700" }}
+                  sx={{ ...serviceNameIconSx, color: "#fffb00" }}
                 />
               ) : (
-                <CheckCircleIcon
+                <CheckCircleOutline
                   sx={{ ...serviceNameIconSx, color: "#ffffff" }}
                 />
               )}
             </span>
-            <span>task id: {platform.task_id}</span>
+            <span>
+              task id: {platform.task_id} ({platform.instance_id})
+            </span>
           </PlatformInfoBox>
         ) : null}
       </Content>

--- a/studio/app/common/core/platform_metadata.py
+++ b/studio/app/common/core/platform_metadata.py
@@ -98,21 +98,19 @@ def _get_ecs_instance_id() -> str:
         return NO_ECS_INSTANCE_DEFAULT
 
 
-def _mask_instance_id(instance_id: str) -> str:
-    """Truncate an EC2 instance ID to a short prefix for safe exposure.
+def _truncate_id(value: str, max_length: int) -> str:
+    """Truncate an ID string to *max_length* characters for safe exposure.
 
-    Example: ``i-0a1b2c3d4e5f67890`` → ``i-0a1b2c``
-
-    The ``i-`` prefix and the first 6 hex characters are preserved so
-    the value remains useful for prefix-searching in AWS Console or log files.
+    Returns the original value unchanged when it is already short enough.
     """
-    _VISIBLE_CHARS = 6
-    prefix, _, hex_part = instance_id.partition("-")
-    if not hex_part or len(hex_part) <= _VISIBLE_CHARS:
-        return instance_id
-    return f"{prefix}-{hex_part[:_VISIBLE_CHARS]}"
+    if len(value) <= max_length:
+        return value
+    return value[:max_length]
 
 
-ECS_TASK_ID: str = _get_ecs_task_id()
+_ECS_TASK_ID_LENGTH = 10
+_ECS_INSTANCE_ID_LENGTH = 8  # "i-" prefix (2) + 6 hex chars
+
+ECS_TASK_ID: str = _truncate_id(_get_ecs_task_id(), _ECS_TASK_ID_LENGTH)
 ECS_SERVICE_NAME: str = _get_ecs_service_name()
-ECS_INSTANCE_ID: str = _mask_instance_id(_get_ecs_instance_id())
+ECS_INSTANCE_ID: str = _truncate_id(_get_ecs_instance_id(), _ECS_INSTANCE_ID_LENGTH)

--- a/studio/app/common/core/platform_metadata.py
+++ b/studio/app/common/core/platform_metadata.py
@@ -15,6 +15,7 @@ _ECS_METADATA_TIMEOUT = 2
 
 NO_ECS_TASK_DEFAULT = "local"
 NO_ECS_SERVICE_DEFAULT = "none"
+NO_ECS_INSTANCE_DEFAULT = "none"
 
 
 def _get_ecs_task_id() -> str:
@@ -51,5 +52,67 @@ def _get_ecs_service_name() -> str:
         return NO_ECS_SERVICE_DEFAULT
 
 
+def _get_ecs_instance_id() -> str:
+    """Resolve the EC2 instance ID backing the current ECS task.
+
+    Uses the ECS metadata endpoint to obtain the cluster and task ARN,
+    then calls the ECS API (DescribeTasks → DescribeContainerInstances)
+    to look up the underlying EC2 instance ID.
+    Returns ``NO_ECS_INSTANCE_DEFAULT`` when the information is unavailable
+    (e.g. Fargate, local development, or insufficient IAM permissions).
+    """
+    meta_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+    if not meta_uri:
+        return NO_ECS_INSTANCE_DEFAULT
+    try:
+        req = urllib.request.Request(f"{meta_uri}/task")
+        with urllib.request.urlopen(req, timeout=_ECS_METADATA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+
+        task_arn = data.get("TaskARN", "")
+        cluster_arn = data.get("Cluster", "")
+        if not task_arn or not cluster_arn:
+            return NO_ECS_INSTANCE_DEFAULT
+
+        import boto3
+
+        ecs = boto3.client("ecs")
+        tasks_resp = ecs.describe_tasks(cluster=cluster_arn, tasks=[task_arn])
+        tasks = tasks_resp.get("tasks", [])
+        if not tasks:
+            return NO_ECS_INSTANCE_DEFAULT
+
+        container_instance_arn = tasks[0].get("containerInstanceArn", "")
+        if not container_instance_arn:
+            return NO_ECS_INSTANCE_DEFAULT
+
+        ci_resp = ecs.describe_container_instances(
+            cluster=cluster_arn, containerInstances=[container_instance_arn]
+        )
+        instances = ci_resp.get("containerInstances", [])
+        if not instances:
+            return NO_ECS_INSTANCE_DEFAULT
+
+        return instances[0].get("ec2InstanceId", NO_ECS_INSTANCE_DEFAULT)
+    except Exception:
+        return NO_ECS_INSTANCE_DEFAULT
+
+
+def _mask_instance_id(instance_id: str) -> str:
+    """Truncate an EC2 instance ID to a short prefix for safe exposure.
+
+    Example: ``i-0a1b2c3d4e5f67890`` → ``i-0a1b2c``
+
+    The ``i-`` prefix and the first 6 hex characters are preserved so
+    the value remains useful for prefix-searching in AWS Console or log files.
+    """
+    _VISIBLE_CHARS = 6
+    prefix, _, hex_part = instance_id.partition("-")
+    if not hex_part or len(hex_part) <= _VISIBLE_CHARS:
+        return instance_id
+    return f"{prefix}-{hex_part[:_VISIBLE_CHARS]}"
+
+
 ECS_TASK_ID: str = _get_ecs_task_id()
 ECS_SERVICE_NAME: str = _get_ecs_service_name()
+ECS_INSTANCE_ID: str = _mask_instance_id(_get_ecs_instance_id())

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -7,7 +7,11 @@ from typing_extensions import Optional
 
 from studio.app.common.core.auth.auth_dependencies import get_current_user
 from studio.app.common.core.logger import VALID_LOG_LEVELS, AppLogger
-from studio.app.common.core.platform_metadata import ECS_SERVICE_NAME, ECS_TASK_ID
+from studio.app.common.core.platform_metadata import (
+    ECS_INSTANCE_ID,
+    ECS_SERVICE_NAME,
+    ECS_TASK_ID,
+)
 from studio.app.common.core.utils.log_reader import LogLevel, LogReader
 from studio.app.common.schemas.outputs import PaginatedLineResult, PlatformInfo
 from studio.app.common.schemas.users import User
@@ -72,7 +76,11 @@ async def get_log_data(
     levels: List[LogLevel] = Query(default=[LogLevel.ALL]),
 ):
     try:
-        platform = PlatformInfo(service_name=ECS_SERVICE_NAME, task_id=ECS_TASK_ID)
+        platform = PlatformInfo(
+            service_name=ECS_SERVICE_NAME,
+            task_id=ECS_TASK_ID,
+            instance_id=ECS_INSTANCE_ID,
+        )
         stop_offset = None
         log_reader = LogReader(
             levels=levels, filter_user_id=current_user.uid if current_user else None

--- a/studio/app/common/schemas/outputs.py
+++ b/studio/app/common/schemas/outputs.py
@@ -37,6 +37,7 @@ class TextPosition:
 class PlatformInfo:
     service_name: str
     task_id: str
+    instance_id: str
 
 
 @dataclass


### PR DESCRIPTION
### Content

Adjusted the display of platform information in the log viewer.

#### Added an icon to indicate the service type (free/premium) status

- free service
  <img width="385" height="47" alt="image" src="https://github.com/user-attachments/assets/c57c4a8b-caa1-46d8-9e37-2fe922d564ca" />
- premium service
  <img width="443" height="47" alt="image" src="https://github.com/user-attachments/assets/7f65279b-0d55-4c3e-b0b6-55647abce875" />

#### Added instance IDs corresponding to task IDs

- image
  <img width="385" height="47" alt="image" src="https://github.com/user-attachments/assets/471268f5-8be3-4ef7-b78e-b444c0025e70" />

*For security reasons, only a portion of the information is displayed.

### References

- #462

### Manual Testcases

- [x] Verification in a local environment
  - In the local environment, the following settings are fixed.
    > Platform service name: none
    > task id: local (none)
- [x] Verification in a cloud environment