### PR TITLE
Improve premium instance assignment documentation

### DIFF
--- a/infrastructure/documentation/FREE_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/FREE_MANAGER_ARCHITECTURE.md
@@ -842,6 +842,12 @@ aws ecs describe-services \
 
 ## Comparison: Free Tier vs Premium Tier
 
+Detailed premium-side mechanics are in
+[PREMIUM_USER_ASSIGNMENT.md](./PREMIUM_USER_ASSIGNMENT.md)
+(5-tier assignment, standby pool, migration) and
+[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)
+(Manager vs Cleanup split, frontend lifecycle, log playbook).
+
 | Aspect | Free Tier | Premium Tier |
 |--------|-----------|--------------|
 | **Architecture** | Auto Scaling Group (ASG) | Individual EC2 instances |
@@ -852,6 +858,6 @@ aws ecs describe-services \
 | **Max Instances** | 10 (configurable) | Unlimited (cost-limited) |
 | **Cost Model** | Shared resources | Dedicated resources |
 | **Monitoring** | Every 5 minutes | Every 15 minutes |
-| **Migration** | Multi-instance rebalancing | Autoscaling pool -> dedicated |
+| **Migration** | Multi-instance rebalancing | 5-tier priority cascade; autoscaling pool → dedicated (see [Priority Matrix](./PREMIUM_USER_ASSIGNMENT.md#assignment-priority-matrix)) |
 | **Workflow Protection** | SQL-level (active_wf = 0) | User stays on dedicated instance |
 | **Post-Migration** | Experiment sync via internal API | N/A |

--- a/infrastructure/documentation/FREE_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/FREE_MANAGER_ARCHITECTURE.md
@@ -433,6 +433,14 @@ migrated regardless of last activity time.
 **Input:** `instance_id`
 **Output:** List of user IDs safe to migrate
 
+> **Terminology note.** "Idle" on the free tier means `active_workflow_count = 0`
+> -- a migration-safety check, not an activity cutoff. The premium tier uses
+> "idle" in four distinct senses (idle instance, idle premium user, idle /
+> stale assignment, idle browser tab), none of which match this definition.
+> See the "Disambiguation" section in
+> [PREMIUM_USER_ASSIGNMENT.md](./PREMIUM_USER_ASSIGNMENT.md) when reading
+> across both documents.
+
 #### get_users_per_instance()
 
 **File:** `infrastructure/terraform/free_manager_package/free_user_utils.py`

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -438,7 +438,7 @@ The `handler()` function routes events based on type:
 | `POST action=release` | `release_premium_user()` | User release |
 | `POST action=update_activity` | `handle_activity_update()` | Heartbeat/activity update |
 
-#### Scheduled Monitoring: `handle_scheduled_monitoring()`
+#### Scheduled Monitoring
 
 Runs every 15 minutes. Step numbering matches the comments in the source. Some step numbers (8, 10) bundle related sub-operations:
 
@@ -462,7 +462,7 @@ Runs every 15 minutes. Step numbering matches the comments in the source. Some s
 
 The scaling lock is always cleared in the `finally` block, even on error.
 
-#### scale_down_if_possible()
+#### Scale-Down (`scale_down_if_possible`)
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Scale down premium instances by stopping idle ones
@@ -694,14 +694,14 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 **Solution:** CloudWatch metrics-based locking:
 
-#### is_premium_scaling_in_progress()
+#### Scaling Lock Check (`is_premium_scaling_in_progress`)
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Check if a scaling operation is already running
 **Input:** None (reads CloudWatch metric)
 **Output:** True if lock set within last 15 minutes
 
-#### set_premium_scaling_lock()
+#### Scaling Lock Management (`set_premium_scaling_lock`)
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Set or clear the scaling lock via CloudWatch
@@ -722,7 +722,7 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 **Solution:** Premium Cleanup reconciliation:
 
-#### reconcile_instance_states()
+#### Instance State Reconciliation (`reconcile_instance_states`)
 
 **File:** `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py`
 **Purpose:** Sync DB instance states with actual AWS states

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -71,11 +71,11 @@ graph TB
     E --> H
     F --> H
 
-    style C fill:#90EE90
-    style D fill:#87CEEB
-    style J fill:#FFB6C1
-    style E fill:#DDA0DD
-    style F fill:#DDA0DD
+    style C fill:#90EE90,color:#1a1a1a
+    style D fill:#87CEEB,color:#1a1a1a
+    style J fill:#FFB6C1,color:#1a1a1a
+    style E fill:#DDA0DD,color:#1a1a1a
+    style F fill:#DDA0DD,color:#1a1a1a
 ```
 
 ### Key Constraints Satisfied

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -8,6 +8,13 @@
 - **Conservative scaling** keeps `max(1, active_users + 1)` instances running and requires `idle_instances >= 2` before stopping any
 - **Frontend integration** provides auto-assignment on login, inactivity monitoring (1h warning, 2h release), heartbeat-based activity tracking, and leader-tab polling while on a shared instance
 
+> **Sister document:**
+> This file focuses on the **system architecture** — Manager / Cleanup
+> Lambda split, frontend lifecycle, and operational diagnostics (log
+> playbook). For the **assignment flow** — 5-tier priority cascade,
+> standby pool, migration, and release paths — see
+> [PREMIUM_USER_ASSIGNMENT.md](./PREMIUM_USER_ASSIGNMENT.md).
+
 ---
 
 ## Key Architectural Principles
@@ -479,6 +486,9 @@ Guards:
 - Deregisters from ECS before stopping to prevent ghost
   registrations
 
+> For the scale-up / scale-down asymmetry comparison, see
+> [PREMIUM_USER_ASSIGNMENT.md → 5. Scaling System (scale-up and scale-down)](./PREMIUM_USER_ASSIGNMENT.md#5-scaling-system-scale-up-and-scale-down).
+
 #### Terraform Configuration
 
 ```hcl
@@ -776,7 +786,7 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 | `ActivePremiumUsers` | Users with active assignments | Count |
 | `IdlePremiumUsers` | Total premium users - active users | Count |
 | `RunningInstances` | EC2 instances in "running" state | Count |
-| `IdleInstances` | Running instances with 0 assignments | Count |
+| `IdleInstances` | Running instances with 0 assigned users (see [Idle instance](./PREMIUM_USER_ASSIGNMENT.md#idle-instance) in the Glossary) | Count |
 | `ScalingInProgress` | Lock to prevent concurrent operations | None (0 or 1) |
 
 **Namespace:** `OptiNiSt/PremiumManager/{env_prefix}` where `env_prefix` is the Terraform `environment` variable (e.g. `staging`, `prod`).
@@ -900,7 +910,9 @@ All resource names are prefixed with the Terraform `environment` variable (shown
 |---|---|
 | `handler()` | Main entry point, routes events by type |
 | `handle_scheduled_monitoring()` | 15-min monitoring cycle (10 operations) |
-| `scale_down_if_possible()` | Conservative scaling algorithm |
+| `scale_premium_instances_if_needed()` | Scale up by starting stopped or creating new instances when `running_count < active_users` |
+| `_create_running_instances_locked()` | Create running instances under distributed lock (called by `scale_premium_instances_if_needed()`) |
+| `scale_down_if_possible()` | Conservative scale-down: requires `running_count > max(1, active_users + 1)` AND `idle_instances >= 2` |
 | `update_premium_service_desired_count()` | Sync ECS desired count |
 | `assign_premium_user()` | Real-time user assignment (API) - 5-tier priority: dedicated > shared > standby > autoscaling pool > stopped > new |
 | `release_premium_user()` | Real-time user release (API) |
@@ -1124,6 +1136,11 @@ Displays a warning when premium users have been inactive for 1 hour.
 | `logPremiumUiEvent()` | POST /users/me/premium/ui-event | Fire-and-forget UI event log (CloudWatch timing correlation); errors swallowed |
 
 The browser-close path also calls `POST /users/me/premium/release-beacon` directly via `navigator.sendBeacon` -- it has no wrapper function since it must run without axios during `beforeunload`.
+
+> For the `X-Routing-ID` / `X-User-Tier` header protocol and the
+> backend generation/validation flow, see
+> [ALB_ROUTING_ARCHITECTURE.md](./ALB_ROUTING_ARCHITECTURE.md).
+> `getRoutingInfo()` in the table above is the frontend-side wrapper.
 
 ### Frontend Files Summary
 

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -84,9 +84,14 @@ by `PREMIUM_STOPPED_MAX_AGE_HOURS`. The full lifecycle (creation,
 replenishment, aging, excess trim, failure cleanup) is documented under
 [Standby Pool Management](#2-standby-pool-management).
 
-The standby pool is owned by Premium Manager (start / stop / terminate);
-Premium Cleanup only performs read-only health checks
-(`ensure_standby_pool_capacity()`).
+The standby pool is primarily owned by Premium Manager (create / start /
+stop / terminate). Premium Cleanup does not create, start, or stop
+instances, but its `ensure_standby_pool_capacity()` will **demote** excess
+standby rows by setting `is_standby = 0` so that Manager's normal
+scale-down / idle cleanup path can reclaim the instance on the next cycle.
+The full responsibility split is in the
+[Manager vs Cleanup responsibility split](#manager-vs-cleanup-responsibility-split-standby)
+subsection under Standby Pool Management.
 
 ### `is_standby` column semantics
 
@@ -111,10 +116,10 @@ real user.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> StandbyRow: create_and_stop_standby_instance()<br/>INSERT is_standby=1, user_id=NULL
-    StandbyRow --> Deleted: assign_premium_user() Tier 3<br/>DELETE standby placeholder<br/>(premium_manager.py:3735)
-    Deleted --> UserRow: store_user_assignment()<br/>INSERT is_standby=0, user_id=&lt;uid&gt;
-    UserRow --> [*]: release / cleanup<br/>DELETE row
+    [*] --> StandbyRow: create_and_stop_standby_instance()<br/>INSERT is_standby=1 user_id=NULL
+    StandbyRow --> Deleted: assign_premium_user Tier 3<br/>DELETE standby placeholder<br/>(premium_manager.py line 3735)
+    Deleted --> UserRow: store_user_assignment()<br/>INSERT is_standby=0 with real user_id
+    UserRow --> [*]: release or cleanup<br/>DELETE row
     StandbyRow --> [*]: terminate_aged_stopped_instances()<br/>or cleanup_excess_standby_instances()<br/>DELETE row
 ```
 
@@ -355,7 +360,7 @@ sequenceDiagram
     alt Tier 4: AWS Stopped Instance
         DB-->>PM: Found stopped instance (not standby)
         PM->>EC2: Start Instance
-        EC2-->>PM: Instance running (typically 60-90s; waiter caps at 6 min)
+        EC2-->>PM: Instance running (typically 60-90s, waiter caps at 6 min)
         PM->>PM: Create Target Group + Rule
         PM-->>User: Assigned (60s-6min wait)
     else Tier 5: Scale New Instance
@@ -471,11 +476,170 @@ On any failure after partial resource creation, the handler cleans up:
 
 ### 2. Standby Pool Management
 
-**Storage:** Standby instances are tracked in the `premium_user_assignments` table with:
+#### Conceptual overview
+
+The standby pool is a small set of **stopped** premium EC2 instances kept
+pre-provisioned so that incoming premium `/assign` calls can skip the
+4-8 minute "create from launch template" path and instead use the
+5-15 second "start a stopped instance" path. See the
+[Standby pool](#standby-pool) entry in the Glossary for the conceptual
+definition, DB representation, and cross-document disambiguation. This
+section is the **operational** reference: lifecycle, entry/exit paths,
+responsibility split, and configuration.
+
+#### Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped: create_and_stop_standby_instance()
+    [*] --> Stopped: register_orphaned_stopped_instances()
+    Running --> Stopped: convert_idle_instances_to_standby_immediate()
+    Stopped --> Consumed: assign_premium_user() Tier 3
+    Stopped --> Terminated: terminate_aged_stopped_instances()
+    Stopped --> Terminated: cleanup_excess_standby_instances()
+    Stopped --> DbOnly: cleanup_failed_standby_instances()
+    Stopped --> Demoted: ensure_standby_pool_capacity() (Cleanup)
+    Consumed --> [*]
+    Terminated --> [*]
+    DbOnly --> [*]
+    Demoted --> [*]
+```
+
+States:
+- **Stopped** -- standby placeholder row exists with `is_standby = 1, user_id = NULL`, EC2 is stopped.
+- **Running** -- real premium EC2 with assigned users (not a standby).
+  Shown only as the source of the `convert_idle_instances_to_standby_immediate()` arrow.
+- **Consumed** -- standby was picked by Tier 3; placeholder row is DELETEd and a user row is INSERTed.
+- **Terminated** -- standby row DELETEd and EC2 terminated (aging / excess trim).
+- **DbOnly** -- DB row DELETEd only; EC2 was already gone.
+- **Demoted** -- row remains but `is_standby` set to `0`; reclaimed on a later scale-down.
+
+Each arrow is labelled with the function that drives the transition; the
+corresponding DB and EC2 effects are tabulated in the Entry / Exit tables
+below.
+
+#### Entry paths: how an `is_standby = 1` row is created
+
+There are **three** ways a standby placeholder row ever gets into
+`premium_user_assignments`. All three funnel through `store_user_assignment()`
+with `is_standby=True, user_id=NULL`.
+
+| # | Function | Caller / trigger | EC2 action | DB action |
+|---|---|---|---|---|
+| 1 | `create_and_stop_standby_instance()` | `handle_scheduled_monitoring()` replenish, and Tier 3 backfill immediately after a standby is consumed | `run_instances` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped', target_group_arn='standby', alb_rule_arn='standby', standby_created_at=NOW()` |
+| 2 | `register_orphaned_stopped_instances()` | `handle_scheduled_monitoring()` step that runs after `scale_down_if_possible()` | None (only adopts an existing stopped EC2) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` for every AWS-stopped premium instance with zero rows in `premium_user_assignments` |
+| 3 | `convert_idle_instances_to_standby_immediate()` | Called from inside `scale_down_if_possible()` -- the scheduled monitor path, and also runs when the last user releases on an instance | `deregister_from_ecs` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` on the just-idled instance |
+
+The invariant is that the table never holds more than one `is_standby=1`
+row per `instance_id`: (1) and (3) create fresh rows, while (2) only
+adopts instances that have no existing row at all.
+
+#### Exit paths: how an `is_standby = 1` row is consumed or removed
+
+| Path | Function | Caller / trigger | DB action | EC2 action |
+|---|---|---|---|---|
+| **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (see [premium_manager.py:3735](../terraform/premium_manager_package/premium_manager.py#L3735)) | `start_instances` (via `start_standby_instance()`) |
+| **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | DELETE the `is_standby=1` row at [premium_manager.py:1540-1544](../terraform/premium_manager_package/premium_manager.py#L1540-L1544), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
+| **Aged-out** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | DELETE the row | `terminate_instances` |
+| **Excess trim** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | DELETE the row | `terminate_instances` |
+| **Failed cleanup** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
+| **Demoted** | `ensure_standby_pool_capacity()` [**Cleanup Lambda**] | Hourly cleanup schedule, when `standby_stopped > target_stopped` | UPDATE `is_standby = 0` on the oldest excess rows (ordered by `last_activity DESC` keep-the-newest) | None (row becomes a normal stopped-instance row; Manager will reclaim via scale-down) |
+
+#### `convert_idle_instances_to_standby_immediate()`
+
+**File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
+**Purpose:** When scale-down detects idle running instances, stop them and
+convert each to a standby placeholder **within the same invocation** --
+instead of waiting for the next 15-minute monitor cycle. This shortens the
+"last user released → instance stopped" latency to ~30-60 s for the common
+case where the idle detection and the user release happen on the same
+Lambda run.
+**Input:** None (enumerates idle running instances itself)
+**Output:** None (logs per-instance outcome)
+**Calls:** `get_assigned_users_for_instance()` → `convert_running_instance_to_standby()` → `ecs.deregister_container_instance()` → `ec2.stop_instances()` → `store_user_assignment(is_standby=True)`
+
+**Key behaviors:**
+- Enumerates **all** idle running instances (no per-call cap; bounded
+  implicitly by Lambda timeout and ECS waiter delays)
+- Only runs from inside `scale_down_if_possible()`, so it inherits the
+  scale-down guard (`running_count > max(1, active_users + 1)` AND
+  `idle_instances >= 2`)
+- Mutation is INSERT a **new** `is_standby=1` row -- the previous user's
+  assignment row must already be gone (DELETE by release / cleanup before
+  this point)
+
+This is the third entry path in the lifecycle diagram. The function name
+first appeared only in the Key Functions Reference; this subsection is the
+specification called out by Finding 4.
+
+#### Manager vs Cleanup responsibility split (standby)
+
+| Capability | Premium Manager | Premium Cleanup |
+|---|---|---|
+| CREATE standby (new EC2, stop it) | Yes (`create_and_stop_standby_instance()`) | No |
+| START a standby (consume) | Yes (`start_standby_instance()`) | No |
+| STOP a running instance into the pool | Yes (`convert_idle_instances_to_standby_immediate()`) | No |
+| ADOPT an unknown stopped EC2 as standby | Yes (`register_orphaned_stopped_instances()`) | No |
+| TERMINATE an aged / excess standby | Yes (`terminate_aged_stopped_instances()`, `cleanup_excess_standby_instances()`) | No |
+| DELETE orphan DB rows for vanished EC2s | Yes (`cleanup_failed_standby_instances()`) | No |
+| UPDATE `is_standby=0` on excess rows (demote) | No | Yes (`ensure_standby_pool_capacity()`) |
+| READ / report pool status | Yes (metrics, status JSON) | Yes (monitoring, alarms) |
+
+The only Cleanup-side mutation on the standby pool is the demotion UPDATE
+above; all start/stop/terminate calls live in Manager. The demotion is
+deliberate: it turns a misclassified "standby" row back into a normal
+stopped-instance row so Manager's existing idle-cleanup machinery (which
+only looks at `is_standby=0`) can recycle it without needing a
+standby-specific code path.
+
+#### Scheduled-monitor step order (standby-relevant steps)
+
+Within `handle_scheduled_monitoring()` (the 15-minute loop), the standby
+touchpoints run in this order:
+
+1. `cleanup_failed_standby_instances()` -- prunes orphan DB rows first so
+   later steps see an accurate picture.
+2. `scale_down_if_possible()` -- may call
+   `convert_idle_instances_to_standby_immediate()` on currently-idle
+   running instances.
+3. `register_orphaned_stopped_instances()` -- adopts any AWS-stopped
+   premium instance that has no row at all.
+4. `terminate_aged_stopped_instances()` -- enforces
+   `PREMIUM_STOPPED_MAX_AGE_HOURS`.
+5. If `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`, call
+   `cleanup_excess_standby_instances(excess)` -- oldest-first trim.
+
+The full 12-step sequence of `handle_scheduled_monitoring()` (including
+the non-standby steps) is enumerated in
+[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+
+#### Configuration values
+
+| Env var | Code default | Terraform default | Effect |
+|---|---|---|---|
+| `PREMIUM_STANDBY_POOL_SIZE` | `1` | `1` | Target count of stopped standby EC2s. `create_and_stop_standby_instance()` refuses to add more once this is hit; `cleanup_excess_standby_instances()` trims the oldest above it. Increasing this improves assignment latency for bursts at the cost of steady-state EBS storage. |
+| `PREMIUM_STOPPED_MAX_AGE_HOURS` | `4` | `4` | How long an individual stopped standby EC2 may live before `terminate_aged_stopped_instances()` terminates it. Bounds EBS accumulation and forces periodic launch-template refresh. The age source is the EC2 `StateTransitionReason` timestamp, falling back to `standby_created_at` if not parseable. |
+| `PREMIUM_EXTRA_CAPACITY` | `2` | `1` | Used by `calculate_max_capacity()` for scale-up ceiling; **not** a standby-pool knob despite the adjacent name. Included here only to disambiguate against `PREMIUM_STANDBY_POOL_SIZE`. |
+
+Terraform overrides take precedence over the code defaults at deploy time;
+the code defaults are only used if the env var is missing entirely. The
+`PREMIUM_EXTRA_CAPACITY` value actually used in production is therefore
+`1`, not the `2` written in the Python fallback.
+
+#### Storage (DB representation)
+
+Standby instances are tracked in the `premium_user_assignments` table with:
 - `is_standby = 1`
 - `user_id = NULL` (no real user)
+- `status = 'active'` (same `status` column used for real assignments; uniqueness is enforced by `idx_unique_user_assignment` being conditional on `user_id IS NOT NULL`, so multiple standby rows can coexist)
 - `target_group_arn = 'standby'`
 - `alb_rule_arn = 'standby'`
+- `instance_state = 'stopped'` (queried by `get_available_standby_instances()`)
+- `standby_created_at` = `NOW()` at insert time, used as an age fallback and for oldest-first excess trim
+
+See the [`is_standby` column semantics](#is_standby-column-semantics)
+subsection in the Glossary for the full column-value table and the
+non-UPDATE lifecycle.
 
 ### create_and_stop_standby_instance()
 
@@ -496,20 +660,39 @@ On any failure after partial resource creation, the handler cleans up:
 ### start_standby_instance()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
-**Purpose:** Start a stopped standby instance and prepare for user assignment
+**Purpose:** Start a stopped standby instance and prepare for user
+assignment. This function only handles the **start** transition; it does
+**not** touch the standby placeholder row itself.
 **Input:** instance_id (str)
 **Output:** True on success, False on failure
-**Calls:** ec2.start_instances() -> clear_ecs_agent_checkpoint()
+**Calls:** `ec2.start_instances()` -> `ec2.get_waiter('instance_running')` -> `clear_ecs_agent_checkpoint()`
 
 **Key behaviors:**
 - Waits for running state (delay=5s, max 24 attempts)
 - Clears stale ECS agent checkpoint so it re-registers
-- Updates `instance_state` to `'running'` for non-standby assignments
+- Updates `instance_state` to `'running'` for any pre-existing **non-standby**
+  assignment rows on this instance (there should be none on a true Tier 3
+  path; the clause is defensive)
 
 ```sql
--- Key constraint: only update non-standby assignments
+-- Defensive: only update non-standby rows on this instance
 WHERE instance_id = %s AND is_standby = 0
 ```
+
+**Important:** The `is_standby = 1` placeholder row is **not** deleted
+here. Row deletion happens in the caller:
+- On a Tier 3 user assignment, the inline DELETE at
+  [premium_manager.py:3735](../terraform/premium_manager_package/premium_manager.py#L3735)
+  removes the placeholder just before the new user row is inserted.
+- On a migration-driven start, the DELETE inside
+  `try_reserve_instance_for_migration()` at
+  [premium_manager.py:1540-1544](../terraform/premium_manager_package/premium_manager.py#L1540-L1544)
+  removes it before the reservation is written.
+
+In other words, `start_standby_instance()` is shared between both exit
+paths ("Assigned" and "Migrated" in the
+[Exit paths table](#exit-paths-how-an-is_standby--1-row-is-consumed-or-removed));
+only the DB mutation differs between the two callers.
 
 ### 3. Orphaned Instance Registration
 
@@ -861,11 +1044,15 @@ Shared instance optimization complete: 1 users migrated
 | Function | Purpose |
 |----------|---------|
 | `create_and_stop_standby_instance()` | Create instance, stop for pool (distributed lock) |
-| `start_standby_instance()` | Start standby + clear ECS checkpoint |
+| `start_standby_instance()` | Start standby + clear ECS checkpoint (does NOT delete placeholder row) |
+| `convert_idle_instances_to_standby_immediate()` | Stop idle running instances and convert to standby in-line during scale-down (see [spec](#convert_idle_instances_to_standby_immediate)) |
 | `get_available_standby_instances()` | Query standby pool (is_standby=1) |
-| `register_orphaned_stopped_instances()` | Auto-register stopped instances as standby |
-| `get_standby_count()` | Count current standby pool size |
-| `get_standby_pool_count()` | Count standby instances by state |
+| `register_orphaned_stopped_instances()` | Adopt AWS-stopped / DB-less instances into the standby pool |
+| `terminate_aged_stopped_instances()` | Terminate standby EC2 beyond `PREMIUM_STOPPED_MAX_AGE_HOURS` |
+| `cleanup_excess_standby_instances()` | Trim oldest standbys when `count > PREMIUM_STANDBY_POOL_SIZE` |
+| `cleanup_failed_standby_instances()` | DELETE orphan DB rows for EC2s that no longer exist in AWS |
+| `get_standby_count()` | Scalar `COUNT(*)` of `is_standby=1, status='active'` rows |
+| `get_standby_pool_count()` | Dict keyed by `instance_state` (e.g. `{stopped: N, running: N}`) |
 
 ### Migration & Scaling
 

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -635,10 +635,6 @@ Lambda run.
   assignment row must already be gone (DELETE by release / cleanup before
   this point)
 
-This is the third entry path in the lifecycle diagram. The function name
-first appeared only in the Key Functions Reference; this subsection is the
-specification called out by Finding 4.
-
 #### Manager vs Cleanup responsibility split (standby)
 
 | Capability | Premium Manager | Premium Cleanup |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -204,8 +204,8 @@ user stops interacting
 ```
 
 The exact timing, thresholds, and the full comparison of all four
-release paths are expanded in the "Inactivity & Release" section of
-[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+release paths are expanded in **Inactivity & Release Paths** under
+*Implementation Details* below.
 
 ### Soft release (`pending_release`)
 
@@ -226,9 +226,8 @@ window can resume on the same instance without a cold reassignment.
 Other release paths (hard `DELETE /assign` without beacon token, backend
 `release_premium_user()` on logout, `cleanup_stale_assignments()` at 3h)
 DELETE the row directly without going through pending_release. The full
-comparison of the four release paths is expanded in the "Inactivity &
-Release" section of
-[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+comparison of the four release paths is in **Inactivity & Release Paths**
+under *Implementation Details* below.
 
 ---
 
@@ -494,10 +493,7 @@ graph TB
 
 The bullets above describe each tier's happy path. The cascade in
 `assign_premium_user()` (in `premium_manager.py`) has three non-obvious
-properties worth calling out. Function and variable names are used
-throughout rather than line numbers, so that this section stays
-accurate as the code moves; grep or jump-to-definition on the
-identifier when investigating.
+properties worth calling out.
 
 - **Tier 2 vs Tier 3 (unconditional precedence).** If
   `least_loaded_instance` is non-null after the Tier 1 scan, Tier 2
@@ -850,6 +846,116 @@ subscribers.
   distributed lock
 - Always calls `invoke_migration_async()` and
   `update_premium_service_desired_count()` after scaling
+
+---
+
+### 6. Inactivity & Release Paths
+
+Premium assignments can be released by four distinct paths, reached
+under different conditions and with different latencies. This
+subsection is the canonical comparison referenced from the Glossary's
+*Soft release* and *Disambiguation* entries.
+
+#### Client-side inactivity timer
+
+The frontend runs an inactivity monitor in
+`PremiumAssignmentContext.tsx` (the `checkInactivity` effect) that
+observes `lastActivity` across tabs and fires on two hard-coded
+thresholds:
+
+| Threshold | Effect |
+|---|---|
+| 1 hour | Surface the `InactivityWarning` snackbar with a countdown (`INACTIVITY_WARNING_DURATION_MINUTES = 60` from `const/Subscription.ts` drives the countdown display) |
+| 2 hours | Call `autoReleaseOnLogout()`, which issues `DELETE /premium/assign` with a beacon token |
+
+The monitor polls every 30 s and listens for cross-tab activity events
+(`onActivityFromOtherTab`) so activity in another tab dismisses the
+warning on this one. On tab close / hard navigation,
+`navigator.sendBeacon` hits the same endpoint with the same beacon
+token -- the auto-release path and the beacon path converge on the
+backend.
+
+> **Threshold coupling.** The 1 h / 2 h thresholds are hard-coded in
+> `PremiumAssignmentContext.tsx`. `INACTIVITY_WARNING_DURATION_MINUTES`
+> controls only the countdown shown in the snackbar; changing it
+> without also changing the hard-coded thresholds would cause the
+> displayed countdown to disagree with the actual auto-release time.
+
+#### Server-side grace window (beacon / auto-release path)
+
+When the DELETE request carries a valid beacon token,
+`release_premium_user()` takes the soft branch: the assignment row is
+not deleted, it is transitioned to `pending_release`
+(`status = 'terminating'`). The row still counts as occupation during
+the grace window (see the *Soft release* entry in the Glossary).
+
+The grace window has duration `PENDING_RELEASE_GRACE_SECONDS = 120`
+(`aws_constants.py`). Expiration is handled by
+`finalize_expired_pending_releases()`, which runs as one of the steps
+in `handle_scheduled_monitoring()` (the 15-minute Manager loop). So
+the observed latency from grace start to row deletion is:
+
+- **Minimum:** ~2 min (grace just expired as a monitor run starts)
+- **Maximum:** ~17 min (grace expires just after a monitor run)
+
+If the user re-opens the tab within the grace window,
+`restore_pending_release()` (called at the top of
+`assign_premium_user()`) flips `status` back to `'active'` on the same
+row and returns `assignment_source: "restored_from_pending_release"`.
+No new target group, no ALB rule churn; `is_shared` is preserved.
+
+#### The four release paths
+
+| # | Path | Trigger | Backend entry | Uses pending_release? | Row deletion latency |
+|---|---|---|---|---|---|
+| 1 | Beacon on tab close | `navigator.sendBeacon` on `beforeunload` | `release_premium_user()` (beacon branch) | Yes | 120 s grace + up to ~15 min until finalize |
+| 2 | Frontend auto-release | 2 h of measured inactivity | `release_premium_user()` (beacon branch) | Yes | Same as path 1 |
+| 3 | Hard release | Manual logout, or explicit `DELETE /premium/assign` without beacon token | `release_premium_user()` (hard branch) | No | Immediate (within the same Lambda invocation) |
+| 4 | Stale-assignment safety net | `last_activity` older than `PREMIUM_IDLE_TIMEOUT_HOURS` with no release having fired | `cleanup_stale_assignments()` in the Premium Cleanup Lambda | No | Up to 1 h after the timeout (hourly Cleanup cadence) |
+
+Paths 1 and 2 share the same backend code (they differ only in what
+triggered the frontend). Path 3 is the legacy / explicit logout path.
+Path 4 is the safety net for missing beacons -- it catches clients
+that crashed before `sendBeacon` could fire, or browsers that killed
+the tab too hard for the beacon to reach the ALB.
+
+> **`PREMIUM_IDLE_TIMEOUT_HOURS` value in production.** The Terraform
+> variable is `3` for both the Manager and the Cleanup Lambda
+> (`premium_manager.tf`). The `premium_cleanup_package/README.md` still
+> documents it as `2`; treat the Terraform value as the source of
+> truth. Path 4 therefore fires no earlier than 3 h after last
+> activity, plus up to 1 h of scheduler latency.
+
+#### Post-release: idle-instance handling
+
+Once a release path removes the last `is_standby = 0` user row from an
+instance, the instance meets the Glossary's formal definition of
+idle. Two paths can then stop it:
+
+- **Fast path (same invocation).** The hard branch of
+  `release_premium_user()` can stop the just-idled instance and flip
+  its row to `is_standby = 1` within the same Lambda run via
+  `convert_idle_instances_to_standby_immediate()`. This is gated by
+  the scale-down criteria (`running_count > max(1, active_users + 1)`
+  AND `idle_instances >= 2`), so it only fires when headroom exists.
+- **Slow path (next monitor cycle).** The 15-minute
+  `handle_scheduled_monitoring()` run calls `scale_down_if_possible()`,
+  which applies the same gate on whatever instances became idle since
+  the last run.
+
+The beacon / auto-release paths do **not** trigger the fast path
+directly -- they only mark `pending_release`. The fast path only
+runs when the row is actually DELETEd (by
+`finalize_expired_pending_releases()` at grace expiration, or by the
+hard-release path on the same call).
+
+#### Subsystem ownership
+
+| Subsystem | Owns |
+|---|---|
+| Frontend (`PremiumAssignmentContext.tsx`) | Inactivity detection, warning surface, auto-release trigger, `sendBeacon` on tab close |
+| Premium Manager (real-time) | `release_premium_user()`, `restore_pending_release()`, `finalize_expired_pending_releases()`, `scale_down_if_possible()`, `convert_idle_instances_to_standby_immediate()` |
+| Premium Cleanup (hourly) | `cleanup_stale_assignments()` (path 4 only) |
 
 ---
 

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -424,6 +424,35 @@ DELETE the row directly without going through pending_release. The full
 comparison of the four release paths is in **Inactivity & Release Paths**
 under *Implementation Details* below.
 
+### Ghost ECS container instance
+
+A **ghost ECS container instance** (or simply "ghost instance" in log
+messages) is an ECS container-instance registration whose backing EC2
+instance is no longer reachable — it has been stopped, terminated, or
+has lost its ECS agent connection. The registration remains in the ECS
+cluster's capacity pool, consuming a slot in the ECS scheduler's view
+of available capacity even though no container can actually be placed
+on it.
+
+Ghosts arise when an EC2 instance is stopped or terminated outside the
+normal `deregister_from_ecs → stop_instances` ordering — for example,
+an AWS health event, a manual console stop, or an error path that
+skipped the deregistration step. The scale-down code path deregisters
+from ECS **before** stopping to prevent ghosts, but edge cases can
+still create them.
+
+`cleanup_ghost_ecs_registrations()` runs as step 10b of the 15-minute
+`handle_scheduled_monitoring()` cycle. It lists all premium container
+instances (`attribute:tier == premium`), checks each one's EC2 state
+and agent connectivity, and force-deregisters any that qualify. For
+running EC2 instances with a disconnected agent, a 5-minute grace
+period (tagged on first sighting) prevents deregistering instances
+that are merely rebooting their agent.
+
+> For the full deregistration rules, grace-period tagging, and
+> troubleshooting log strings, see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Ghost ECS Container Instances](./PREMIUM_MANAGER_ARCHITECTURE.md#4-ghost-ecs-container-instances).
+
 ---
 
 ## Implementation Details

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -75,13 +75,13 @@ graph TB
         D --> K[User Logged In]
     end
 
-    style C1 fill:#90EE90
-    style C2 fill:#FFD700
-    style C3 fill:#FFA500
-    style C4 fill:#87CEEB
-    style C5 fill:#DDA0DD
-    style C6 fill:#FFB6C1
-    style J fill:#FFFFFF
+    style C1 fill:#90EE90,color:#1a1a1a
+    style C2 fill:#FFD700,color:#1a1a1a
+    style C3 fill:#FFA500,color:#1a1a1a
+    style C4 fill:#87CEEB,color:#1a1a1a
+    style C5 fill:#DDA0DD,color:#1a1a1a
+    style C6 fill:#FFB6C1,color:#1a1a1a
+    style J fill:#FFFFFF,color:#1a1a1a
 ```
 
 > **Color key:** 🟢 Tier 1 (Dedicated) · 🟡 Tier 2 (Shared) ·
@@ -254,10 +254,10 @@ graph TB
         N --> P[User on Dedicated Instance]
     end
 
-    style A fill:#FFA500
-    style P fill:#90EE90
-    style G fill:#87CEEB
-    style J fill:#DDA0DD
+    style A fill:#FFA500,color:#1a1a1a
+    style P fill:#90EE90,color:#1a1a1a
+    style G fill:#87CEEB,color:#1a1a1a
+    style J fill:#DDA0DD,color:#1a1a1a
 ```
 
 ---

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -561,25 +561,25 @@ stateDiagram-v2
     [*] --> Stopped: create_and_stop_standby_instance()
     [*] --> Stopped: register_orphaned_stopped_instances()
     Running --> Stopped: convert_idle_instances_to_standby_immediate()
-    Stopped --> Consumed: assign_premium_user() Tier 3
+    Stopped --> Assigned: assign_premium_user() Tier 3
     Stopped --> Terminated: terminate_aged_stopped_instances()
     Stopped --> Terminated: cleanup_excess_standby_instances()
     Stopped --> DbOnly: cleanup_failed_standby_instances()
-    Stopped --> Demoted: ensure_standby_pool_capacity() (Cleanup)
-    Consumed --> [*]
+    Stopped --> Cleared: ensure_standby_pool_capacity() (Cleanup)
+    Assigned --> [*]
     Terminated --> [*]
     DbOnly --> [*]
-    Demoted --> [*]
+    Cleared --> [*]
 ```
 
 States:
 - **Stopped** -- standby placeholder row exists with `is_standby = 1, user_id = NULL`, EC2 is stopped.
 - **Running** -- real premium EC2 with assigned users (not a standby).
   Shown only as the source of the `convert_idle_instances_to_standby_immediate()` arrow.
-- **Consumed** -- standby was picked by Tier 3; placeholder row is DELETEd and a user row is INSERTed.
-- **Terminated** -- standby row DELETEd and EC2 terminated (aging / excess trim).
+- **Assigned** -- standby was picked by Tier 3; placeholder row is DELETEd and a user row is INSERTed.
+- **Terminated** -- standby row DELETEd and EC2 terminated (aged or excess).
 - **DbOnly** -- DB row DELETEd only; EC2 was already gone.
-- **Demoted** -- row remains but `is_standby` set to `0`; reclaimed on a later scale-down.
+- **Cleared** -- row remains but `is_standby` set to `0`; reclaimed on a later scale-down.
 
 Each arrow is labelled with the function that drives the transition; the
 corresponding DB and EC2 effects are tabulated in the Entry / Exit tables
@@ -607,10 +607,10 @@ adopts instances that have no existing row at all.
 |---|---|---|---|---|
 | **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (the inline DELETE/INSERT lives in the Tier 3 block of `assign_premium_user()`) | `start_instances` (via `start_standby_instance()`) |
 | **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | DELETE the `is_standby=1` row (inline DELETE inside `try_reserve_instance_for_migration()`), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
-| **Aged-out** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | DELETE the row | `terminate_instances` |
-| **Excess trim** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | DELETE the row | `terminate_instances` |
-| **Failed cleanup** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
-| **Demoted** | `ensure_standby_pool_capacity()` [**Cleanup Lambda**] | Hourly cleanup schedule, when `standby_stopped > target_stopped` | UPDATE `is_standby = 0` on the oldest excess rows (ordered by `last_activity DESC` keep-the-newest) | None (row becomes a normal stopped-instance row; Manager will reclaim via scale-down) |
+| **Terminated (aged)** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | DELETE the row | `terminate_instances` |
+| **Terminated (excess)** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | DELETE the row | `terminate_instances` |
+| **Cleaned up** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
+| **Cleared** | `ensure_standby_pool_capacity()` [**Cleanup Lambda**] | Hourly cleanup schedule, when `standby_stopped > target_stopped` | UPDATE `is_standby = 0` on the oldest excess rows (ordered by `last_activity DESC` keep-the-newest) | None (row becomes a normal stopped-instance row; Manager will reclaim via scale-down) |
 
 #### `convert_idle_instances_to_standby_immediate()`
 
@@ -642,7 +642,7 @@ Lambda run.
 | CREATE standby (new EC2, stop it) | Yes (`create_and_stop_standby_instance()`) | No |
 | START a standby (consume) | Yes (`start_standby_instance()`) | No |
 | STOP a running instance into the pool | Yes (`convert_idle_instances_to_standby_immediate()`) | No |
-| ADOPT an unknown stopped EC2 as standby | Yes (`register_orphaned_stopped_instances()`) | No |
+| REGISTER an unknown stopped EC2 as standby | Yes (`register_orphaned_stopped_instances()`) | No |
 | TERMINATE an aged / excess standby | Yes (`terminate_aged_stopped_instances()`, `cleanup_excess_standby_instances()`) | No |
 | DELETE orphan DB rows for vanished EC2s | Yes (`cleanup_failed_standby_instances()`) | No |
 | UPDATE `is_standby=0` on excess rows (demote) | No | Yes (`ensure_standby_pool_capacity()`) |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -140,7 +140,7 @@ This document covers one Lambda -- the Premium Manager -- acting across several 
 | Capacity scaling (up)                | Scaling system                                | `scale_premium_instances_if_needed()`, `_create_running_instances_locked()`             |
 | Shared-to-dedicated migration        | Background migration                          | `process_shared_instance_optimization()`, `migrate_user_to_dedicated_instance()`, `invoke_migration_async()` |
 | Concurrency / race prevention        | Locking                                       | `distributed_lock()` (MySQL `GET_LOCK`), `try_reserve_instance_transaction()` (`SELECT FOR UPDATE`), `is_creation_lock_held()` |
-| Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)) | `handle_scheduled_monitoring()`, [`scale_down_if_possible()`](./PREMIUM_MANAGER_ARCHITECTURE.md#scale_down_if_possible) |
+| Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)) | `handle_scheduled_monitoring()`, [`scale_down_if_possible()`](./PREMIUM_MANAGER_ARCHITECTURE.md#scale-down-scale_down_if_possible) |
 | Stale assignment + ALB rule hygiene  | Premium Cleanup Lambda (separate)             | See [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)               |
 
 ## Provisioning Flow Diagrams
@@ -899,7 +899,7 @@ shortening the "last user released → instance stopped" latency to
 
 > Full specification (File / Purpose / Input / Output / Calls and
 > detailed guard bullets) is in
-> [PREMIUM_MANAGER_ARCHITECTURE.md → scale_down_if_possible()](./PREMIUM_MANAGER_ARCHITECTURE.md#scale_down_if_possible).
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Scale-Down](./PREMIUM_MANAGER_ARCHITECTURE.md#scale-down-scale_down_if_possible).
 
 ---
 
@@ -1049,7 +1049,7 @@ both see same available instance.
 
 **Solution:** Database-level locking with `SELECT FOR UPDATE`:
 
-#### try_reserve_instance_transaction()
+#### Atomic Instance Reservation (`try_reserve_instance_transaction`)
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Atomically reserve an instance using row-level locking

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -37,200 +37,6 @@
    - Auto-migration when new instances become ready
    - Workflow-safe: skips users with active workflows
 
-## Glossary / Key Concepts
-
-This section is the shared vocabulary used throughout the premium assignment
-documentation. Later sections reference these definitions rather than
-redefining them. When writing or reading test cases for the assignment
-system, each row in the tables below is a candidate test condition.
-
-### Assignment state of a premium user
-
-A premium user who has been through the `/assign` flow ends up in exactly
-one of four states. These states differ in infrastructure (real EC2 vs
-shared pool) **and** in DB representation, even though the frontend
-collapses three of them into a single "please wait" toast.
-
-| State | `instance_id` | `is_shared` | `is_standby` | Meaning |
-|---|---|---|---|---|
-| **Dedicated** | `i-xxxx` (real EC2) | `false` | `false` | The user is the sole premium assignment on that EC2 instance. Target group is per-user; the ALB rule routes only this user. |
-| **Shared** | `i-xxxx` (real EC2) | `true` | `false` | The user is co-located with one or more other premium users on a real premium EC2 instance. The Lambda picked the least-loaded running instance because no idle dedicated instance was available at assign time. Will migrate to a dedicated instance when one becomes available. |
-| **Autoscaling Pool** | `"autoscaling-pool"` (sentinel) | `true` | `false` | Fallback marker used when no running premium instance and no standby were available. Routed via the shared ASG target group (same pool as free tier), **not** a real premium EC2. Will migrate to a real premium instance once one comes up. |
-| **Unassigned** | — | — | — | No row exists (either the user is not premium, or `/assign` returned a hard error and `assignmentResult` stayed null on the frontend). |
-
-Uniqueness is enforced per-user (`idx_unique_user_assignment` conditional
-UNIQUE on `user_id WHERE user_id IS NOT NULL`), **not** per-instance.
-Multiple user rows can share the same `instance_id` (that is exactly what
-the Shared state is).
-
-The difference between Shared and Autoscaling Pool is critical when
-debugging: Shared runs on a real premium EC2 that the Manager owns, whereas
-Autoscaling Pool routes through the free-tier ASG target group. The toast
-copy collapses them, but infra-layer behaviour (scaling triggers, migration
-paths, routing) differs.
-
-### Standby pool
-
-The **standby pool** is a set of stopped EC2 instances maintained solely to
-shortcut the premium-user startup path. Starting a stopped instance is
-~5-15 seconds, whereas creating a new one from the launch template is
-4-8 minutes; keeping a small pool of pre-stopped instances therefore trades
-storage / EBS cost for startup latency on incoming premium assignments.
-
-A standby instance is represented in `premium_user_assignments` by a
-**placeholder row** with `is_standby = 1` and `user_id = NULL`. The pool is
-sized by `PREMIUM_STANDBY_POOL_SIZE`, and individual standbys are aged out
-by `PREMIUM_STOPPED_MAX_AGE_HOURS`. The full lifecycle (creation,
-replenishment, aging, excess trim, failure cleanup) is documented under
-[Standby Pool Management](#2-standby-pool-management).
-
-The standby pool is primarily owned by Premium Manager (create / start /
-stop / terminate). Premium Cleanup does not create, start, or stop
-instances, but its `ensure_standby_pool_capacity()` will **demote** excess
-standby rows by setting `is_standby = 0` so that Manager's normal
-scale-down / idle cleanup path can reclaim the instance on the next cycle.
-The full responsibility split is in the
-[Manager vs Cleanup responsibility split](#manager-vs-cleanup-responsibility-split-standby)
-subsection under Standby Pool Management.
-
-### `is_standby` column semantics
-
-`is_standby` is a `BOOLEAN NOT NULL` column (MySQL `TINYINT`) with
-`server_default = "0"`, defined in
-[e701e7250019_create_premium_management_system.py:89-93](../../studio/alembic/versions/e701e7250019_create_premium_management_system.py#L89-L93).
-It discriminates two kinds of rows:
-
-| Value | `user_id` | `target_group_arn` / `alb_rule_arn` | Meaning |
-|---|---|---|---|
-| `0` (default) | set (FK to `users.id`) | real ARN, or sentinel `"autoscaling-pool"` / `"reserving"` | Real user assignment row (Dedicated / Shared / Autoscaling Pool / in-flight reservation) |
-| `1` | `NULL` | `"standby"` / `"standby"` | Standby pool placeholder -- no owning user, the EC2 instance is stopped waiting to be assigned |
-
-`NULL` is not valid for this column; unless database corruption occurs the
-value is always 0 or 1.
-
-**Lifecycle transitions.** Importantly, there is **no in-place
-`1 → 0` UPDATE**. A standby instance being assigned to a user is
-implemented as a DELETE of the standby placeholder followed by an INSERT of
-a fresh user-owned assignment row. The `is_standby = 1` row never carries a
-real user.
-
-```mermaid
-stateDiagram-v2
-    [*] --> StandbyRow: create_and_stop_standby_instance()<br/>INSERT is_standby=1 user_id=NULL
-    StandbyRow --> Deleted: assign_premium_user Tier 3<br/>DELETE standby placeholder<br/>(premium_manager.py line 3735)
-    Deleted --> UserRow: store_user_assignment()<br/>INSERT is_standby=0 with real user_id
-    UserRow --> [*]: release or cleanup<br/>DELETE row
-    StandbyRow --> [*]: terminate_aged_stopped_instances()<br/>or cleanup_excess_standby_instances()<br/>DELETE row
-```
-
-**Tier 3 vs Tier 4 at the DB level.** These two tiers both source a stopped
-EC2 instance but their DB representations differ:
-
-- **Tier 3 (standby stopped)** -- instance is stopped AND has a placeholder
-  row with `is_standby = 1, user_id = NULL`. Visible to
-  `get_available_standby_instances()`.
-- **Tier 4 (non-standby stopped)** -- instance is stopped but has **no row
-  at all** in `premium_user_assignments`. Discovered by EC2 describe calls.
-  At the start of every `/assign` invocation,
-  `register_orphaned_stopped_instances()` normalises any untracked stopped
-  instances into standby rows, so in steady state Tier 4 is rarely reached
-  in the happy path; it remains as a true fallback for races or after
-  cleanup lag.
-
-### Idle instance
-
-An **idle instance** is a running premium EC2 instance with zero assigned
-real users.
-
-> Formally: an instance `i` is idle when no row exists in
-> `premium_user_assignments` satisfying
-> `instance_id = i AND is_standby = 0 AND status IN ('active', 'terminating')`.
-
-This matches the query used by `get_assigned_users_for_instance()`
-(in `premium_manager.py`), which backs `scale_down_if_possible()` and
-the `IdleInstances` CloudWatch metric. Note that `'terminating'` is
-the DB encoding of the `pending_release` state (see "Soft release"
-below).
-
-**What counts / does not count as occupation:**
-
-| Row shape | Counts as occupation? | Notes |
-|---|---|---|
-| `is_standby = 0`, `status = 'active'`, real `user_id` | **Yes** | Normal active user |
-| `is_standby = 0`, `status = 'terminating'` (pending_release), real `user_id` | **Yes** | Pending_release rows DO keep the instance non-idle during the 120s grace window. A comment in `get_assigned_users_for_instance()` spells this out: *"Include pending_release so instance isn't treated as idle during grace"* |
-| `is_standby = 1`, `user_id = NULL` (standby placeholder) | **No** | Standby rows never count as occupation; the instance is stopped, not running |
-| `is_standby = 0`, `user_id = <uid>`, `target_group_arn = 'reserving'` | **Yes** | The row has a real `user_id` and `status = 'active'`, so the occupation query matches. The reservation is either promoted to a full assignment within the same Lambda invocation or cleaned up by `release_instance_reservation()` on failure |
-
-**Scale-down threshold.** `scale_down_if_possible()` only stops an idle
-instance when
-`running_count > max(1, active_users + 1)` **AND** `idle_instances >= 2`.
-The `+ 1` safety margin is kept by scale-down; scale-up has no such margin.
-
-### Disambiguation: the four meanings of "idle"
-
-The documentation uses "idle" as shorthand in four distinct senses.
-When reading any section, identify the subject before interpreting the
-term.
-
-| Term | Subject | Exact condition | Where it appears |
-|---|---|---|---|
-| **Idle instance** | EC2 instance | Running with 0 qualifying assignment rows (formal definition above) | `scale_down_if_possible()`, `IdleInstances` CloudWatch metric |
-| **Idle premium user** | User account | Premium subscriber with no active assignment row -- computed as `total_premium_users − active_users` | `IdlePremiumUsers` CloudWatch metric |
-| **Idle assignment** (stale) | DB row | `last_activity < NOW() − PREMIUM_IDLE_TIMEOUT_HOURS` (Terraform: 3 hours) | `cleanup_stale_assignments()` in Premium Cleanup |
-| **Idle user (browser)** | Browser tab | No user interaction for the threshold (1h warning surfaces; 2h triggers auto-release) | `PremiumAssignmentContext.tsx` inactivity monitor |
-
-The Free tier uses "idle" with a fifth, unrelated meaning: `FreeUserAssignment.active_workflow_count = 0`
-(see [FREE_MANAGER_ARCHITECTURE.md](./FREE_MANAGER_ARCHITECTURE.md)). Premium's
-`active_workflow_count` serves the same migration-safety role but is **not**
-what "idle instance" or "idle assignment" mean on the premium side.
-
-**Causal chain (browser idle → instance idle → scale-down):**
-
-```
-user stops interacting
-  → 1h passes: InactivityWarning snackbar surfaces (60-min countdown)
-  → 2h passes: frontend DELETE /premium/assign (or sendBeacon on browser close)
-      → backend creates pending_release row (status='terminating'), 120s grace
-      → 120s later: finalize_expired_pending_releases() DELETEs the row
-           and tears down ALB resources
-  → [alternate safety-net path if frontend didn't fire] 3h passes:
-      → Premium Cleanup cleanup_stale_assignments() DELETEs the stale row
-  → Row gone: instance now has 0 qualifying assignments → instance is idle
-  → Next 15-min monitor run: scale_down_if_possible() stops the instance if
-    running_count > max(1, active_users+1) AND idle_instances >= 2
-  → OR, if the last premium user just left on this same release call,
-    convert_idle_instances_to_standby_immediate() may stop the instance
-    within the same invocation instead of waiting for the 15-min cycle.
-```
-
-The exact timing, thresholds, and the full comparison of all four
-release paths are expanded in **Inactivity & Release Paths** under
-*Implementation Details* below.
-
-### Soft release (`pending_release`)
-
-When a user releases via the **beacon path** (`navigator.sendBeacon` on
-browser close, or the frontend auto-release at 2h), the backend does **not**
-delete the row immediately. It transitions the row to the `pending_release`
-state for a grace period, so that a user who re-opens the tab within the
-window can resume on the same instance without a cold reassignment.
-
-| Property | Value |
-|---|---|
-| DB representation | `status = 'terminating'` (the `pending_release` sentinel reuses the `TERMINATING` enum value -- safe because all status checks go through the `PremiumAssignment` enum constants in `aws_constants.py`, not raw strings) |
-| Grace period duration | `PENDING_RELEASE_GRACE_SECONDS = 120` (2 minutes), defined in `aws_constants.py` |
-| Effect on idle counting during grace | Instance is **not** idle; the pending_release row counts as occupation (see the `get_assigned_users_for_instance()` query) |
-| Grace expiration handler | `finalize_expired_pending_releases()` (step 10a of the 15-min monitor) -- DELETEs the row and tears down ALB resources |
-| Resume path | `restore_pending_release()` at the start of `assign_premium_user()` -- UPDATEs `status` back to `'active'` on the same row if the EC2 instance still exists; returns with `assignment_source: "restored_from_pending_release"`. `is_shared` is **not** touched |
-
-Other release paths (hard `DELETE /assign` without beacon token, backend
-`release_premium_user()` on logout, `cleanup_stale_assignments()` at 3h)
-DELETE the row directly without going through pending_release. The full
-comparison of the four release paths is in **Inactivity & Release Paths**
-under *Implementation Details* below.
-
----
-
 ## Architecture Overview
 
 ```mermaid
@@ -444,6 +250,170 @@ graph TB
 
 ---
 
+## Glossary / Key Concepts
+
+This section is the shared vocabulary used throughout the premium assignment
+documentation. Later sections reference these definitions rather than
+redefining them. When writing or reading test cases for the assignment
+system, each row in the tables below is a candidate test condition.
+
+### Assignment state of a premium user
+
+A premium user who has been through the `/assign` flow ends up in exactly
+one of four states. These states differ in infrastructure (real EC2 vs
+shared pool) **and** in DB representation, even though the frontend
+collapses three of them into a single "please wait" toast.
+
+| State | `instance_id` | `is_shared` | `is_standby` | Meaning |
+|---|---|---|---|---|
+| **Dedicated** | `i-xxxx` (real EC2) | `false` | `false` | The user is the sole premium assignment on that EC2 instance. Target group is per-user; the ALB rule routes only this user. |
+| **Shared** | `i-xxxx` (real EC2) | `true` | `false` | The user is co-located with one or more other premium users on a real premium EC2 instance. The Lambda picked the least-loaded running instance because no idle dedicated instance was available at assign time. Will migrate to a dedicated instance when one becomes available. |
+| **Autoscaling Pool** | `"autoscaling-pool"` (sentinel) | `true` | `false` | Fallback marker used when no running premium instance and no standby were available. Routed via the shared ASG target group (same pool as free tier), **not** a real premium EC2. Will migrate to a real premium instance once one comes up. |
+| **Unassigned** | — | — | — | No row exists (either the user is not premium, or `/assign` returned a hard error and `assignmentResult` stayed null on the frontend). |
+
+Uniqueness is enforced per-user (`idx_unique_user_assignment` conditional
+UNIQUE on `user_id WHERE user_id IS NOT NULL`), **not** per-instance.
+Multiple user rows can share the same `instance_id` (that is exactly what
+the Shared state is).
+
+The difference between Shared and Autoscaling Pool is critical when
+debugging: Shared runs on a real premium EC2 that the Manager owns, whereas
+Autoscaling Pool routes through the free-tier ASG target group. The toast
+copy collapses them, but infra-layer behaviour (scaling triggers, migration
+paths, routing) differs.
+
+### Standby pool
+
+The **standby pool** is a set of stopped EC2 instances maintained solely to
+shortcut the premium-user startup path. Starting a stopped instance is
+~5-15 seconds, whereas creating a new one from the launch template is
+4-8 minutes; keeping a small pool of pre-stopped instances therefore trades
+storage / EBS cost for startup latency on incoming premium assignments.
+
+A standby instance is represented in `premium_user_assignments` by a
+**placeholder row** with `is_standby = 1` and `user_id = NULL`. The pool is
+sized by `PREMIUM_STANDBY_POOL_SIZE`, and individual standbys are aged out
+by `PREMIUM_STOPPED_MAX_AGE_HOURS`. The full lifecycle (creation,
+replenishment, aging, excess trim, failure cleanup) is documented under
+[Standby Pool Management](#2-standby-pool-management).
+
+The `is_standby` column discriminates the two row kinds that co-exist in
+the `premium_user_assignments` table:
+
+| `is_standby` | `user_id` | Meaning |
+|---|---|---|
+| `0` (default) | set (FK to `users.id`) | Real user assignment row (Dedicated / Shared / Autoscaling Pool / in-flight reservation) |
+| `1` | `NULL` | Standby pool placeholder -- the EC2 instance is stopped waiting to be assigned |
+
+There is **no in-place `1 → 0` UPDATE** on this column. A standby being
+assigned to a user is implemented as DELETE of the placeholder followed by
+INSERT of a fresh user row; the invariant is enforced by the Tier 3 block
+in `assign_premium_user()` and by `try_reserve_instance_for_migration()`.
+The `is_standby = 1` row therefore never carries a real user.
+
+The standby pool is primarily owned by Premium Manager (create / start /
+stop / terminate). Premium Cleanup does not create, start, or stop
+instances, but its `ensure_standby_pool_capacity()` will **demote** excess
+standby rows by setting `is_standby = 0` so that Manager's normal
+scale-down / idle cleanup path can reclaim the instance on the next cycle.
+The full responsibility split is in the
+[Manager vs Cleanup responsibility split](#manager-vs-cleanup-responsibility-split-standby)
+subsection under Standby Pool Management.
+
+### Idle instance
+
+An **idle instance** is a running premium EC2 instance with zero assigned
+real users.
+
+> Formally: an instance `i` is idle when no row exists in
+> `premium_user_assignments` satisfying
+> `instance_id = i AND is_standby = 0 AND status IN ('active', 'terminating')`.
+
+This matches the query used by `get_assigned_users_for_instance()`
+(in `premium_manager.py`), which backs `scale_down_if_possible()` and
+the `IdleInstances` CloudWatch metric. Note that `'terminating'` is
+the DB encoding of the `pending_release` state (see "Soft release"
+below).
+
+**What counts / does not count as occupation:**
+
+| Row shape | Counts as occupation? | Notes |
+|---|---|---|
+| `is_standby = 0`, `status = 'active'`, real `user_id` | **Yes** | Normal active user |
+| `is_standby = 0`, `status = 'terminating'` (pending_release), real `user_id` | **Yes** | Pending_release rows DO keep the instance non-idle during the 120s grace window. A comment in `get_assigned_users_for_instance()` spells this out: *"Include pending_release so instance isn't treated as idle during grace"* |
+| `is_standby = 1`, `user_id = NULL` (standby placeholder) | **No** | Standby rows never count as occupation; the instance is stopped, not running |
+| `is_standby = 0`, `user_id = <uid>`, `target_group_arn = 'reserving'` | **Yes** | The row has a real `user_id` and `status = 'active'`, so the occupation query matches. The reservation is either promoted to a full assignment within the same Lambda invocation or cleaned up by `release_instance_reservation()` on failure |
+
+**Scale-down threshold.** `scale_down_if_possible()` only stops an idle
+instance when
+`running_count > max(1, active_users + 1)` **AND** `idle_instances >= 2`.
+The `+ 1` safety margin is kept by scale-down; scale-up has no such margin.
+
+### Disambiguation: the four meanings of "idle"
+
+The documentation uses "idle" as shorthand in four distinct senses.
+When reading any section, identify the subject before interpreting the
+term.
+
+| Term | Subject | Exact condition | Where it appears |
+|---|---|---|---|
+| **Idle instance** | EC2 instance | Running with 0 qualifying assignment rows (formal definition above) | `scale_down_if_possible()`, `IdleInstances` CloudWatch metric |
+| **Idle premium user** | User account | Premium subscriber with no active assignment row -- computed as `total_premium_users − active_users` | `IdlePremiumUsers` CloudWatch metric |
+| **Idle assignment** (stale) | DB row | `last_activity < NOW() − PREMIUM_IDLE_TIMEOUT_HOURS` (Terraform: 3 hours) | `cleanup_stale_assignments()` in Premium Cleanup |
+| **Idle user (browser)** | Browser tab | No user interaction for the threshold (1h warning surfaces; 2h triggers auto-release) | `PremiumAssignmentContext.tsx` inactivity monitor |
+
+The Free tier uses "idle" with a fifth, unrelated meaning: `FreeUserAssignment.active_workflow_count = 0`
+(see [FREE_MANAGER_ARCHITECTURE.md](./FREE_MANAGER_ARCHITECTURE.md)). Premium's
+`active_workflow_count` serves the same migration-safety role but is **not**
+what "idle instance" or "idle assignment" mean on the premium side.
+
+**Causal chain (browser idle → instance idle → scale-down):**
+
+```
+user stops interacting
+  → 1h passes: InactivityWarning snackbar surfaces (60-min countdown)
+  → 2h passes: frontend DELETE /premium/assign (or sendBeacon on browser close)
+      → backend creates pending_release row (status='terminating'), 120s grace
+      → 120s later: finalize_expired_pending_releases() DELETEs the row
+           and tears down ALB resources
+  → [alternate safety-net path if frontend didn't fire] 3h passes:
+      → Premium Cleanup cleanup_stale_assignments() DELETEs the stale row
+  → Row gone: instance now has 0 qualifying assignments → instance is idle
+  → Next 15-min monitor run: scale_down_if_possible() stops the instance if
+    running_count > max(1, active_users+1) AND idle_instances >= 2
+  → OR, if the last premium user just left on this same release call,
+    convert_idle_instances_to_standby_immediate() may stop the instance
+    within the same invocation instead of waiting for the 15-min cycle.
+```
+
+The exact timing, thresholds, and the full comparison of all four
+release paths are expanded in **Inactivity & Release Paths** under
+*Implementation Details* below.
+
+### Soft release (`pending_release`)
+
+When a user releases via the **beacon path** (`navigator.sendBeacon` on
+browser close, or the frontend auto-release at 2h), the backend does **not**
+delete the row immediately. It transitions the row to the `pending_release`
+state for a grace period, so that a user who re-opens the tab within the
+window can resume on the same instance without a cold reassignment.
+
+| Property | Value |
+|---|---|
+| DB representation | `status = 'terminating'` (the `pending_release` sentinel reuses the `TERMINATING` enum value -- safe because all status checks go through the `PremiumAssignment` enum constants in `aws_constants.py`, not raw strings) |
+| Grace period duration | `PENDING_RELEASE_GRACE_SECONDS = 120` (2 minutes), defined in `aws_constants.py` |
+| Effect on idle counting during grace | Instance is **not** idle; the pending_release row counts as occupation (see the `get_assigned_users_for_instance()` query) |
+| Grace expiration handler | `finalize_expired_pending_releases()` (step 10a of the 15-min monitor) -- DELETEs the row and tears down ALB resources |
+| Resume path | `restore_pending_release()` at the start of `assign_premium_user()` -- UPDATEs `status` back to `'active'` on the same row if the EC2 instance still exists; returns with `assignment_source: "restored_from_pending_release"`. `is_shared` is **not** touched |
+
+Other release paths (hard `DELETE /assign` without beacon token, backend
+`release_premium_user()` on logout, `cleanup_stale_assignments()` at 3h)
+DELETE the row directly without going through pending_release. The full
+comparison of the four release paths is in **Inactivity & Release Paths**
+under *Implementation Details* below.
+
+---
+
 ## Implementation Details
 
 ### 1. User Assignment Handler
@@ -488,6 +458,17 @@ graph TB
   the cascade starting at Tier 1 -- there is no server-side wait-queue
   or reserved slot for the retrying user. See **Tier Cascade: Precedence
   & Reachability** below for details.
+
+**Tier 3 vs Tier 4 at the DB level.** Both tiers source a stopped EC2
+instance but differ in DB representation. Tier 3 (standby stopped) means
+the instance is stopped **and** has a placeholder row with
+`is_standby = 1, user_id = NULL`; the row is visible to
+`get_available_standby_instances()`. Tier 4 (non-standby stopped) means the
+instance is stopped but has **no row at all** in `premium_user_assignments`
+and is only discovered via EC2 describe calls. The pre-cascade
+`register_orphaned_stopped_instances()` adopts any such AWS-only stopped
+instance into Tier 3 before the cascade runs, which is the schema-level
+basis for the "Tier 4 unreachable on the happy path" property noted below.
 
 **Tier Cascade: Precedence & Reachability**
 

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -81,8 +81,13 @@ graph TB
     style C4 fill:#87CEEB
     style C5 fill:#DDA0DD
     style C6 fill:#FFB6C1
-    style J fill:#98FB98
+    style J fill:#FFFFFF
 ```
+
+> **Color key:** 🟢 Tier 1 (Dedicated) · 🟡 Tier 2 (Shared) ·
+> 🔵 Tier 3 (Standby) · 🟠 Tier 3.5 (Autoscaling) ·
+> 🟣 Tier 4 (Stopped) · 🔴 Tier 5 (New) ·
+> ⚪ Auto-Migrate
 
 ### Assignment Priority Matrix
 

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -275,14 +275,43 @@ graph TB
 
 ### Assignment Priority Matrix
 
-| Tier | Source | Wait Time | User Experience | Cost | Use Case |
-|------|--------|-----------|-----------------|------|----------|
-| 1 | Dedicated Running | 0s | Best (exclusive) | Highest | Active user pool |
-| 2 | Shared Instance | 0s | Good (shared) | Medium | Burst capacity |
-| 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning / re-login |
-| 3.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Last-resort fallback (no standby) |
-| 4 | AWS Stopped | 60s-6min | Acceptable | Low | Fallback recovery |
-| 5 | New Instance | 4-8 min | Poor (scaling) | Highest | Last resort |
+| Tier | Source | Wait Time | User Experience | Cost | Use Case | Reachability |
+|------|--------|-----------|-----------------|------|----------|--------------|
+| 1 | Dedicated Running | 0s | Best (exclusive) | Highest | Active user pool | Reachable |
+| 2 | Shared Instance | 0s | Good (shared) | Medium | Burst capacity | Reachable |
+| 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning / re-login | Reachable |
+| 3.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Last-resort fallback (no standby) | Reachable (always succeeds when reached -- see Precedence & Reachability Notes below) |
+| 4 | AWS Stopped | 60s-6min | Acceptable | Low | Defensive fallback | **Unreachable on the happy path** -- `register_orphaned_stopped_instances()` absorbs stopped instances into Tier 3 before the cascade runs |
+| 5 | New Instance | 4-8 min | Poor (scaling) | Highest | Last resort | Reachable only when Tier 3.5 is skipped (i.e. no stopped / pending / running capacity at all); returns HTTP 202, client retries from Tier 1 |
+
+#### Precedence & Reachability Notes
+
+The flowchart above shows the six tiers as parallel branches, but the
+code evaluates them **sequentially** as a fallthrough cascade. Three
+properties of that cascade are not obvious from the diagram alone:
+
+- **Tier 2 wins unconditionally over Tier 3** when both are viable.
+  The rationale is **immediacy over exclusivity**: a 0-second shared
+  assignment (plus a background scale-up to dedicated) is preferred to
+  a 5-15s standby start, because the user is unblocked immediately and
+  async migration will move them to a dedicated instance when capacity
+  arrives.
+
+- **Tier 4 is unreachable on the happy path.** The pre-cascade call to
+  `register_orphaned_stopped_instances()` adopts any AWS-stopped
+  instance into the standby pool (Tier 3) before the cascade runs, so
+  the Tier 4 candidate list is empty during normal operation. Tier 4
+  exists only as a defensive fallback if adoption itself failed.
+
+- **Tier 5 never returns HTTP 200.** It returns HTTP 202 (with
+  `retry_after`) when scaling is in progress or was just initiated,
+  and HTTP 503 only when scaling is blocked. A 202 directs the client
+  to retry, and the retry re-enters the cascade from Tier 1 -- there
+  is no server-side wait-queue or reserved slot for the retrying user.
+
+For the code-level walkthrough with line-level references to where each
+of these properties is enforced, see **Tier Cascade: Precedence &
+Reachability** under *Implementation Details > `assign_premium_user()`*.
 
 ### Responsibility Matrix
 
@@ -455,7 +484,62 @@ graph TB
 - **Tier 4 (AWS Stopped):** Start non-standby stopped instance,
   wait up to 6 minutes for running state (typical cold start is 60-90s)
 - **Tier 5 (Scale New):** If launching instances exist, return 202;
-  otherwise call `scale_premium_instances_if_needed()` and return 202
+  otherwise call `scale_premium_instances_if_needed()` and return 202.
+  The 202 directs the client to retry after `retry_after` seconds; the
+  retry re-enters `assign_premium_user()` from the top and re-evaluates
+  the cascade starting at Tier 1 -- there is no server-side wait-queue
+  or reserved slot for the retrying user. See **Tier Cascade: Precedence
+  & Reachability** below for the line-level references.
+
+**Tier Cascade: Precedence & Reachability**
+
+The bullets above describe each tier's happy path. The cascade as
+implemented at
+[premium_manager.py:3210-3413](../terraform/premium_manager_package/premium_manager.py#L3210-L3413)
+has three non-obvious properties worth calling out:
+
+- **Tier 2 vs Tier 3 (unconditional precedence).** If
+  `least_loaded_instance` is non-null after the Tier 1 scan, Tier 2
+  captures the user at
+  [premium_manager.py:3224-3232](../terraform/premium_manager_package/premium_manager.py#L3224-L3232),
+  and the Tier 3 block at
+  [premium_manager.py:3246](../terraform/premium_manager_package/premium_manager.py#L3246)
+  is skipped by its `if not instance_to_use` guard -- no gate allows
+  the cascade to prefer a 5-15s standby start over a 0s shared
+  assignment even when both are viable. The rationale is *immediacy
+  over exclusivity*; `invoke_migration_async()` will move the user to a
+  dedicated instance once capacity arrives.
+
+- **Tier 3.5 vs Tier 4 (Tier 4 is unreachable on the happy path).**
+  Tier 3.5's gate is
+  `no_premium_available = (len(running_instances) == 0 or not available_dedicated)`
+  ([premium_manager.py:3281-3283](../terraform/premium_manager_package/premium_manager.py#L3281-L3283)).
+  By the time the cascade reaches Tier 3.5, `available_dedicated` is
+  guaranteed to be `None` (otherwise Tier 1 would have captured the
+  user), so `not available_dedicated` is always true and Tier 3.5
+  always succeeds when reached. The pre-cascade call to
+  `register_orphaned_stopped_instances()` at
+  [premium_manager.py:3094](../terraform/premium_manager_package/premium_manager.py#L3094)
+  adopts any AWS-only stopped instance into the standby pool before the
+  cascade runs, so by the time the Tier 4 block filters for
+  `aws_only_stopped` at
+  [premium_manager.py:3305-3315](../terraform/premium_manager_package/premium_manager.py#L3305-L3315)
+  the filter is empty. Tier 4 only fires if adoption itself failed
+  (e.g. DB error during the pre-cascade step).
+
+- **Tier 5 retry semantics.** Tier 5 never returns HTTP 200. If scaling
+  is already in progress
+  ([premium_manager.py:3356-3369](../terraform/premium_manager_package/premium_manager.py#L3356-L3369))
+  or was freshly initiated
+  ([premium_manager.py:3371-3385](../terraform/premium_manager_package/premium_manager.py#L3371-L3385)),
+  it returns HTTP 202 with `retry_after: 180`; only if scaling is
+  blocked does it return HTTP 503. A 202 retry re-enters
+  `assign_premium_user()` from the top
+  ([premium_manager.py:2849](../terraform/premium_manager_package/premium_manager.py#L2849))
+  -- the in-progress scale-up does not leave a reservation for the
+  retrying user; it just creates instances that Tier 1 or Tier 2 will
+  pick up on the next attempt. `increment_assignment_attempts()` is
+  bookkeeping only; it does not change tier selection.
 
 **Post-assignment Steps:**
 1. Create target group (or use autoscaling target group for pool)

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -951,6 +951,33 @@ the tab too hard for the beacon to reach the ALB.
 > truth. Path 4 therefore fires no earlier than 3 h after last
 > activity, plus up to 1 h of scheduler latency.
 
+#### Known limitation: no automatic re-assignment after auto-release
+
+When the 2-hour auto-release fires (`autoReleaseOnLogout()`), the frontend
+clears `assignmentResult`, the warning state, and the beacon token — but it
+does **not** clear the `hasAttemptedAutoAssignment` flag in `sessionStorage`.
+Because `autoAssignOnLogin()` checks this flag before calling `/assign`,
+**no automatic re-assignment occurs** even if the user resumes activity on
+the same tab.
+
+The backend's `restore_pending_release()` grace window (120 s) exists to
+cover the case where a user returns quickly, but it is unreachable in this
+scenario because the frontend never re-calls `/assign`.
+
+**User-visible effect:** after the 2-hour auto-release the user remains
+logged in but without premium compute resources, and there is no UI prompt
+to re-acquire them.
+
+**Current workarounds:**
+
+| Action | Why it works |
+|---|---|
+| Log out → log back in | Clears `hasAttemptedAutoAssignment` (flag is reset on logout) |
+| Close the tab → open a new tab | `sessionStorage` is per-tab; the new tab starts with the flag unset |
+
+A page reload (F5) within the same tab does **not** help because
+`sessionStorage` survives reloads.
+
 #### Post-release: idle-instance handling
 
 Once a release path removes the last `is_standby = 0` user row from an

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -7,6 +7,13 @@
 - **Automatic migration** moves users from shared to dedicated instances, inline when possible and async otherwise
 - **Workflow safety** prevents migration of users with active workflows
 
+> **Sister document:**
+> This file focuses on the **assignment flow** — 5-tier priority cascade,
+> standby pool, migration, and release paths. For the **system
+> architecture** — Manager / Cleanup Lambda split, frontend lifecycle,
+> and log playbook — see
+> [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+
 ## Key Architectural Principles
 
 1. **Priority-Based Assignment**

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -37,6 +37,197 @@
    - Auto-migration when new instances become ready
    - Workflow-safe: skips users with active workflows
 
+## Glossary / Key Concepts
+
+This section is the shared vocabulary used throughout the premium assignment
+documentation. Later sections reference these definitions rather than
+redefining them. When writing or reading test cases for the assignment
+system, each row in the tables below is a candidate test condition.
+
+### Assignment state of a premium user
+
+A premium user who has been through the `/assign` flow ends up in exactly
+one of four states. These states differ in infrastructure (real EC2 vs
+shared pool) **and** in DB representation, even though the frontend
+collapses three of them into a single "please wait" toast.
+
+| State | `instance_id` | `is_shared` | `is_standby` | Meaning |
+|---|---|---|---|---|
+| **Dedicated** | `i-xxxx` (real EC2) | `false` | `false` | The user is the sole premium assignment on that EC2 instance. Target group is per-user; the ALB rule routes only this user. |
+| **Shared** | `i-xxxx` (real EC2) | `true` | `false` | The user is co-located with one or more other premium users on a real premium EC2 instance. The Lambda picked the least-loaded running instance because no idle dedicated instance was available at assign time. Will migrate to a dedicated instance when one becomes available. |
+| **Autoscaling Pool** | `"autoscaling-pool"` (sentinel) | `true` | `false` | Fallback marker used when no running premium instance and no standby were available. Routed via the shared ASG target group (same pool as free tier), **not** a real premium EC2. Will migrate to a real premium instance once one comes up. |
+| **Unassigned** | — | — | — | No row exists (either the user is not premium, or `/assign` returned a hard error and `assignmentResult` stayed null on the frontend). |
+
+Uniqueness is enforced per-user (`idx_unique_user_assignment` conditional
+UNIQUE on `user_id WHERE user_id IS NOT NULL`), **not** per-instance.
+Multiple user rows can share the same `instance_id` (that is exactly what
+the Shared state is).
+
+The difference between Shared and Autoscaling Pool is critical when
+debugging: Shared runs on a real premium EC2 that the Manager owns, whereas
+Autoscaling Pool routes through the free-tier ASG target group. The toast
+copy collapses them, but infra-layer behaviour (scaling triggers, migration
+paths, routing) differs.
+
+### Standby pool
+
+The **standby pool** is a set of stopped EC2 instances maintained solely to
+shortcut the premium-user startup path. Starting a stopped instance is
+~5-15 seconds, whereas creating a new one from the launch template is
+4-8 minutes; keeping a small pool of pre-stopped instances therefore trades
+storage / EBS cost for startup latency on incoming premium assignments.
+
+A standby instance is represented in `premium_user_assignments` by a
+**placeholder row** with `is_standby = 1` and `user_id = NULL`. The pool is
+sized by `PREMIUM_STANDBY_POOL_SIZE`, and individual standbys are aged out
+by `PREMIUM_STOPPED_MAX_AGE_HOURS`. The full lifecycle (creation,
+replenishment, aging, excess trim, failure cleanup) is documented under
+[Standby Pool Management](#2-standby-pool-management).
+
+The standby pool is owned by Premium Manager (start / stop / terminate);
+Premium Cleanup only performs read-only health checks
+(`ensure_standby_pool_capacity()`).
+
+### `is_standby` column semantics
+
+`is_standby` is a `BOOLEAN NOT NULL` column (MySQL `TINYINT`) with
+`server_default = "0"`, defined in
+[e701e7250019_create_premium_management_system.py:89-93](../../studio/alembic/versions/e701e7250019_create_premium_management_system.py#L89-L93).
+It discriminates two kinds of rows:
+
+| Value | `user_id` | `target_group_arn` / `alb_rule_arn` | Meaning |
+|---|---|---|---|
+| `0` (default) | set (FK to `users.id`) | real ARN, or sentinel `"autoscaling-pool"` / `"reserving"` | Real user assignment row (Dedicated / Shared / Autoscaling Pool / in-flight reservation) |
+| `1` | `NULL` | `"standby"` / `"standby"` | Standby pool placeholder -- no owning user, the EC2 instance is stopped waiting to be assigned |
+
+`NULL` is not valid for this column; unless database corruption occurs the
+value is always 0 or 1.
+
+**Lifecycle transitions.** Importantly, there is **no in-place
+`1 → 0` UPDATE**. A standby instance being assigned to a user is
+implemented as a DELETE of the standby placeholder followed by an INSERT of
+a fresh user-owned assignment row. The `is_standby = 1` row never carries a
+real user.
+
+```mermaid
+stateDiagram-v2
+    [*] --> StandbyRow: create_and_stop_standby_instance()<br/>INSERT is_standby=1, user_id=NULL
+    StandbyRow --> Deleted: assign_premium_user() Tier 3<br/>DELETE standby placeholder<br/>(premium_manager.py:3735)
+    Deleted --> UserRow: store_user_assignment()<br/>INSERT is_standby=0, user_id=&lt;uid&gt;
+    UserRow --> [*]: release / cleanup<br/>DELETE row
+    StandbyRow --> [*]: terminate_aged_stopped_instances()<br/>or cleanup_excess_standby_instances()<br/>DELETE row
+```
+
+**Tier 3 vs Tier 4 at the DB level.** These two tiers both source a stopped
+EC2 instance but their DB representations differ:
+
+- **Tier 3 (standby stopped)** -- instance is stopped AND has a placeholder
+  row with `is_standby = 1, user_id = NULL`. Visible to
+  `get_available_standby_instances()`.
+- **Tier 4 (non-standby stopped)** -- instance is stopped but has **no row
+  at all** in `premium_user_assignments`. Discovered by EC2 describe calls.
+  At the start of every `/assign` invocation,
+  `register_orphaned_stopped_instances()` normalises any untracked stopped
+  instances into standby rows, so in steady state Tier 4 is rarely reached
+  in the happy path; it remains as a true fallback for races or after
+  cleanup lag.
+
+### Idle instance
+
+An **idle instance** is a running premium EC2 instance with zero assigned
+real users.
+
+> Formally: an instance `i` is idle when no row exists in
+> `premium_user_assignments` satisfying
+> `instance_id = i AND is_standby = 0 AND status IN ('active', 'terminating')`.
+
+This matches the query in
+[get_assigned_users_for_instance() at premium_manager.py:835-841](../terraform/premium_manager_package/premium_manager.py#L835-L841)
+that backs `scale_down_if_possible()` and the `IdleInstances` CloudWatch
+metric. Note that `'terminating'` is the DB encoding of the
+`pending_release` state (see "Soft release" below).
+
+**What counts / does not count as occupation:**
+
+| Row shape | Counts as occupation? | Notes |
+|---|---|---|
+| `is_standby = 0`, `status = 'active'`, real `user_id` | **Yes** | Normal active user |
+| `is_standby = 0`, `status = 'terminating'` (pending_release), real `user_id` | **Yes** | Pending_release rows DO keep the instance non-idle during the 120s grace window. Comment at [premium_manager.py:834](../terraform/premium_manager_package/premium_manager.py#L834): *"Include pending_release so instance isn't treated as idle during grace"* |
+| `is_standby = 1`, `user_id = NULL` (standby placeholder) | **No** | Standby rows never count as occupation; the instance is stopped, not running |
+| `is_standby = 0`, `user_id = <uid>`, `target_group_arn = 'reserving'` | **Yes** | The row has a real `user_id` and `status = 'active'`, so the occupation query matches. The reservation is either promoted to a full assignment within the same Lambda invocation or cleaned up by `release_instance_reservation()` on failure |
+
+**Scale-down threshold.** `scale_down_if_possible()` only stops an idle
+instance when
+`running_count > max(1, active_users + 1)` **AND** `idle_instances >= 2`
+(see [premium_manager.py:4878-4880](../terraform/premium_manager_package/premium_manager.py#L4878-L4880)).
+The `+ 1` safety margin is kept by scale-down; scale-up has no such margin.
+
+### Disambiguation: the four meanings of "idle"
+
+The documentation uses "idle" as shorthand in four distinct senses.
+When reading any section, identify the subject before interpreting the
+term.
+
+| Term | Subject | Exact condition | Where it appears |
+|---|---|---|---|
+| **Idle instance** | EC2 instance | Running with 0 qualifying assignment rows (formal definition above) | `scale_down_if_possible()`, `IdleInstances` CloudWatch metric |
+| **Idle premium user** | User account | Premium subscriber with no active assignment row -- computed as `total_premium_users − active_users` | `IdlePremiumUsers` CloudWatch metric |
+| **Idle assignment** (stale) | DB row | `last_activity < NOW() − PREMIUM_IDLE_TIMEOUT_HOURS` (Terraform: 3 hours) | `cleanup_stale_assignments()` in Premium Cleanup |
+| **Idle user (browser)** | Browser tab | No user interaction for the threshold (1h warning surfaces; 2h triggers auto-release) | `PremiumAssignmentContext.tsx` inactivity monitor |
+
+The Free tier uses "idle" with a fifth, unrelated meaning: `FreeUserAssignment.active_workflow_count = 0`
+(see [FREE_MANAGER_ARCHITECTURE.md](./FREE_MANAGER_ARCHITECTURE.md)). Premium's
+`active_workflow_count` serves the same migration-safety role but is **not**
+what "idle instance" or "idle assignment" mean on the premium side.
+
+**Causal chain (browser idle → instance idle → scale-down):**
+
+```
+user stops interacting
+  → 1h passes: InactivityWarning snackbar surfaces (60-min countdown)
+  → 2h passes: frontend DELETE /premium/assign (or sendBeacon on browser close)
+      → backend creates pending_release row (status='terminating'), 120s grace
+      → 120s later: finalize_expired_pending_releases() DELETEs the row
+           and tears down ALB resources
+  → [alternate safety-net path if frontend didn't fire] 3h passes:
+      → Premium Cleanup cleanup_stale_assignments() DELETEs the stale row
+  → Row gone: instance now has 0 qualifying assignments → instance is idle
+  → Next 15-min monitor run: scale_down_if_possible() stops the instance if
+    running_count > max(1, active_users+1) AND idle_instances >= 2
+  → OR, if the last premium user just left on this same release call,
+    convert_idle_instances_to_standby_immediate() may stop the instance
+    within the same invocation instead of waiting for the 15-min cycle.
+```
+
+The exact timing, thresholds, and the full comparison of all four
+release paths are expanded in the "Inactivity & Release" section of
+[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+
+### Soft release (`pending_release`)
+
+When a user releases via the **beacon path** (`navigator.sendBeacon` on
+browser close, or the frontend auto-release at 2h), the backend does **not**
+delete the row immediately. It transitions the row to the `pending_release`
+state for a grace period, so that a user who re-opens the tab within the
+window can resume on the same instance without a cold reassignment.
+
+| Property | Value | Source |
+|---|---|---|
+| DB representation | `status = 'terminating'` (the `pending_release` sentinel reuses the `TERMINATING` enum value -- safe because all status checks go through the `PremiumAssignment` enum constants, not raw strings) | [aws_constants.py:207-211](../aws_constants.py#L207-L211) |
+| Grace period duration | `PENDING_RELEASE_GRACE_SECONDS = 120` (2 minutes) | [aws_constants.py:213](../aws_constants.py#L213) |
+| Effect on idle counting during grace | Instance is **not** idle; the pending_release row counts as occupation | [premium_manager.py:835-841](../terraform/premium_manager_package/premium_manager.py#L835-L841) |
+| Grace expiration handler | `finalize_expired_pending_releases()` (step 10a of the 15-min monitor) -- DELETEs the row and tears down ALB resources | [premium_manager.py:768-771](../terraform/premium_manager_package/premium_manager.py#L768-L771) |
+| Resume path | `restore_pending_release()` at the start of `assign_premium_user()` -- UPDATEs `status` back to `'active'` on the same row if the EC2 instance still exists; returns with `assignment_source: "restored_from_pending_release"`. `is_shared` is **not** touched | [premium_manager.py:720-725](../terraform/premium_manager_package/premium_manager.py#L720-L725) |
+
+Other release paths (hard `DELETE /assign` without beacon token, backend
+`release_premium_user()` on logout, `cleanup_stale_assignments()` at 3h)
+DELETE the row directly without going through pending_release. The full
+comparison of the four release paths is expanded in the "Inactivity &
+Release" section of
+[PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md).
+
+---
+
 ## Architecture Overview
 
 ```mermaid

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -128,8 +128,8 @@ This document covers one Lambda -- the Premium Manager -- acting across several 
 | Capacity scaling (up)                | Scaling system                                | `scale_premium_instances_if_needed()`, `_create_running_instances_locked()`             |
 | Shared-to-dedicated migration        | Background migration                          | `process_shared_instance_optimization()`, `migrate_user_to_dedicated_instance()`, `invoke_migration_async()` |
 | Concurrency / race prevention        | Locking                                       | `distributed_lock()` (MySQL `GET_LOCK`), `try_reserve_instance_transaction()` (`SELECT FOR UPDATE`), `is_creation_lock_held()` |
-| Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see `PREMIUM_MANAGER_ARCHITECTURE.md`) | `handle_scheduled_monitoring()`, `scale_down_if_possible()`                             |
-| Stale assignment + ALB rule hygiene  | Premium Cleanup Lambda (separate)             | See `PREMIUM_MANAGER_ARCHITECTURE.md`                                                   |
+| Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)) | `handle_scheduled_monitoring()`, [`scale_down_if_possible()`](./PREMIUM_MANAGER_ARCHITECTURE.md#scale_down_if_possible) |
+| Stale assignment + ALB rule hygiene  | Premium Cleanup Lambda (separate)             | See [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)               |
 
 ## Provisioning Flow Diagrams
 
@@ -266,7 +266,7 @@ collapses three of them into a single "please wait" toast.
 
 | State | `instance_id` | `is_shared` | `is_standby` | Meaning |
 |---|---|---|---|---|
-| **Dedicated** | `i-xxxx` (real EC2) | `false` | `false` | The user is the sole premium assignment on that EC2 instance. Target group is per-user; the ALB rule routes only this user. |
+| **Dedicated** | `i-xxxx` (real EC2) | `false` | `false` | The user is the sole premium assignment on that EC2 instance. Target group is per-user; the ALB rule routes only this user (see [ALB_ROUTING_ARCHITECTURE.md](./ALB_ROUTING_ARCHITECTURE.md) for the routing-ID / ALB-rule binding). |
 | **Shared** | `i-xxxx` (real EC2) | `true` | `false` | The user is co-located with one or more other premium users on a real premium EC2 instance. The Lambda picked the least-loaded running instance because no idle dedicated instance was available at assign time. Will migrate to a dedicated instance when one becomes available. |
 | **Autoscaling Pool** | `"autoscaling-pool"` (sentinel) | `true` | `false` | Fallback marker used when no running premium instance and no standby were available. Routed via the shared ASG target group (same pool as free tier), **not** a real premium EC2. Will migrate to a real premium instance once one comes up. |
 | **Unassigned** | — | — | — | No row exists (either the user is not premium, or `/assign` returned a hard error and `assignmentResult` stayed null on the frontend). |
@@ -418,7 +418,7 @@ under *Implementation Details* below.
 
 ### 1. User Assignment Handler
 
-### assign_premium_user()
+#### assign_premium_user()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Assign a premium instance using 5-tier priority fallback
@@ -516,6 +516,11 @@ properties worth calling out.
 6. If `needs_scaling`: call `scale_premium_instances_if_needed()` + `invoke_migration_async()`
 7. Store assignment via `store_user_assignment()`
 8. Initialize activity tracking
+
+> For the end-to-end specification of Routing ID (HMAC-SHA256 of UID)
+> and ALB listener-rule matching, see
+> [ALB_ROUTING_ARCHITECTURE.md](./ALB_ROUTING_ARCHITECTURE.md).
+> This subsection covers only the Premium Manager's operations.
 
 **Error Recovery:**
 On any failure after partial resource creation, the handler cleans up:
@@ -687,11 +692,11 @@ Standby instances are tracked in the `premium_user_assignments` table with:
 - `instance_state = 'stopped'` (queried by `get_available_standby_instances()`)
 - `standby_created_at` = `NOW()` at insert time, used as an age fallback and for oldest-first excess trim
 
-See the [`is_standby` column semantics](#is_standby-column-semantics)
-subsection in the Glossary for the full column-value table and the
-non-UPDATE lifecycle.
+See the [Standby pool](#standby-pool) entry in the Glossary for the
+`is_standby` column-value table and the non-UPDATE (DELETE + INSERT)
+invariant.
 
-### create_and_stop_standby_instance()
+#### create_and_stop_standby_instance()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Create a new EC2 instance and stop it for standby pool
@@ -707,7 +712,7 @@ non-UPDATE lifecycle.
 - Waits for running, then stops, then waits for stopped
 - Registers with `is_standby=1` in DB
 
-### start_standby_instance()
+#### start_standby_instance()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Start a stopped standby instance and prepare for user
@@ -745,7 +750,7 @@ only the DB mutation differs between the two callers.
 
 ### 3. Orphaned Instance Registration
 
-### register_orphaned_stopped_instances()
+#### register_orphaned_stopped_instances()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Find stopped EC2 instances not tracked in DB and register as standby
@@ -759,7 +764,7 @@ are both untracked in the standby pool and unassigned to any user.
 
 ### 4. Background Migration System
 
-### process_shared_instance_optimization()
+#### process_shared_instance_optimization()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Find users on shared/autoscaling instances and migrate to dedicated
@@ -787,7 +792,7 @@ and via `invoke_migration_async()` after shared/autoscaling assignments.
 WHERE active_workflow_count = 0
 ```
 
-### migrate_user_to_dedicated_instance()
+#### migrate_user_to_dedicated_instance()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Migrate one user from shared/autoscaling to a dedicated instance
@@ -805,9 +810,17 @@ WHERE active_workflow_count = 0
   target group, updates DB with `is_shared=0`
 - Triggers experiment metadata sync on new instance
 
-### 5. Scaling System
+### 5. Scaling System (scale-up and scale-down)
 
-### scale_premium_instances_if_needed()
+Premium instance capacity is adjusted by two separate functions with
+**asymmetric** thresholds. Scale-up (`scale_premium_instances_if_needed()`)
+fires when `running_count < active_users` -- no safety margin. Scale-down
+(`scale_down_if_possible()`) requires `running_count > max(1, active_users + 1)`
+**AND** `idle_instances >= 2` -- a `+ 1` margin plus a minimum-idle guard.
+The asymmetry means the system scales up eagerly but scales down
+conservatively, avoiding instance churn.
+
+#### scale_premium_instances_if_needed()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Scale up premium instances based on active assignment demand
@@ -820,13 +833,36 @@ subscribers.
 
 **Key behaviors:**
 - Blocked if launching instances exist or `CREATE_RUNNING_LOCK` held
-- No-op if `running_count >= active_users` (sufficient capacity). Note this is distinct from `scale_down_if_possible()`, which keeps `max(1, active_users + 1)` -- scale-up has no `+ 1` safety margin, so the scale-down headroom only exists after a full monitor cycle runs
+- No-op if `running_count >= active_users` (sufficient capacity). Note this is distinct from [`scale_down_if_possible()`](#scale-down-scale_down_if_possible), which keeps `max(1, active_users + 1)` -- scale-up has no `+ 1` safety margin, so the scale-down headroom only exists after a full monitor cycle runs
 - Prefers starting stopped instances (fastest) over creating new
 - Clears ECS agent checkpoints after starting stopped instances
 - Falls back to `_create_running_instances_locked()` under
   distributed lock
 - Always calls `invoke_migration_async()` and
   `update_premium_service_desired_count()` after scaling
+
+#### Scale-down (`scale_down_if_possible`)
+
+Runs as step 5 of `handle_scheduled_monitoring()` (the 15-minute cycle).
+Stops idle running instances subject to **two** guard conditions that must
+both be true:
+
+1. `running_count > max(1, active_users + 1)` -- headroom exists beyond
+   the `+ 1` safety margin.
+2. `idle_instances >= 2` -- at least two instances have zero qualifying
+   assignment rows, so one will remain idle after stopping.
+
+For each instance selected for scale-down, the function deregisters the
+EC2 from ECS **before** issuing `stop_instances` to prevent ghost
+container-instance registrations. It may also call
+`convert_idle_instances_to_standby_immediate()` to stop-and-demote
+idle instances to standby (`is_standby = 1`) within the same invocation,
+shortening the "last user released → instance stopped" latency to
+~30-60 s instead of waiting for the next 15-minute cycle.
+
+> Full specification (File / Purpose / Input / Output / Calls and
+> detailed guard bullets) is in
+> [PREMIUM_MANAGER_ARCHITECTURE.md → scale_down_if_possible()](./PREMIUM_MANAGER_ARCHITECTURE.md#scale_down_if_possible).
 
 ---
 
@@ -949,7 +985,7 @@ both see same available instance.
 
 **Solution:** Database-level locking with `SELECT FOR UPDATE`:
 
-### try_reserve_instance_transaction()
+#### try_reserve_instance_transaction()
 
 **File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
 **Purpose:** Atomically reserve an instance using row-level locking
@@ -1079,10 +1115,13 @@ including standby pool entries.
 | `ActivePremiumUsers` | Users with active assignments | Count |
 | `IdlePremiumUsers` | Premium users without assignments | Count |
 | `RunningInstances` | EC2 instances in "running" state | Count |
-| `IdleInstances` | Running instances with 0 users | Count |
+| `IdleInstances` | Running instances with 0 assigned users (see [Idle instance](#idle-instance)) | Count |
 | `ScalingInProgress` | Lock to prevent concurrent operations | None (0 or 1) |
 
 **Namespace:** `OptiNiSt/PremiumManager/{env_prefix}` where `env_prefix` is the Terraform `environment` variable (e.g. `staging`, `prod`).
+
+> For the Cleanup Lambda's perspective on these metrics, see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Monitoring and Metrics](./PREMIUM_MANAGER_ARCHITECTURE.md#monitoring-and-metrics).
 
 ### Key Log Events
 
@@ -1172,6 +1211,9 @@ Shared instance optimization complete: 1 users migrated
 
 `PREMIUM_IDLE_TIMEOUT_HOURS` is set in the Manager's Terraform block but is only read by the Cleanup Lambda; it does not influence Manager behavior.
 
+> For the full Manager + Cleanup environment variable set, see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Environment Variables](./PREMIUM_MANAGER_ARCHITECTURE.md#environment-variables).
+
 ### Triggers
 
 | Lambda          | Trigger              | Frequency        | EventBridge Rule                       |
@@ -1179,6 +1221,9 @@ Shared instance optimization complete: 1 users migrated
 | Premium Manager | User assign/release  | On-demand (API)  | N/A                                    |
 | Premium Manager | Scheduled monitoring | Every 15 minutes | `{env_prefix}-premium-manager-schedule` |
 | Premium Manager | Migration check      | After assignment | N/A (async self-invocation)            |
+
+> For Premium Cleanup Lambda triggers, see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Triggers](./PREMIUM_MANAGER_ARCHITECTURE.md#triggers).
 
 ---
 
@@ -1227,25 +1272,10 @@ Shared instance optimization complete: 1 users migrated
 | `update_premium_service_desired_count()` | Sync ECS desired count |
 | `trigger_experiment_sync()` | Sync experiment metadata after migration |
 
-### Locking & Concurrency
-
-| Function | Purpose |
-|----------|---------|
-| `distributed_lock()` | MySQL GET_LOCK context manager |
-| `try_reserve_instance_transaction()` | DB transaction lock for reservation |
-| `is_creation_lock_held()` | Check if another Lambda holds a lock |
-| `is_premium_scaling_in_progress()` | Check CloudWatch metric lock |
-| `set_premium_scaling_lock()` | Set/clear CloudWatch scaling lock |
-
-### Monitoring & Cleanup
-
-| Function | Purpose |
-|----------|---------|
-| `publish_premium_metrics()` | Publish CloudWatch metrics |
-| `cleanup_failed_standby_instances()` | Remove DB entries for terminated instances |
-| `cleanup_ghost_ecs_registrations()` | Deregister orphaned ECS container instances |
-| `cleanup_orphaned_ec2_instances()` | Stop premium EC2 not in ECS cluster |
-| `handle_scheduled_monitoring()` | 15-minute monitoring loop (12 steps: scale-down, ECS sync, standby-pool hygiene, pending-release finalization, ghost/orphan cleanup, shared-instance optimization -- see `PREMIUM_MANAGER_ARCHITECTURE.md`) |
+> For locking primitives (`distributed_lock()`, `try_reserve_instance_transaction()`, etc.)
+> and monitoring / cleanup functions (`publish_premium_metrics()`,
+> `handle_scheduled_monitoring()`, etc.), see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → Key Functions Reference](./PREMIUM_MANAGER_ARCHITECTURE.md#key-functions-reference).
 
 ---
 
@@ -1259,3 +1289,7 @@ All resource names are prefixed with the Terraform `environment` variable (shown
 - **CloudWatch Log Group:** `/aws/lambda/{env_prefix}-premium-manager` (30 day retention)
 - **Launch Template:** Defined by `PREMIUM_LAUNCH_TEMPLATE_ID`
 - **RDS Table:** `premium_user_assignments` (assignments + standby pool)
+
+> For Premium Cleanup Lambda, its EventBridge rules, and the full
+> resource inventory, see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → AWS Resources](./PREMIUM_MANAGER_ARCHITECTURE.md#aws-resources).

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -146,25 +146,24 @@ real users.
 > `premium_user_assignments` satisfying
 > `instance_id = i AND is_standby = 0 AND status IN ('active', 'terminating')`.
 
-This matches the query in
-[get_assigned_users_for_instance() at premium_manager.py:835-841](../terraform/premium_manager_package/premium_manager.py#L835-L841)
-that backs `scale_down_if_possible()` and the `IdleInstances` CloudWatch
-metric. Note that `'terminating'` is the DB encoding of the
-`pending_release` state (see "Soft release" below).
+This matches the query used by `get_assigned_users_for_instance()`
+(in `premium_manager.py`), which backs `scale_down_if_possible()` and
+the `IdleInstances` CloudWatch metric. Note that `'terminating'` is
+the DB encoding of the `pending_release` state (see "Soft release"
+below).
 
 **What counts / does not count as occupation:**
 
 | Row shape | Counts as occupation? | Notes |
 |---|---|---|
 | `is_standby = 0`, `status = 'active'`, real `user_id` | **Yes** | Normal active user |
-| `is_standby = 0`, `status = 'terminating'` (pending_release), real `user_id` | **Yes** | Pending_release rows DO keep the instance non-idle during the 120s grace window. Comment at [premium_manager.py:834](../terraform/premium_manager_package/premium_manager.py#L834): *"Include pending_release so instance isn't treated as idle during grace"* |
+| `is_standby = 0`, `status = 'terminating'` (pending_release), real `user_id` | **Yes** | Pending_release rows DO keep the instance non-idle during the 120s grace window. A comment in `get_assigned_users_for_instance()` spells this out: *"Include pending_release so instance isn't treated as idle during grace"* |
 | `is_standby = 1`, `user_id = NULL` (standby placeholder) | **No** | Standby rows never count as occupation; the instance is stopped, not running |
 | `is_standby = 0`, `user_id = <uid>`, `target_group_arn = 'reserving'` | **Yes** | The row has a real `user_id` and `status = 'active'`, so the occupation query matches. The reservation is either promoted to a full assignment within the same Lambda invocation or cleaned up by `release_instance_reservation()` on failure |
 
 **Scale-down threshold.** `scale_down_if_possible()` only stops an idle
 instance when
-`running_count > max(1, active_users + 1)` **AND** `idle_instances >= 2`
-(see [premium_manager.py:4878-4880](../terraform/premium_manager_package/premium_manager.py#L4878-L4880)).
+`running_count > max(1, active_users + 1)` **AND** `idle_instances >= 2`.
 The `+ 1` safety margin is kept by scale-down; scale-up has no such margin.
 
 ### Disambiguation: the four meanings of "idle"
@@ -216,13 +215,13 @@ delete the row immediately. It transitions the row to the `pending_release`
 state for a grace period, so that a user who re-opens the tab within the
 window can resume on the same instance without a cold reassignment.
 
-| Property | Value | Source |
-|---|---|---|
-| DB representation | `status = 'terminating'` (the `pending_release` sentinel reuses the `TERMINATING` enum value -- safe because all status checks go through the `PremiumAssignment` enum constants, not raw strings) | [aws_constants.py:207-211](../aws_constants.py#L207-L211) |
-| Grace period duration | `PENDING_RELEASE_GRACE_SECONDS = 120` (2 minutes) | [aws_constants.py:213](../aws_constants.py#L213) |
-| Effect on idle counting during grace | Instance is **not** idle; the pending_release row counts as occupation | [premium_manager.py:835-841](../terraform/premium_manager_package/premium_manager.py#L835-L841) |
-| Grace expiration handler | `finalize_expired_pending_releases()` (step 10a of the 15-min monitor) -- DELETEs the row and tears down ALB resources | [premium_manager.py:768-771](../terraform/premium_manager_package/premium_manager.py#L768-L771) |
-| Resume path | `restore_pending_release()` at the start of `assign_premium_user()` -- UPDATEs `status` back to `'active'` on the same row if the EC2 instance still exists; returns with `assignment_source: "restored_from_pending_release"`. `is_shared` is **not** touched | [premium_manager.py:720-725](../terraform/premium_manager_package/premium_manager.py#L720-L725) |
+| Property | Value |
+|---|---|
+| DB representation | `status = 'terminating'` (the `pending_release` sentinel reuses the `TERMINATING` enum value -- safe because all status checks go through the `PremiumAssignment` enum constants in `aws_constants.py`, not raw strings) |
+| Grace period duration | `PENDING_RELEASE_GRACE_SECONDS = 120` (2 minutes), defined in `aws_constants.py` |
+| Effect on idle counting during grace | Instance is **not** idle; the pending_release row counts as occupation (see the `get_assigned_users_for_instance()` query) |
+| Grace expiration handler | `finalize_expired_pending_releases()` (step 10a of the 15-min monitor) -- DELETEs the row and tears down ALB resources |
+| Resume path | `restore_pending_release()` at the start of `assign_premium_user()` -- UPDATEs `status` back to `'active'` on the same row if the EC2 instance still exists; returns with `assignment_source: "restored_from_pending_release"`. `is_shared` is **not** touched |
 
 Other release paths (hard `DELETE /assign` without beacon token, backend
 `release_premium_user()` on logout, `cleanup_stale_assignments()` at 3h)
@@ -489,57 +488,47 @@ graph TB
   retry re-enters `assign_premium_user()` from the top and re-evaluates
   the cascade starting at Tier 1 -- there is no server-side wait-queue
   or reserved slot for the retrying user. See **Tier Cascade: Precedence
-  & Reachability** below for the line-level references.
+  & Reachability** below for details.
 
 **Tier Cascade: Precedence & Reachability**
 
-The bullets above describe each tier's happy path. The cascade as
-implemented at
-[premium_manager.py:3210-3413](../terraform/premium_manager_package/premium_manager.py#L3210-L3413)
-has three non-obvious properties worth calling out:
+The bullets above describe each tier's happy path. The cascade in
+`assign_premium_user()` (in `premium_manager.py`) has three non-obvious
+properties worth calling out. Function and variable names are used
+throughout rather than line numbers, so that this section stays
+accurate as the code moves; grep or jump-to-definition on the
+identifier when investigating.
 
 - **Tier 2 vs Tier 3 (unconditional precedence).** If
   `least_loaded_instance` is non-null after the Tier 1 scan, Tier 2
-  captures the user at
-  [premium_manager.py:3224-3232](../terraform/premium_manager_package/premium_manager.py#L3224-L3232),
-  and the Tier 3 block at
-  [premium_manager.py:3246](../terraform/premium_manager_package/premium_manager.py#L3246)
-  is skipped by its `if not instance_to_use` guard -- no gate allows
-  the cascade to prefer a 5-15s standby start over a 0s shared
-  assignment even when both are viable. The rationale is *immediacy
-  over exclusivity*; `invoke_migration_async()` will move the user to a
-  dedicated instance once capacity arrives.
+  captures the user immediately; the Tier 3 block is skipped by its
+  `if not instance_to_use` guard. No gate allows the cascade to prefer
+  a 5-15 s standby start over a 0 s shared assignment even when both
+  are viable. The rationale is *immediacy over exclusivity*;
+  `invoke_migration_async()` will move the user to a dedicated
+  instance once capacity arrives.
 
 - **Tier 3.5 vs Tier 4 (Tier 4 is unreachable on the happy path).**
   Tier 3.5's gate is
-  `no_premium_available = (len(running_instances) == 0 or not available_dedicated)`
-  ([premium_manager.py:3281-3283](../terraform/premium_manager_package/premium_manager.py#L3281-L3283)).
+  `no_premium_available = (len(running_instances) == 0 or not available_dedicated)`.
   By the time the cascade reaches Tier 3.5, `available_dedicated` is
   guaranteed to be `None` (otherwise Tier 1 would have captured the
   user), so `not available_dedicated` is always true and Tier 3.5
   always succeeds when reached. The pre-cascade call to
-  `register_orphaned_stopped_instances()` at
-  [premium_manager.py:3094](../terraform/premium_manager_package/premium_manager.py#L3094)
-  adopts any AWS-only stopped instance into the standby pool before the
-  cascade runs, so by the time the Tier 4 block filters for
-  `aws_only_stopped` at
-  [premium_manager.py:3305-3315](../terraform/premium_manager_package/premium_manager.py#L3305-L3315)
-  the filter is empty. Tier 4 only fires if adoption itself failed
+  `register_orphaned_stopped_instances()` adopts any AWS-only stopped
+  instance into the standby pool before the cascade runs, so by the
+  time the Tier 4 block filters for AWS-only stopped instances the
+  filter is empty. Tier 4 only fires if adoption itself failed
   (e.g. DB error during the pre-cascade step).
 
-- **Tier 5 retry semantics.** Tier 5 never returns HTTP 200. If scaling
-  is already in progress
-  ([premium_manager.py:3356-3369](../terraform/premium_manager_package/premium_manager.py#L3356-L3369))
-  or was freshly initiated
-  ([premium_manager.py:3371-3385](../terraform/premium_manager_package/premium_manager.py#L3371-L3385)),
-  it returns HTTP 202 with `retry_after: 180`; only if scaling is
-  blocked does it return HTTP 503. A 202 retry re-enters
-  `assign_premium_user()` from the top
-  ([premium_manager.py:2849](../terraform/premium_manager_package/premium_manager.py#L2849))
-  -- the in-progress scale-up does not leave a reservation for the
-  retrying user; it just creates instances that Tier 1 or Tier 2 will
-  pick up on the next attempt. `increment_assignment_attempts()` is
-  bookkeeping only; it does not change tier selection.
+- **Tier 5 retry semantics.** Tier 5 never returns HTTP 200. If a
+  scale-up is already in progress or was freshly initiated, it returns
+  HTTP 202 with `retry_after: 180`; only if scaling is blocked does it
+  return HTTP 503. A 202 retry re-enters `assign_premium_user()` from
+  the top -- the in-progress scale-up does not leave a reservation for
+  the retrying user, it just creates instances that Tier 1 or Tier 2
+  will pick up on the next attempt. `increment_assignment_attempts()`
+  is bookkeeping only; it does not change tier selection.
 
 **Post-assignment Steps:**
 1. Create target group (or use autoscaling target group for pool)
@@ -622,8 +611,8 @@ adopts instances that have no existing row at all.
 
 | Path | Function | Caller / trigger | DB action | EC2 action |
 |---|---|---|---|---|
-| **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (see [premium_manager.py:3735](../terraform/premium_manager_package/premium_manager.py#L3735)) | `start_instances` (via `start_standby_instance()`) |
-| **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | DELETE the `is_standby=1` row at [premium_manager.py:1540-1544](../terraform/premium_manager_package/premium_manager.py#L1540-L1544), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
+| **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (the inline DELETE/INSERT lives in the Tier 3 block of `assign_premium_user()`) | `start_instances` (via `start_standby_instance()`) |
+| **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | DELETE the `is_standby=1` row (inline DELETE inside `try_reserve_instance_for_migration()`), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
 | **Aged-out** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | DELETE the row | `terminate_instances` |
 | **Excess trim** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | DELETE the row | `terminate_instances` |
 | **Failed cleanup** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
@@ -765,13 +754,12 @@ WHERE instance_id = %s AND is_standby = 0
 
 **Important:** The `is_standby = 1` placeholder row is **not** deleted
 here. Row deletion happens in the caller:
-- On a Tier 3 user assignment, the inline DELETE at
-  [premium_manager.py:3735](../terraform/premium_manager_package/premium_manager.py#L3735)
-  removes the placeholder just before the new user row is inserted.
+- On a Tier 3 user assignment, the inline DELETE inside the Tier 3
+  block of `assign_premium_user()` removes the placeholder just before
+  the new user row is inserted.
 - On a migration-driven start, the DELETE inside
-  `try_reserve_instance_for_migration()` at
-  [premium_manager.py:1540-1544](../terraform/premium_manager_package/premium_manager.py#L1540-L1544)
-  removes it before the reservation is written.
+  `try_reserve_instance_for_migration()` removes it before the
+  reservation is written.
 
 In other words, `start_standby_instance()` is shared between both exit
 paths ("Assigned" and "Migrated" in the


### PR DESCRIPTION
## Summary

Systematically improve three premium instance assignment documentation files based on a specification-level review that identified 8 findings: missing definitions, fragmented explanations, nnecessary duplication, ambiguous state transitions, and inconsistent diagrams.

After this change the documents are self-contained specifications — readers no longer need to cross-reference source code to understand the system.

- **Files changed:** `PREMIUM_USER_ASSIGNMENT.md`, `PREMIUM_MANAGER_ARCHITECTURE.md`, `FREE_MANAGER_ARCHITECTURE.md`
- **Change type:** Documentation only (no code changes)
- **Initial analysis:** #550 

## Changes by Step

### Step 1: Glossary / Key Concepts (Findings 2, 3, 6)

- Add 4-state definition table (Dedicated / Shared / Autoscaling Pool / Unassigned) with DB column values
- Document `is_standby` value semantics and lifecycle
- Add `pending_release` grace period specification
- Add disambiguation table for the four distinct uses of "idle" on the premium tier
- Add formal definition of "idle instance" including counting rules

### Step 2: Standby Pool overview (Finding 4)

- Add conceptual overview and design rationale for the standby pool
- Add `stateDiagram-v2` lifecycle diagram (Stopped → Consumed / Terminated / Demoted)
- Add entry paths and exit paths tables
- Add Manager vs Cleanup responsibility split table
- Document configuration value interactions (`PREMIUM_STANDBY_POOL_SIZE`, etc.)

### Step 3: Tier transitions (Finding 5)

- Add Reachability column to Priority Matrix
- Add Precedence & Reachability Notes (Tier 2 vs 3 precedence, Tier 4 unreachability, Tier 5 retry semantics)
- Split into two-level structure: concept-only version in Architecture Overview, code-level walkthrough in Implementation Details

### Step 3.5: Source code reference simplification

- Replace all `premium_manager.py:NNNN` line-number references with function/constant name-based citations
- Improve documentation resilience to code refactoring

### Step 4: Inactivity timeline (Finding 7)

- Add new "Inactivity & Release Paths" section under Implementation Details
- Add unified comparison table for the four release paths (Beacon / Auto-release / Hard release / Cleanup Lambda)
- Document client-side inactivity timer specification (1h warning, 2h auto-release, 30s polling)
- Document server-side grace window latency bounds (min ~2m / max ~17m)
- Contrast post-release fast path vs slow path for idle-instance handling

### Step 4.5: Glossary adjustment

- Dissolve `is_standby column semantics` subsection and redistribute content
- Relocate Glossary block between Provisioning Flow Diagrams and Implementation Details

### Step 5: Structural changes (Finding 1)

- Deduplicate 5 tail sections (Metrics / Env Vars / Functions / Triggers / Resources) with cross-document pointers
- Add Scale-down subsection documenting scale-up/scale-down asymmetry side by side
- Normalize heading levels (`###` → `####` for proper parent-child hierarchy)
- Add sister-document notes to both Executive Summaries
- Add ALB routing cross-references
- Add cross-references from `FREE_MANAGER_ARCHITECTURE.md` to premium docs

### Step 6: Diagram cleanup (Finding 8)

- Audit all 12 diagrams (7 Mermaid + 5 ASCII) across both files
- Add color legend to tier cascade flowchart
- Change Auto-Migrate node color to white (`#FFFFFF`) for visual separation from Tier 1 green

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| No file splitting (Frontend / Log Playbook stay in ARCHITECTURE.md) | Current 2-file structure is sufficient; splitting increases navigation cost |
| No ASCII → Mermaid conversion | Detailed process flows are more readable in ASCII |
| Remove all line-number references | Line numbers silently drift on code refactoring |
| Maintain self-containment of each document | Cross-references are added, but each document remains independently readable |

## Test plan

- [ ] Verify Mermaid diagrams (flowchart / sequence / stateDiagram) render correctly on GitHub
- [ ] Verify cross-reference links (`[text](#anchor)` / `[text](./FILE.md#anchor)`) resolve correctly
- [ ] Verify each step commit is independently reviewable (`git log --oneline` shows 10 commits)
