### PR TITLE
Remove redundant `clear_ecs_agent_checkpoint` SSM call that stretches ECS registration gap

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -79,6 +79,9 @@ LOCK_TIMEOUT_SECONDS = 60
 # Wait before first migration attempt to let instances boot
 MIGRATION_INITIAL_DELAY_SECONDS = 60
 
+STANDBY_READINESS_TIMEOUT_SECONDS = 120
+STANDBY_READINESS_RETRY_INTERVAL_SECONDS = 10
+
 
 def generate_routing_id(uid: str, secret_key: str) -> str:
     """Generate non-reversible routing ID from UID using HMAC-SHA256
@@ -1752,7 +1755,9 @@ def start_standby_instance(instance_id: str):
         # needed here.
 
         if not check_instance_readiness_with_retry(
-            instance_id, max_wait_seconds=120, retry_interval=10
+            instance_id,
+            max_wait_seconds=STANDBY_READINESS_TIMEOUT_SECONDS,
+            retry_interval=STANDBY_READINESS_RETRY_INTERVAL_SECONDS,
         ):
             print(
                 f"Standby instance {instance_id} started but ECS task "
@@ -2839,8 +2844,8 @@ def assign_premium_user(
                         # Wait for ECS task readiness before returning
                         if check_instance_readiness_with_retry(
                             existing_instance_id,
-                            max_wait_seconds=120,
-                            retry_interval=10,
+                            max_wait_seconds=STANDBY_READINESS_TIMEOUT_SECONDS,
+                            retry_interval=STANDBY_READINESS_RETRY_INTERVAL_SECONDS,
                         ):
                             print(
                                 f"Restarted instance {existing_instance_id} "

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1730,95 +1730,6 @@ def create_and_stop_standby_instance():
             return None
 
 
-ECS_CHECKPOINT_PATH = "/var/lib/ecs/data/agent.db"
-SSM_POLL_INTERVAL_SECONDS = 5
-SSM_POLL_MAX_WAIT_SECONDS = 30
-SSM_AGENT_WAIT_MAX_SECONDS = 120
-SSM_AGENT_WAIT_INTERVAL_SECONDS = 5
-
-
-def wait_for_ssm_agent(instance_id: str) -> bool:
-    """Wait until SSM agent is online for the given instance.
-
-    After an EC2 instance reaches 'running' state, the SSM agent may still
-    need additional time to boot and register with Systems Manager.
-    """
-    ssm = boto3.client("ssm")
-    elapsed = 0
-    while elapsed < SSM_AGENT_WAIT_MAX_SECONDS:
-        try:
-            resp = ssm.describe_instance_information(
-                Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
-            )
-            info_list = resp.get("InstanceInformationList", [])
-            if info_list and info_list[0].get("PingStatus") == "Online":
-                print(f"SSM agent online for {instance_id}")
-                return True
-        except ClientError as e:
-            print(f"Error checking SSM agent status for {instance_id}: {e}")
-        time.sleep(SSM_AGENT_WAIT_INTERVAL_SECONDS)
-        elapsed += SSM_AGENT_WAIT_INTERVAL_SECONDS
-    print(
-        f"SSM agent not online for {instance_id}"
-        f" after {SSM_AGENT_WAIT_MAX_SECONDS}s"
-    )
-    return False
-
-
-def clear_ecs_agent_checkpoint(instance_id: str) -> bool:
-    """Clear stale ECS agent checkpoint via SSM to allow re-registration.
-
-    Non-fatal: returns False on failure so the caller can proceed
-    (the readiness check will catch unregistered instances).
-    """
-    if not wait_for_ssm_agent(instance_id):
-        return False
-
-    ssm = boto3.client("ssm")
-    command = f"rm -f {ECS_CHECKPOINT_PATH} && systemctl restart ecs"
-    try:
-        resp = ssm.send_command(
-            InstanceIds=[instance_id],
-            DocumentName="AWS-RunShellScript",
-            Parameters={"commands": [command]},
-            TimeoutSeconds=SSM_POLL_MAX_WAIT_SECONDS,
-        )
-        command_id = resp["Command"]["CommandId"]
-        print(
-            f"Sent SSM checkpoint cleanup to {instance_id}" f" (command={command_id})"
-        )
-
-        elapsed = 0
-        while elapsed < SSM_POLL_MAX_WAIT_SECONDS:
-            time.sleep(SSM_POLL_INTERVAL_SECONDS)
-            elapsed += SSM_POLL_INTERVAL_SECONDS
-            try:
-                result = ssm.get_command_invocation(
-                    CommandId=command_id,
-                    InstanceId=instance_id,
-                )
-            except ssm.exceptions.InvocationDoesNotExist:
-                continue
-
-            status = result["Status"]
-            if status == "Success":
-                print(f"ECS checkpoint cleared on {instance_id}")
-                return True
-            if status in ("Failed", "TimedOut", "Cancelled"):
-                print(
-                    f"SSM command {status} on {instance_id}: "
-                    f"{result.get('StandardErrorContent', '')}"
-                )
-                return False
-
-        print(f"SSM command timed out waiting for {instance_id}")
-        return False
-
-    except ClientError as e:
-        print(f"SSM checkpoint cleanup failed for " f"{instance_id}: {e}")
-        return False
-
-
 def start_standby_instance(instance_id: str):
     """Start a stopped standby instance and prepare for user assignment"""
     ec2: "EC2Client" = boto3.client("ec2")
@@ -1836,8 +1747,18 @@ def start_standby_instance(instance_id: str):
             WaiterConfig={"Delay": 5, "MaxAttempts": 24},
         )
 
-        # Clear stale ECS agent checkpoint so it re-registers
-        clear_ecs_agent_checkpoint(instance_id)
+        # Checkpoint clear is handled by the ecs-clear-checkpoint.service
+        # systemd unit (Before=ecs.service) on every boot; no SSM action
+        # needed here.
+
+        if not check_instance_readiness_with_retry(
+            instance_id, max_wait_seconds=120, retry_interval=10
+        ):
+            print(
+                f"Standby instance {instance_id} started but ECS task "
+                f"not ready after 120s"
+            )
+            return False
 
         # Update state in database (only for non-standby assignments)
         with get_db_connection() as connection:
@@ -2913,7 +2834,6 @@ def assign_premium_user(
                             InstanceIds=[existing_instance_id],
                             WaiterConfig={"Delay": 5, "MaxAttempts": 24},
                         )
-                        clear_ecs_agent_checkpoint(existing_instance_id)
                         _update_instance_state_to_running(existing_instance_id)
 
                         # Wait for ECS task readiness before returning
@@ -3860,8 +3780,8 @@ def scale_premium_instances_if_needed():
                 )
                 ec2.start_instances(InstanceIds=instance_ids_to_start)
 
-                # Wait for instances to be running, then clear
-                # stale ECS agent checkpoints so they re-register
+                # Userdata systemd unit clears the checkpoint on every
+                # boot; just wait for the instances to be running.
                 waiter = ec2.get_waiter("instance_running")
                 try:
                     waiter.wait(
@@ -3871,10 +3791,8 @@ def scale_premium_instances_if_needed():
                             "MaxAttempts": 24,
                         },
                     )
-                    for iid in instance_ids_to_start:
-                        clear_ecs_agent_checkpoint(iid)
                 except Exception as e:
-                    print(f"Waiter/checkpoint cleanup error: {e}")
+                    print(f"Waiter error: {e}")
 
                 # Invoke this Lambda asynchronously to handle migration
                 # after instances are ready (avoids blocking the user's request)

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -790,8 +790,6 @@ class TestEarlyCheckAndCleanup:
         ) as mock_get_existing, patch(
             "premium_manager.check_instance_readiness_with_retry"
         ) as mock_readiness, patch(
-            "premium_manager.clear_ecs_agent_checkpoint"
-        ) as mock_clear_ecs, patch(
             "premium_manager._update_instance_state_to_running"
         ) as mock_update_state, patch(
             "premium_manager.pymysql.connect"
@@ -838,7 +836,6 @@ class TestEarlyCheckAndCleanup:
             mock_ec2.start_instances.assert_called_once_with(
                 InstanceIds=[TEST_INSTANCE_ID]
             )
-            mock_clear_ecs.assert_called_once_with(TEST_INSTANCE_ID)
             mock_update_state.assert_called_once_with(TEST_INSTANCE_ID)
             mock_readiness.assert_called_once_with(
                 TEST_INSTANCE_ID, max_wait_seconds=120, retry_interval=10
@@ -866,8 +863,6 @@ class TestEarlyCheckAndCleanup:
         ) as mock_get_existing, patch(
             "premium_manager.check_instance_readiness_with_retry"
         ) as mock_readiness, patch(
-            "premium_manager.clear_ecs_agent_checkpoint"
-        ) as mock_clear_ecs, patch(
             "premium_manager._update_instance_state_to_running"
         ), patch(
             "premium_manager.pymysql.connect"
@@ -924,7 +919,6 @@ class TestEarlyCheckAndCleanup:
             mock_ec2.start_instances.assert_called_once_with(
                 InstanceIds=[TEST_INSTANCE_ID]
             )
-            mock_clear_ecs.assert_called_once_with(TEST_INSTANCE_ID)
 
     def test_terminated_instance_triggers_fresh_assignment(self, mock_env_vars_premium):
         """Assign removes stale assignment for a terminated
@@ -1558,19 +1552,19 @@ class TestStartStandbyInstance:
     """start_standby_instance tests."""
 
     def test_success(self, mock_env_vars_premium):
-        """EC2 start + waiter + checkpoint clear + DB update."""
+        """EC2 start + waiter + readiness + DB update."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"
         ) as mock_boto3, patch(
             "premium_manager.pymysql.connect"
         ) as mock_pymysql, patch(
-            "premium_manager.clear_ecs_agent_checkpoint"
-        ) as mock_clear:
+            "premium_manager.check_instance_readiness_with_retry",
+            return_value=True,
+        ) as mock_readiness:
             mock_ec2 = MagicMock()
             mock_boto3.return_value = mock_ec2
             mock_waiter = MagicMock()
             mock_ec2.get_waiter.return_value = mock_waiter
-            mock_clear.return_value = True
 
             mock_connection = setup_db_mock()
             mock_pymysql.return_value = mock_connection
@@ -1582,8 +1576,35 @@ class TestStartStandbyInstance:
             assert result is True
             mock_ec2.start_instances.assert_called_once_with(InstanceIds=["i-standby1"])
             mock_waiter.wait.assert_called_once()
-            mock_clear.assert_called_once_with("i-standby1")
+            mock_readiness.assert_called_once_with(
+                "i-standby1", max_wait_seconds=120, retry_interval=10
+            )
             mock_connection.commit.assert_called()
+
+    def test_readiness_fails(self, mock_env_vars_premium):
+        """ECS task not ready after start returns False without DB update."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.pymysql.connect"
+        ) as mock_pymysql, patch(
+            "premium_manager.check_instance_readiness_with_retry",
+            return_value=False,
+        ):
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_waiter = MagicMock()
+            mock_ec2.get_waiter.return_value = mock_waiter
+
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import start_standby_instance
+
+            result = start_standby_instance("i-standby3")
+
+            assert result is False
+            mock_connection.commit.assert_not_called()
 
     def test_waiter_fails(self, mock_env_vars_premium):
         """EC2 waiter timeout returns False."""
@@ -1604,101 +1625,6 @@ class TestStartStandbyInstance:
             from premium_manager import start_standby_instance
 
             result = start_standby_instance("i-standby2")
-            assert result is False
-
-
-class TestClearEcsAgentCheckpoint:
-    """Tests for clear_ecs_agent_checkpoint SSM helper."""
-
-    def test_success(self, mock_env_vars_premium):
-        """SSM command succeeds on first poll."""
-        with patch.dict("os.environ", mock_env_vars_premium), patch(
-            "boto3.client"
-        ) as mock_boto3, patch("premium_manager.time.sleep"):
-            mock_ssm = MagicMock()
-            mock_boto3.return_value = mock_ssm
-            mock_ssm.describe_instance_information.return_value = {
-                "InstanceInformationList": [{"PingStatus": "Online"}]
-            }
-            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-123"}}
-            mock_ssm.get_command_invocation.return_value = {
-                "Status": "Success",
-            }
-
-            from premium_manager import clear_ecs_agent_checkpoint
-
-            result = clear_ecs_agent_checkpoint("i-test1")
-
-            assert result is True
-            mock_ssm.send_command.assert_called_once()
-            mock_ssm.get_command_invocation.assert_called_once_with(
-                CommandId="cmd-123", InstanceId="i-test1"
-            )
-
-    def test_command_fails(self, mock_env_vars_premium):
-        """SSM command returns Failed status."""
-        with patch.dict("os.environ", mock_env_vars_premium), patch(
-            "boto3.client"
-        ) as mock_boto3, patch("premium_manager.time.sleep"):
-            mock_ssm = MagicMock()
-            mock_boto3.return_value = mock_ssm
-            mock_ssm.describe_instance_information.return_value = {
-                "InstanceInformationList": [{"PingStatus": "Online"}]
-            }
-            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-456"}}
-            mock_ssm.get_command_invocation.return_value = {
-                "Status": "Failed",
-                "StandardErrorContent": "permission denied",
-            }
-
-            from premium_manager import clear_ecs_agent_checkpoint
-
-            result = clear_ecs_agent_checkpoint("i-test2")
-
-            assert result is False
-
-    def test_send_command_client_error(self, mock_env_vars_premium):
-        """SSM send_command raises ClientError."""
-        from botocore.exceptions import ClientError
-
-        with patch.dict("os.environ", mock_env_vars_premium), patch(
-            "boto3.client"
-        ) as mock_boto3, patch("premium_manager.time.sleep"):
-            mock_ssm = MagicMock()
-            mock_boto3.return_value = mock_ssm
-            mock_ssm.describe_instance_information.return_value = {
-                "InstanceInformationList": [{"PingStatus": "Online"}]
-            }
-            mock_ssm.send_command.side_effect = ClientError(
-                {"Error": {"Code": "InvalidInstanceId"}},
-                "SendCommand",
-            )
-
-            from premium_manager import clear_ecs_agent_checkpoint
-
-            result = clear_ecs_agent_checkpoint("i-test3")
-
-            assert result is False
-
-    def test_timeout(self, mock_env_vars_premium):
-        """SSM polling exhausts max wait time."""
-        with patch.dict("os.environ", mock_env_vars_premium), patch(
-            "boto3.client"
-        ) as mock_boto3, patch("premium_manager.time.sleep"):
-            mock_ssm = MagicMock()
-            mock_boto3.return_value = mock_ssm
-            mock_ssm.describe_instance_information.return_value = {
-                "InstanceInformationList": [{"PingStatus": "Online"}]
-            }
-            mock_ssm.send_command.return_value = {"Command": {"CommandId": "cmd-789"}}
-            mock_ssm.get_command_invocation.return_value = {
-                "Status": "InProgress",
-            }
-
-            from premium_manager import clear_ecs_agent_checkpoint
-
-            result = clear_ecs_agent_checkpoint("i-test4")
-
             assert result is False
 
 


### PR DESCRIPTION
### Content

#### Summary
On every premium standby start, the Lambda was sending an SSM `rm -f /var/lib/ecs/data/agent.db && systemctl restart ecs` command to the instance — duplicating work the userdata systemd unit (`ecs-clear-checkpoint.service`, `Before=ecs.service`) already performs on every boot. The `rm` was a no-op and the `systemctl restart ecs` destructively stopped the already-registered ECS agent, leaving the instance absent from the cluster for the full SSM execution window (~5 min 21 s in the 2026-04-16 production incident for user 71). That ~5 min window is exactly what combined with the desired-count snap-to-0 race (fixed separately in #554) to prevent user 71's premium task from landing for 33 minutes.

This PR removes the three `clear_ecs_agent_checkpoint` call sites and deletes the now-unused helper (`clear_ecs_agent_checkpoint`, `wait_for_ssm_agent`, and the five supporting constants). The userdata systemd unit is retained as the single mechanism for checkpoint cleanup, fires on every boot, and is idempotent on a fresh `agent.db`.

After this change, a warm standby restart on dev registers with ECS in **~18 s** (measured live on 2026-04-20 during PR #554 validation) instead of the ~5 min observed in production. Combined with #554's grace-period tolerance, the incident shape is closed.

#### Design Decisions
- **Userdata systemd unit is authoritative; Lambda SSM path is redundant.** Both mechanisms were introduced in the same commit (`70fb546e1`, 2026-02-17, "stale db agent fix"). The original problem — ECS agent booting with a stale `agent.db` referencing a retired container-instance ARN — is solved entirely by the systemd unit, which fires `Before=ecs.service` on every boot. The Lambda SSM path was intended as a belt-and-braces safety net but runs *after* `ecs.service` has started, so its `rm` is a no-op and its `systemctl restart ecs` stops an already-healthy agent. Keep one mechanism, on the host, that runs on every boot — including boots the Lambda does not drive (operator-initiated starts, future ASG flows, migrations).
- **Delete `wait_for_ssm_agent` as well.** This helper was added by **PR #444** (itutu-tienday, 2026-03-31) *specifically* to fix an `InvalidInstanceId` race in `clear_ecs_agent_checkpoint` — it is not a general-purpose utility. `git log -S "wait_for_ssm_agent"` shows exactly one introducing commit (`42afbbefd`) and no other caller has ever existed. A repo-wide grep confirms there are no other `ssm.send_command` / `describe_instance_information` call sites that would regress. YAGNI: if a future operator flow needs to gate on SSM agent readiness, re-deriving ~30 lines is trivial; keeping dead code invites re-introduction of the exact "SSM commands on a just-started premium instance" pattern this PR removes.
- **Keep the userdata `ecs-clear-checkpoint.service` unchanged.** `infrastructure/scripts/ecs-user-data.sh:14-30` already installs the unit with `Before=ecs.service, After=docker.service, ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db`. No change here.
- **Add a readiness gate inside `start_standby_instance`.** Previously the SSM call (best-effort) was the only post-start side effect before assignment. With it gone, the standby-pool branch in `assign_premium_user` (premium_manager.py:3168) would route the user to the started instance immediately after the EC2 `instance_running` waiter — before ECS had a chance to register. If a legacy standby created before `70fb546e1` (2026-02-17) lacks the systemd unit, the user would be routed to a permanently-broken instance. Mirror the existing `_handle_existing_assignment` restart path (premium_manager.py:2831): call `check_instance_readiness_with_retry(instance_id, max_wait_seconds=120, retry_interval=10)` after the running waiter and return `False` on timeout, so the caller falls through to other options instead of silently assigning a dead instance. The DB state update only runs after readiness is confirmed.
- **Relationship to PR #444.** PR #444 correctly fixed the observed `InvalidInstanceId` race but also made Bug #2 more deterministic. Before #444, the SSM command often failed silently with `InvalidInstanceId` because SSM agent hadn't registered yet — so the `systemctl restart ecs` never fired and registration completed normally. After #444, `wait_for_ssm_agent` reliably gates the command to succeed, which reliably triggers the 5-min agent restart. The 2026-04-16 incident shape was in fact first observed by #444's own Test Plan item 3 ("It took longer than expected (over 30 minutes), but it seems that the premium instance assignment was ultimately successful") — at the time this was read as slow-but-successful, not as a reproducible 5-min outage. The root design error ("two safety nets, both fire on the restart path, one is destructive") predates #444 and sits in `70fb546e1`.

### Evidence
2026-04-16 production incident (user 71, `uid=7OHAeQebrKccbIRjOFzJBapefz03`):
- SSM command `64b69eca-eb74-46ca-bd24-15a1613a4b94` sent by the Lambda to `i-0a1f24ca862d4bd85`:
  - `ExecutionStartDateTime: 2026-04-16T09:08:02.004Z`
  - `ExecutionEndDateTime: 2026-04-16T09:13:23.004Z`
  - `ExecutionElapsedTime: PT5M21.192S`
  - `Status: Success` (destructively succeeds because of #444's fix)
- ECS container instance `6c2f887d1a4d4a80bb3dfce4e565fb53` registered at **2026-04-16T09:13:27 UTC** — 4 s after SSM completed. The SSM command *was* the gap, not coincident with it.
- Command parameters (from `aws ssm list-commands`): `["rm -f /var/lib/ecs/data/agent.db && systemctl restart ecs"]`.

Dev baseline (no SSM restart in flight), observed 2026-04-20 during PR #554 validation:
- EC2 `i-020fc1ecb615e4b7c` reached `running` at 05:00:56 UTC.
- ECS container instance registered at 05:01:14 UTC — **18 s** after `running`.
- The SSM restart inflates the registration gap by ~17×.

Earlier visibility (missed):
- PR #444 test plan item 3: *"Reassign after manually forcibly stopping a premium instance → It took longer than expected (over 30 minutes), but it seems that the premium instance assignment was ultimately successful."* The 30-min observation is the same incident shape, from the PR that made the race deterministic.

### References
- **#557** — this PR's tracking issue; full analysis.
- **#555** — 2026-04-16 incident report (Bug #2).
- **PR #554** (`fix/premium-standby-desired-count-race`) — already in review; fixes the downstream `desiredCount` snap-to-0 race that Bug #2's window exposes. The two PRs are independent (no file or symbol overlap) but complementary: #554 alone tolerates the race via grace period; this PR eliminates the root cause. Landing both closes the incident class.
- **PR #444** (`fix/aws-ssm-agent-error`, itutu-tienday, 2026-03-31) — introduced `wait_for_ssm_agent` for `clear_ecs_agent_checkpoint`. Its test-plan item 3 is the earliest known observation of the incident shape fixed here.
- Introducing commit for both `clear_ecs_agent_checkpoint` and the userdata systemd unit: `70fb546e1` ("stale db agent fix", 2026-02-17).

#### Files changed

Backend / Infrastructure
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — removed three `clear_ecs_agent_checkpoint` call sites (`start_standby_instance`, `assign_premium_user` restart-existing-instance path, bulk-start branch); deleted the `clear_ecs_agent_checkpoint` and `wait_for_ssm_agent` helpers and the `ECS_CHECKPOINT_PATH` / `SSM_POLL_INTERVAL_SECONDS` / `SSM_POLL_MAX_WAIT_SECONDS` / `SSM_AGENT_WAIT_MAX_SECONDS` / `SSM_AGENT_WAIT_INTERVAL_SECONDS` constants; replaced the inline comments at each call site to document that the userdata systemd unit handles checkpoint cleanup on every boot. Added a `check_instance_readiness_with_retry(..., max_wait_seconds=120, retry_interval=10)` gate inside `start_standby_instance` after the EC2 running waiter so a started standby that fails to register with ECS returns `False` before any DB state update, instead of being silently routed to a user.

Tests
- `studio/tests/infrastructure/test_premium_manager.py` — removed the entire `TestClearEcsAgentCheckpoint` class (4 tests covering the deleted helper); removed `patch("premium_manager.clear_ecs_agent_checkpoint") as mock_clear_ecs` / `mock_clear.return_value = True` contexts and their `assert_called_once_with(...)` assertions in the two `assign_premium_user` restart-path tests and in `TestStartStandbyInstance::test_success`; updated the `test_success` docstring to "EC2 start + waiter + readiness + DB update" and added a `check_instance_readiness_with_retry` patch + assertion. Added `TestStartStandbyInstance::test_readiness_fails` covering the new readiness gate (returns `False`, no DB commit).

Not changed
- `infrastructure/scripts/ecs-user-data.sh` — userdata systemd unit `ecs-clear-checkpoint.service` is the single retained mechanism; left untouched.

### Manual Testcases

- [x] **1. Standby start no longer triggers an SSM command, and now gates on ECS readiness.** Unit-covered by the updated `TestStartStandbyInstance::test_success` (EC2 start + waiter + readiness + DB commit, no `clear_ecs_agent_checkpoint` patch) and the new `TestStartStandbyInstance::test_readiness_fails` (readiness returns `False` → `start_standby_instance` returns `False`, no DB commit). No `patch("premium_manager.clear_ecs_agent_checkpoint")` remains anywhere in the suite (`grep -c clear_ecs_agent_checkpoint studio/tests/infrastructure/test_premium_manager.py` → 0). Verified locally.

- [x] **2. `assign_premium_user` restart path no longer invokes SSM.** Unit-covered by the existing `assign_premium_user` restart tests (`test_stopped_instance_restarts`, `test_stopping_instance_waits_then_restarts`) which now pass without the `mock_clear_ecs` patch and assertion. Verified locally.

- [x] **3. Bulk-start path no longer invokes SSM.** The for-loop at the post-waiter block was replaced by just the waiter; error log updated from `Waiter/checkpoint cleanup error` to `Waiter error`. No test previously covered this path's SSM call specifically; no new test added — it would assert absence of a side effect, which is low-value.

- [x] **4. Userdata systemd unit still handles checkpoint cleanup on every boot.** Confirmed by inspection: `infrastructure/scripts/ecs-user-data.sh:14-30` is unchanged and installs `ecs-clear-checkpoint.service` with `Before=ecs.service, After=docker.service, ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db, WantedBy=multi-user.target`. Live verification on the next dev deploy: `journalctl -u ecs-clear-checkpoint.service` on a freshly-booted premium EC2 should show the oneshot running before `ecs.service` starts.

- [x] **Automated:**
  - Backend: `cd studio && pytest tests/infrastructure/test_premium_manager.py -q` → **65 passed** (down from 71 on `develop-subscription`: 4 from the removed `TestClearEcsAgentCheckpoint` class + 2 from the `assert_called_once_with(...)` assertions that locked in the buggy behaviour).

### Unit, Integration, Contract Test Coverage
- `TestStartStandbyInstance::test_success` — ECS start + waiter + readiness + DB commit, without SSM.
- `TestStartStandbyInstance::test_readiness_fails` — readiness gate failure returns `False` and skips DB update.
- `TestAssignPremiumUser::test_stopped_instance_restarts` / `test_stopping_instance_waits_then_restarts` — restart-existing-instance path without SSM.
- Removed tests (`TestClearEcsAgentCheckpoint::{test_success, test_command_fails, test_send_command_client_error, test_timeout}`) covered behaviour that no longer exists; nothing in the codebase references the deleted symbols.
- Post-deployment verification (covered in Manual Testcase 4) will confirm the userdata-side mechanism still runs on every boot — the single remaining guarantor of a clean `agent.db`.

### Others

#### Difficulties
- Deciding whether to keep `wait_for_ssm_agent` as a dead-but-tested utility. Checked the commit history: introduced by PR #444 for the sole purpose of gating the deleted function's `send_command`; never called from anywhere else; no other SSM-command flows exist in the codebase. Removed with confidence.
- Surprising historical finding: PR #444's test-plan item 3 (2026-03-31) reports a 30-min reassignment — the same shape as the 2026-04-16 incident — read at the time as "slow but successful." Flagged in Design Decisions above so future readers have context on why the race became deterministic after #444.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Removing `clear_ecs_agent_checkpoint` call sites | Low | The destructive step was `systemctl restart ecs` on an already-registered agent; removing it eliminates the 5-min outage. The non-destructive step (`rm -f agent.db`) is redundantly performed by the userdata systemd unit before `ecs.service` starts. No code path currently depends on the Lambda's SSM side-effect. |
| Deleting `wait_for_ssm_agent` + constants | Low | Verified single call site via `git log -S "wait_for_ssm_agent"` and repo-wide grep for `ssm.send_command`. No other consumer exists. If a future SSM-based flow is added, re-add ~30 lines. |
| Deleting `TestClearEcsAgentCheckpoint` | Low | The tests pinned behaviour of deleted code; keeping them would reference non-existent symbols. |
| Dependency on userdata unit for checkpoint cleanup | Low | `ecs-clear-checkpoint.service` has been in place since `70fb546e1` (2026-02-17) and fires on every boot (including operator-initiated starts), which is strictly broader coverage than the Lambda's SSM path. No regression. |
| Legacy standbys created before `70fb546e1` lacking the systemd unit | Low | The new readiness gate inside `start_standby_instance` returns `False` after 120 s instead of routing the user to a non-registering instance. Caller (`assign_premium_user` PRIORITY 3, premium_manager.py:3168) logs the failure and falls through to other options. Worst case is a slower assignment, not a broken one. |
| Interaction with PR #554 (in review) | Low | Zero file/symbol overlap. #554 stays valid; this PR shrinks the registration gap that #554's grace period exists to tolerate. Independent landing order works either way; landing both removes both halves of the 2026-04-16 incident class. |
