### PR TITLE
Fix ghost-cleanup race where terminated EC2 with agent still connected

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -5098,11 +5098,14 @@ def cleanup_ghost_ecs_registrations():
 
     Only targets instances with attribute:tier == premium.
 
-    Deregistration rules:
-      - EC2 stopped/terminated/gone: deregister immediately.
+    Deregistration rules (EC2 state decides first; agentConnected is consulted
+    only after the instance is alive):
+      - No ec2InstanceId mapping: deregister immediately.
+      - EC2 stopped/terminated/shutting-down/gone: deregister immediately.
+      - EC2 running + agent connected: clear any stale disconnect tag.
       - EC2 running + agent disconnected: tag with a timestamp on first
-        sighting, deregister after _AGENT_DISCONNECT_GRACE_SECONDS.
-        The tag is cleared automatically if the agent reconnects.
+        sighting, deregister after _AGENT_DISCONNECT_GRACE_SECONDS. The tag
+        is cleared automatically if the agent reconnects.
 
     Called every 15 minutes by handle_scheduled_monitoring.
     """
@@ -5139,118 +5142,143 @@ def cleanup_ghost_ecs_registrations():
         ghost_instances = []
         reconnected_ec2_ids = []
 
-        for container_instance in describe_response.get("containerInstances", []):
+        container_instances = describe_response.get("containerInstances", [])
+
+        # Batched describe_instances has no partial-result mode
+        # — any unknown ID fails the call.
+        ec2_ids = [
+            ci["ec2InstanceId"] for ci in container_instances if ci.get("ec2InstanceId")
+        ]
+        ec2_state_by_id: dict = {}
+        ec2_tags_by_id: dict = {}
+
+        def _record(reservations):
+            for reservation in reservations:
+                for instance in reservation.get("Instances", []):
+                    inst_id = instance.get("InstanceId")
+                    if not inst_id:
+                        continue
+                    ec2_state_by_id[inst_id] = instance["State"]["Name"]
+                    ec2_tags_by_id[inst_id] = {
+                        t["Key"]: t["Value"] for t in instance.get("Tags", [])
+                    }
+
+        if ec2_ids:
+            try:
+                ec2_response = ec2.describe_instances(InstanceIds=ec2_ids)
+                _record(ec2_response.get("Reservations", []))
+            except ClientError as e:
+                if e.response["Error"]["Code"] != "InvalidInstanceID.NotFound":
+                    raise
+                for ec2_id in ec2_ids:
+                    try:
+                        per = ec2.describe_instances(InstanceIds=[ec2_id])
+                        _record(per.get("Reservations", []))
+                    except ClientError as inner:
+                        if (
+                            inner.response["Error"]["Code"]
+                            != "InvalidInstanceID.NotFound"
+                        ):
+                            raise
+
+        for container_instance in container_instances:
             container_instance_arn = container_instance.get("containerInstanceArn")
             ec2_instance_id = container_instance.get("ec2InstanceId")
             agent_connected = container_instance.get("agentConnected", False)
             status = container_instance.get("status", "UNKNOWN")
 
-            # Agent reconnected — clear any disconnect tag (best-effort)
-            if agent_connected:
-                if ec2_instance_id:
-                    reconnected_ec2_ids.append(ec2_instance_id)
-                continue
-
-            # Agent is disconnected — check EC2 state to decide what to do
+            # EC2 state decides first — a terminated EC2 is a ghost even
+            # if the ECS agent still briefly reports as connected.
             if not ec2_instance_id:
-                # No EC2 mapping at all — deregister immediately
                 ghost_instances.append(
                     {
                         "container_instance_arn": container_instance_arn,
                         "ec2_instance_id": ec2_instance_id,
-                        "reason": "Disconnected agent with no EC2 instance mapping",
+                        "reason": "Container instance has no EC2 mapping",
                         "status": status,
                     }
                 )
                 continue
 
-            if ec2_instance_id:
-                try:
-                    ec2_response = ec2.describe_instances(InstanceIds=[ec2_instance_id])
-                    if ec2_response["Reservations"]:
-                        instance = ec2_response["Reservations"][0]["Instances"][0]
-                        instance_state = instance["State"]["Name"]
+            instance_state = ec2_state_by_id.get(ec2_instance_id)
+            if instance_state is None:
+                ghost_instances.append(
+                    {
+                        "container_instance_arn": container_instance_arn,
+                        "ec2_instance_id": ec2_instance_id,
+                        "reason": "EC2 instance does not exist",
+                        "status": status,
+                    }
+                )
+                continue
 
-                        # EC2 is dead → deregister immediately
-                        if instance_state in [
-                            InstanceState.STOPPED,
-                            InstanceState.TERMINATED,
-                            InstanceState.SHUTTING_DOWN,
-                        ]:
-                            ghost_instances.append(
-                                {
-                                    "container_instance_arn": container_instance_arn,
-                                    "ec2_instance_id": ec2_instance_id,
-                                    "reason": f"EC2 instance is {instance_state}",
-                                    "status": status,
-                                }
-                            )
-                            continue
+            if instance_state in [
+                InstanceState.STOPPED,
+                InstanceState.TERMINATED,
+                InstanceState.SHUTTING_DOWN,
+            ]:
+                ghost_instances.append(
+                    {
+                        "container_instance_arn": container_instance_arn,
+                        "ec2_instance_id": ec2_instance_id,
+                        "reason": f"EC2 instance is {instance_state}",
+                        "status": status,
+                    }
+                )
+                continue
 
-                        # EC2 is running but agent disconnected — apply grace period
-                        tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
-                        first_seen = tags.get(_DISCONNECT_TAG_KEY)
+            # EC2 is alive. Agent connected → clear any disconnect tag.
+            if agent_connected:
+                reconnected_ec2_ids.append(ec2_instance_id)
+                continue
 
-                        if not first_seen:
-                            now_str = datetime.now(timezone.utc).isoformat()
-                            print(
-                                f"Agent disconnected on {ec2_instance_id}, "
-                                f"starting grace period"
-                            )
-                            ec2.create_tags(
-                                Resources=[ec2_instance_id],
-                                Tags=[
-                                    {
-                                        "Key": _DISCONNECT_TAG_KEY,
-                                        "Value": now_str,
-                                    }
-                                ],
-                            )
-                            continue
+            # EC2 alive + agent disconnected — apply grace period.
+            tags = ec2_tags_by_id.get(ec2_instance_id, {})
+            first_seen = tags.get(_DISCONNECT_TAG_KEY)
 
-                        # Tag exists — check if grace period has elapsed
-                        try:
-                            first_seen_dt = datetime.fromisoformat(first_seen)
-                        except (ValueError, TypeError):
-                            first_seen_dt = datetime.now(timezone.utc)
+            if not first_seen:
+                now_str = datetime.now(timezone.utc).isoformat()
+                print(
+                    f"Agent disconnected on {ec2_instance_id}, "
+                    f"starting grace period"
+                )
+                ec2.create_tags(
+                    Resources=[ec2_instance_id],
+                    Tags=[
+                        {
+                            "Key": _DISCONNECT_TAG_KEY,
+                            "Value": now_str,
+                        }
+                    ],
+                )
+                continue
 
-                        elapsed = (
-                            datetime.now(timezone.utc) - first_seen_dt
-                        ).total_seconds()
+            try:
+                first_seen_dt = datetime.fromisoformat(first_seen)
+            except (ValueError, TypeError):
+                first_seen_dt = datetime.now(timezone.utc)
 
-                        if elapsed < _AGENT_DISCONNECT_GRACE_SECONDS:
-                            print(
-                                f"Agent disconnected on {ec2_instance_id} "
-                                f"for {int(elapsed)}s, within grace period"
-                            )
-                            continue
+            elapsed = (datetime.now(timezone.utc) - first_seen_dt).total_seconds()
 
-                        ghost_instances.append(
-                            {
-                                "container_instance_arn": container_instance_arn,
-                                "ec2_instance_id": ec2_instance_id,
-                                "reason": (
-                                    f"ECS agent disconnected for "
-                                    f"{int(elapsed)}s (grace period "
-                                    f"{_AGENT_DISCONNECT_GRACE_SECONDS}s)"
-                                ),
-                                "status": status,
-                            }
-                        )
-                        continue
+            if elapsed < _AGENT_DISCONNECT_GRACE_SECONDS:
+                print(
+                    f"Agent disconnected on {ec2_instance_id} "
+                    f"for {int(elapsed)}s, within grace period"
+                )
+                continue
 
-                except Exception as e:
-                    if "InvalidInstanceID" in str(e):
-                        ghost_instances.append(
-                            {
-                                "container_instance_arn": container_instance_arn,
-                                "ec2_instance_id": ec2_instance_id,
-                                "reason": "EC2 instance does not exist",
-                                "status": status,
-                            }
-                        )
-                        continue
-                    raise
+            ghost_instances.append(
+                {
+                    "container_instance_arn": container_instance_arn,
+                    "ec2_instance_id": ec2_instance_id,
+                    "reason": (
+                        f"ECS agent disconnected for "
+                        f"{int(elapsed)}s (grace period "
+                        f"{_AGENT_DISCONNECT_GRACE_SECONDS}s)"
+                    ),
+                    "status": status,
+                }
+            )
 
         # Clear disconnect tags on instances whose agents have reconnected
         if reconnected_ec2_ids:

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2627,7 +2627,15 @@ class TestCleanupGhostECSRegistrations:
             }
             mock_ec2.describe_instances.return_value = {
                 "Reservations": [
-                    {"Instances": [{"State": {"Name": "stopped"}, "Tags": []}]}
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-stopped1",
+                                "State": {"Name": "stopped"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
                 ]
             }
 
@@ -2663,7 +2671,15 @@ class TestCleanupGhostECSRegistrations:
             }
             mock_ec2.describe_instances.return_value = {
                 "Reservations": [
-                    {"Instances": [{"State": {"Name": "running"}, "Tags": []}]}
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-running1",
+                                "State": {"Name": "running"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
                 ]
             }
 
@@ -2704,6 +2720,7 @@ class TestCleanupGhostECSRegistrations:
                     {
                         "Instances": [
                             {
+                                "InstanceId": "i-grace1",
                                 "State": {"Name": "running"},
                                 "Tags": [
                                     {
@@ -2750,6 +2767,7 @@ class TestCleanupGhostECSRegistrations:
                     {
                         "Instances": [
                             {
+                                "InstanceId": "i-expired1",
                                 "State": {"Name": "running"},
                                 "Tags": [
                                     {
@@ -2790,6 +2808,19 @@ class TestCleanupGhostECSRegistrations:
                         "ec2InstanceId": "i-healthy1",
                         "agentConnected": True,
                         "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-healthy1",
+                                "State": {"Name": "running"},
+                                "Tags": [],
+                            }
+                        ]
                     }
                 ]
             }
@@ -2834,7 +2865,20 @@ class TestCleanupGhostECSRegistrations:
             }
             mock_ec2.describe_instances.return_value = {
                 "Reservations": [
-                    {"Instances": [{"State": {"Name": "terminated"}, "Tags": []}]}
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-healthy",
+                                "State": {"Name": "running"},
+                                "Tags": [],
+                            },
+                            {
+                                "InstanceId": "i-ghost",
+                                "State": {"Name": "terminated"},
+                                "Tags": [],
+                            },
+                        ]
+                    }
                 ]
             }
 
@@ -2848,13 +2892,156 @@ class TestCleanupGhostECSRegistrations:
                 containerInstance=ghost_arn,
                 force=True,
             )
-            # EC2 describe only called for the disconnected instance
-            mock_ec2.describe_instances.assert_called_once_with(InstanceIds=["i-ghost"])
+            # describe_instances is batched across both IDs
+            mock_ec2.describe_instances.assert_called_once_with(
+                InstanceIds=["i-healthy", "i-ghost"]
+            )
             # Healthy instance's tag is cleared
             mock_ec2.delete_tags.assert_any_call(
                 Resources=["i-healthy"],
                 Tags=[{"Key": "optinist:agent-disconnected-at"}],
             )
+
+    def test_deregisters_connected_agent_when_ec2_terminated(
+        self, mock_env_vars_premium
+    ):
+        """Regression for #549: a CI reporting agentConnected=True is still
+        deregistered when its underlying EC2 has been terminated."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/term1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-term1",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-term1",
+                                "State": {"Name": "terminated"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
+            # delete_tags fires once via the post-deregister cleanup, never as
+            # a "reconnect" tag-clear — the CI was not treated as healthy.
+            mock_ec2.delete_tags.assert_called_once_with(
+                Resources=["i-term1"],
+                Tags=[{"Key": "optinist:agent-disconnected-at"}],
+            )
+
+    def test_falls_back_to_per_id_describe_on_invalid_instance_id(
+        self, mock_env_vars_premium
+    ):
+        """When one EC2 ID is long-gone (past AWS's ~1h visibility window),
+        the batched describe_instances raises InvalidInstanceID.NotFound for
+        the whole call. The cleanup must fall back to per-ID describe so the
+        live CI is processed normally and the gone CI is deregistered via the
+        state=None branch, instead of the outer except swallowing the error
+        and skipping the entire cycle."""
+        from botocore.exceptions import ClientError
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            live_arn = "arn:aws:ecs:r:a:ci/live1"
+            gone_arn = "arn:aws:ecs:r:a:ci/gone1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [live_arn, gone_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": live_arn,
+                        "ec2InstanceId": "i-live",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "containerInstanceArn": gone_arn,
+                        "ec2InstanceId": "i-gone",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+
+            not_found = ClientError(
+                {
+                    "Error": {
+                        "Code": "InvalidInstanceID.NotFound",
+                        "Message": "The instance ID 'i-gone' does not exist",
+                    }
+                },
+                "DescribeInstances",
+            )
+
+            def describe_side_effect(**kwargs):
+                ids = kwargs["InstanceIds"]
+                if len(ids) > 1:
+                    raise not_found
+                if ids == ["i-live"]:
+                    return {
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-live",
+                                        "State": {"Name": "running"},
+                                        "Tags": [],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                raise not_found
+
+            mock_ec2.describe_instances.side_effect = describe_side_effect
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            # Exactly the gone CI is deregistered; the live one is not.
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=gone_arn,
+                force=True,
+            )
+            # One batch call + one per-ID call per original ID on fallback.
+            id_lists = [
+                c.kwargs["InstanceIds"]
+                for c in mock_ec2.describe_instances.call_args_list
+            ]
+            assert ["i-live", "i-gone"] in id_lists
+            assert ["i-live"] in id_lists
+            assert ["i-gone"] in id_lists
 
     def test_deregisters_disconnected_without_ec2_id(self, mock_env_vars_premium):
         """Container instance with disconnected agent and no ec2InstanceId
@@ -2888,4 +3075,38 @@ class TestCleanupGhostECSRegistrations:
                 force=True,
             )
             # No EC2 calls should be made
+            mock_ec2.describe_instances.assert_not_called()
+
+    def test_deregisters_connected_without_ec2_id(self, mock_env_vars_premium):
+        """CI with no ec2InstanceId is deregistered even when
+        agentConnected=True (the pre-#549 short-circuit treated any connected
+        agent as healthy regardless of EC2 mapping)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/no-ec2-conn"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
             mock_ec2.describe_instances.assert_not_called()

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -2649,6 +2649,51 @@ class TestCleanupGhostECSRegistrations:
                 force=True,
             )
 
+    def test_deregisters_shutting_down_ec2_immediately(self, mock_env_vars_premium):
+        """Instance whose EC2 is shutting-down (the typical transient state
+        during the #549 race) gets deregistered with no grace."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/shutdown1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-shutdown1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-shutdown1",
+                                "State": {"Name": "shutting-down"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ci_arn,
+                force=True,
+            )
+
     def test_tags_running_instance_on_first_disconnect(self, mock_env_vars_premium):
         """Running EC2 with disconnected agent gets tagged but not deregistered."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
@@ -2691,6 +2736,54 @@ class TestCleanupGhostECSRegistrations:
             mock_ec2.create_tags.assert_called_once()
             tag_call = mock_ec2.create_tags.call_args
             assert tag_call.kwargs["Resources"] == ["i-running1"]
+            assert tag_call.kwargs["Tags"][0]["Key"] == "optinist:agent-disconnected-at"
+
+    def test_pending_ec2_is_not_deregistered(self, mock_env_vars_premium):
+        """EC2 still booting (state=pending) is treated as alive — not in the
+        STOPPED/TERMINATED/SHUTTING_DOWN dead set. With agent disconnected
+        (not yet registered), the grace-period tag is started; deregister is
+        not called. Pins the alive-set boundary so a future "deregister
+        anything not running" tweak can't silently kill booting CIs."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            ci_arn = "arn:aws:ecs:r:a:ci/pending1"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ci_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ci_arn,
+                        "ec2InstanceId": "i-pending1",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-pending1",
+                                "State": {"Name": "pending"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_not_called()
+            mock_ec2.create_tags.assert_called_once()
+            tag_call = mock_ec2.create_tags.call_args
+            assert tag_call.kwargs["Resources"] == ["i-pending1"]
             assert tag_call.kwargs["Tags"][0]["Key"] == "optinist:agent-disconnected-at"
 
     def test_skips_within_grace_period(self, mock_env_vars_premium):


### PR DESCRIPTION
### Content

#### Summary

`cleanup_ghost_ecs_registrations()` short-circuited as healthy whenever the
ECS agent reported `agentConnected=true`, regardless of the EC2 instance's
actual state. When a premium EC2 was terminated directly (manual action,
scaling, OS-level shutdown), there is a brief window where ECS still reports
`agentConnected=true` for the now-dead container instance. The function
treated those CIs as healthy and never deregistered them, leaving stale ACTIVE
capacity that `update_premium_service_desired_count()` then used to compute a
`desiredCount` pointing at a vanished instance.

This PR moves the EC2-state check ahead of the `agentConnected` short-circuit,
batches the per-CI `describe_instances` call into a single up-front call (with
a per-ID fallback when one ID has aged past AWS's ~1h visibility window), and
adds three regression tests pinning the new ordering.

#### Design Decisions

- **EC2 state decides first; `agentConnected` is consulted only after the
  instance is alive.** This is the bug fix proper — the old order was the
  literal source of #549. The new ordering is: no EC2 mapping → deregister;
  EC2 stopped/terminated/shutting-down/gone → deregister; EC2 running + agent
  connected → clear stale disconnect tag; EC2 running + agent disconnected →
  apply existing grace-period logic.

- **Batch `describe_instances` once for all premium CIs**, instead of one call
  per CI inside the loop. At pool size ≤10 this is a small win on cold-path
  latency and API call count, but the larger benefit is centralising the
  EC2-state lookup so the per-CI loop reads from a dict instead of issuing
  network calls and handling per-call exceptions inline.

- **Per-ID fallback only on `InvalidInstanceID.NotFound` from the batched
  call.** The batched API has no partial-success mode — one missing ID fails
  the entire call. When that happens (an EC2 has aged past AWS's ~1h
  visibility window), we fall back to per-ID describes. Each per-ID call that
  raises `InvalidInstanceID.NotFound` is silently absorbed (the missing entry
  flows into the `state is None` branch and the CI is deregistered with reason
  "EC2 instance does not exist"). Any other `ClientError` re-raises and the
  cycle aborts — the next 15-min run retries. We considered continue-on-error
  here but rejected it: a missing entry triggers deregister, so naïvely
  continuing on a transient `Throttling` would erroneously deregister a
  healthy CI. "Abort and retry next cycle" is the safer failure mode.

- **Removed the `InvalidInstanceID`-substring exception handler** that lived
  inside the per-CI loop in the old code. Its behaviour is now expressed
  declaratively via the `state is None` branch (`InvalidInstanceID.NotFound`
  during the per-ID fallback → not in the dict → deregister as "EC2 instance
  does not exist"), and the explicit error-code check is more correct than
  the old `"InvalidInstanceID" in str(e)` substring match.

- **Behaviour change on `agentConnected=true + no ec2InstanceId`:** the old
  code's first-line short-circuit on `agentConnected` meant such a CI was
  treated as healthy. The new ordering deregisters it. An EC2-backed CI
  should always have an `ec2InstanceId`; if it doesn't, the CI cannot be
  acted on usefully and the safer disposition is to deregister rather than
  let it accumulate. Pinned by a new regression test
  (`test_deregisters_connected_without_ec2_id`).

- **Grace-period logic is unchanged.** Tag creation, elapsed-time check, and
  deregister-after-`_AGENT_DISCONNECT_GRACE_SECONDS` all moved verbatim into
  the "EC2 alive + agent disconnected" branch. The only difference is reading
  tags from the up-front lookup dict instead of a per-CI `describe_instances`
  reservation.

- **Out of scope:** re-introducing the rolled-back step 11b
  (`update_premium_service_desired_count()` after cleanup in
  `handle_scheduled_monitoring`). With this fix the ghost is identified
  in-cycle, but same-invocation desired-count convergence still requires
  the 11b call. That's a separate decision and a separate PR.

### References

- **Issue #549** — full symptom analysis, root cause, and the two recommended
  options. This PR implements Option A (refactor the cleanup) and rules out
  Option B (EventBridge `ecs:RUNNING` events).
- **PR #551** (rolled back) — removed the in-cycle
  `update_premium_service_desired_count()` after cleanup. Its rollback is why
  the bug's impact is no longer partially masked, which is what made #549
  observable.
- `infrastructure/terraform/premium_manager_package/premium_manager.py:5096` —
  `cleanup_ghost_ecs_registrations` (function entry).

#### Files changed

Backend / Infrastructure
- `infrastructure/terraform/premium_manager_package/premium_manager.py` —
  rewrote the per-CI loop in `cleanup_ghost_ecs_registrations` so EC2 state
  decides first; added an up-front batched `describe_instances` with a
  per-ID `InvalidInstanceID.NotFound` fallback; removed the per-CI
  `try/except` substring-match handler now that the missing-instance case
  is expressed via the lookup-miss branch; updated the docstring to reflect
  the new ordering and to keep the reconnect-tag-clear note.

Tests
- `studio/tests/infrastructure/test_premium_manager.py` — added
  `InstanceId` to the existing mock `describe_instances` reservations (now
  required by the lookup map); updated
  `test_mixed_cluster_only_deregisters_ghost` to assert the batched call
  shape (`InstanceIds=["i-healthy", "i-ghost"]` instead of one call per
  ghost); added three regression tests:
  `test_deregisters_connected_agent_when_ec2_terminated` (the #549
  scenario), `test_falls_back_to_per_id_describe_on_invalid_instance_id`
  (the long-gone-ID fallback path), and
  `test_deregisters_connected_without_ec2_id` (pins the
  `agentConnected=true + no ec2InstanceId` behaviour change).

Not changed
- `infrastructure/terraform/premium_manager.tf`, IAM, alarms, dashboards —
  no Terraform changes; no new permissions; no new resources. The Lambda
  role already has `ec2:DescribeInstances`.
- `cleanup_orphaned_ec2_instances` and the scaling-lock path — untouched.
  This PR only changes the ghost-cleanup function.

### Manual Testcases

- **1. EC2 terminated with agent still reporting connected → deregistered
  in the same invocation.** Unit-covered by the new
  `TestCleanupGhostECSRegistrations::test_deregisters_connected_agent_when_ec2_terminated`:
  mocks one CI with `agentConnected=true, ec2InstanceId=i-term1` and
  `describe_instances` returning `State.Name=terminated`; asserts
  `deregister_container_instance` is called once with that ARN and
  `force=True`, and that the post-deregister `delete_tags` call fires
  exactly once on `i-term1` (not on any other instance). This is the
  regression-guard for #549.

- **2. Long-gone EC2 ID (past AWS's ~1h visibility window) → fallback to
  per-ID describe; gone CI deregistered, live CI processed normally.**
  Unit-covered by the new
  `test_falls_back_to_per_id_describe_on_invalid_instance_id`: mocks the
  batched `describe_instances` to raise `InvalidInstanceID.NotFound`,
  fallback per-ID returns the live instance and re-raises `NotFound` for
  the gone one; asserts only the gone CI is deregistered, the live CI
  is left ACTIVE, and the call shape is one batch call followed by two
  per-ID calls.

- **3. CI with no `ec2InstanceId` and `agentConnected=true` → deregistered.**
  Unit-covered by the new `test_deregisters_connected_without_ec2_id`.
  Pins the documented behaviour change so it isn't silently re-flipped
  by a future short-circuit reintroduction.

- **4. Pre-existing scenarios (running healthy, grace-period start,
  grace-period in progress, grace-period expired, mixed-cluster
  one-ghost-one-healthy, no-EC2-mapping disconnected, agent reconnected,
  empty cluster) → unchanged behaviour.** Unit-covered by the existing 8
  tests in `TestCleanupGhostECSRegistrations`, all of which were updated
  to include `InstanceId` in their `describe_instances` reservation
  fixtures and continue to pass.

- **5. Live (dev) — direct-terminate one premium EC2 and observe
  same-invocation deregister.** Procedure (run after deploy):

  ```
  aws ecs list-container-instances --cluster <cluster> \
    --filter "attribute:tier == premium"
  aws ec2 terminate-instances --instance-ids <one-premium-id>
  # within ~30 s
  aws lambda invoke --function-name <premium-manager> \
    --invocation-type RequestResponse /tmp/out.json
  aws logs filter-log-events --log-group-name /aws/lambda/<premium-manager> \
    --start-time <ms>
  ```

  Pass criteria: log line `Deregistering ghost container instance ...
  reason: EC2 instance is terminated` (or `shutting-down` if caught
  mid-transition) and `Cleaned up 1 ghost ECS registrations` in the same
  invocation that fires after termination — not the following 15-min
  cycle. No spurious deregistrations of other healthy CIs.

- **Automated:**
  `pytest studio/tests/infrastructure/test_premium_manager.py::TestCleanupGhostECSRegistrations -q`
  → **11 passed** (8 pre-existing, 3 new).

### Unit, Integration, Contract Test Coverage

- `TestCleanupGhostECSRegistrations::test_deregisters_connected_agent_when_ec2_terminated` —
  pins #549 fix.
- `TestCleanupGhostECSRegistrations::test_falls_back_to_per_id_describe_on_invalid_instance_id` —
  pins the per-ID fallback path.
- `TestCleanupGhostECSRegistrations::test_deregisters_connected_without_ec2_id` —
  pins the `agentConnected=true + no ec2InstanceId` behaviour change.
- `TestCleanupGhostECSRegistrations::test_mixed_cluster_only_deregisters_ghost` —
  updated to assert the batched call shape.
- 7 other pre-existing tests in the class — updated for the new
  `InstanceId` field and continue to pass.
- No contract tests touched.

### Others

#### Difficulties

- The naïve "continue on any per-ID error" form for the fallback path is
  actively dangerous: a missing entry in the lookup map triggers the
  `state is None` deregister branch, so a transient `Throttling` would
  erroneously deregister a healthy CI. Settled on "abort cycle on
  non-`NotFound`, retry next cycle" as the safer failure mode. A safe
  continue-on-error would need a third per-CI disposition
  ("transient-failure → skip this cycle"), which is more code for a
  scenario that essentially doesn't occur at premium pool size ≤10.
- Behaviour change on `agentConnected=true + no ec2InstanceId` was
  surfaced only by writing the regression test for it. The old
  short-circuit treated such a CI as healthy; the new ordering
  deregisters it. Documented and pinned rather than preserved — an
  EC2-backed CI without an `ec2InstanceId` is a state we cannot act
  on usefully and shouldn't accumulate.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Reordered EC2-state-vs-agentConnected check | Low | Bug-fix proper; new test pins the formerly-broken case. The four healthy-path tests (running+connected, running+disconnected first-sighting, within-grace, post-grace) all continue to pass unchanged. |
| Batched `describe_instances` | Low | Premium pool is bounded by `max_premium_instances` (single digits in dev). API accepts up to 1000 IDs per call. Net API impact: 1 call instead of N. |
| Per-ID fallback aborts cycle on non-`NotFound` `ClientError` | Low | The fallback only fires after a batched `NotFound` (already a rare path). `DescribeInstances` rate limits are well above what this code touches. Failure mode is "skip this 15-min cycle and retry next" — self-healing, no spurious deregistrations. |
| New-EC2 eventual-consistency race (instance launched but not yet visible to `describe_instances` before ECS lists its CI) | Very low | EC2 visibility lands well before ECS-agent registration in observed practice. The race window is essentially zero, and would manifest as one premature deregister of a CI that would re-register on next agent connection. Not worth defensive code. |
| Behaviour change on `agentConnected=true + no ec2InstanceId` | Low | Documented and tested. Such a CI has no recoverable identity to act on; deregistering is the safer disposition. |
| Same-invocation `desiredCount` convergence | Out of scope | Without the rolled-back step 11b, the corrected CI set is consumed by the next 15-min `update_premium_service_desired_count()` call, not the same invocation. Re-landing 11b is a separate PR. |
| Rollback | Trivial | `git revert`. No data migration, no state transitions, no consumers to re-notify. |
