### PR TITLE
update_premium_service_desired_count bug

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -4157,26 +4157,27 @@ def check_instance_readiness_with_retry(
 
 
 def update_premium_service_desired_count():
-    """
-    Update the ECS premium service desired count to match the number of
-    running premium instances.
+    """Update the ECS premium service desired count to match the number
+    of premium instances that are either ECS-registered or still inside
+    the boot grace period.
 
-    This ensures that each premium instance has an ECS task running on it,
-    which is required for the instance to be considered "ready" for user assignments.
+    Booting standbys must keep a service slot reserved. If desiredCount
+    is dropped during the gap between EC2 `running` and ECS agent
+    registration, ECS cancels the pending task placement and never
+    re-fires it once the agent finally registers, leaving the instance
+    with no premium task and the user stuck on the waiting popup.
 
-    The function:
-    1. Counts running premium EC2 instances (by Tier=premium tag)
-    2. Updates the ECS service desired count to match
-    3. ECS will then place one task per instance (with tier=premium
-        placement constraint)
+    The grace period mirrors cleanup_orphaned_ec2_instances() so the two
+    are symmetric: instances we don't yet treat as orphans must keep
+    their service slot.
     """
     try:
         cluster_name = get_required_env_var("CLUSTER_NAME")
         service_name = get_required_env_var("PREMIUM_SERVICE_NAME")
 
         ecs: "ECSClient" = boto3.client("ecs")
+        ec2: "EC2Client" = boto3.client("ec2")
 
-        # Get current service status
         service_response = ecs.describe_services(
             cluster=cluster_name, services=[service_name]
         )
@@ -4191,24 +4192,71 @@ def update_premium_service_desired_count():
         current_desired_count = service_response["services"][0]["desiredCount"]
         current_running_count = service_response["services"][0]["runningCount"]
 
-        # Count ACTIVE ECS container instances (not EC2 instances,
-        # which may include orphans that never joined the cluster)
+        # ACTIVE premium ECS container instances (post-registration).
         ci_response = ecs.list_container_instances(
             cluster=cluster_name,
             filter="attribute:tier == premium",
             status="ACTIVE",
         )
         ci_arns = ci_response.get("containerInstanceArns", [])
-        running_premium_count = len(ci_arns)
+        registered_ec2_ids: set = set()
+        if ci_arns:
+            desc = ecs.describe_container_instances(
+                cluster=cluster_name,
+                containerInstances=ci_arns,
+            )
+            for ci in desc.get("containerInstances", []):
+                registered_ec2_ids.add(ci["ec2InstanceId"])
+        registered_count = len(registered_ec2_ids)
+
+        # Booting standbys: premium-tagged EC2s running but not yet
+        # ECS-registered, still inside the orphan grace period. Same
+        # filters as cleanup_orphaned_ec2_instances() so the two stay
+        # symmetric.
+        ec2_response = ec2.describe_instances(
+            Filters=[
+                {
+                    "Name": "instance-state-name",
+                    "Values": [InstanceState.RUNNING],
+                },
+                {
+                    "Name": "tag:Tier",
+                    "Values": [
+                        PremiumInstanceConfig.INSTANCE_IDENTIFIER,
+                        PremiumInstanceConfig.INSTANCE_IDENTIFIER.capitalize(),
+                    ],
+                },
+                {
+                    "Name": "tag:Name",
+                    "Values": [PremiumInstanceConfig.get_instance_name_pattern()],
+                },
+            ]
+        )
+        now = datetime.now(timezone.utc)
+        booting_count = 0
+        for reservation in ec2_response["Reservations"]:
+            for instance in reservation["Instances"]:
+                if instance["InstanceId"] in registered_ec2_ids:
+                    continue
+                launch_time = instance.get("LaunchTime")
+                if not launch_time:
+                    continue
+                age_minutes = (now - launch_time).total_seconds() / 60
+                if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
+                    booting_count += 1
+
+        running_premium_count = registered_count + booting_count
 
         print(
             f"ECS Service Status: "
             f"desired={current_desired_count}, "
             f"running={current_running_count}"
         )
-        print(f"Premium ECS container instances: " f"{running_premium_count} active")
+        print(
+            f"Premium instances: {registered_count} registered + "
+            f"{booting_count} booting"
+        )
 
-        # Update service desired count if different from instance count
         if running_premium_count != current_desired_count:
             print(
                 f"Updating ECS service desired count: {current_desired_count} "

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -4192,58 +4192,20 @@ def update_premium_service_desired_count():
         current_desired_count = service_response["services"][0]["desiredCount"]
         current_running_count = service_response["services"][0]["runningCount"]
 
-        # ACTIVE premium ECS container instances (post-registration).
-        ci_response = ecs.list_container_instances(
-            cluster=cluster_name,
-            filter="attribute:tier == premium",
-            status="ACTIVE",
-        )
-        ci_arns = ci_response.get("containerInstanceArns", [])
-        registered_ec2_ids: set = set()
-        if ci_arns:
-            desc = ecs.describe_container_instances(
-                cluster=cluster_name,
-                containerInstances=ci_arns,
-            )
-            for ci in desc.get("containerInstances", []):
-                registered_ec2_ids.add(ci["ec2InstanceId"])
+        registered_ec2_ids = _list_premium_ecs_registered_ec2_ids(ecs, cluster_name)
         registered_count = len(registered_ec2_ids)
 
-        # Booting standbys: premium-tagged EC2s running but not yet
-        # ECS-registered, still inside the orphan grace period. Same
-        # filters as cleanup_orphaned_ec2_instances() so the two stay
-        # symmetric.
-        ec2_response = ec2.describe_instances(
-            Filters=[
-                {
-                    "Name": "instance-state-name",
-                    "Values": [InstanceState.RUNNING],
-                },
-                {
-                    "Name": "tag:Tier",
-                    "Values": [
-                        PremiumInstanceConfig.INSTANCE_IDENTIFIER,
-                        PremiumInstanceConfig.INSTANCE_IDENTIFIER.capitalize(),
-                    ],
-                },
-                {
-                    "Name": "tag:Name",
-                    "Values": [PremiumInstanceConfig.get_instance_name_pattern()],
-                },
-            ]
-        )
         now = datetime.now(timezone.utc)
         booting_count = 0
-        for reservation in ec2_response["Reservations"]:
-            for instance in reservation["Instances"]:
-                if instance["InstanceId"] in registered_ec2_ids:
-                    continue
-                launch_time = instance.get("LaunchTime")
-                if not launch_time:
-                    continue
-                age_minutes = (now - launch_time).total_seconds() / 60
-                if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
-                    booting_count += 1
+        for instance in _list_premium_ec2_instances_running(ec2):
+            if instance["InstanceId"] in registered_ec2_ids:
+                continue
+            launch_time = instance.get("LaunchTime")
+            if not launch_time:
+                continue
+            age_minutes = (now - launch_time).total_seconds() / 60
+            if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
+                booting_count += 1
 
         running_premium_count = registered_count + booting_count
 
@@ -5419,103 +5381,115 @@ def cleanup_ghost_ecs_registrations():
         print(f"Error cleaning up ghost ECS registrations: {str(e)}")
 
 
-ORPHAN_GRACE_PERIOD_MINUTES = 15
+# Shared by update_premium_service_desired_count and
+# cleanup_orphaned_ec2_instances. Typical boot-to-ECS-register takes
+# 1-2 minutes; 10 gives a comfortable multiple while capping how long
+# a permanently-broken boot can inflate desiredCount or delay orphan
+# cleanup to a single reconciliation cycle.
+ORPHAN_GRACE_PERIOD_MINUTES = 10
+
+
+def _list_premium_ecs_registered_ec2_ids(ecs, cluster_name) -> set:
+    """EC2 instance IDs backing ACTIVE premium ECS container instances."""
+    ci_response = ecs.list_container_instances(
+        cluster=cluster_name,
+        filter="attribute:tier == premium",
+        status="ACTIVE",
+    )
+    ci_arns = ci_response.get("containerInstanceArns", [])
+    if not ci_arns:
+        return set()
+    desc = ecs.describe_container_instances(
+        cluster=cluster_name,
+        containerInstances=ci_arns,
+    )
+    return {ci["ec2InstanceId"] for ci in desc.get("containerInstances", [])}
+
+
+def _list_premium_ec2_instances_running(ec2) -> list:
+    """Running EC2 instances tagged as premium for this environment.
+
+    Single source of truth for the premium-EC2 tag/name filter so the
+    desired-count and orphan-cleanup paths cannot drift apart — any
+    instance one path sees, the other must see.
+    """
+    resp = ec2.describe_instances(
+        Filters=[
+            {
+                "Name": "instance-state-name",
+                "Values": [InstanceState.RUNNING],
+            },
+            {
+                "Name": "tag:Tier",
+                "Values": [
+                    PremiumInstanceConfig.INSTANCE_IDENTIFIER,
+                    PremiumInstanceConfig.INSTANCE_IDENTIFIER.capitalize(),
+                ],
+            },
+            {
+                "Name": "tag:Name",
+                "Values": [PremiumInstanceConfig.get_instance_name_pattern()],
+            },
+        ]
+    )
+    return [i for r in resp["Reservations"] for i in r["Instances"]]
 
 
 def cleanup_orphaned_ec2_instances():
     """Stop EC2 instances tagged Tier=premium that are running
     but not registered as ECS container instances.
 
-    Orphaned instances inflate desiredCount and waste resources.
-    A 15-minute grace period avoids stopping instances that are
-    still booting and haven't joined ECS yet.
+    Orphaned instances inflate desiredCount and waste resources. The
+    grace period avoids stopping instances that are still booting and
+    haven't joined ECS yet; must stay symmetric with
+    update_premium_service_desired_count.
     """
     try:
         cluster_name = get_required_env_var("CLUSTER_NAME")
         ecs: "ECSClient" = boto3.client("ecs")
         ec2: "EC2Client" = boto3.client("ec2")
 
-        # Collect EC2 IDs of ACTIVE premium ECS container instances
-        ci_response = ecs.list_container_instances(
-            cluster=cluster_name,
-            status="ACTIVE",
-            filter="attribute:tier == premium",
-        )
-        ci_arns = ci_response.get("containerInstanceArns", [])
-
-        ecs_ec2_ids: set = set()
-        if ci_arns:
-            desc = ecs.describe_container_instances(
-                cluster=cluster_name,
-                containerInstances=ci_arns,
-            )
-            for ci in desc.get("containerInstances", []):
-                ecs_ec2_ids.add(ci["ec2InstanceId"])
-
-        # List all running premium-tagged EC2 instances for this environment
-        ec2_response = ec2.describe_instances(
-            Filters=[
-                {
-                    "Name": "instance-state-name",
-                    "Values": [InstanceState.RUNNING],
-                },
-                {
-                    "Name": "tag:Tier",
-                    "Values": [
-                        PremiumInstanceConfig.INSTANCE_IDENTIFIER,
-                        PremiumInstanceConfig.INSTANCE_IDENTIFIER.capitalize(),
-                    ],
-                },
-                {
-                    "Name": "tag:Name",
-                    "Values": [PremiumInstanceConfig.get_instance_name_pattern()],
-                },
-            ]
-        )
-
-        from datetime import datetime, timezone
+        ecs_ec2_ids = _list_premium_ecs_registered_ec2_ids(ecs, cluster_name)
+        instances = _list_premium_ec2_instances_running(ec2)
 
         now = datetime.now(timezone.utc)
         stopped_count = 0
 
-        for reservation in ec2_response["Reservations"]:
-            for instance in reservation["Instances"]:
-                iid = instance["InstanceId"]
-                if iid in ecs_ec2_ids:
+        for instance in instances:
+            iid = instance["InstanceId"]
+            if iid in ecs_ec2_ids:
+                continue
+
+            launch_time = instance.get("LaunchTime")
+            if launch_time:
+                age_minutes = (now - launch_time).total_seconds() / 60
+                if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
+                    print(
+                        f"Orphan {iid} running "
+                        f"{age_minutes:.0f}m, "
+                        f"within grace period"
+                    )
                     continue
 
-                launch_time = instance.get("LaunchTime")
-                if launch_time:
-                    age_minutes = (now - launch_time).total_seconds() / 60
-                    if age_minutes < ORPHAN_GRACE_PERIOD_MINUTES:
-                        print(
-                            f"Orphan {iid} running "
-                            f"{age_minutes:.0f}m, "
-                            f"within grace period"
-                        )
-                        continue
+            print(f"Stopping orphaned EC2 instance {iid}")
+            ec2.stop_instances(InstanceIds=[iid])
+            stopped_count += 1
 
-                print(f"Stopping orphaned EC2 instance {iid}")
-                ec2.stop_instances(InstanceIds=[iid])
-                stopped_count += 1
-
-                # Register as standby so terminate_aged_stopped_instances()
-                # can find and terminate after PREMIUM_STOPPED_MAX_AGE_HOURS.
-                try:
-                    store_user_assignment(
-                        user_id=None,
-                        instance_id=iid,
-                        target_group_arn=PremiumAssignment.STANDBY,
-                        rule_arn=PremiumAssignment.STANDBY,
-                        instance_state=InstanceState.STOPPED,
-                        is_shared=False,
-                        is_standby=True,
-                    )
-                    print(
-                        f"Registered orphaned instance {iid} " f"as standby in database"
-                    )
-                except Exception as e:
-                    print(f"Failed to register standby for " f"{iid}: {str(e)}")
+            # Register as standby so terminate_aged_stopped_instances()
+            # can find and terminate after PREMIUM_STOPPED_MAX_AGE_HOURS.
+            try:
+                store_user_assignment(
+                    user_id=None,
+                    instance_id=iid,
+                    target_group_arn=PremiumAssignment.STANDBY,
+                    rule_arn=PremiumAssignment.STANDBY,
+                    instance_state=InstanceState.STOPPED,
+                    is_shared=False,
+                    is_standby=True,
+                )
+                print(f"Registered orphaned instance {iid} " f"as standby in database")
+            except Exception as e:
+                print(f"Failed to register standby for " f"{iid}: {str(e)}")
 
         print(f"Orphan cleanup: stopped {stopped_count} " f"instance(s)")
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1702,23 +1702,31 @@ class TestClearEcsAgentCheckpoint:
             assert result is False
 
 
-class TestDesiredCountUsesECS:
-    """update_premium_service_desired_count uses ECS
-    container instance count, not EC2 instance count."""
+class TestDesiredCountReservesBootingStandbys:
+    """update_premium_service_desired_count counts ACTIVE ECS container
+    instances plus premium EC2s still inside the boot grace period, so
+    a standby that is still registering with ECS keeps its service
+    slot reserved instead of having its task placement cancelled."""
 
-    def test_updates_from_ecs_count(self, mock_env_vars_premium):
-        """desiredCount is set from ECS container instances."""
+    @staticmethod
+    def _setup_boto3(mock_boto3, mock_ecs, mock_ec2):
+        def boto3_client_side_effect(service):
+            if service == "ecs":
+                return mock_ecs
+            if service == "ec2":
+                return mock_ec2
+            return MagicMock()
+
+        mock_boto3.side_effect = boto3_client_side_effect
+
+    def test_updates_from_registered_count_when_no_booting(self, mock_env_vars_premium):
+        """One registered CI, no booting EC2 -> desiredCount = 1."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
             mock_ecs = MagicMock()
-
-            def boto3_client_side_effect(service):
-                if service == "ecs":
-                    return mock_ecs
-                return MagicMock()
-
-            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ec2 = MagicMock()
+            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
 
             mock_ecs.describe_services.return_value = {
                 "services": [{"desiredCount": 4, "runningCount": 1}]
@@ -1726,28 +1734,45 @@ class TestDesiredCountUsesECS:
             mock_ecs.list_container_instances.return_value = {
                 "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
             }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
+                        "ec2InstanceId": "i-registered1",
+                    }
+                ]
+            }
+            # Only the registered EC2 is running; no booting orphans.
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-registered1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=60)
+                                ),
+                            }
+                        ]
+                    }
+                ]
+            }
 
             from premium_manager import update_premium_service_desired_count
 
             update_premium_service_desired_count()
 
             mock_ecs.update_service.assert_called_once()
-            call_kwargs = mock_ecs.update_service.call_args[1]
-            assert call_kwargs["desiredCount"] == 1
+            assert mock_ecs.update_service.call_args[1]["desiredCount"] == 1
 
     def test_no_update_when_counts_match(self, mock_env_vars_premium):
-        """No update when desired already matches ECS count."""
+        """desired already matches registered + booting -> no update."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
             mock_ecs = MagicMock()
-
-            def boto3_client_side_effect(service):
-                if service == "ecs":
-                    return mock_ecs
-                return MagicMock()
-
-            mock_boto3.side_effect = boto3_client_side_effect
+            mock_ec2 = MagicMock()
+            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
 
             mock_ecs.describe_services.return_value = {
                 "services": [{"desiredCount": 2, "runningCount": 2}]
@@ -1758,6 +1783,19 @@ class TestDesiredCountUsesECS:
                     "arn:aws:ecs:us-east-1:123:ci/b",
                 ]
             }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
+                        "ec2InstanceId": "i-r1",
+                    },
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/b",
+                        "ec2InstanceId": "i-r2",
+                    },
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {"Reservations": []}
 
             from premium_manager import update_premium_service_desired_count
 
@@ -1765,31 +1803,50 @@ class TestDesiredCountUsesECS:
 
             mock_ecs.update_service.assert_not_called()
 
-    def test_does_not_use_ec2_describe_instances(self, mock_env_vars_premium):
-        """update_premium_service_desired_count must not
-        call ec2.describe_instances (old counting method)."""
+    def test_counts_booting_standby_within_grace_period(self, mock_env_vars_premium):
+        """Standby EC2 that just started but hasn't joined ECS yet is
+        counted toward desiredCount so its task placement isn't
+        cancelled before the agent registers."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
             mock_ecs = MagicMock()
             mock_ec2 = MagicMock()
-
-            def boto3_client_side_effect(service):
-                if service == "ecs":
-                    return mock_ecs
-                if service == "ec2":
-                    return mock_ec2
-                return MagicMock()
-
-            mock_boto3.side_effect = boto3_client_side_effect
+            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
 
             mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 2, "runningCount": 2}]
+                "services": [{"desiredCount": 1, "runningCount": 1}]
             }
             mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": [
-                    "arn:aws:ecs:us-east-1:123:ci/a",
-                    "arn:aws:ecs:us-east-1:123:ci/b",
+                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
+                        "ec2InstanceId": "i-registered1",
+                    }
+                ]
+            }
+            # i-booting1 is running but NOT in ECS yet, launched 3 min ago.
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-registered1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=60)
+                                ),
+                            },
+                            {
+                                "InstanceId": "i-booting1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=3)
+                                ),
+                            },
+                        ]
+                    }
                 ]
             }
 
@@ -1797,7 +1854,109 @@ class TestDesiredCountUsesECS:
 
             update_premium_service_desired_count()
 
-            mock_ec2.describe_instances.assert_not_called()
+            mock_ecs.update_service.assert_called_once()
+            assert mock_ecs.update_service.call_args[1]["desiredCount"] == 2
+
+    def test_ignores_orphan_past_grace_period(self, mock_env_vars_premium):
+        """EC2 running past grace period without joining ECS is treated
+        as an orphan and not counted (cleanup_orphaned_ec2_instances
+        will stop it)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
+
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 2, "runningCount": 1}]
+            }
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
+                        "ec2InstanceId": "i-registered1",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-registered1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=60)
+                                ),
+                            },
+                            {
+                                "InstanceId": "i-orphan1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=30)
+                                ),
+                            },
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import update_premium_service_desired_count
+
+            update_premium_service_desired_count()
+
+            mock_ecs.update_service.assert_called_once()
+            assert mock_ecs.update_service.call_args[1]["desiredCount"] == 1
+
+    def test_does_not_double_count_registered_instance(self, mock_env_vars_premium):
+        """A registered CI whose EC2 is also returned by describe_instances
+        is counted once, not twice."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = MagicMock()
+            mock_ec2 = MagicMock()
+            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
+
+            mock_ecs.describe_services.return_value = {
+                "services": [{"desiredCount": 0, "runningCount": 0}]
+            }
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
+                        "ec2InstanceId": "i-registered1",
+                    }
+                ]
+            }
+            # Same EC2 is returned by describe_instances; should not be
+            # counted again as "booting".
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-registered1",
+                                "LaunchTime": (
+                                    datetime.now(timezone.utc) - timedelta(minutes=2)
+                                ),
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import update_premium_service_desired_count
+
+            update_premium_service_desired_count()
+
+            mock_ecs.update_service.assert_called_once()
+            assert mock_ecs.update_service.call_args[1]["desiredCount"] == 1
 
 
 class TestRoutingIdContract:

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1709,7 +1709,22 @@ class TestDesiredCountReservesBootingStandbys:
     slot reserved instead of having its task placement cancelled."""
 
     @staticmethod
-    def _setup_boto3(mock_boto3, mock_ecs, mock_ec2):
+    def _make_mocks(
+        mock_boto3,
+        *,
+        desired,
+        running,
+        registered=(),
+        ec2_instances=(),
+    ):
+        """Configure boto3 mocks for update_premium_service_desired_count tests.
+
+        registered: iterable of (ci_arn, ec2_id) pairs for ECS container instances.
+        ec2_instances: iterable of (instance_id, minutes_since_launch) pairs.
+        """
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+
         def boto3_client_side_effect(service):
             if service == "ecs":
                 return mock_ecs
@@ -1719,44 +1734,50 @@ class TestDesiredCountReservesBootingStandbys:
 
         mock_boto3.side_effect = boto3_client_side_effect
 
+        mock_ecs.describe_services.return_value = {
+            "services": [{"desiredCount": desired, "runningCount": running}]
+        }
+        mock_ecs.list_container_instances.return_value = {
+            "containerInstanceArns": [arn for arn, _ in registered]
+        }
+        mock_ecs.describe_container_instances.return_value = {
+            "containerInstances": [
+                {"containerInstanceArn": arn, "ec2InstanceId": ec2_id}
+                for arn, ec2_id in registered
+            ]
+        }
+        now = datetime.now(timezone.utc)
+        reservations = (
+            [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": iid,
+                            "LaunchTime": now - timedelta(minutes=mins),
+                        }
+                        for iid, mins in ec2_instances
+                    ]
+                }
+            ]
+            if ec2_instances
+            else []
+        )
+        mock_ec2.describe_instances.return_value = {"Reservations": reservations}
+
+        return mock_ecs, mock_ec2
+
     def test_updates_from_registered_count_when_no_booting(self, mock_env_vars_premium):
         """One registered CI, no booting EC2 -> desiredCount = 1."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
-            mock_ecs = MagicMock()
-            mock_ec2 = MagicMock()
-            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
-
-            mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 4, "runningCount": 1}]
-            }
-            mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
-            }
-            mock_ecs.describe_container_instances.return_value = {
-                "containerInstances": [
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
-                        "ec2InstanceId": "i-registered1",
-                    }
-                ]
-            }
-            # Only the registered EC2 is running; no booting orphans.
-            mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {
-                        "Instances": [
-                            {
-                                "InstanceId": "i-registered1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=60)
-                                ),
-                            }
-                        ]
-                    }
-                ]
-            }
+            mock_ecs, _ = self._make_mocks(
+                mock_boto3,
+                desired=4,
+                running=1,
+                registered=[("arn:aws:ecs:us-east-1:123:ci/a", "i-registered1")],
+                ec2_instances=[("i-registered1", 60)],
+            )
 
             from premium_manager import update_premium_service_desired_count
 
@@ -1770,32 +1791,15 @@ class TestDesiredCountReservesBootingStandbys:
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
-            mock_ecs = MagicMock()
-            mock_ec2 = MagicMock()
-            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
-
-            mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 2, "runningCount": 2}]
-            }
-            mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": [
-                    "arn:aws:ecs:us-east-1:123:ci/a",
-                    "arn:aws:ecs:us-east-1:123:ci/b",
-                ]
-            }
-            mock_ecs.describe_container_instances.return_value = {
-                "containerInstances": [
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
-                        "ec2InstanceId": "i-r1",
-                    },
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/b",
-                        "ec2InstanceId": "i-r2",
-                    },
-                ]
-            }
-            mock_ec2.describe_instances.return_value = {"Reservations": []}
+            mock_ecs, _ = self._make_mocks(
+                mock_boto3,
+                desired=2,
+                running=2,
+                registered=[
+                    ("arn:aws:ecs:us-east-1:123:ci/a", "i-r1"),
+                    ("arn:aws:ecs:us-east-1:123:ci/b", "i-r2"),
+                ],
+            )
 
             from premium_manager import update_premium_service_desired_count
 
@@ -1810,45 +1814,13 @@ class TestDesiredCountReservesBootingStandbys:
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
-            mock_ecs = MagicMock()
-            mock_ec2 = MagicMock()
-            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
-
-            mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 1, "runningCount": 1}]
-            }
-            mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
-            }
-            mock_ecs.describe_container_instances.return_value = {
-                "containerInstances": [
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
-                        "ec2InstanceId": "i-registered1",
-                    }
-                ]
-            }
-            # i-booting1 is running but NOT in ECS yet, launched 3 min ago.
-            mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {
-                        "Instances": [
-                            {
-                                "InstanceId": "i-registered1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=60)
-                                ),
-                            },
-                            {
-                                "InstanceId": "i-booting1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=3)
-                                ),
-                            },
-                        ]
-                    }
-                ]
-            }
+            mock_ecs, _ = self._make_mocks(
+                mock_boto3,
+                desired=1,
+                running=1,
+                registered=[("arn:aws:ecs:us-east-1:123:ci/a", "i-registered1")],
+                ec2_instances=[("i-registered1", 60), ("i-booting1", 3)],
+            )
 
             from premium_manager import update_premium_service_desired_count
 
@@ -1864,44 +1836,13 @@ class TestDesiredCountReservesBootingStandbys:
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
-            mock_ecs = MagicMock()
-            mock_ec2 = MagicMock()
-            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
-
-            mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 2, "runningCount": 1}]
-            }
-            mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
-            }
-            mock_ecs.describe_container_instances.return_value = {
-                "containerInstances": [
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
-                        "ec2InstanceId": "i-registered1",
-                    }
-                ]
-            }
-            mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {
-                        "Instances": [
-                            {
-                                "InstanceId": "i-registered1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=60)
-                                ),
-                            },
-                            {
-                                "InstanceId": "i-orphan1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=30)
-                                ),
-                            },
-                        ]
-                    }
-                ]
-            }
+            mock_ecs, _ = self._make_mocks(
+                mock_boto3,
+                desired=2,
+                running=1,
+                registered=[("arn:aws:ecs:us-east-1:123:ci/a", "i-registered1")],
+                ec2_instances=[("i-registered1", 60), ("i-orphan1", 30)],
+            )
 
             from premium_manager import update_premium_service_desired_count
 
@@ -1916,40 +1857,13 @@ class TestDesiredCountReservesBootingStandbys:
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3:
-            mock_ecs = MagicMock()
-            mock_ec2 = MagicMock()
-            self._setup_boto3(mock_boto3, mock_ecs, mock_ec2)
-
-            mock_ecs.describe_services.return_value = {
-                "services": [{"desiredCount": 0, "runningCount": 0}]
-            }
-            mock_ecs.list_container_instances.return_value = {
-                "containerInstanceArns": ["arn:aws:ecs:us-east-1:123:ci/a"]
-            }
-            mock_ecs.describe_container_instances.return_value = {
-                "containerInstances": [
-                    {
-                        "containerInstanceArn": "arn:aws:ecs:us-east-1:123:ci/a",
-                        "ec2InstanceId": "i-registered1",
-                    }
-                ]
-            }
-            # Same EC2 is returned by describe_instances; should not be
-            # counted again as "booting".
-            mock_ec2.describe_instances.return_value = {
-                "Reservations": [
-                    {
-                        "Instances": [
-                            {
-                                "InstanceId": "i-registered1",
-                                "LaunchTime": (
-                                    datetime.now(timezone.utc) - timedelta(minutes=2)
-                                ),
-                            }
-                        ]
-                    }
-                ]
-            }
+            mock_ecs, _ = self._make_mocks(
+                mock_boto3,
+                desired=0,
+                running=0,
+                registered=[("arn:aws:ecs:us-east-1:123:ci/a", "i-registered1")],
+                ec2_instances=[("i-registered1", 2)],
+            )
 
             from premium_manager import update_premium_service_desired_count
 


### PR DESCRIPTION
### Content

#### Summary
`update_premium_service_desired_count()` counted only ACTIVE ECS container instances, so a standby EC2 that was `running` but had not yet registered with ECS was invisible to reconciliation. When the 15-min scheduled Lambda fired during that registration gap it authoritatively snapped `desiredCount` to 0, ECS cancelled the pending task placement, and nothing re-fired when the agent later registered — the user's dedicated instance never received its premium task. Observed live in the 2026-04-16 incident for user 71: DB row written at 09:08:36 UTC, ECS CI registered at 09:13:27 UTC, but `desiredCount` was snapped to 0 at 09:11:23 UTC; task did not land until 09:41:40 UTC — 33 min after assignment.

This PR teaches reconciliation to reserve a service slot for premium EC2s that are `running` but not yet ECS-registered *within the orphan grace period*. The grace period stays shared with `cleanup_orphaned_ec2_instances()` so the two paths cannot disagree on what counts as "still booting" vs. "orphan."

#### Design Decisions
- **Count registered CIs + booting EC2s, not one or the other.** The introducing commit (`f21f50a438`, PR #323) moved counting from EC2 → ECS to exclude permanent orphans that inflated `desiredCount`. That intent is preserved; the fix reintroduces only EC2s inside `ORPHAN_GRACE_PERIOD_MINUTES`, and deduplicates by `ec2InstanceId` so a CI that registers mid-scan is not double-counted.
- **Symmetric grace period with `cleanup_orphaned_ec2_instances()`.** Both functions share `ORPHAN_GRACE_PERIOD_MINUTES`. If cleanup treats an instance as "still could be booting," reconciliation must also keep its service slot; otherwise `desiredCount` drops while cleanup leaves the EC2 up, reproducing the original bug. Any future change to the grace period must stay shared.
- **Shared tag/name filter via `_list_premium_ec2_instances_running()`.** Reconciliation and cleanup must agree exactly on which EC2s are "premium for this environment." Duplicating the tag-filter block invited silent drift; one helper makes divergence impossible.
- **Lowered grace period 15 → 10 minutes.** Typical boot-to-ECS-register is 1–2 minutes on this AMI; 10 gives a ~5× buffer while halving the window during which a genuinely broken boot keeps `desiredCount` inflated or orphan cleanup delays acting. Applied to both paths together to preserve symmetry.
- **Replaced `test_does_not_use_ec2_describe_instances`.** The old test locked in the buggy behavior by asserting EC2 was *not* queried. Replaced with positive coverage (registered-only, no-op match, booting-within-grace, post-grace orphan, no double-count).

### Evidence
2026-04-16 production incident (user 71, `uid=7OHAeQebrKccbIRjOFzJBapefz03`), all timestamps UTC:
- 09:07:45 — EC2 `i-0a1f24ca862d4bd85` reached `running` state.
- 09:08:36 — DB `premium_user_assignments` row written (`is_shared=0, status=active, instance_id=i-0a1f24ca862d4bd85`).
- 09:11:23 — Scheduled Lambda fired: `ECS Service Status: desired=1, running=0` → `Updating ECS service desired count: 1 -> 0` (this PR's regression case).
- 09:13:27 — ECS container instance `6c2f887d1a4d4a80bb3dfce4e565fb53` finally registered (2 min *after* the snap).
- 09:09–09:27 — CloudWatch `HealthyHostCount` for `targetgroup/premium-71-tg/fde897f66248cb45` was 0 at every datapoint.
- 09:41:40 — Premium task placed (33 min after assignment; user's last activity was 09:27:05 UTC, i.e. 14 min earlier).

### References
- Introducing commit: `f21f50a438` / PR #323 ("Premium middleware, efs mount path, add tests", 2026-02-18) — moved counting from EC2 to ECS without preserving a slot for booting standbys.
- Related, not fixed here: Bug #2 (`clear_ecs_agent_checkpoint` SSM restart duplicates userdata systemd unit, ~5 min outage) and Bug #3 (silent frontend fallback to free tier with no UI surfacing). Both will ship as separate PRs; they reduce but do not eliminate Bug #1's surface area, and Bug #1 is the authoritative `desiredCount` snap that lands on its own.
- `REPORT_0416.md` (branch-local) — full three-bug analysis.

#### Files changed

Backend / Infrastructure
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — rewrote `update_premium_service_desired_count()` to count ACTIVE ECS CIs plus premium EC2s still inside the orphan grace period, deduplicated by `ec2InstanceId`; extracted `_list_premium_ecs_registered_ec2_ids()` and `_list_premium_ec2_instances_running()` as the single source of truth for the premium-EC2 discovery filter, reused by `cleanup_orphaned_ec2_instances()`; lowered `ORPHAN_GRACE_PERIOD_MINUTES` 15 → 10 with an inline comment tying the value to observed boot times and both consuming paths.

Tests
- `studio/tests/infrastructure/test_premium_manager.py` — replaced `TestDesiredCountUsesECS` (which locked in the buggy behavior, including a `test_does_not_use_ec2_describe_instances` assertion) with `TestDesiredCountReservesBootingStandbys`: `test_updates_from_registered_count_when_no_booting`, `test_no_update_when_counts_match`, `test_counts_booting_standby_within_grace_period`, `test_ignores_orphan_past_grace_period`, `test_does_not_double_count_registered_instance`.

### Manual Testcases

- [ ] **1. Booting-standby scenario is counted.** Unit-covered by `test_counts_booting_standby_within_grace_period`: one registered CI (`i-registered1`, launched 60 min ago) plus one running EC2 not yet in ECS (`i-booting1`, launched 3 min ago) → asserts `update_service` called with `desiredCount=2`. Reproduces the 2026-04-16 incident shape; fails against pre-fix code (would call with `desiredCount=1`).

- [ ] **2. Post-grace orphan is not counted.** Unit-covered by `test_ignores_orphan_past_grace_period`: registered CI plus EC2 running 30 min without joining ECS → asserts `desiredCount=1`, leaving the orphan to `cleanup_orphaned_ec2_instances()`. Preserves the original PR #323 intent.

- [x] **3. No double-counting at registration boundary.** Unit-covered by `test_does_not_double_count_registered_instance`: same `ec2InstanceId` returned by both `list_container_instances` and `describe_instances` → `desiredCount=1`, not 2. Guards the race where a CI registers between the two AWS calls.

- [x] **4. No-op when counts already match.** Unit-covered by `test_no_update_when_counts_match`: two registered CIs, no booting EC2s, `desiredCount=2` already → `update_service` not called. Confirms reconciliation is idempotent in the steady state.

- [x] **Automated:**
  - Backend: `cd studio && pytest tests/infrastructure/test_premium_manager.py -q` → **71 passed**.

### Unit, Integration, Contract Test Coverage
- `studio/tests/infrastructure/test_premium_manager.py::TestDesiredCountReservesBootingStandbys` — 5 tests pinning the new counting semantics (registered-only, no-op match, booting-within-grace, post-grace orphan, dedupe).
- Existing `TestClearEcsAgentCheckpoint`, `TestStartStandbyInstance`, and the `assign_premium_user` restart-path tests pass unchanged under the refactor.

### Others

#### Difficulties
- The 15 → 10 minute grace-period change touches `cleanup_orphaned_ec2_instances()` behavior as well. Kept shared intentionally (symmetry is the invariant) and called out in the `ORPHAN_GRACE_PERIOD_MINUTES` comment. If boot times regress on a future AMI pin, both paths adjust together.
- The introducing commit's docstring still claimed "Counts running premium EC2 instances (by Tier=premium tag)" while the body counted ACTIVE CIs. Docstring rewritten to describe the actual (now correct) semantics.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `update_premium_service_desired_count` counting change | Low | Additive: same ACTIVE CIs as before, plus booting EC2s inside grace, deduplicated by `ec2InstanceId`. Five unit tests pin the semantics. Steady-state (no booting standbys) is unchanged. |
| `ORPHAN_GRACE_PERIOD_MINUTES` 15 → 10 | Low | Applied to both consuming paths simultaneously, preserving symmetry. Observed boot times are 1–2 min on the current AMI; 10 is a ~5× buffer. If a future AMI regresses boot time past 10 min, orphan cleanup would start reaping valid boots — raise the constant rather than decouple the paths. |
| `_list_premium_ec2_instances_running` / `_list_premium_ecs_registered_ec2_ids` extraction | Low | Pure refactor; filter/args match the inlined versions exactly. `cleanup_orphaned_ec2_instances()` covered by its existing tests. |
| Pagination | Pre-existing, low | Neither helper paginates `list_container_instances` / `describe_instances` / `describe_container_instances` (100-item cap on the last). Not introduced by this PR; deferred unless premium fleet scales past that ceiling. |
