### PR TITLE
Patch 2:  cross-env tag scope, stale routing_id, and ghost-cleanup desiredCount drift

### DIFF
--- a/frontend/src/store/slice/User/UserSlice.ts
+++ b/frontend/src/store/slice/User/UserSlice.ts
@@ -86,6 +86,8 @@ export const userSlice = createSlice({
       .addMatcher(
         isAnyOf(login.fulfilled, proxyLogin.fulfilled),
         (_, action) => {
+          // Prior user's routing_id would replay with the new JWT → 403.
+          routingService.clearRoutingInfo()
           saveToken(action.payload.access_token)
           saveRefreshToken(action.payload.refresh_token)
           saveExToken(action.payload.ex_token)

--- a/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
+++ b/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
@@ -189,6 +189,66 @@ describe("UserSlice", () => {
     })
   })
 
+  describe("login.fulfilled", () => {
+    it("should clear stale routing info before saving new tokens", () => {
+      const state = userSlice.reducer(undefined, { type: "@@INIT" })
+
+      const loginFulfilledAction = {
+        type: "user/login/fulfilled",
+        payload: {
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          ex_token: "new-ex",
+        },
+      }
+
+      userSlice.reducer(state, loginFulfilledAction)
+
+      expect(mockClearRoutingInfo).toHaveBeenCalledTimes(1)
+      expect(mockSaveToken).toHaveBeenCalledWith("new-access")
+      expect(mockSaveRefreshToken).toHaveBeenCalledWith("new-refresh")
+      expect(mockSaveExToken).toHaveBeenCalledWith("new-ex")
+
+      const clearOrder = mockClearRoutingInfo.mock.invocationCallOrder[0]
+      const saveOrder = mockSaveToken.mock.invocationCallOrder[0]
+      expect(clearOrder).toBeLessThan(saveOrder)
+    })
+  })
+
+  describe("login.rejected", () => {
+    it("should fully reset auth state on login failure", () => {
+      const stateWithUser: User = {
+        currentUser: {
+          id: 1,
+          uid: "test",
+          email: "test@example.com",
+        } as User["currentUser"],
+        listUserSearch: undefined,
+        listUser: undefined,
+        loading: true,
+        logoutGeneration: 3,
+      }
+
+      const nextState = userSlice.reducer(stateWithUser, {
+        type: "user/login/rejected",
+        error: { message: "bad credentials" },
+      })
+
+      expect(mockRemoveToken).toHaveBeenCalledTimes(1)
+      expect(mockRemoveRefreshToken).toHaveBeenCalledTimes(1)
+      expect(mockRemoveExToken).toHaveBeenCalledTimes(1)
+      expect(mockClearRoutingInfo).toHaveBeenCalledTimes(1)
+      expect(mockSaveToken).not.toHaveBeenCalled()
+      expect(mockSaveRefreshToken).not.toHaveBeenCalled()
+      expect(mockSaveExToken).not.toHaveBeenCalled()
+
+      expect(nextState.currentUser).toBeUndefined()
+      expect(nextState.listUser).toBeUndefined()
+      expect(nextState.listUserSearch).toBeUndefined()
+      expect(nextState.loading).toBe(false)
+    })
+  })
+
   describe("getMe.rejected", () => {
     it("should clear currentUser but not clear tokens", () => {
       const stateWithUser: User = {

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -32,7 +32,7 @@ WantedBy=multi-user.target
 UNIT_EOF
 
 systemctl daemon-reload
-systemctl enable ecs-clear-checkpoint.service
+systemctl enable --now ecs-clear-checkpoint.service
 fi
 
 # =====================================================================

--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -237,7 +237,6 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
           "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${aws_instance.background.id}",
         ]
       },
-      # EC2 stop/start for premium instances (by tag)
       {
         Effect = "Allow"
         Action = [
@@ -247,7 +246,8 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
         Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
         Condition = {
           StringEquals = {
-            "ec2:ResourceTag/Service" = "premium-tier"
+            "ec2:ResourceTag/Service"     = "premium-tier"
+            "ec2:ResourceTag/Environment" = local.environment_label
           }
         }
       },

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -380,7 +380,6 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         ]
         Resource = "*"
       },
-      # EC2 Management actions (scoped to premium instances by tag)
       {
         Effect = "Allow"
         Action = [
@@ -391,7 +390,8 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
         Condition = {
           StringEquals = {
-            "ec2:ResourceTag/Service" = "premium-tier"
+            "ec2:ResourceTag/Service"     = "premium-tier"
+            "ec2:ResourceTag/Environment" = local.environment_label
           }
         }
       },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2284,6 +2284,9 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # 11. Stop orphaned EC2 instances not in ECS cluster
             cleanup_orphaned_ec2_instances()
 
+            # 11b. Re-sync desiredCount — 10b/11 may have removed ACTIVE CIs.
+            update_premium_service_desired_count()
+
             # 12. Optimize shared instances (safety net)
             try:
                 try:

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -241,14 +241,13 @@ resource "aws_iam_role_policy" "ecs_instance_enhanced_monitoring" {
         Resource = aws_autoscaling_group.main.arn
       },
       {
-        # Premium has no ASG: the probe self-terminates instead. Tag-scoped
-        # so only premium instances can be targets.
         Effect   = "Allow"
         Action   = "ec2:TerminateInstances"
         Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
         Condition = {
           StringEquals = {
-            "ec2:ResourceTag/Service" = "premium-tier"
+            "ec2:ResourceTag/Service"     = "premium-tier"
+            "ec2:ResourceTag/Environment" = local.environment_label
           }
         }
       }

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2497,6 +2497,85 @@ class TestHandleScheduledMonitoring:
 
             assert call_order == ["register_orphans", "terminate_aged"]
 
+    def test_resyncs_desired_count_after_ghost_cleanup(self, mock_env_vars_premium):
+        """update_premium_service_desired_count must run AFTER
+        cleanup_ghost_ecs_registrations and cleanup_orphaned_ec2_instances
+        so deregistered ghost CIs and stopped orphans propagate to the
+        ECS service desiredCount in the same Lambda run — otherwise the
+        service keeps trying to place a task on nothing until the next
+        15-min cycle."""
+        call_order = []
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.is_premium_scaling_in_progress", return_value=False
+        ), patch("premium_manager.set_premium_scaling_lock"), patch(
+            "premium_manager.count_active_premium_users", return_value=0
+        ), patch(
+            "premium_manager.count_total_premium_users", return_value=0
+        ), patch(
+            "premium_manager.get_all_premium_instances_with_states",
+            return_value=[],
+        ), patch(
+            "premium_manager.get_assigned_users_for_instance",
+            return_value=[],
+        ), patch(
+            "premium_manager.publish_premium_metrics"
+        ), patch(
+            "premium_manager.scale_down_if_possible"
+        ), patch(
+            "premium_manager.update_premium_service_desired_count",
+            side_effect=lambda: call_order.append("update_desired"),
+        ), patch(
+            "premium_manager.cleanup_failed_standby_instances"
+        ), patch(
+            "premium_manager.register_orphaned_stopped_instances"
+        ), patch(
+            "premium_manager.terminate_aged_stopped_instances"
+        ), patch(
+            "premium_manager.get_standby_count", return_value=0
+        ), patch(
+            "premium_manager.finalize_expired_pending_releases",
+            return_value=[],
+        ), patch(
+            "premium_manager.cleanup_ghost_ecs_registrations",
+            side_effect=lambda: call_order.append("cleanup_ghost"),
+        ), patch(
+            "premium_manager.cleanup_orphaned_ec2_instances",
+            side_effect=lambda: call_order.append("cleanup_orphaned"),
+        ), patch(
+            "premium_manager.fix_incorrect_is_shared_flags",
+            return_value={"fixed_count": 0},
+        ), patch(
+            "premium_manager.process_shared_instance_optimization",
+            return_value={"migrations_performed": 0, "shared_instances_found": 0},
+        ):
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+            assert result["statusCode"] == 200
+
+            assert "cleanup_ghost" in call_order
+            assert "cleanup_orphaned" in call_order
+            assert call_order.count("update_desired") >= 2, (
+                "expected update_premium_service_desired_count to fire at "
+                "step 6 AND step 11b"
+            )
+
+            last_update_idx = (
+                len(call_order) - 1 - call_order[::-1].index("update_desired")
+            )
+            cleanup_ghost_idx = call_order.index("cleanup_ghost")
+            cleanup_orphaned_idx = call_order.index("cleanup_orphaned")
+
+            assert last_update_idx > cleanup_ghost_idx, (
+                "update_premium_service_desired_count must run after "
+                "cleanup_ghost_ecs_registrations"
+            )
+            assert last_update_idx > cleanup_orphaned_idx, (
+                "update_premium_service_desired_count must run after "
+                "cleanup_orphaned_ec2_instances"
+            )
+
 
 class TestGetUserUidFromId:
     """Reverse UID lookup from numeric DB ID."""


### PR DESCRIPTION
### Content

#### Summary
Three follow-ups surfaced while driving the parent PR's manual testcases on development:
- **Cross-environment blast radius:** dev IAM roles could terminate/stop/start prod premium EC2s because tag-scoping only matched `Service=premium-tier`, and a prod instance shares that tag in the same AWS account.
- **Stale `routing_id` replay → 403 on login:** frontend persisted `routing_id` in `localStorage` and replayed it with the next user's JWT, failing `SecureRoutingMiddleware`'s stateless HMAC check.
- **Ghost-cleanup left `desiredCount` stale:** `handle_scheduled_monitoring` computed service desiredCount *before* deregistering ghost CIs and stopping orphaned EC2s, so the service sat with `desiredCount=1` pointed at vanished capacity until the next 15-min Lambda cycle.

Each fix is scoped, idempotent, and carries a regression guard. A fourth item (slow first-boot → ~8 min unusable window) is documented as the remaining follow-up and is out of scope here.

#### Problem & Investigation (brief)
While validating the parent PR's testcases on dev we hit three orthogonal issues:

1. **Tag scope** — noticed `i-02b02192cd80d2062` is tagged `Environment=Production, Service=premium-tier` in the same account as dev. Dev IAM policies only conditioned on `Service`, so a dev bug/compromise could terminate prod premium EC2s.
2. **403 loop on re-login in Chrome, but not Safari** — traced to `RoutingService` persisting `routing_id` in `localStorage` under a flat key. `SecureRoutingMiddleware` recomputes `HMAC-SHA256(jwt_uid, SECRET)[:16]` per request and rejects on mismatch; when User A logged out without `clearRoutingInfo()` firing (tab close / session expiry / profile share), User B's JWT replayed User A's stored `routing_id` → 403. Safari was unaffected because cookie jars are per-browser.
3. **ECS service "unable to place task" right after TC3** — ordering bug in `handle_scheduled_monitoring`: step 6 `update_premium_service_desired_count()` counts ACTIVE CIs while the ghost is still ACTIVE; step 10b then deregisters the ghost, leaving `desiredCount` pointing at vanished capacity until the next cycle.

A fourth item — a ~8 min first-boot window where a premium EC2 is `running` but its ECS agent hasn't come online, so the ALB target group is empty and requests 403 — was also surfaced but is not fixed here. It traces to `cloud-final.service` blocking `ecs.service` on the stock ECS-optimized AMI while user-data does `yum update` + package install + `docker pull`. The recommended fix is baking a custom AMI; tracked as a separate follow-up.

#### Design Decisions
- **Tag scope: add `Environment` to the IAM `Condition`, not rename tags.** Renaming `Service=premium-tier` per-env (e.g. `premium-tier-dev`) would touch every discovery query across `premium_manager.py`. A second condition key composes with the existing one and reuses `local.environment_label`, which already drives every other env-scoped resource. The prod stack auto-scopes to `Environment=Production` from the same Terraform.
- **Routing_id: clear on `login.fulfilled` instead of on logout.** Logout paths are many (explicit click, token expiry, tab close, cross-tab sign-in). Making the *gain-of-identity* event the idempotent reset point guarantees coverage regardless of how the prior session ended. The axios response interceptor repopulates `routing_id` on the next authenticated request, so there's no window where the header is missing.
- **Ghost cleanup: re-call `update_premium_service_desired_count()` at step 11b rather than reorder steps.** `update_premium_service_desired_count` is idempotent (describe + list + conditional `update_service`); steps 10b and 11 are not trivially movable because they depend on the earlier discovery phase. One extra call costs ~2 ECS API reads in the no-change case and collapses the correction window from 15 min to same-run.
- **`ecs-clear-checkpoint.service`: `enable --now` instead of `enable`.** First-boot symlink wasn't picked up because the unit is enabled after `multi-user.target`'s activation graph is computed. `--now` starts it in the same boot; harmless because the oneshot is idempotent on a fresh `agent.db`.

### Evidence
- Routing_id replay: `Routing ID mismatch detected - rejecting request. Expected: d0250e94..., Got: aa8f73b6...` (`SecureRoutingMiddleware`) reproduced in two-browser TC4; gone after frontend patch.
- Ghost-cleanup drift: `describe-services development-premium-optinist-cloud-service` immediately after TC3 termination showed `"unable to place a task because no container instance met all of its requirements"` with `desiredCount=1` and zero ACTIVE CIs.

### References
- Parent PR: `fix/long-time-migrate-users-lock` (migration lock contention + ghost capacity miscalculation).

#### Files changed

Backend / Infrastructure
- `infrastructure/terraform/security.tf` — add `ec2:ResourceTag/Environment = local.environment_label` to the ECS instance role's `ec2:TerminateInstances` condition; removed the now-redundant inline comment.
- `infrastructure/terraform/premium_manager.tf` — same `Environment` tag scope on the Lambda role's `ec2:{Stop,Start,Terminate}Instances` condition.
- `infrastructure/terraform/dev_schedule.tf` — same `Environment` tag scope on the dev-scheduler premium branch's `ec2:{Start,Stop}Instances` condition.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — add step 11b: second `update_premium_service_desired_count()` call after `cleanup_ghost_ecs_registrations` and `cleanup_orphaned_ec2_instances` so capacity removals propagate to ECS `desiredCount` in the same Lambda run.
- `infrastructure/scripts/ecs-user-data.sh` — `systemctl enable --now ecs-clear-checkpoint.service` so the unit fires on first boot instead of only on subsequent boots.

Frontend
- `frontend/src/store/slice/User/UserSlice.ts` — call `routingService.clearRoutingInfo()` on `login.fulfilled` / `proxyLogin.fulfilled` before `saveToken(...)` to prevent a prior user's `routing_id` from replaying with a new JWT.

Tests
- `studio/tests/infrastructure/test_premium_manager.py` — `TestHandleScheduledMonitoring::test_resyncs_desired_count_after_ghost_cleanup` asserts `update_premium_service_desired_count` runs *after* both cleanup steps AND fires at least twice per run (step 6 + step 11b), so accidentally removing either call is caught. Verified to fail against pre-fix code.
- `frontend/src/store/slice/User/__tests__/UserSlice.test.ts` — new `login.fulfilled` case asserts `clearRoutingInfo` is called and that its invocation order precedes `saveToken`. New `login.rejected` case pins the full auth-reset contract (all tokens removed, routing cleared, no saves, state returns to initial) so the shared matchers can't drift as they evolve.

### Manual Testcases

**TC-A — Cross-environment tag scope (dev IAM cannot touch prod premium EC2s)**
- Who: engineer with dev AWS credentials.
- What: `aws ec2 terminate-instances --instance-ids i-02b02192cd80d2062` (prod premium instance, same account) using a role that assumes the updated dev policies.
- Expected: `UnauthorizedOperation` — condition `ec2:ResourceTag/Environment = development` fails against the prod tag. Before this patch the call would have succeeded.

**TC-B — Stale routing_id no longer replays across logins**
- Who: QA in Chrome.
- What: log in as User A → close tab without explicit logout → open new tab → log in as User B → call any authenticated endpoint (e.g. `GET /is_standalone`).
- Expected: 200 OK. Before this patch: 403 with `Routing ID mismatch detected` in backend logs. Re-run in Safari to confirm no regression in the working path.

**TC-C — Ghost cleanup resyncs desiredCount in the same run**
- Who: engineer driving the parent PR's TC3.
- What: terminate the single ACTIVE premium CI mid-run so it becomes a ghost → wait for the next `handle_scheduled_monitoring` invocation.
- Expected: `describe-services development-premium-optinist-cloud-service` shows `desiredCount=0` at the end of the same run. Before this patch: `desiredCount=1` with `"unable to place a task"` event until the next 15-min cycle.

Automated:
- `cd studio && python -m pytest tests/infrastructure/test_premium_manager.py::TestHandleScheduledMonitoring` — 2 tests pass
- `cd frontend && yarn test -- --testPathPattern="UserSlice.test.ts" --watchAll=false` — 15 tests pass

### Unit, Integration, Contract Test Coverage
- `test_resyncs_desired_count_after_ghost_cleanup` — ordering invariant regression guard for step 11b, plus a `call_order.count("update_desired") >= 2` assertion so removing either the step-6 or step-11b call fails CI.
- `login.fulfilled` test in `UserSlice.test.ts` — asserts `clearRoutingInfo` runs before `saveToken`.
- `login.rejected` test in `UserSlice.test.ts` — pins the auth-failure reset contract (tokens removed, routing cleared, no saves, state reset) to catch refactors of the shared matchers.
- Terraform changes are IAM-condition-only; validated by `terraform plan` against both dev and prod workspaces (no resource replacement, condition block diff only).

### Others

#### Difficulties
- Reproducing the routing_id replay required two browsers and a tab-close (not an explicit logout) to skip the existing `clearRoutingInfo` path — easy to miss in QA since Safari's separate cookie jar masked it.
- Deferred: the ~8 min first-boot unusable window traces to `cloud-final.service` blocking `ecs.service`. Not fixable in user-data; the recommended path is baking a custom ECS AMI. Left as a separate follow-up.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| IAM tag scope (`security.tf`, `premium_manager.tf`, `dev_schedule.tf`) | Low | Condition is additive (AND with existing `Service` key). On dev, `Environment=development`; on prod, auto-scopes to `Environment=Production` from the same code. If any existing premium EC2 is missing the `Environment` tag, the policy will deny — tag coverage verified via `aws ec2 describe-instances` in dev. |
| `handle_scheduled_monitoring` step 11b | Low | `update_premium_service_desired_count` is idempotent; extra call costs ~2 ECS API reads in the no-change case. Regression guard in place. |
| `UserSlice.ts` `clearRoutingInfo` on login | Low | Axios response interceptor repopulates `routing_id` on the next authenticated request. No window where the header is missing because the first post-login request is what receives the new `routing_id` from the backend. |
| `ecs-user-data.sh` `enable --now` | Low | Oneshot is idempotent on fresh `agent.db`; only effect is that it now fires on first boot instead of skipping until reboot. |
