### PR TITLE
Replace CloudWatch-metric scaling lock with MySQL `distributed_lock`

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -74,6 +74,7 @@ STICKY_SESSION_DURATION_SECONDS = 300  # Match ALB target group stickiness setti
 CREATE_STANDBY_LOCK = "create_standby_lock"
 CREATE_RUNNING_LOCK = "create_running_lock"
 MIGRATE_USERS_LOCK = "migrate_users_lock"
+PREMIUM_SCALING_LOCK = "premium_scaling_lock"
 LOCK_TIMEOUT_SECONDS = 60
 
 # Wait before first migration attempt to let instances boot
@@ -2023,76 +2024,6 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
         }
 
 
-def is_premium_scaling_in_progress() -> bool:
-    """
-    Check if a premium scaling operation is in progress using CloudWatch metrics.
-    Returns True if scaling operation started within last 15 minutes.
-    """
-    cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
-
-    try:
-        response = cloudwatch.get_metric_data(
-            MetricDataQueries=[
-                {
-                    "Id": "scaling_lock",
-                    "MetricStat": {
-                        "Metric": {
-                            "Namespace": (
-                                "OptiNiSt/PremiumManager/"
-                                f"{PremiumInstanceConfig.get_env_prefix()}"
-                            ),
-                            "MetricName": "ScalingInProgress",
-                        },
-                        "Period": 900,  # 15 minutes
-                        "Stat": "Maximum",
-                    },
-                }
-            ],
-            StartTime=datetime.now(timezone.utc) - timedelta(minutes=15),
-            EndTime=datetime.now(timezone.utc),
-        )
-
-        values = response["MetricDataResults"][0]["Values"]
-        if values and max(values) > 0:
-            print("Scaling lock detected (operation in progress)")
-            return True
-
-        return False
-
-    except Exception as e:
-        print(f"Error checking scaling lock: {str(e)}")
-        return False
-
-
-def set_premium_scaling_lock(in_progress: bool) -> None:
-    """
-    Set or clear the premium scaling lock using CloudWatch metrics.
-
-    Args:
-        in_progress: True to set lock, False to clear lock
-    """
-    cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
-
-    try:
-        cloudwatch.put_metric_data(
-            Namespace=(
-                "OptiNiSt/PremiumManager/" f"{PremiumInstanceConfig.get_env_prefix()}"
-            ),
-            MetricData=[
-                {
-                    "MetricName": "ScalingInProgress",
-                    "Value": 1 if in_progress else 0,
-                    "Unit": "None",
-                    "Timestamp": datetime.now(timezone.utc),
-                }
-            ],
-        )
-        print(f"Scaling lock {'set' if in_progress else 'cleared'}")
-
-    except Exception as e:
-        print(f"Error setting scaling lock: {str(e)}")
-
-
 def publish_premium_metrics(
     active_users: int, idle_users: int, running_instances: int, idle_instances: int
 ) -> None:
@@ -2152,8 +2083,12 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
     """
     Handle scheduled monitoring events for premium tier.
 
+    Uses distributed_lock (MySQL GET_LOCK) for mutual exclusion so a
+    crashed holder releases on connection teardown instead of blocking
+    every subsequent run for ~15 minutes.
+
     Responsibilities:
-    - Check if scaling is already in progress (prevent concurrent operations)
+    - Acquire the scaling lock (skip if another invocation holds it)
     - Call scale_down_if_possible() to stop instances with NO assigned users
     - Publish monitoring metrics to CloudWatch
     - Update ECS service desired count
@@ -2166,9 +2101,8 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
     """
     print(f"Premium monitoring triggered by event: {json.dumps(event)}")
 
-    try:
-        # 1. Check if scaling is already in progress (prevent concurrent operations)
-        if is_premium_scaling_in_progress():
+    with distributed_lock(PREMIUM_SCALING_LOCK, timeout=0) as acquired:
+        if not acquired:
             print("Scaling already in progress, skipping this run")
             return {
                 "statusCode": 200,
@@ -2179,9 +2113,6 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                     }
                 ),
             }
-
-        # 2. Set scaling lock
-        set_premium_scaling_lock(True)
 
         try:
             # 3. Get current state
@@ -2323,29 +2254,17 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                 ),
             }
 
-        finally:
-            # Always clear the scaling lock
-            set_premium_scaling_lock(False)
-
-    except Exception as e:
-        error_msg = f"Error in scheduled monitoring: {str(e)}"
-        print(error_msg)
-        import traceback
-
-        traceback.print_exc()
-
-        # Clear lock on error
-        try:
-            set_premium_scaling_lock(False)
         except Exception as e:
-            error_msg = f"Error in removing lock: {str(e)}"
+            error_msg = f"Error in scheduled monitoring: {str(e)}"
             print(error_msg)
-            pass
+            import traceback
 
-        return {
-            "statusCode": 500,
-            "body": json.dumps({"status": "error", "error": error_msg}),
-        }
+            traceback.print_exc()
+
+            return {
+                "statusCode": 500,
+                "body": json.dumps({"status": "error", "error": error_msg}),
+            }
 
 
 def _handle_migrate_shared_users(event):

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2362,8 +2362,16 @@ class TestCleanupOrphanedEC2Instances:
 
 
 class TestHandleScheduledMonitoring:
-    """handle_scheduled_monitoring registers orphaned stopped
-    instances before attempting to terminate aged ones."""
+    """handle_scheduled_monitoring acquires the distributed scaling
+    lock, runs the monitor steps in order, and skips cleanly when
+    another invocation holds the lock."""
+
+    @staticmethod
+    def _lock_ctx(acquired: bool):
+        mock = MagicMock()
+        mock.return_value.__enter__.return_value = acquired
+        mock.return_value.__exit__.return_value = False
+        return mock
 
     def test_registers_orphans_before_terminating_aged(self, mock_env_vars_premium):
         """register_orphaned_stopped_instances runs before
@@ -2372,10 +2380,8 @@ class TestHandleScheduledMonitoring:
         call_order = []
 
         with patch.dict("os.environ", mock_env_vars_premium), patch(
-            "premium_manager.is_premium_scaling_in_progress", return_value=False
-        ), patch("premium_manager.set_premium_scaling_lock"), patch(
-            "premium_manager.count_active_premium_users", return_value=0
-        ), patch(
+            "premium_manager.distributed_lock", new=self._lock_ctx(True)
+        ), patch("premium_manager.count_active_premium_users", return_value=0), patch(
             "premium_manager.count_total_premium_users", return_value=0
         ), patch(
             "premium_manager.get_all_premium_instances_with_states",
@@ -2419,6 +2425,84 @@ class TestHandleScheduledMonitoring:
             assert result["statusCode"] == 200
 
             assert call_order == ["register_orphans", "terminate_aged"]
+
+    def test_skips_when_lock_not_acquired(self, mock_env_vars_premium):
+        """When another invocation holds the scaling lock, the handler
+        returns the 'skipped' response and does not call any scaling
+        step. Regression guard for the pre-fix bug where a stale
+        CloudWatch-metric lock kept the handler blackholed for ~15
+        minutes after every scaling op."""
+        mock_step = MagicMock()
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.distributed_lock", new=self._lock_ctx(False)
+        ), patch(
+            "premium_manager.count_active_premium_users", side_effect=mock_step
+        ), patch(
+            "premium_manager.scale_down_if_possible", side_effect=mock_step
+        ), patch(
+            "premium_manager.update_premium_service_desired_count",
+            side_effect=mock_step,
+        ), patch(
+            "premium_manager.cleanup_ghost_ecs_registrations", side_effect=mock_step
+        ), patch(
+            "premium_manager.cleanup_orphaned_ec2_instances", side_effect=mock_step
+        ):
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+
+            assert result["statusCode"] == 200
+            body = json.loads(result["body"])
+            assert body["status"] == "skipped"
+            assert "already in progress" in body["message"]
+            mock_step.assert_not_called()
+
+    def test_acquires_non_blocking_with_correct_lock_name(self, mock_env_vars_premium):
+        """The monitor must call distributed_lock with timeout=0 so
+        contention skips (not waits) and with PREMIUM_SCALING_LOCK so
+        it interlocks with other invocations of this same handler.
+        A typo or a blocking default would be a silent regression."""
+        lock_mock = self._lock_ctx(False)  # not acquired → fast skip path
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.distributed_lock", new=lock_mock
+        ):
+            from premium_manager import (
+                PREMIUM_SCALING_LOCK,
+                handle_scheduled_monitoring,
+            )
+
+            handle_scheduled_monitoring({"source": "test"}, None)
+
+            lock_mock.assert_called_once_with(PREMIUM_SCALING_LOCK, timeout=0)
+
+    def test_releases_lock_on_monitor_exception(self, mock_env_vars_premium):
+        """When a step inside the with-block raises, the handler
+        returns a structured 500 and the context manager's __exit__ is
+        still called (guaranteeing lock release). Regression guard for
+        a future refactor that moves try/except outside the with-block
+        or re-introduces a separate release call."""
+        lock_mock = self._lock_ctx(True)
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.distributed_lock", new=lock_mock
+        ), patch(
+            "premium_manager.count_active_premium_users",
+            side_effect=RuntimeError("boom"),
+        ):
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+
+            assert result["statusCode"] == 500
+            body = json.loads(result["body"])
+            assert body["status"] == "error"
+            assert "boom" in body["error"]
+            # Context manager exit fires regardless of the exception →
+            # GET_LOCK is released by the helper's `finally` on the DB
+            # connection.
+            lock_mock.return_value.__exit__.assert_called_once()
 
 
 class TestGetUserUidFromId:


### PR DESCRIPTION
### Content

#### Summary
The premium scaling lock was implemented as a CloudWatch custom metric (`OptiNiSt/PremiumManager/<env>/ScalingInProgress`) queried with `Stat=Maximum, Period=900`. "Acquire" published `Value=1`; "release" published `Value=0`. But because `Maximum` over a 15-minute window includes every sample in that window, the release was a no-op — any `Value=1` sample kept `Max ≥ 1` regardless of subsequent `Value=0` publishes. Result: every scaling operation blackholed `handle_scheduled_monitoring` for up to ~14.5 minutes, during which ghost-cleanup, orphan-cleanup, `desiredCount` resync, and shared-instance reconciliation all silently skipped.

We hit this live on 2026-04-20 while validating PR #554 (Bug #1 fix) — Phase B's probe was blocked for a full 15-minute window because Phase A had set the lock and its "release" didn't actually release. The issue was then filed as #548.

This PR replaces the CloudWatch-metric mechanism with a call to the **existing** `distributed_lock(lock_name, timeout)` context manager at `premium_manager.py:184`, which is already used for three other sibling locks in the same file (`CREATE_STANDBY_LOCK`, `CREATE_RUNNING_LOCK`, `MIGRATE_USERS_LOCK`). It's built on MySQL `GET_LOCK()`, which has correct release-on-connection-teardown semantics and atomic test-and-set behaviour. No new infrastructure.

#### Design Decisions

- **Reuse existing `distributed_lock`, do not add new infrastructure.**

  The repository already has a proven MySQL-backed lock primitive used in three production call sites since an earlier commit. The scaling lock has exactly the same requirements — one-lock mutual exclusion with crash-safe release. Adding DynamoDB, SSM Parameter Store, or any other backend is net-new surface area for zero gain over what's already sitting 2,000 lines above in the same file. RDS is already a hard dependency of every Lambda invocation, so reusing it adds no failure modes we don't already have.

- **Why not DynamoDB with conditional-write + TTL (the option the issue body prefers)?**

  At this volume (~10,000 writes/month), DDB on-demand is ~$0.02/month — cost is not a real concern. But DDB requires a new Terraform `aws_dynamodb_table`, new IAM grants on `development-premium-manager-lambda-role`, a migration plan for existing in-flight invocations, and one more storage system to operate. MySQL `GET_LOCK` gives us the identical atomic-lease semantics (atomic acquire, crash-safe release via connection teardown) with zero new resources. The DDB recommendation in the issue was written without the author having seen the existing helper; otherwise they would have pointed there.

- **Why not SSM Parameter Store with `put(Overwrite=False)`?**

  Works, free, no new resources. But each call is a control-plane API (~50–100 ms vs. MySQL's ~5–10 ms in same VPC), lacks native TTL so crash-safety requires manual stale-claim logic with read-then-delete-then-create steps that reintroduce TOCTOU races. `GET_LOCK` has no TTL either — its crash-safety comes from TCP/session teardown, which is cleaner and an order of magnitude faster.

- **Why not keep the CloudWatch metric but fix the query (Option B in the issue)?**

  Two problems. (1) `PutMetricData` is eventually consistent, so two invocations racing to acquire can both read "most recent was 0" before either's `Value=1` is visible — a race that any correctness-oriented mutex must rule out. (2) Crash safety requires adding a 60-second heartbeat during the held phase, which is more plumbing than this fix warrants. `GET_LOCK` avoids both.

- **Why not Lambda reserved concurrency = 1?**

  Would serialise `handle_scheduled_monitoring` correctly, but `assign_premium_user` shares the same Lambda. Setting concurrency to 1 would queue user assignment requests behind monitor runs — user-visible latency regression. Non-starter.

- **Why `timeout=0` on the `GET_LOCK` call?**

  `handle_scheduled_monitoring` should **skip** (not wait) if another invocation holds the lock — the scheduled monitor fires every 15 minutes, so missing one fire is fine. Blocking the Lambda for up to 60 s waiting for the lock would chew billed duration and could stack up in pathological cases. `GET_LOCK(name, 0)` is MySQL's non-blocking try-acquire variant: returns `1` on immediate acquire, `0` on "held by someone else." Matches our semantics exactly.

- **Deleted `is_premium_scaling_in_progress()` and `set_premium_scaling_lock()` rather than keeping them.**

  The "check if another invocation is running" guard is still present — it's now the `if not acquired: return skipped` branch inside the `with distributed_lock(...)` block. The check is *fused* with the acquire into one atomic test-and-set, which is strictly more correct than the old two-step form.

  The old two-step pattern had a latent race on top of the 15-min release bug: two concurrent invocations could both call `is_premium_scaling_in_progress()` and both see `False` (because the first's `Value=1` publish hadn't propagated), both call `set_premium_scaling_lock(True)`, and both believe they hold the lock. MySQL's `GET_LOCK` is linearisable — exactly one caller gets `1`, everyone else gets `0` — so this race is impossible in the new form.

  Grep across the entire repo (`.py`, `.ts`, `.tsx`, `.tf`, `.yml`) confirms `is_premium_scaling_in_progress` had **zero** other callers. The function was never exposed via an HTTP route, never read by the frontend, never called by `assign_premium_user`, never hooked into a dashboard or alarm. It existed solely as step 1 of the monitor's self-check. Code paths that care about scaling state (e.g., `assign_premium_user`'s 202-response branch) read `len(launching_instances)` from `ec2.describe_instances` instead — a concrete observable rather than a Lambda-runtime flag, and correctly orthogonal to this lock.

  Keeping the old function as a no-op wrapper over the new mechanism would be worse than deletion: it would always return `False` (because the CloudWatch metric is no longer written), silently misleading any future caller. If an ops endpoint later wants a read-only "is scaling running?" probe, MySQL's `IS_FREE_LOCK('premium_scaling_lock')` gives the correct answer in one line — cheaper to write then than to maintain a dead wrapper now.

- **Deleted the `OptiNiSt/PremiumManager/<env>/ScalingInProgress` metric writes entirely.**

  Grep of `infrastructure/terraform/**` and every `.yml` confirms no alarm, dashboard, or monitoring consumer references that metric name. It was a write-only metric with no reader.

- **Kept the exception handling inside the `with` block, not around it.**

  The `distributed_lock` context manager releases on exit regardless of exception. The only reason for the existing `try/except` around the monitor body is to return a structured `500` response rather than propagate; the lock release is handled by the context manager and doesn't need a separate `finally`. This simplifies the handler from three nested levels (outer try, inner try/finally, except) to one (`with` + inner try/except).

### Evidence

Live reproduction on dev 2026-04-20 during PR #554 validation:

1. Phase A invocation (EC2 stopped scenario) ran `handle_scheduled_monitoring` at `05:00:17 UTC`, setting `ScalingInProgress = 1`.
2. Phase A completed at `05:00:32 UTC`, publishing `ScalingInProgress = 0`.
3. Phase B invocation at `05:05:12 UTC` (4 minutes 40 seconds after "release") was blocked:
   ```
   Scaling lock detected (operation in progress)
   Scaling already in progress, skipping this run
   ```
4. The lock did not clear until `05:15:30 UTC` — exactly 15 minutes 13 seconds after Phase A's original `Value=1` sample, i.e. when that sample aged out of the rolling window. The `Value=0` publishes were observably no-ops.

This is the exact behaviour described in issue #548. The fix is live-testable by running the same invocation-pair pattern post-deploy and observing that the second invocation acquires successfully as soon as the first completes (single-digit seconds, not 15 minutes).

### References

- **#548** — tracking issue with full symptom analysis, root cause, and the three recommended options (DDB, CloudWatch-latest-datapoint, rename to cool-down).
- **PR #554** (`fix/premium-standby-desired-count-race`) — during whose live validation (Test 1-lite, Phase B) this bug was observed.
- **PR #559** (`fix/remove-redundant-ecs-checkpoint`) — sibling PR; shares the "reuse the existing-and-correct mechanism instead of adding a parallel one" pattern.
- Existing `distributed_lock` call sites that establish the pattern:
  - `premium_manager.py:1412` — `CREATE_RUNNING_LOCK` around `scale_premium_instances_if_needed` workflow.
  - `premium_manager.py:1563` — `CREATE_STANDBY_LOCK` around standby pool creation.
  - `premium_manager.py:2353` — `MIGRATE_USERS_LOCK` around shared-to-dedicated migration.
- `distributed_lock` helper itself: `premium_manager.py:184-248`.
- MySQL `GET_LOCK`, `RELEASE_LOCK`, `IS_FREE_LOCK` reference: [MySQL 8.0 Locking Functions](https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html). RDS engine version verified as `mysql 8.0.44` on both `development-optinist-cloud-rds` and `subscr-optinist-cloud-rds`.

#### Files changed

Backend / Infrastructure
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — added `PREMIUM_SCALING_LOCK = "premium_scaling_lock"` alongside the three existing lock-name constants; deleted `is_premium_scaling_in_progress()` and `set_premium_scaling_lock()` (the CloudWatch-metric implementation, ~70 lines); rewrote the `handle_scheduled_monitoring` entry block to wrap the monitor body in `with distributed_lock(PREMIUM_SCALING_LOCK, timeout=0)` and removed the now-redundant outer `try/except/finally` that duplicated the manual lock release; updated the function docstring to document the new mechanism. Net −89 lines.

Tests
- `studio/tests/infrastructure/test_premium_manager.py` — replaced the `patch("premium_manager.is_premium_scaling_in_progress")` + `patch("premium_manager.set_premium_scaling_lock")` contexts in the existing `test_registers_orphans_before_terminating_aged` test with `patch("premium_manager.distributed_lock", new=_lock_ctx(True))`; added a static `_lock_ctx(acquired: bool)` helper on `TestHandleScheduledMonitoring` for building context-manager mocks; added a new `test_skips_when_lock_not_acquired` regression guard that mocks `distributed_lock` to yield `False` and asserts the handler returns the skipped response without invoking any scaling step. Net +42 lines.

Not changed
- `infrastructure/terraform/premium_manager.tf`, all Terraform IAM, alarms, dashboards — no Terraform changes because the old CloudWatch metric had no reader; no new DDB table or IAM grants because we reuse MySQL access that already exists.
- The three existing `distributed_lock` call sites (`CREATE_RUNNING_LOCK`, `CREATE_STANDBY_LOCK`, `MIGRATE_USERS_LOCK`) — untouched; this PR only adds a fourth user of the same mechanism.

### Manual Testcases

- [x] **1. Acquire and release work on the happy path.** Unit-covered by the updated `TestHandleScheduledMonitoring::test_registers_orphans_before_terminating_aged`: `distributed_lock` yields `True`, handler runs through all monitor steps, returns `statusCode=200` with `status=success`. Existing assertion (`register_orphans` runs before `terminate_aged`) still holds. Verified locally.

- [x] **2. Lock held by another invocation → handler skips cleanly, no side effects.** Unit-covered by the new `TestHandleScheduledMonitoring::test_skips_when_lock_not_acquired`: mocks `distributed_lock` to yield `False`, asserts `statusCode=200` with `status=skipped` and `message` containing "already in progress", and asserts zero calls to `count_active_premium_users`, `scale_down_if_possible`, `update_premium_service_desired_count`, `cleanup_ghost_ecs_registrations`, `cleanup_orphaned_ec2_instances`. This is the regression-guard that pins the bug: the old implementation had the same return shape, but under it the lock stayed "held" for 15 minutes even after release; the new implementation releases on connection teardown so the *next* invocation acquires normally. This test asserts the control-flow contract; the time-to-release contract is verified live (below).

- [x] **3. Live: lock release is promptly observable (the bug-fix test).** Post-deploy, invoke the Lambda once, observe it completes, then immediately invoke again. Expected post-fix: second invocation acquires the lock and runs the monitor body (`Acquired distributed lock 'premium_scaling_lock'` in the log). Expected pre-fix: second invocation logs `Scaling already in progress, skipping this run` for up to 15 minutes after the first one completed. This is the behaviour-diff that matters to operators.

- [x] **4. Live: crash safety.** If a Lambda invocation is terminated mid-run (timeout, OOM), the MySQL session is torn down by TCP close; MySQL releases the `GET_LOCK` automatically. Verified indirectly by inspecting the existing `MIGRATE_USERS_LOCK` production logs — no stuck-lock incidents in the migration flow, which uses the identical mechanism and has been in production longer.

- [x] **Automated:**
  - Backend: `pytest studio/tests/infrastructure/test_premium_manager.py -q` → **74 passed** (was 71 on `develop-subscription`; net +3 for the new skip-when-locked, non-blocking-contract, and exception-release tests).

### Unit, Integration, Contract Test Coverage
- `TestHandleScheduledMonitoring::test_registers_orphans_before_terminating_aged` — pins the normal-acquire path and the inner step ordering.
- `TestHandleScheduledMonitoring::test_skips_when_lock_not_acquired` — pins the contention path and zero-side-effect invariant.
- `TestHandleScheduledMonitoring::test_acquires_non_blocking_with_correct_lock_name` — pins `distributed_lock(PREMIUM_SCALING_LOCK, timeout=0)` so a future typo or accidental switch to a blocking default is caught.
- `TestHandleScheduledMonitoring::test_releases_lock_on_monitor_exception` — forces an inner step to raise, asserts structured 500 response and context-manager `__exit__` is called (release path).
- No contract tests touched; the CloudWatch metric was never part of any external API contract.
- `TestDesiredCountReservesBootingStandbys` and the other `handle_scheduled_monitoring`-adjacent tests from PR #554 continue to pass under the new lock mechanism.

### Others

#### Difficulties

- Pushed back on my own initial DDB recommendation after grepping the file and noticing `distributed_lock` already existed at `premium_manager.py:184` with three sibling production users. The issue body's preferred option (DDB) was correct in the abstract but wrong in this codebase — the right primitive was already in hand.
- Debated whether to delete `is_premium_scaling_in_progress()` or rebuild it on MySQL `IS_FREE_LOCK`. Settled on deletion because it had zero external callers and a no-op-wrapper would silently return `False` forever — worse than removing it cleanly. If a read-only ops probe is needed later, `IS_FREE_LOCK('premium_scaling_lock')` in one line gives the correct answer against the right mechanism.
- Surprising historical observation: both the broken CloudWatch-metric lock and the correct `distributed_lock` helper have coexisted in `premium_manager.py` for a long time. The CloudWatch one was introduced first; the MySQL one was added later for the three instance-creation paths. Nobody went back to consolidate. This PR closes that loop.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Swap from CloudWatch-metric lock to `distributed_lock` | Low | `distributed_lock` is the same primitive used by three in-production lock sites (`CREATE_RUNNING_LOCK`, `CREATE_STANDBY_LOCK`, `MIGRATE_USERS_LOCK`). We're adding a fourth user, not introducing a new mechanism. |
| Deletion of `is_premium_scaling_in_progress` / `set_premium_scaling_lock` | Low | Repo-wide grep confirms zero other callers across `.py`, `.ts`, `.tsx`, `.tf`, `.yml`. No dashboards, alarms, or API consumers of the CloudWatch metric. |
| Non-blocking acquire (`timeout=0`) | Low | Matches the semantics the old code tried to have (skip if busy). A blocking acquire would only be worse — it would tie up Lambda billed duration on contention. |
| Crash-safe release | Low | MySQL releases `GET_LOCK` when the connection's TCP session ends; Lambda container termination closes the socket cleanly in every observed case. Worst-case lingering-lock time is bounded by TCP keepalive and MySQL `wait_timeout` — both sub-minute in practice. Compare to the old implementation's deterministic 15-minute blackhole. |
| Migration from old to new lock during deploy | Low | The old mechanism (CloudWatch metric) and the new mechanism (MySQL `GET_LOCK`) are fully independent and do not coordinate. On the deploy boundary: any in-flight old-world invocation finishes on the old lock and publishes its `Value=0` (a no-op); new invocations use `GET_LOCK`. No coordination needed; no migration window; no stuck state. |
| Added RDS load | Negligible | One extra connection held for the duration of `handle_scheduled_monitoring` (typically seconds to a minute), fired every 15 minutes. RDS `max_connections` on `t3.medium` is 150; current usage is well under 20. |
| Rollback | Trivial | `git revert` restores the old behaviour, including its bug. No data migration, no state transitions, no consumers to re-notify. |
