### PR TITLE
Add EC2 Image Builder pipeline for custom ECS-optimized AMI

### DIFF
--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -1,0 +1,619 @@
+# Custom AMI: Pre-Baked Packages for Fast Instance Boot
+
+## Executive Summary
+
+- **Custom AMI** eliminates ~5 minutes of package installation from every EC2 instance boot, reducing startup from ~8 minutes to ~2 minutes
+- **Pre-baked packages** (yum packages, AWS CLI v2, Docker, CloudWatch agent) are installed once at AMI build time instead of on every first boot
+- **EC2 Image Builder** is used as the build pipeline — automated monthly rebuilds keep the AMI patched with security updates
+- **Bake marker** (`/etc/optinist-ami-baked`) lets the user-data script detect a pre-baked AMI and skip package installation at boot
+- **Feature-flagged** via `var.use_custom_ami` (default `false`) — switching back to the stock AMI requires only a single variable change
+
+## Key Architectural Principles
+
+1. **Zero-Impact Feature Flag**
+   - All custom AMI resources (Image Builder pipeline, IAM, SSM parameter) use `count = var.use_custom_ami ? 1 : 0`
+   - When disabled, launch templates use the stock Amazon ECS-optimized AMI (`data.aws_ami.ecs_optimized`)
+   - Switching back to stock AMI requires only setting `use_custom_ami = false` and running `terraform apply`
+
+2. **SSM Parameter as AMI ID Registry**
+   - The active AMI ID is stored in SSM Parameter Store (`/${environment}/optinist/custom-ami-id`)
+   - Launch templates read the AMI ID from SSM at `terraform plan` time via `data.aws_ssm_parameter`
+   - Terraform creates the SSM parameter with `ignore_changes = [value]`, so pipeline updates do not conflict with Terraform state
+   - **Note (provisional):** SSM parameter update is currently manual after each build; future automation via EventBridge + Lambda is planned
+
+3. **Single User-Data Script for Both AMI Types**
+   - `ecs-user-data.sh` detects the bake marker file and branches:
+     - Pre-baked AMI: skips package installation, adds `/usr/local/bin` to PATH
+     - Stock AMI: runs full `yum update` + `yum install` + AWS CLI v2 standalone install
+   - All runtime-specific steps (ECS config, swap, CloudWatch, Docker, git clone, ECR pull, EFS mount) remain unchanged regardless of AMI type
+
+4. **Immutable Build Components and Recipes**
+   - EC2 Image Builder components and recipes are immutable in AWS — content changes require a version bump
+   - `var.custom_ami_version` controls all version strings; bumping it forces Terraform to create new resources via `create_before_destroy`
+
+5. **Encrypted AMI with Same-Account Distribution**
+   - Recipe specifies `encrypted = true` (AWS-managed CMK) for the root EBS volume
+   - Distribution configuration has no `launch_permission` block — same-account AMIs are automatically available without explicit permissions
+   - Explicit `launch_permission` triggers AWS "sharing" logic, which is incompatible with AWS-managed CMK encrypted snapshots
+
+---
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "AMI Build Pipeline (EC2 Image Builder, Monthly Cron)"
+        A[Cron: 1st of month 03:00 UTC] --> B[Launch t3.medium Build Instance]
+        B --> C[Build Phase: Install Packages]
+        C --> D[Validate Phase: Verify Installations]
+        D --> E[Snapshot: Create AMI]
+        E --> F[Test Phase: Boot Fresh Instance from AMI]
+        F --> G[Distribute: Tag and Register AMI]
+        G --> H[Cleanup: Terminate Build/Test Instances]
+    end
+
+    subgraph "AMI Selection Flow"
+        I[SSM Parameter<br/>custom-ami-id] --> J{use_custom_ami?}
+        J -->|true| K[Read AMI ID from SSM]
+        J -->|false| L[Use Stock ECS-Optimized AMI]
+        K --> M[Launch Templates]
+        L --> M
+    end
+
+    subgraph "Instance Boot (Performance Impact)"
+        M --> N[EC2 Instance Starts]
+        N --> O{/etc/optinist-ami-baked?}
+        O -->|Exists| P[Skip Package Install<br/>~2 min total boot]
+        O -->|Not Found| Q[Full Package Install<br/>~8 min total boot]
+    end
+
+    H -.->|Manual: update SSM| I
+
+    style P fill:#90EE90
+    style Q fill:#FFB6C1
+    style H fill:#87CEEB
+    style I fill:#FFD700
+```
+
+### Responsibility Matrix
+
+| Concern | Owner | Key Resource / File |
+|---------|-------|---------------------|
+| Custom AMI selection at deploy time | Terraform local | `local.effective_ami_id` in `compute.tf` |
+| Bake-aware boot logic (skip packages) | User-data script | `ecs-user-data.sh` |
+| AMI ID storage | SSM Parameter Store | `/${environment}/optinist/custom-ami-id` |
+| AMI build orchestration | EC2 Image Builder pipeline | `image_builder.tf` |
+| Package installation (bake time) | Build component YAML | `optinist-packages.yml` |
+| Installation validation (bake time) | Validate component YAML | `optinist-validate.yml` |
+| Old AMI cleanup | Lifecycle policy | `image_builder.tf` |
+| Build log retention | S3 lifecycle rule | `infrastructure.tf` |
+
+---
+
+## Implementation Details
+
+### 1. AMI Selection Logic (`compute.tf`)
+
+**File:** `infrastructure/terraform/compute.tf`
+**Purpose:** Conditionally read the custom AMI ID from SSM and expose as `local.effective_ami_id` for all launch templates
+
+```hcl
+data "aws_ssm_parameter" "custom_ami_id" {
+  count      = var.use_custom_ami ? 1 : 0
+  name       = "/${var.environment}/optinist/custom-ami-id"
+  depends_on = [aws_ssm_parameter.custom_ami_id]
+}
+
+locals {
+  effective_ami_id = (
+    var.use_custom_ami
+    ? data.aws_ssm_parameter.custom_ami_id[0].value
+    : data.aws_ami.ecs_optimized.id
+  )
+}
+```
+
+**Launch templates using `local.effective_ami_id`:**
+
+| Launch Template | File | Tier |
+|----------------|------|------|
+| `aws_launch_template.ecs` | `compute.tf` | Free tier (ASG) |
+| `aws_launch_template.premium` | `compute.tf` | Premium tier (Lambda-managed) |
+| `aws_launch_template.background` | `background_service.tf` | Background service |
+
+### 2. User-Data Bake Detection (`ecs-user-data.sh`)
+
+**File:** `infrastructure/scripts/ecs-user-data.sh`
+**Purpose:** Detect a pre-baked custom AMI and skip package installation — this is where the boot time improvement is realized
+
+```bash
+if [ -f /etc/optinist-ami-baked ]; then
+    echo "$(date): Pre-baked AMI detected, skipping package installation"
+    cat /etc/optinist-ami-baked
+    export PATH="/usr/local/bin:$PATH"
+else
+    echo "$(date): Stock AMI detected, installing packages"
+    yum update -y
+    yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+    curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+    cd /tmp && unzip -qo awscliv2.zip
+    /tmp/aws/install --update
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+    echo "$(date): Package installation complete"
+fi
+```
+
+**Package fix notes (also applied to stock AMI path):**
+- `mysql-client` removed — does not exist in Amazon Linux 2; `mysql` package provides the client binary
+- `awscli` v1 replaced — yum package no longer available in AL2 repos; standalone AWS CLI v2 installer used instead
+- `export PATH="/usr/local/bin:$PATH"` — required for pre-baked AMI because AWS CLI v2 installs to `/usr/local/bin`, which is not in the default PATH at user-data execution time
+
+### 3. Build Component (`optinist-packages.yml`)
+
+**File:** `infrastructure/image_builder/components/optinist-packages.yml`
+**Purpose:** Define which packages are pre-installed into the custom AMI at bake time
+
+**Build phase steps:**
+
+| Step | Action | Notes |
+|------|--------|-------|
+| `SystemUpdate` | `yum update -y` | Apply latest patches |
+| `InstallYumPackages` | `yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent` | Core packages |
+| `InstallAWSCLIv2` | Remove awscli v1, install standalone v2, verify with `grep -q "aws-cli/2"` | Replaces broken v1 yum package |
+| `EnableDockerService` | `systemctl enable docker` | Enabled but NOT started (instance shuts down for snapshot) |
+| `CreateBakeMarker` | Write `/etc/optinist-ami-baked` with timestamp and package list | Detected by user-data at boot |
+| `CleanupYumCache` | `yum clean all` + `rm -rf /var/cache/yum` | Reduces AMI snapshot size |
+
+**AWSTOE error handling:** Each step uses a single `|` block with `set -e` at the top. This prevents error masking — AWSTOE evaluates the exit code of the **last** item in `commands`, so trailing `echo` statements would mask failures in preceding commands.
+
+### 4. Validate Component (`optinist-validate.yml`)
+
+**File:** `infrastructure/image_builder/components/optinist-validate.yml`
+**Purpose:** Verify all installations before and after AMI snapshot
+
+**Build phase (pre-snapshot validation):**
+
+| Step | Validation |
+|------|------------|
+| `ValidateYumPackages` | `rpm -q` / `which` for each package |
+| `ValidateAWSCLIv2` | Diagnostic `ls`/`which` + version check `grep -q "aws-cli/2"` |
+| `ValidateDockerEnabled` | `systemctl is-enabled docker` |
+| `ValidateBakeMarker` | `test -f /etc/optinist-ami-baked` |
+| `ValidateEFSUtils` | Check `/usr/bin/mount.efs` or `/sbin/mount.efs` |
+
+**Test phase (fresh instance from AMI):**
+
+| Step | Validation |
+|------|------------|
+| `TestBakeMarkerPersisted` | Confirm marker survived snapshot |
+| `TestDockerStarts` | `systemctl start docker`, check version, then stop |
+| `TestAWSCLIFunctional` | `aws sts get-caller-identity` (warn-only, no instance role during test) |
+
+---
+
+## Edge Case Handling
+
+### 1. AWSTOE Error Masking
+
+**Problem:** AWSTOE evaluates the exit code of the **last** item in a step's `commands` array. A trailing `echo` (always exit 0) masks failures in preceding shell blocks.
+
+**Solution:** Each step uses a single `|` block with `set -e`. All commands within one block share a single exit code, and `set -e` aborts on the first non-zero exit.
+
+### 2. AWS-Managed CMK Encrypted Snapshot Sharing
+
+**Problem:** Distribution fails with `Snapshots encrypted with the AWS Managed CMK can't be shared` when `launch_permission` includes explicit `user_ids`.
+
+**Solution:** Remove `launch_permission` entirely. AMIs are automatically available to the account that creates them. Even specifying the same account's ID triggers AWS "sharing" logic, which conflicts with AWS-managed CMK encryption.
+
+### 3. Component Version Immutability
+
+**Problem:** Changing YAML content without bumping the version causes Terraform to fail because Image Builder components and recipes are immutable.
+
+**Solution:** Always bump `custom_ami_version` before `terraform apply` when component YAML files change. `create_before_destroy` lifecycle ensures the old resources remain until new ones are ready.
+
+### 4. Parent AMI Drift
+
+**Problem:** Amazon regularly publishes new ECS-optimized AMIs. Without protection, Terraform would force-recreate the recipe on every `plan`.
+
+**Solution:** Recipe uses `ignore_changes = [parent_image]`. To pick up a newer base AMI, bump `custom_ami_version` — this creates a new recipe referencing the latest base AMI.
+
+### 5. Stock AMI Fallback on Build Failure
+
+**Problem:** If the Image Builder pipeline fails, no custom AMI is available.
+
+**Solution:** The SSM parameter is initially set to the stock ECS-optimized AMI ID. Until a successful build overwrites it, all launch templates use the stock AMI. The user-data `else` branch handles stock AMI boot correctly.
+
+---
+
+## Operational Procedures
+
+### Procedure A: Initial Setup (First-Time Deployment)
+
+This procedure enables the custom AMI feature, builds the first AMI via Image Builder, and switches all launch templates to use it.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Step 1: Enable Feature Flag                              │
+│    → Set use_custom_ami = true in terraform.tfvars       │
+│    → Set custom_ami_version = "1.0.0"                    │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 2: terraform apply                                  │
+│    → Creates: IAM roles, components, recipe,             │
+│      infrastructure config, distribution config,         │
+│      pipeline, lifecycle policy, SSM parameter           │
+│    → SSM parameter initialized with stock AMI ID         │
+│    → Launch templates still use stock AMI                 │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 3: Trigger First AMI Build                          │
+│    → Run: aws imagebuilder                               │
+│        start-image-pipeline-execution                    │
+│        --image-pipeline-arn <PIPELINE_ARN>               │
+│        --region ap-northeast-1                           │
+│    → Pipeline ARN: terraform output                      │
+│        image_builder_pipeline_arn                        │
+│    → Wait ~20-30 min for build + test + distribution     │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 4: Find Built AMI ID                                │
+│    → AWS Console: EC2 Image Builder > Image pipelines    │
+│      > Click pipeline > Output images > AMI ID           │
+│    → Or CLI: aws imagebuilder                            │
+│        list-image-pipeline-images                        │
+│        --image-pipeline-arn <PIPELINE_ARN>               │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 5: Update SSM Parameter (manual) ⚠                  │
+│    → Run: aws ssm put-parameter                          │
+│        --name "/<environment>/optinist/custom-ami-id"    │
+│        --value "ami-0xxxxxxxxxxxxxxxxx"                  │
+│        --type String --overwrite                         │
+│        --region ap-northeast-1                           │
+│                                                          │
+│    ⚠ This step is currently manual.                      │
+│    Future: EventBridge + Lambda will automate this       │
+│    on pipeline completion.                               │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 6: terraform apply                                  │
+│    → Launch templates pick up new AMI from SSM           │
+│    → Free-tier ASG: instance_refresh performs             │
+│      rolling replacement                                 │
+│    → Premium: new instances use custom AMI via            │
+│      launch template $Latest                             │
+│    → Background: Terraform recreates instance            │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 7: Verify                                           │
+│    → See "Verification Procedure" below                  │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Procedure B: AMI Content Fix / Rebuild
+
+When the pre-baked package set changes (component YAML files modified), a version bump and AMI rebuild are required.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Step 1: Edit YAML and Bump Version                       │
+│    → Modify component YAML files as needed               │
+│    → Bump custom_ami_version in terraform.tfvars         │
+│      (e.g., "1.0.0" → "1.0.1")                          │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 2: terraform apply                                  │
+│    → Terraform creates new components and recipe         │
+│      (create_before_destroy)                             │
+│    → Pipeline references the new recipe                  │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 3: Trigger Build                                    │
+│    → Same as Procedure A Step 3                          │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 4: Find AMI ID + Update SSM ⚠                       │
+│    → Same as Procedure A Steps 4-5                       │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 5: terraform apply                                  │
+│    → Launch templates pick up new AMI                    │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 6: Verify                                           │
+│    → See "Verification Procedure" below                  │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Procedure C: Monthly Automated AMI Rebuild (Cron)
+
+The build pipeline runs automatically on the 1st of each month at 03:00 UTC (12:00 JST) to keep the custom AMI patched.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Automatic: Pipeline executes on cron schedule            │
+│    → Same base AMI, same component versions              │
+│    → Picks up latest yum security patches via            │
+│      yum update -y                                       │
+│    → Build takes ~20-30 min                              │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Manual: Find AMI ID + Update SSM ⚠                       │
+│    → Same as Procedure A Steps 4-5                       │
+│                                                          │
+│    ⚠ Currently requires manual intervention.             │
+│    The cron builds an AMI, but it is NOT automatically   │
+│    activated. Until EventBridge + Lambda automation is    │
+│    implemented, an operator must:                        │
+│    1. Check build completion in AWS Console               │
+│    2. Update SSM parameter with new AMI ID               │
+│    3. Run terraform apply to update launch templates     │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Manual: terraform apply                                  │
+│    → Launch templates pick up new AMI                    │
+│    → Existing running instances are NOT affected         │
+│    → New instances (premium cold starts, ASG scaling)    │
+│      use the updated AMI                                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Procedure D: Rollback to Stock AMI
+
+If the custom AMI causes issues, revert to the stock ECS-optimized AMI:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Step 1: Disable Feature Flag                             │
+│    → Set use_custom_ami = false in terraform.tfvars      │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 2: terraform apply                                  │
+│    → Launch templates revert to stock AMI                │
+│    → Image Builder resources are destroyed               │
+│    → SSM parameter is deleted                            │
+└──────────────────────────────────────────────────────────┘
+                         ↓
+┌──────────────────────────────────────────────────────────┐
+│ Step 3: Replace Running Instances                        │
+│    → Free tier: ASG instance_refresh replaces instances  │
+│    → Premium: terminate existing, Lambda creates new     │
+│    → Background: Terraform recreates                     │
+│                                                          │
+│    User-data detects no bake marker and installs         │
+│    packages normally (else branch)                       │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Verification Procedure
+
+After switching to a new custom AMI, verify on a newly launched instance:
+
+```bash
+# 1. Confirm bake marker exists
+cat /etc/optinist-ami-baked
+# Expected: BAKED_DATE=..., BAKED_BY=ec2-image-builder, PACKAGES=...
+
+# 2. Confirm user-data skipped package installation
+grep "Pre-baked AMI detected" /var/log/ecs-setup.log
+# Expected: "<timestamp>: Pre-baked AMI detected, skipping package installation"
+
+# 3. Verify AWS CLI v2
+aws --version
+# Expected: aws-cli/2.x.x ...
+
+# 4. Verify packages
+rpm -q amazon-ssm-agent amazon-efs-utils amazon-cloudwatch-agent git docker
+which mysql nc
+
+# 5. Check boot time improvement
+systemd-analyze blame | head -5
+# Expected: cloud-final.service < 2 min (vs ~8 min on stock AMI)
+
+# 6. Confirm ECS agent registered
+curl -s http://localhost:51678/v1/metadata | python -m json.tool
+# Expected: valid JSON with Cluster name matching expected cluster
+```
+
+---
+
+## Configuration
+
+### Terraform Variables
+
+| Variable | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `use_custom_ami` | `bool` | `false` | Feature flag: enable/disable Image Builder and custom AMI usage |
+| `custom_ami_version` | `string` | `"1.0.0"` | Component and recipe version; bump to force new resources |
+
+### AMI Build Pipeline Settings (EC2 Image Builder)
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| Build instance type | `t3.medium` | Sufficient for yum + downloads; same family as production |
+| Build subnet | `aws_subnet.public1` | Public IP for internet access; avoids NAT gateway cost |
+| Build security group | `aws_security_group.ecs` | Allows all egress for package downloads |
+| Terminate on failure | `true` | Clean up failed build instances automatically |
+| Schedule | `cron(0 3 1 * ? *)` | 1st of each month, 03:00 UTC (12:00 JST) |
+| Test timeout | 60 minutes | Allows time for test phase instance boot and validation |
+| AMI encryption | AWS-managed CMK | Default encryption for EBS snapshots |
+| Root volume | 30 GB, gp3 | Matches production launch template configuration |
+
+### Lifecycle Policy Settings
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| Action | DELETE | Remove old AMIs and their snapshots |
+| Age threshold | 90 days | Retains ~3 monthly builds for rollback |
+| Resource selection | Tag filter: `Service=image-builder`, `Project=optinist-cloud` | Scoped to Image Builder AMIs only |
+
+### S3 Log Retention
+
+| Prefix | Expiration | Purpose |
+|--------|-----------|---------|
+| `image-builder-logs/` | 30 days (noncurrent: 7 days) | Build instance logs from Image Builder |
+
+---
+
+## Monitoring and Metrics
+
+### Build Logs
+
+**Location:** S3 bucket `{env_prefix}-optinist-cloud-storage/image-builder-logs/`
+**Retention:** 30 days (auto-expire via S3 lifecycle rule)
+**Content:** AWSTOE step execution output including all `echo` and command output from component YAML steps
+
+### Monitoring AMI Build Status
+
+```bash
+# List recent pipeline executions
+aws imagebuilder list-image-pipeline-images \
+  --image-pipeline-arn <PIPELINE_ARN> \
+  --region ap-northeast-1
+
+# Check specific image build status
+aws imagebuilder get-image \
+  --image-build-version-arn <IMAGE_ARN> \
+  --region ap-northeast-1 \
+  --query 'image.state'
+```
+
+### Key Log Events (in `/var/log/ecs-setup.log`)
+
+**Pre-baked AMI detected:**
+```
+<timestamp>: Pre-baked AMI detected, skipping package installation
+BAKED_DATE=2026-04-21T03:15:22Z
+BAKED_BY=ec2-image-builder
+PACKAGES=amazon-ssm-agent,mysql,...
+```
+
+**Stock AMI fallback:**
+```
+<timestamp>: Stock AMI detected, installing packages
+<timestamp>: Package installation complete
+```
+
+---
+
+## Provisional Items and Future Improvements
+
+The following aspects of the current implementation are provisional and planned for enhancement:
+
+### 1. SSM Parameter Update Automation (Not Yet Implemented)
+
+**Current state:** After each pipeline build (cron or manual), an operator must manually:
+1. Find the new AMI ID from the pipeline output
+2. Run `aws ssm put-parameter` to update the SSM parameter
+3. Run `terraform apply` to update launch templates
+
+**Planned automation:**
+- EventBridge rule to capture Image Builder pipeline completion events
+- Lambda function to extract the AMI ID and update the SSM parameter
+- The IAM policy for `ssm:PutParameter` is already provisioned on the build instance role in anticipation of this automation
+
+### 2. Active Instance Replacement
+
+**Current state:** After switching AMI, existing running instances continue on the old AMI until naturally replaced:
+- Free tier: ASG `instance_refresh` performs rolling replacement
+- Premium: instances are replaced on next user assignment cycle or termination
+- Background: Terraform recreates the instance on `apply`
+
+**Consideration:** No forced replacement mechanism exists for premium instances currently in use. They will pick up the new AMI on next cold start.
+
+### 3. ECR Image Pre-Pull at Bake Time
+
+**Current state:** Docker images are pulled from ECR at boot time in user-data. This takes ~1-2 minutes.
+
+**Potential improvement:** Pre-pull the application Docker image during AMI bake. This would require the build instance to have ECR access and would couple AMI builds to application deployments (bake-on-deploy model).
+
+---
+
+## AWS Resources
+
+All resource names are prefixed with the Terraform `environment` variable (shown here as `{env_prefix}`).
+
+### IAM
+
+| Resource | Name | Purpose |
+|----------|------|---------|
+| IAM Role | `{env_prefix}-image-builder-role` | EC2 trust policy for build instances |
+| Instance Profile | `{env_prefix}-image-builder-profile` | Attached to build EC2 instances |
+| IAM Role | `{env_prefix}-imagebuilder-lifecycle-role` | Lifecycle policy execution role |
+
+**Managed policies on build role:**
+- `EC2InstanceProfileForImageBuilder`
+- `AmazonSSMManagedInstanceCore`
+
+**Inline policies on build role:**
+- SSM `PutParameter` + `GetParameter` on `parameter/${environment}/optinist/custom-ami-id`
+- S3 `PutObject` on `{app_storage_bucket}/image-builder-logs/*`
+
+### EC2 Image Builder
+
+| Resource | Name | Purpose |
+|----------|------|---------|
+| Component | `{env_prefix}-packages-v{version}` | Build component (package installation) |
+| Component | `{env_prefix}-validate-v{version}` | Validation component |
+| Recipe | `{env_prefix}-ecs-recipe-v{version}` | AMI recipe (base AMI + components + EBS config) |
+| Infrastructure Config | `{env_prefix}-image-builder-infra` | Build instance configuration |
+| Distribution Config | `{env_prefix}-image-distribution` | AMI distribution settings |
+| Pipeline | `{env_prefix}-ami-pipeline` | Monthly build orchestration |
+| Lifecycle Policy | `{env_prefix}-ami-lifecycle` | 90-day AMI retention |
+
+### SSM
+
+| Parameter | Purpose |
+|-----------|---------|
+| `/{environment}/optinist/custom-ami-id` | Active custom AMI ID (initially set to stock AMI) |
+
+### Terraform Outputs
+
+| Output | Description | Sensitive |
+|--------|-------------|-----------|
+| `image_builder_pipeline_arn` | Pipeline ARN (for manual execution) | No |
+| `custom_ami_ssm_parameter` | SSM parameter name | No |
+| `effective_ami_id` | Currently active AMI ID | Yes |
+| `ami_source` | "custom (Image Builder)" or "stock (Amazon ECS-optimized)" | No |
+
+---
+
+## Cost Estimate
+
+| Resource | Monthly Cost |
+|----------|-------------|
+| Pipeline execution (t3.medium, ~20 min/month) | ~$0.10 |
+| AMI storage (3 retained, ~8 GB snapshot each) | ~$1.20 |
+| S3 build logs (auto-expire 30 days) | < $0.01 |
+| **Total** | **~$1.30/month** |
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `infrastructure/terraform/compute.tf` | Custom AMI selection logic (`local.effective_ami_id`), free and premium launch templates |
+| `infrastructure/scripts/ecs-user-data.sh` | Bake marker detection and conditional package installation |
+| `infrastructure/terraform/image_builder.tf` | EC2 Image Builder Terraform resources (IAM, components, recipe, pipeline, lifecycle, SSM, outputs) |
+| `infrastructure/image_builder/components/optinist-packages.yml` | Build component: package installation steps |
+| `infrastructure/image_builder/components/optinist-validate.yml` | Validate component: installation verification |
+| `infrastructure/terraform/background_service.tf` | Background launch template (uses `local.effective_ami_id`) |
+| `infrastructure/terraform/main.tf` | Variable definitions (`use_custom_ami`, `custom_ami_version`) |
+| `infrastructure/terraform/infrastructure.tf` | S3 lifecycle rule for `image-builder-logs/` |
+| `infrastructure/terraform/environments/development.tfvars.example` | Example tfvars with custom AMI settings |
+| `infrastructure/terraform/environments/production.tfvars.example` | Example tfvars with custom AMI settings |

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -9,62 +9,75 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Starting system package update"'
-            - yum update -y
-            - 'echo "$(date): System update complete"'
+            - |
+              set -e
+              echo "$(date): Starting system package update"
+              yum update -y
+              echo "$(date): System update complete"
 
       - name: InstallYumPackages
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Installing yum packages"'
-            - yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
-            - 'echo "$(date): Yum packages installed"'
+            - |
+              set -e
+              echo "$(date): Installing yum packages"
+              yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+              echo "$(date): Yum packages installed"
 
       - name: InstallAWSCLIv2
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Installing AWS CLI v2"'
             - |
+              set -e
+              echo "$(date): Installing AWS CLI v2"
               # Remove awscli v1 if present (no longer in AL2 repos)
               yum remove -y awscli 2>/dev/null || true
+              # Ensure unzip is available (not always present on ECS-optimized AMI)
+              yum install -y unzip
               # Install AWS CLI v2 standalone
-              curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+              curl -fSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
               cd /tmp && unzip -qo awscliv2.zip
               /tmp/aws/install --update
               rm -rf /tmp/aws /tmp/awscliv2.zip
-              # Verify
+              # Verify v2 is installed
               /usr/local/bin/aws --version
-            - 'echo "$(date): AWS CLI v2 installed"'
+              /usr/local/bin/aws --version 2>&1 | grep -q "aws-cli/2"
+              echo "$(date): AWS CLI v2 installed successfully"
 
       - name: EnableDockerService
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Enabling Docker service"'
-            - systemctl enable docker
-            - 'echo "$(date): Docker service enabled"'
+            - |
+              set -e
+              echo "$(date): Enabling Docker service"
+              systemctl enable docker
+              echo "$(date): Docker service enabled"
 
       - name: CreateBakeMarker
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Creating bake marker file"'
             - |
+              set -e
+              echo "$(date): Creating bake marker file"
               cat > /etc/optinist-ami-baked <<MARKER
               BAKED_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
               BAKED_BY=ec2-image-builder
               PACKAGES=amazon-ssm-agent,mysql,amazon-efs-utils,nc,git,docker,amazon-cloudwatch-agent,awscli-v2
               MARKER
               chmod 644 /etc/optinist-ami-baked
-            - 'echo "$(date): Bake marker created"'
+              echo "$(date): Bake marker created"
 
       - name: CleanupYumCache
         action: ExecuteBash
         inputs:
           commands:
-            - 'echo "$(date): Cleaning up yum cache to reduce AMI size"'
-            - yum clean all
-            - rm -rf /var/cache/yum
-            - 'echo "$(date): Cleanup complete"'
+            - |
+              set -e
+              echo "$(date): Cleaning up yum cache to reduce AMI size"
+              yum clean all
+              rm -rf /var/cache/yum
+              echo "$(date): Cleanup complete"

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -1,0 +1,72 @@
+name: optinist-ecs-packages
+description: >
+  Install system packages and AWS CLI v2 for OptiNiSt ECS instances.
+  Eliminates ~4-6 min of yum install from every instance boot.
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: SystemUpdate
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Starting system package update"
+            - yum update -y
+            - echo "$(date): System update complete"
+
+      - name: InstallYumPackages
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Installing yum packages"
+            - yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+            - echo "$(date): Yum packages installed"
+
+      - name: InstallAWSCLIv2
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Installing AWS CLI v2"
+            - |
+              # Remove awscli v1 if present (no longer in AL2 repos)
+              yum remove -y awscli 2>/dev/null || true
+              # Install AWS CLI v2 standalone
+              curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+              cd /tmp && unzip -qo awscliv2.zip
+              /tmp/aws/install --update
+              rm -rf /tmp/aws /tmp/awscliv2.zip
+              # Verify
+              /usr/local/bin/aws --version
+            - echo "$(date): AWS CLI v2 installed"
+
+      - name: EnableDockerService
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Enabling Docker service"
+            - systemctl enable docker
+            - echo "$(date): Docker service enabled"
+
+      - name: CreateBakeMarker
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Creating bake marker file"
+            - |
+              cat > /etc/optinist-ami-baked <<MARKER
+              BAKED_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+              BAKED_BY=ec2-image-builder
+              PACKAGES=amazon-ssm-agent,mysql,amazon-efs-utils,nc,git,docker,amazon-cloudwatch-agent,awscli-v2
+              MARKER
+              chmod 644 /etc/optinist-ami-baked
+            - echo "$(date): Bake marker created"
+
+      - name: CleanupYumCache
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "$(date): Cleaning up yum cache to reduce AMI size"
+            - yum clean all
+            - rm -rf /var/cache/yum
+            - echo "$(date): Cleanup complete"

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -1,7 +1,5 @@
 name: optinist-ecs-packages
-description: >
-  Install system packages and AWS CLI v2 for OptiNiSt ECS instances.
-  Eliminates ~4-6 min of yum install from every instance boot.
+description: "Install system packages and AWS CLI v2 for OptiNiSt ECS instances. Eliminates ~4-6 min of yum install from every instance boot."
 schemaVersion: 1.0
 
 phases:
@@ -11,23 +9,23 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Starting system package update"
+            - 'echo "$(date): Starting system package update"'
             - yum update -y
-            - echo "$(date): System update complete"
+            - 'echo "$(date): System update complete"'
 
       - name: InstallYumPackages
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Installing yum packages"
+            - 'echo "$(date): Installing yum packages"'
             - yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
-            - echo "$(date): Yum packages installed"
+            - 'echo "$(date): Yum packages installed"'
 
       - name: InstallAWSCLIv2
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Installing AWS CLI v2"
+            - 'echo "$(date): Installing AWS CLI v2"'
             - |
               # Remove awscli v1 if present (no longer in AL2 repos)
               yum remove -y awscli 2>/dev/null || true
@@ -38,21 +36,21 @@ phases:
               rm -rf /tmp/aws /tmp/awscliv2.zip
               # Verify
               /usr/local/bin/aws --version
-            - echo "$(date): AWS CLI v2 installed"
+            - 'echo "$(date): AWS CLI v2 installed"'
 
       - name: EnableDockerService
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Enabling Docker service"
+            - 'echo "$(date): Enabling Docker service"'
             - systemctl enable docker
-            - echo "$(date): Docker service enabled"
+            - 'echo "$(date): Docker service enabled"'
 
       - name: CreateBakeMarker
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Creating bake marker file"
+            - 'echo "$(date): Creating bake marker file"'
             - |
               cat > /etc/optinist-ami-baked <<MARKER
               BAKED_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -60,13 +58,13 @@ phases:
               PACKAGES=amazon-ssm-agent,mysql,amazon-efs-utils,nc,git,docker,amazon-cloudwatch-agent,awscli-v2
               MARKER
               chmod 644 /etc/optinist-ami-baked
-            - echo "$(date): Bake marker created"
+            - 'echo "$(date): Bake marker created"'
 
       - name: CleanupYumCache
         action: ExecuteBash
         inputs:
           commands:
-            - echo "$(date): Cleaning up yum cache to reduce AMI size"
+            - 'echo "$(date): Cleaning up yum cache to reduce AMI size"'
             - yum clean all
             - rm -rf /var/cache/yum
-            - echo "$(date): Cleanup complete"
+            - 'echo "$(date): Cleanup complete"'

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -1,0 +1,128 @@
+name: optinist-ecs-validate
+description: >
+  Validate that all required packages are correctly installed
+  in the OptiNiSt ECS AMI.
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: ValidateYumPackages
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating yum package installations ==="
+            - |
+              FAILED=0
+              for pkg in amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent; do
+                if rpm -q "$pkg" >/dev/null 2>&1 || which "$pkg" >/dev/null 2>&1; then
+                  echo "OK: $pkg"
+                else
+                  echo "FAIL: $pkg not found"
+                  FAILED=1
+                fi
+              done
+              if [ $FAILED -ne 0 ]; then
+                echo "One or more yum packages failed validation"
+                exit 1
+              fi
+              echo "All yum packages validated successfully"
+
+      - name: ValidateAWSCLIv2
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating AWS CLI v2 ==="
+            - |
+              if /usr/local/bin/aws --version 2>&1 | grep -q "aws-cli/2"; then
+                echo "OK: AWS CLI v2 found"
+                /usr/local/bin/aws --version
+              else
+                echo "AWS CLI v2 not found or wrong version"
+                exit 1
+              fi
+
+      - name: ValidateDockerEnabled
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating Docker service ==="
+            - |
+              if systemctl is-enabled docker >/dev/null 2>&1; then
+                echo "OK: Docker service is enabled"
+              else
+                echo "Docker service is not enabled"
+                exit 1
+              fi
+
+      - name: ValidateBakeMarker
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating bake marker ==="
+            - |
+              if [ -f /etc/optinist-ami-baked ]; then
+                echo "OK: Bake marker found"
+                cat /etc/optinist-ami-baked
+              else
+                echo "Bake marker /etc/optinist-ami-baked not found"
+                exit 1
+              fi
+
+      - name: ValidateEFSUtils
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating EFS mount helper ==="
+            - |
+              if [ -f /usr/bin/mount.efs ] || [ -f /sbin/mount.efs ]; then
+                echo "OK: EFS mount helper found"
+              else
+                echo "EFS mount helper (mount.efs) not found"
+                exit 1
+              fi
+
+  - name: test
+    steps:
+      - name: TestBakeMarkerPersisted
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Testing bake marker on fresh instance from AMI ==="
+            - |
+              if [ -f /etc/optinist-ami-baked ]; then
+                echo "OK: Bake marker persisted in AMI"
+                cat /etc/optinist-ami-baked
+              else
+                echo "Bake marker did not persist into AMI"
+                exit 1
+              fi
+
+      - name: TestDockerStarts
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Testing Docker can start ==="
+            - |
+              systemctl start docker
+              sleep 5
+              if systemctl is-active docker >/dev/null 2>&1; then
+                echo "OK: Docker started successfully"
+                docker info --format '{{.ServerVersion}}'
+              else
+                echo "Docker failed to start"
+                exit 1
+              fi
+              systemctl stop docker
+
+      - name: TestAWSCLIFunctional
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Testing AWS CLI functionality ==="
+            - |
+              if /usr/local/bin/aws sts get-caller-identity >/dev/null 2>&1; then
+                echo "OK: AWS CLI can make API calls"
+              else
+                echo "WARN: AWS CLI API call failed (expected if no instance role during test)"
+              fi

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -30,13 +30,22 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - echo "=== Validating AWS CLI v2 ==="
             - |
+              echo "=== Validating AWS CLI v2 ==="
+              # Diagnostic: show what exists at expected paths
+              echo "Checking /usr/local/bin/aws:"
+              ls -la /usr/local/bin/aws 2>&1 || echo "  Not found at /usr/local/bin/aws"
+              echo "Checking /usr/local/aws-cli/:"
+              ls -la /usr/local/aws-cli/ 2>&1 || echo "  /usr/local/aws-cli/ not found"
+              echo "Checking which aws:"
+              which aws 2>&1 || echo "  aws not in PATH"
+              # Actual validation
               if /usr/local/bin/aws --version 2>&1 | grep -q "aws-cli/2"; then
                 echo "OK: AWS CLI v2 found"
                 /usr/local/bin/aws --version
               else
-                echo "AWS CLI v2 not found or wrong version"
+                echo "FAIL: AWS CLI v2 not found or wrong version"
+                /usr/local/bin/aws --version 2>&1 || true
                 exit 1
               fi
 

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -1,7 +1,5 @@
 name: optinist-ecs-validate
-description: >
-  Validate that all required packages are correctly installed
-  in the OptiNiSt ECS AMI.
+description: "Validate that all required packages are correctly installed in the OptiNiSt ECS AMI."
 schemaVersion: 1.0
 
 phases:
@@ -108,7 +106,7 @@ phases:
               sleep 5
               if systemctl is-active docker >/dev/null 2>&1; then
                 echo "OK: Docker started successfully"
-                docker info --format '{{.ServerVersion}}'
+                docker --version
               else
                 echo "Docker failed to start"
                 exit 1

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -29,9 +29,23 @@ UNIT_EOF
 systemctl daemon-reload
 systemctl enable ecs-clear-checkpoint.service
 
-# Install packages
-yum update -y
-yum install -y amazon-ssm-agent mysql amazon-efs-utils nc mysql-client git docker amazon-cloudwatch-agent awscli
+# Install packages (skip if AMI is pre-baked by Image Builder)
+if [ -f /etc/optinist-ami-baked ]; then
+    echo "$(date): Pre-baked AMI detected, skipping package installation"
+    cat /etc/optinist-ami-baked
+    # AWS CLI v2 installed to /usr/local/bin by Image Builder
+    export PATH="/usr/local/bin:$PATH"
+else
+    echo "$(date): Stock AMI detected, installing packages"
+    yum update -y
+    yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+    # Install AWS CLI v2 (awscli v1 package no longer available in AL2 repos)
+    curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+    cd /tmp && unzip -qo awscliv2.zip
+    /tmp/aws/install --update
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+    echo "$(date): Package installation complete"
+fi
 
 # Setup swap as memory safety net (defense-in-depth for OOM prevention)
 # This provides a buffer before OOM killer activates, giving workflows

--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -16,7 +16,7 @@
 # ===========================
 resource "aws_launch_template" "background" {
   name_prefix   = "${local.env_prefix}-background-"
-  image_id      = data.aws_ami.ecs_optimized.id
+  image_id      = local.effective_ami_id
   instance_type = var.background_instance_type
 
   vpc_security_group_ids = [aws_security_group.ecs.id]

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -120,9 +120,23 @@ data "aws_ami" "ecs_optimized" {
   }
 }
 
+# Custom AMI from Image Builder (when enabled)
+data "aws_ssm_parameter" "custom_ami_id" {
+  count = var.use_custom_ami ? 1 : 0
+  name  = "/${var.environment}/optinist/custom-ami-id"
+}
+
+locals {
+  effective_ami_id = (
+    var.use_custom_ami
+    ? data.aws_ssm_parameter.custom_ami_id[0].value
+    : data.aws_ami.ecs_optimized.id
+  )
+}
+
 resource "aws_launch_template" "ecs" {
   name_prefix   = "${local.env_prefix}-ecs-"
-  image_id      = data.aws_ami.ecs_optimized.id
+  image_id      = local.effective_ami_id
   instance_type = var.free_instance_type
   key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
 
@@ -342,7 +356,7 @@ resource "aws_ecs_service" "premium" {
 # Premium Launch Template - Optimized for dedicated premium users
 resource "aws_launch_template" "premium" {
   name_prefix   = "${local.env_prefix}-premium-"
-  image_id      = data.aws_ami.ecs_optimized.id
+  image_id      = local.effective_ami_id
   instance_type = var.premium_instance_type
   key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
 

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -121,9 +121,12 @@ data "aws_ami" "ecs_optimized" {
 }
 
 # Custom AMI from Image Builder (when enabled)
+# depends_on ensures the SSM parameter resource is created before this
+# data source tries to read it on first apply with use_custom_ami = true.
 data "aws_ssm_parameter" "custom_ami_id" {
-  count = var.use_custom_ami ? 1 : 0
-  name  = "/${var.environment}/optinist/custom-ami-id"
+  count      = var.use_custom_ami ? 1 : 0
+  name       = "/${var.environment}/optinist/custom-ami-id"
+  depends_on = [aws_ssm_parameter.custom_ami_id]
 }
 
 locals {

--- a/infrastructure/terraform/environments/development.tfvars.example
+++ b/infrastructure/terraform/environments/development.tfvars.example
@@ -84,6 +84,12 @@ asg_min_size         = 1
 asg_max_size         = 2
 asg_desired_capacity = 1
 
+# EC2 Image Builder — Custom AMI (reduces instance boot from ~8 min to ~2 min)
+# Set to true after initial terraform apply to create the Image Builder pipeline.
+# See image_builder.tf for deployment workflow.
+use_custom_ami = false
+# custom_ami_version = "1.0.0"   # Bump to force a new AMI build
+
 # No test users initially
 test_users = []
 

--- a/infrastructure/terraform/environments/production.tfvars.example
+++ b/infrastructure/terraform/environments/production.tfvars.example
@@ -81,6 +81,12 @@ EOT
 # ASG configuration
 asg_max_size = 3
 
+# EC2 Image Builder — Custom AMI (reduces instance boot from ~8 min to ~2 min)
+# Set to true after initial terraform apply to create the Image Builder pipeline.
+# See image_builder.tf for deployment workflow.
+use_custom_ami = false
+# custom_ami_version = "1.0.0"   # Bump to force a new AMI build
+
 # Test user configuration
 test_users = []
 

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -394,6 +394,7 @@ output "custom_ami_ssm_parameter" {
 output "effective_ami_id" {
   description = "The AMI ID currently used by launch templates"
   value       = local.effective_ami_id
+  sensitive   = true
 }
 
 output "ami_source" {

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -1,0 +1,374 @@
+# ================================================
+# EC2 Image Builder — Custom ECS-Optimized AMI
+# ================================================
+#
+# Builds a pre-baked AMI with all system packages (yum, AWS CLI v2, Docker,
+# CloudWatch agent, etc.) already installed.  This eliminates ~5 min of
+# yum install/update from every instance first-boot, reducing ECS agent
+# startup from ~8 min to ~2 min.
+#
+# Gated by var.use_custom_ami (default false).  When disabled, launch
+# templates fall back to the stock Amazon ECS-optimized AMI.
+
+# =====================
+# IAM — Build Instance
+# =====================
+resource "aws_iam_role" "image_builder" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name = "${local.env_prefix}-image-builder-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = {
+    Name    = "${local.env_prefix}-image-builder-role"
+    Service = "image-builder"
+  }
+}
+
+resource "aws_iam_instance_profile" "image_builder" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name = "${local.env_prefix}-image-builder-profile"
+  role = aws_iam_role.image_builder[0].name
+}
+
+resource "aws_iam_role_policy_attachment" "image_builder_ec2" {
+  count = var.use_custom_ami ? 1 : 0
+
+  role       = aws_iam_role.image_builder[0].name
+  policy_arn = "arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder"
+}
+
+resource "aws_iam_role_policy_attachment" "image_builder_ssm" {
+  count = var.use_custom_ami ? 1 : 0
+
+  role       = aws_iam_role.image_builder[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Allow build instance to write AMI ID to SSM Parameter Store
+resource "aws_iam_role_policy" "image_builder_ssm_param" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name = "${local.env_prefix}-image-builder-ssm-param"
+  role = aws_iam_role.image_builder[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssm:PutParameter",
+        "ssm:GetParameter"
+      ]
+      Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment}/optinist/custom-ami-id"
+    }]
+  })
+}
+
+# ==========================
+# IAM — Lifecycle Execution
+# ==========================
+resource "aws_iam_role" "image_builder_lifecycle" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name = "${local.env_prefix}-imagebuilder-lifecycle-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "imagebuilder.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = {
+    Name    = "${local.env_prefix}-imagebuilder-lifecycle-role"
+    Service = "image-builder"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "image_builder_lifecycle" {
+  count = var.use_custom_ami ? 1 : 0
+
+  role       = aws_iam_role.image_builder_lifecycle[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/EC2ImageBuilderLifecycleExecutionPolicy"
+}
+
+# ==========
+# Components
+# ==========
+resource "aws_imagebuilder_component" "optinist_packages" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "${local.env_prefix}-packages"
+  platform    = "Linux"
+  version     = var.custom_ami_version
+  description = "Install system packages and AWS CLI v2 for OptiNiSt ECS instances"
+
+  supported_os_versions = ["Amazon Linux 2"]
+
+  data = file("${path.module}/../image_builder/components/optinist-packages.yml")
+
+  tags = {
+    Name    = "${local.env_prefix}-packages-component"
+    Service = "image-builder"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_imagebuilder_component" "optinist_validate" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "${local.env_prefix}-validate"
+  platform    = "Linux"
+  version     = var.custom_ami_version
+  description = "Validate OptiNiSt ECS AMI package installations"
+
+  supported_os_versions = ["Amazon Linux 2"]
+
+  data = file("${path.module}/../image_builder/components/optinist-validate.yml")
+
+  tags = {
+    Name    = "${local.env_prefix}-validate-component"
+    Service = "image-builder"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============
+# Image Recipe
+# ============
+resource "aws_imagebuilder_image_recipe" "optinist" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name         = "${local.env_prefix}-ecs-recipe"
+  parent_image = data.aws_ami.ecs_optimized.id
+  version      = var.custom_ami_version
+  description  = "ECS-optimized AMI with pre-installed OptiNiSt packages"
+
+  component {
+    component_arn = aws_imagebuilder_component.optinist_packages[0].arn
+  }
+
+  component {
+    component_arn = aws_imagebuilder_component.optinist_validate[0].arn
+  }
+
+  block_device_mapping {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size           = 30
+      volume_type           = "gp3"
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+
+  tags = {
+    Name    = "${local.env_prefix}-ecs-recipe"
+    Service = "image-builder"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============================
+# Infrastructure Configuration
+# ============================
+resource "aws_imagebuilder_infrastructure_configuration" "optinist" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name                          = "${local.env_prefix}-image-builder-infra"
+  instance_profile_name         = aws_iam_instance_profile.image_builder[0].name
+  instance_types                = ["t3.medium"]
+  subnet_id                     = aws_subnet.public1.id
+  security_group_ids            = [aws_security_group.ecs.id]
+  terminate_instance_on_failure = true
+
+  logging {
+    s3_logs {
+      s3_bucket_name = aws_s3_bucket.app_storage.id
+      s3_key_prefix  = "image-builder-logs"
+    }
+  }
+
+  tags = {
+    Name    = "${local.env_prefix}-image-builder-infra"
+    Service = "image-builder"
+  }
+}
+
+# ==========================
+# Distribution Configuration
+# ==========================
+resource "aws_imagebuilder_distribution_configuration" "optinist" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "${local.env_prefix}-image-distribution"
+  description = "Distribute OptiNiSt custom AMI within region"
+
+  distribution {
+    region = var.aws_region
+
+    ami_distribution_configuration {
+      name        = "${local.env_prefix}-ecs-{{ imagebuilder:buildDate }}"
+      description = "OptiNiSt ECS-optimized AMI built {{ imagebuilder:buildDate }}"
+
+      ami_tags = {
+        Name        = "${local.env_prefix}-ecs-custom-ami"
+        Service     = "image-builder"
+        Environment = local.environment_label
+        BaseAMI     = data.aws_ami.ecs_optimized.id
+      }
+
+      launch_permission {
+        user_ids = [data.aws_caller_identity.current.account_id]
+      }
+    }
+  }
+
+  tags = {
+    Name    = "${local.env_prefix}-image-distribution"
+    Service = "image-builder"
+  }
+}
+
+# ==============
+# Image Pipeline
+# ==============
+resource "aws_imagebuilder_image_pipeline" "optinist" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "${local.env_prefix}-ami-pipeline"
+  description = "Monthly AMI build for OptiNiSt ECS instances"
+  status      = "ENABLED"
+
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.optinist[0].arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.optinist[0].arn
+  distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.optinist[0].arn
+
+  # Monthly rebuild: 1st of each month at 03:00 UTC (12:00 JST)
+  schedule {
+    schedule_expression                = "cron(0 3 1 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
+  }
+
+  image_tests_configuration {
+    image_tests_enabled = true
+    timeout_minutes     = 60
+  }
+
+  tags = {
+    Name    = "${local.env_prefix}-ami-pipeline"
+    Service = "image-builder"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.image_builder_ec2,
+    aws_iam_role_policy_attachment.image_builder_ssm,
+  ]
+}
+
+# ====================
+# AMI Lifecycle Policy
+# ====================
+resource "aws_imagebuilder_lifecycle_policy" "optinist_cleanup" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "${local.env_prefix}-ami-lifecycle"
+  description = "Retain AMIs for 90 days, delete older ones (~3 monthly builds)"
+  status      = "ENABLED"
+
+  resource_type = "AMI_IMAGE"
+
+  execution_role = aws_iam_role.image_builder_lifecycle[0].arn
+
+  policy_detail {
+    action {
+      type = "DELETE"
+    }
+    filter {
+      type  = "AGE"
+      value = 90
+      unit  = "DAYS"
+    }
+  }
+
+  resource_selection {
+    tag_map = {
+      Service = "image-builder"
+      Project = "optinist-cloud"
+    }
+  }
+
+  tags = {
+    Name    = "${local.env_prefix}-ami-lifecycle"
+    Service = "image-builder"
+  }
+}
+
+# ==============
+# SSM Parameter
+# ==============
+resource "aws_ssm_parameter" "custom_ami_id" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name        = "/${var.environment}/optinist/custom-ami-id"
+  type        = "String"
+  value       = "pending-first-build"
+  description = "Latest custom AMI ID from EC2 Image Builder"
+
+  tags = {
+    Name    = "Custom AMI ID"
+    Service = "image-builder"
+  }
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# =======
+# Outputs
+# =======
+output "image_builder_pipeline_arn" {
+  description = "ARN of the EC2 Image Builder pipeline"
+  value       = var.use_custom_ami ? aws_imagebuilder_image_pipeline.optinist[0].arn : null
+}
+
+output "custom_ami_ssm_parameter" {
+  description = "SSM parameter name for custom AMI ID"
+  value       = var.use_custom_ami ? "/${var.environment}/optinist/custom-ami-id" : null
+}
+
+output "effective_ami_id" {
+  description = "The AMI ID currently used by launch templates"
+  value       = local.effective_ami_id
+}
+
+output "ami_source" {
+  description = "Whether using custom or stock AMI"
+  value       = var.use_custom_ami ? "custom (Image Builder)" : "stock (Amazon ECS-optimized)"
+}

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -56,7 +56,10 @@ resource "aws_iam_role_policy_attachment" "image_builder_ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
-# Allow build instance to write AMI ID to SSM Parameter Store
+# Allow build instance to access SSM Parameter Store.
+# Note: PutParameter is not used at build time (the build instance cannot know
+# the output AMI ID).  Retained for future EventBridge → Lambda automation that
+# will write the AMI ID after pipeline completion.
 resource "aws_iam_role_policy" "image_builder_ssm_param" {
   count = var.use_custom_ami ? 1 : 0
 
@@ -72,6 +75,24 @@ resource "aws_iam_role_policy" "image_builder_ssm_param" {
         "ssm:GetParameter"
       ]
       Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment}/optinist/custom-ami-id"
+    }]
+  })
+}
+
+# Allow build instance to write logs to S3
+# (EC2InstanceProfileForImageBuilder only covers ec2imagebuilder-* buckets)
+resource "aws_iam_role_policy" "image_builder_s3_logs" {
+  count = var.use_custom_ami ? 1 : 0
+
+  name = "${local.env_prefix}-image-builder-s3-logs"
+  role = aws_iam_role.image_builder[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:PutObject"]
+      Resource = "${aws_s3_bucket.app_storage.arn}/image-builder-logs/*"
     }]
   })
 }
@@ -114,7 +135,7 @@ resource "aws_iam_role_policy_attachment" "image_builder_lifecycle" {
 resource "aws_imagebuilder_component" "optinist_packages" {
   count = var.use_custom_ami ? 1 : 0
 
-  name        = "${local.env_prefix}-packages"
+  name        = "${local.env_prefix}-packages-v${replace(var.custom_ami_version, ".", "-")}"
   platform    = "Linux"
   version     = var.custom_ami_version
   description = "Install system packages and AWS CLI v2 for OptiNiSt ECS instances"
@@ -136,7 +157,7 @@ resource "aws_imagebuilder_component" "optinist_packages" {
 resource "aws_imagebuilder_component" "optinist_validate" {
   count = var.use_custom_ami ? 1 : 0
 
-  name        = "${local.env_prefix}-validate"
+  name        = "${local.env_prefix}-validate-v${replace(var.custom_ami_version, ".", "-")}"
   platform    = "Linux"
   version     = var.custom_ami_version
   description = "Validate OptiNiSt ECS AMI package installations"
@@ -161,7 +182,7 @@ resource "aws_imagebuilder_component" "optinist_validate" {
 resource "aws_imagebuilder_image_recipe" "optinist" {
   count = var.use_custom_ami ? 1 : 0
 
-  name         = "${local.env_prefix}-ecs-recipe"
+  name         = "${local.env_prefix}-ecs-recipe-v${replace(var.custom_ami_version, ".", "-")}"
   parent_image = data.aws_ami.ecs_optimized.id
   version      = var.custom_ami_version
   description  = "ECS-optimized AMI with pre-installed OptiNiSt packages"
@@ -189,8 +210,12 @@ resource "aws_imagebuilder_image_recipe" "optinist" {
     Service = "image-builder"
   }
 
+  # Recipes are immutable.  ignore parent_image to prevent forced
+  # recreation when Amazon publishes a new ECS-optimized AMI.
+  # Bump custom_ami_version to pick up a newer base AMI.
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [parent_image]
   }
 }
 
@@ -200,9 +225,10 @@ resource "aws_imagebuilder_image_recipe" "optinist" {
 resource "aws_imagebuilder_infrastructure_configuration" "optinist" {
   count = var.use_custom_ami ? 1 : 0
 
-  name                          = "${local.env_prefix}-image-builder-infra"
-  instance_profile_name         = aws_iam_instance_profile.image_builder[0].name
-  instance_types                = ["t3.medium"]
+  name                  = "${local.env_prefix}-image-builder-infra"
+  instance_profile_name = aws_iam_instance_profile.image_builder[0].name
+  instance_types        = ["t3.medium"]
+  # Public subnet for simplicity; consider private subnet + NAT for production hardening
   subnet_id                     = aws_subnet.public1.id
   security_group_ids            = [aws_security_group.ecs.id]
   terminate_instance_on_failure = true
@@ -239,6 +265,7 @@ resource "aws_imagebuilder_distribution_configuration" "optinist" {
       ami_tags = {
         Name        = "${local.env_prefix}-ecs-custom-ami"
         Service     = "image-builder"
+        Project     = "optinist-cloud"
         Environment = local.environment_label
         BaseAMI     = data.aws_ami.ecs_optimized.id
       }
@@ -288,6 +315,7 @@ resource "aws_imagebuilder_image_pipeline" "optinist" {
   depends_on = [
     aws_iam_role_policy_attachment.image_builder_ec2,
     aws_iam_role_policy_attachment.image_builder_ssm,
+    aws_iam_role_policy.image_builder_s3_logs,
   ]
 }
 
@@ -337,8 +365,8 @@ resource "aws_ssm_parameter" "custom_ami_id" {
 
   name        = "/${var.environment}/optinist/custom-ami-id"
   type        = "String"
-  value       = "pending-first-build"
-  description = "Latest custom AMI ID from EC2 Image Builder"
+  value       = data.aws_ami.ecs_optimized.id
+  description = "Latest custom AMI ID from EC2 Image Builder (initially set to stock AMI)"
 
   tags = {
     Name    = "Custom AMI ID"

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -270,9 +270,10 @@ resource "aws_imagebuilder_distribution_configuration" "optinist" {
         BaseAMI     = data.aws_ami.ecs_optimized.id
       }
 
-      launch_permission {
-        user_ids = [data.aws_caller_identity.current.account_id]
-      }
+      # No launch_permission needed — AMIs are automatically available
+      # to the account that creates them.  Explicitly setting user_ids
+      # triggers "sharing" logic, which conflicts with AWS-managed CMK
+      # encrypted snapshots.
     }
   }
 

--- a/infrastructure/terraform/infrastructure.tf
+++ b/infrastructure/terraform/infrastructure.tf
@@ -420,6 +420,23 @@ resource "aws_s3_bucket_lifecycle_configuration" "app_storage" {
       noncurrent_days = 7
     }
   }
+
+  rule {
+    id     = "expire-image-builder-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "image-builder-logs/"
+    }
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
 }
 
 # Block all public access to S3

--- a/infrastructure/terraform/lambda_layers.tf
+++ b/infrastructure/terraform/lambda_layers.tf
@@ -12,29 +12,17 @@
 # Lambda functions. Using a layer avoids code duplication and ensures
 # all Lambdas use the same constant values.
 
-# Create the layer directory structure
-# Lambda layers for Python must have files under python/ directory
-resource "null_resource" "prepare_aws_constants_layer" {
-  provisioner "local-exec" {
-    command = <<-EOT
-      mkdir -p ${path.module}/aws_constants_layer/python
-      cp ${path.module}/../aws_constants.py ${path.module}/aws_constants_layer/python/aws_constants.py
-    EOT
-  }
-
-  triggers = {
-    # Rebuild layer when aws_constants.py changes
-    code_hash = filesha256("${path.module}/../aws_constants.py")
-  }
-}
-
 # Create ZIP for the layer
+# Uses inline source block so the archive is built at plan time without
+# needing a pre-existing directory (avoids null_resource chicken-and-egg).
 data "archive_file" "aws_constants_layer_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/aws_constants_layer"
   output_path = "${path.module}/aws_constants_layer.zip"
 
-  depends_on = [null_resource.prepare_aws_constants_layer]
+  source {
+    content  = file("${path.module}/../aws_constants.py")
+    filename = "python/aws_constants.py"
+  }
 }
 
 # Create the Lambda Layer

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -292,6 +292,18 @@ variable "dev_schedule_stop_mode" {
   }
 }
 
+variable "use_custom_ami" {
+  description = "Use pre-baked custom AMI from Image Builder instead of stock ECS-optimized AMI"
+  type        = bool
+  default     = false
+}
+
+variable "custom_ami_version" {
+  description = "Image Builder recipe version string (bump to force a new AMI build)"
+  type        = string
+  default     = "1.0.0"
+}
+
 # Data sources
 data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -397,11 +397,14 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           }
         }
       },
-      # EC2 CreateTags (unrestricted — needed by RunInstances TagSpecifications)
+      # EC2 CreateTags (needed by RunInstances TagSpecifications for instances and volumes)
       {
-        Effect   = "Allow"
-        Action   = "ec2:CreateTags"
-        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+        Effect = "Allow"
+        Action = "ec2:CreateTags"
+        Resource = [
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+          "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
+        ]
       },
       # EC2 DeleteTags (scoped to ghost cleanup grace period tag only)
       {


### PR DESCRIPTION
## Summary

Add an EC2 Image Builder pipeline that produces a pre-baked ECS-optimized AMI with all system packages already installed. This eliminates ~5 minutes of `yum update` + `yum install` from every instance first-boot, reducing ECS agent startup from ~8 min to ~2 min.

The feature is gated by a `use_custom_ami` variable (default `false`), so it has **zero impact on existing infrastructure** until explicitly enabled.

**Related issue:** #546 — Premium Instance Warm-Up Gap

## Motivation

On the stock Amazon ECS-optimized AMI, `ecs-user-data.sh` runs sequentially on every first boot:

| Step | Time |
|------|------|
| `yum update -y` | ~2 min |
| `yum install` (9 packages) | ~3 min |
| swap file creation | ~30 s |
| docker pull from ECR | ~1-2 min |
| git clone + config | < 30 s |
| **Total** | **~8 min** |

The ECS agent cannot start until `cloud-final.service` (user-data) completes, leaving an ~8-minute window where the instance appears "running" but cannot serve traffic. Pre-baking packages into the AMI removes the dominant `yum` steps from the critical path.

## Changes

### New files

- **`infrastructure/image_builder/components/optinist-packages.yml`** — Build component that installs all yum packages, AWS CLI v2 (standalone), enables Docker, and writes a bake marker (`/etc/optinist-ami-baked`).

- **`infrastructure/image_builder/components/optinist-validate.yml`** — Validation component that verifies all package installations in the build phase and runs integration tests (Docker start, CLI functionality) on a fresh instance launched from the AMI.

- **`infrastructure/terraform/image_builder.tf`** — All Image Builder Terraform resources:
  - IAM role + instance profile for build instances
  - IAM lifecycle execution role for AMI cleanup
  - Build and validation components
  - Image recipe (base: stock ECS-optimized AMI)
  - Infrastructure configuration (t3.medium, public subnet, ECS security group)
  - Distribution configuration (same region, account-scoped)
  - Image pipeline with monthly schedule (`cron(0 3 1 * ? *)` — 1st of each month, 03:00 UTC / 12:00 JST)
  - AMI lifecycle policy (auto-delete after 90 days, retains ~3 builds)
  - SSM parameter for custom AMI ID
  - Outputs: pipeline ARN, SSM parameter name, effective AMI ID, AMI source

### Modified files

- **`infrastructure/terraform/main.tf`** — Add two variables:
  - `use_custom_ami` (bool, default `false`) — toggle custom AMI usage
  - `custom_ami_version` (string, default `"1.0.0"`) — recipe version, bump to force rebuild

- **`infrastructure/terraform/compute.tf`** — Add SSM data source and `local.effective_ami_id` conditional. Update `image_id` in `aws_launch_template.ecs` (free tier) and `aws_launch_template.premium`.

- **`infrastructure/terraform/background_service.tf`** — Update `image_id` in `aws_launch_template.background`.

- **`infrastructure/terraform/infrastructure.tf`** — Add S3 lifecycle rule to auto-expire Image Builder logs after 30 days.

- **`infrastructure/scripts/ecs-user-data.sh`** — Wrap package installation in a bake marker conditional:
  - If `/etc/optinist-ami-baked` exists: skip yum, add `/usr/local/bin` to PATH
  - If not (stock AMI): run yum install + install AWS CLI v2 standalone
  - Also fixes: `awscli` v1 → v2 (v1 package removed from AL2 repos), removes non-existent `mysql-client` package

## Architecture

```
                    ┌──────────────────────────────────────┐
                    │  EC2 Image Builder Pipeline           │
                    │  (monthly: 1st of month, 03:00 UTC)  │
                    │                                      │
                    │  Base: Amazon ECS-optimized AMI       │
                    │    + yum update                       │
                    │    + yum packages (9 packages)        │
                    │    + AWS CLI v2                       │
                    │    + Docker enabled                   │
                    │    + /etc/optinist-ami-baked marker   │
                    │    + validation tests                 │
                    │                                      │
                    │  Output: custom AMI                   │
                    │    → SSM: /${env}/optinist/custom-ami-id
                    └───────────────┬──────────────────────┘
                                    │
                    ┌───────────────▼──────────────────────┐
                    │  Terraform (use_custom_ami = true)    │
                    │                                      │
                    │  local.effective_ami_id               │
                    │    ├── aws_launch_template.ecs        │
                    │    ├── aws_launch_template.premium    │
                    │    └── aws_launch_template.background │
                    └───────────────┬──────────────────────┘
                                    │
                    ┌───────────────▼──────────────────────┐
                    │  ecs-user-data.sh (on boot)          │
                    │                                      │
                    │  if /etc/optinist-ami-baked exists:   │
                    │    → skip yum (already baked)         │
                    │    → ~2 min boot                      │
                    │  else:                                │
                    │    → full yum install + CLI v2        │
                    │    → ~8 min boot (fallback)           │
                    └──────────────────────────────────────┘
```

## Deployment workflow

| Phase | Action | Risk |
|-------|--------|------|
| 1. Safe prep | `terraform apply` with `use_custom_ami = false` (default) | None — user-data `else` path matches current behavior |
| 2. Enable | Set `use_custom_ami = true`, `terraform apply` | Low — pipeline created but AMI not yet used |
| 3. First build | `aws imagebuilder start-image-pipeline-execution ...` | Low — builds in isolation |
| 4. Switch over | Update SSM parameter with AMI ID, `terraform apply` | Medium — launch templates updated, rolling refresh |
| 5. Rollback | Set `use_custom_ami = false`, `terraform apply` | None — reverts to stock AMI |

## Cost impact

| Resource | Monthly |
|----------|---------|
| Pipeline execution (t3.medium, ~20 min) | ~$0.10 |
| AMI storage (3 retained, ~8 GB each) | ~$1.20 |
| S3 logs | < $0.01 |
| **Total** | **~$1.30/month** |

## Deployment verification procedure

### Phase 1: Post-apply resource check

Verify that `terraform apply` created all resources correctly.

**AWS Console checks:**

- [x] **Image Builder pipeline** — EC2 Image Builder → Image pipelines → `{env_prefix}-ami-pipeline` exists, Status = `ENABLED`
- [x] **SSM parameter** — Systems Manager → Parameter Store → `/{environment}/optinist/custom-ami-id` exists, value is a stock AMI ID (`ami-0...`)
- [x] **Launch templates** — EC2 → Launch Templates → `image_id` still uses stock AMI ID (no disruption to running instances)
- [x] **Running instances** — all existing EC2 instances remain operational, no restarts triggered

### Phase 2: First AMI build

Trigger the pipeline manually (monthly auto-schedule runs on the 1st of each month at 03:00 UTC):

```bash
# Get the pipeline ARN
PIPELINE_ARN=$(terraform output -raw image_builder_pipeline_arn)

# Start a manual build
aws imagebuilder start-image-pipeline-execution \
  --image-pipeline-arn "$PIPELINE_ARN" \
  --region ap-northeast-1
```

- [x] Build starts — monitor at: EC2 Image Builder → Image pipelines → select pipeline → Output images
- [x] Build completes successfully (takes ~15-25 min)
- [x] Output AMI appears in EC2 → AMIs with tags `Service=image-builder`, `Project=optinist-cloud`
- [x] Build logs appear in S3: `{app_storage_bucket}/image-builder-logs/`

### Phase 3: Switch over to custom AMI

```bash
# Write the new AMI ID to SSM (replace with actual AMI ID from Phase 2)
aws ssm put-parameter \
  --name "/${ENVIRONMENT}/optinist/custom-ami-id" \
  --value "ami-0xxxxxxxxxxxxxxxxx" \
  --type String --overwrite \
  --region ap-northeast-1

# Apply to update launch templates
terraform apply -var-file=environments/${ENVIRONMENT}.tfvars
```

- [ ] `terraform plan` shows launch template `image_id` change to the new custom AMI
- [x] `terraform apply` completes without errors

### Phase 4: Instance-level verification

On a **newly launched instance** (after ASG refresh or new premium instance allocation):

```bash
# Connect via SSM Session Manager or SSH, then run:

# 1. Bake marker exists
cat /etc/optinist-ami-baked

# 2. AWS CLI v2
aws --version   # Expected: aws-cli/2.x.x

# 3. All packages pre-installed
rpm -q amazon-ssm-agent amazon-efs-utils amazon-cloudwatch-agent git docker

# 4. User-data skipped package installation
grep "Pre-baked AMI detected" /var/log/cloud-init-output.log

# 5. Boot time improvement
systemd-analyze blame | head -5
# cloud-final.service should be < 2 min (was ~8 min)
```

- [x] Bake marker file exists with build timestamp
- [x] `aws --version` shows `aws-cli/2.x.x`
- [x] All packages report as installed
- [x] "Pre-baked AMI detected" message present in logs
- [ ] `cloud-final.service` completes in < 2 min
- [ ] ECS agent registers within ~2 min of EC2 launch

### Rollback (if needed)

```bash
# Revert to stock AMI
# Option A: Set use_custom_ami = false in tfvars, then terraform apply
# Option B: Update SSM parameter back to stock AMI ID

# User-data detects no bake marker and runs full package installation (original behavior)
```

## Out of scope (future enhancements)

- EventBridge + Lambda for automatic SSM parameter update on pipeline completion
- ECR image pre-pull at bake time
- Multi-environment AMI sharing (build once, share across dev/prod)
