### PR TITLE
Surface and recover from silent free-tier fallback on premium

### DIFF
--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -8,6 +8,8 @@ import { FC, useEffect, useRef, useState } from "react"
 
 import { useSnackbar } from "notistack"
 
+import { Button } from "@mui/material"
+
 import { logPremiumUiEvent } from "api/premium/PremiumAssignmentApi"
 import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
@@ -19,7 +21,10 @@ const PremiumNotificationManager: FC = () => {
     error,
     isAssigning,
     isRetryableError,
+    unreachable,
   } = usePremiumAssignment()
+  const { instanceUnreachable, isUnreachableTerminal } = unreachable.state
+  const retryProbe = unreachable.retryProbe
 
   const [hasShownAssignmentSuccess, setHasShownAssignmentSuccess] =
     useState(false)
@@ -28,6 +33,9 @@ const PremiumNotificationManager: FC = () => {
 
   // Store keys for dismissible notifications
   const waitingKeyRef = useRef<string | number | null>(null)
+  const unreachableKeyRef = useRef<string | number | null>(null)
+  // Lets us detect a non-terminal → terminal transition to upgrade the message.
+  const unreachableTerminalShownRef = useRef(false)
 
   const hasDedicatedInstance =
     assignmentResult?.assigned && !assignmentResult?.is_shared
@@ -77,8 +85,7 @@ const PremiumNotificationManager: FC = () => {
     if (isPremiumUser && needsWaiting) {
       if (!waitingKeyRef.current) {
         const key = enqueueSnackbar(
-          "Please wait while your dedicated premium " +
-            "resource is being prepared.",
+          "Please wait while your dedicated premium resource is being prepared.",
           {
             variant: "info",
             persist: true,
@@ -130,8 +137,7 @@ const PremiumNotificationManager: FC = () => {
         }
 
         enqueueSnackbar(
-          "Premium assignment issue: " +
-            `${error}. Falling back to shared resources.`,
+          `Premium assignment issue: ${error}. Falling back to shared resources.`,
           {
             variant: "warning",
             autoHideDuration: 10000,
@@ -164,11 +170,85 @@ const PremiumNotificationManager: FC = () => {
     }
   }, [assignmentResult])
 
+  useEffect(() => {
+    const shouldShow =
+      isPremiumUser && hasDedicatedInstance && instanceUnreachable
+
+    const messageFor = (terminal: boolean): string =>
+      terminal
+        ? "Your dedicated premium instance is unresponsive after multiple attempts. Please reload the page or contact support."
+        : "Your dedicated premium instance is temporarily unreachable. Retrying…"
+
+    if (shouldShow) {
+      const variantChanged =
+        unreachableKeyRef.current != null &&
+        unreachableTerminalShownRef.current !== isUnreachableTerminal
+      if (variantChanged) {
+        closeSnackbar(unreachableKeyRef.current!)
+        unreachableKeyRef.current = null
+      }
+      if (!unreachableKeyRef.current) {
+        const terminal = isUnreachableTerminal
+        const key = enqueueSnackbar(messageFor(terminal), {
+          variant: "warning",
+          persist: true,
+          action: terminal
+            ? (snackbarKey) => (
+                <Button
+                  size="small"
+                  color="inherit"
+                  onClick={() => {
+                    closeSnackbar(snackbarKey)
+                    retryProbe()
+                  }}
+                >
+                  Retry
+                </Button>
+              )
+            : undefined,
+        })
+        unreachableKeyRef.current = key
+        unreachableTerminalShownRef.current = terminal
+        logPremiumUiEvent("instance_unreachable_popup_shown", {
+          instance_id: assignmentResult?.instance_id ?? null,
+          terminal,
+        })
+      }
+    }
+
+    // Dismiss whenever shouldShow goes false (recovered / non-dedicated / non-premium).
+    if (unreachableKeyRef.current && !shouldShow) {
+      logPremiumUiEvent("instance_unreachable_popup_dismissed", {
+        instance_id: assignmentResult?.instance_id ?? null,
+        reason: !isPremiumUser
+          ? "not_premium"
+          : !hasDedicatedInstance
+            ? "not_dedicated"
+            : "reachable",
+      })
+      closeSnackbar(unreachableKeyRef.current)
+      unreachableKeyRef.current = null
+      unreachableTerminalShownRef.current = false
+    }
+  }, [
+    isPremiumUser,
+    hasDedicatedInstance,
+    instanceUnreachable,
+    isUnreachableTerminal,
+    assignmentResult,
+    enqueueSnackbar,
+    closeSnackbar,
+    retryProbe,
+  ])
+
   // Cleanup waiting notification on unmount
   useEffect(() => {
     return () => {
       if (waitingKeyRef.current) {
         closeSnackbar(waitingKeyRef.current)
+      }
+      if (unreachableKeyRef.current) {
+        closeSnackbar(unreachableKeyRef.current)
       }
     }
   }, [closeSnackbar])

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -1,0 +1,296 @@
+/**
+ * Tests for PremiumNotificationManager's instance-unreachable snackbar.
+ *
+ * Covers:
+ *  - Initial non-terminal snackbar (no Retry button)
+ *  - Non-terminal → terminal transition swaps the snackbar (close + enqueue)
+ *    and the new snackbar carries an actionable Retry button
+ *  - Retry click closes the snackbar and invokes retryProbe
+ *  - Dismiss logs the correct `reason` for each exit path
+ */
+
+import React from "react"
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals"
+import { act, fireEvent, render } from "@testing-library/react"
+
+// --- Snackbar mock -----------------------------------------------------------
+
+type SnackbarCall = {
+  key: string | number
+  message: string
+  options?: {
+    variant?: string
+    action?: (key: string | number) => React.ReactNode
+  }
+}
+
+const mockEnqueueSnackbar = jest.fn() as unknown as jest.Mock<
+  string | number,
+  [string, Record<string, unknown>]
+>
+const mockCloseSnackbar = jest.fn()
+
+let snackbarLog: SnackbarCall[] = []
+let snackbarKeyCounter = 0
+
+jest.mock("notistack", () => ({
+  __esModule: true,
+  useSnackbar: () => ({
+    enqueueSnackbar: mockEnqueueSnackbar,
+    closeSnackbar: mockCloseSnackbar,
+  }),
+  // eslint-disable-next-line react/prop-types
+  SnackbarProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+// --- Context mock ------------------------------------------------------------
+
+type CtxShape = {
+  isPremiumUser: boolean
+  assignmentResult: {
+    instance_id?: string
+    assigned?: boolean
+    is_shared?: boolean
+  } | null
+  error: string | null
+  isAssigning: boolean
+  isRetryableError: boolean
+  unreachable: {
+    state: { instanceUnreachable: boolean; isUnreachableTerminal: boolean }
+    retryProbe: () => void
+  }
+}
+
+let mockCtxValue: CtxShape = {
+  isPremiumUser: true,
+  assignmentResult: null,
+  error: null,
+  isAssigning: false,
+  isRetryableError: false,
+  unreachable: {
+    state: { instanceUnreachable: false, isUnreachableTerminal: false },
+    retryProbe: jest.fn(),
+  },
+}
+
+jest.mock("contexts/PremiumAssignmentContext", () => ({
+  __esModule: true,
+  usePremiumAssignment: () => mockCtxValue,
+}))
+
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+// --- SUT import (after mocks) ------------------------------------------------
+
+const PremiumNotificationManager: React.FC =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("components/Premium/PremiumNotificationManager").default
+
+// --- Helpers -----------------------------------------------------------------
+
+const setCtx = (patch: Partial<CtxShape>) => {
+  mockCtxValue = {
+    ...mockCtxValue,
+    ...patch,
+    unreachable: { ...mockCtxValue.unreachable, ...(patch.unreachable ?? {}) },
+  }
+}
+
+const baseCtx = (): CtxShape => ({
+  isPremiumUser: true,
+  assignmentResult: {
+    instance_id: "inst-A",
+    assigned: true,
+    is_shared: false,
+  },
+  error: null,
+  isAssigning: false,
+  isRetryableError: false,
+  unreachable: {
+    state: { instanceUnreachable: false, isUnreachableTerminal: false },
+    retryProbe: jest.fn(),
+  },
+})
+
+// --- Tests -------------------------------------------------------------------
+
+describe("PremiumNotificationManager — unreachable snackbar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    snackbarLog = []
+    snackbarKeyCounter = 0
+    mockCtxValue = baseCtx()
+
+    mockEnqueueSnackbar.mockImplementation(
+      (message: string, options?: Record<string, unknown>) => {
+        snackbarKeyCounter += 1
+        const key = snackbarKeyCounter
+        snackbarLog.push({
+          key,
+          message,
+          options: options as SnackbarCall["options"],
+        })
+        return key
+      },
+    )
+  })
+
+  test("non-terminal unreachable: enqueues a warning snackbar without Retry action", () => {
+    setCtx({
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: false },
+        retryProbe: jest.fn(),
+      },
+    })
+
+    render(<PremiumNotificationManager />)
+
+    const unreachableCall = snackbarLog.find((c) =>
+      c.message.includes("temporarily unreachable"),
+    )
+    expect(unreachableCall).toBeDefined()
+    expect(unreachableCall?.options?.variant).toBe("warning")
+    expect(unreachableCall?.options?.action).toBeUndefined()
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_popup_shown",
+      expect.objectContaining({ terminal: false, instance_id: "inst-A" }),
+    )
+  })
+
+  test("non-terminal → terminal transition: closes the old snackbar and enqueues a new one with a Retry action", () => {
+    const retry = jest.fn()
+    setCtx({
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: false },
+        retryProbe: retry,
+      },
+    })
+
+    const { rerender } = render(<PremiumNotificationManager />)
+    // First render should have queued one unreachable snackbar (non-terminal).
+    expect(snackbarLog).toHaveLength(1)
+    const firstKey = snackbarLog[0].key
+
+    // Flip to terminal.
+    mockCtxValue = {
+      ...mockCtxValue,
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: true },
+        retryProbe: retry,
+      },
+    }
+    act(() => {
+      rerender(<PremiumNotificationManager />)
+    })
+
+    // The old snackbar must have been closed before the new one was enqueued.
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(firstKey)
+    // And a second snackbar enqueued — this one must carry an action fn.
+    expect(snackbarLog).toHaveLength(2)
+    const terminalCall = snackbarLog[1]
+    expect(terminalCall.message).toMatch(/unresponsive/i)
+    expect(typeof terminalCall.options?.action).toBe("function")
+
+    // Render the action and click the Retry button.
+    const actionEl = terminalCall.options!.action!(terminalCall.key)
+    const { getByRole } = render(<>{actionEl}</>)
+    fireEvent.click(getByRole("button", { name: /retry/i }))
+
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(terminalCall.key)
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  test("unreachable → reachable: dismisses with reason=reachable", () => {
+    setCtx({
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: false },
+        retryProbe: jest.fn(),
+      },
+    })
+
+    const { rerender } = render(<PremiumNotificationManager />)
+    expect(snackbarLog).toHaveLength(1)
+    mockLogPremiumUiEvent.mockClear()
+
+    mockCtxValue = {
+      ...mockCtxValue,
+      unreachable: {
+        state: { instanceUnreachable: false, isUnreachableTerminal: false },
+        retryProbe: jest.fn(),
+      },
+    }
+    act(() => {
+      rerender(<PremiumNotificationManager />)
+    })
+
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_popup_dismissed",
+      expect.objectContaining({
+        reason: "reachable",
+        instance_id: "inst-A",
+      }),
+    )
+  })
+
+  test("dedicated → shared while unreachable: dismisses with reason=not_dedicated", () => {
+    setCtx({
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: false },
+        retryProbe: jest.fn(),
+      },
+    })
+
+    const { rerender } = render(<PremiumNotificationManager />)
+    mockLogPremiumUiEvent.mockClear()
+
+    mockCtxValue = {
+      ...mockCtxValue,
+      assignmentResult: {
+        instance_id: "inst-A",
+        assigned: true,
+        is_shared: true, // flipped to shared
+      },
+    }
+    act(() => {
+      rerender(<PremiumNotificationManager />)
+    })
+
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_popup_dismissed",
+      expect.objectContaining({ reason: "not_dedicated" }),
+    )
+  })
+
+  test("premium → non-premium while unreachable: dismisses with reason=not_premium", () => {
+    setCtx({
+      unreachable: {
+        state: { instanceUnreachable: true, isUnreachableTerminal: false },
+        retryProbe: jest.fn(),
+      },
+    })
+
+    const { rerender } = render(<PremiumNotificationManager />)
+    mockLogPremiumUiEvent.mockClear()
+
+    mockCtxValue = { ...mockCtxValue, isPremiumUser: false }
+    act(() => {
+      rerender(<PremiumNotificationManager />)
+    })
+
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_popup_dismissed",
+      expect.objectContaining({ reason: "not_premium" }),
+    )
+  })
+})

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -29,6 +29,11 @@ import {
 } from "api/premium/PremiumAssignmentApi"
 import { BASE_URL } from "const/API"
 import { PlanName, SubscriptionStatus } from "const/Subscription"
+import { shouldPoll } from "contexts/premium/unreachableMachine"
+import {
+  InstanceUnreachableHandle,
+  useInstanceUnreachableMachine,
+} from "contexts/premium/useInstanceUnreachableMachine"
 import { useSleepDetection } from "hooks/useSleepDetection"
 import { selectLogoutGeneration } from "store/slice/User/UserSelector"
 import { RootState } from "store/store"
@@ -97,6 +102,7 @@ interface PremiumAssignmentState {
   isPremiumUser: boolean
   showInactivityWarning: boolean
   lastActivityTime: number
+  // Orthogonal to instanceUnreachable — same 503 can set both; they are not redundant.
   heartbeatFailing: boolean
 }
 
@@ -108,6 +114,7 @@ interface PremiumAssignmentContextType extends PremiumAssignmentState {
   autoReleaseOnLogout: () => void
   dismissInactivityWarning: () => void
   recordActivity: () => Promise<void>
+  unreachable: InstanceUnreachableHandle
 }
 
 const PremiumAssignmentContext =
@@ -175,6 +182,11 @@ export const PremiumAssignmentProvider: React.FC<{
   const lastActivityTimeRef = useRef(state.lastActivityTime)
   const showInactivityWarningRef = useRef(state.showInactivityWarning)
 
+  const unreachable = useInstanceUnreachableMachine({
+    assignment: state.assignmentResult,
+    isTabLeader,
+  })
+
   // Calculate premium user status
   const isPremiumUser =
     currentUser?.subscription_plan_name === PlanName.PREMIUM &&
@@ -210,6 +222,7 @@ export const PremiumAssignmentProvider: React.FC<{
         lastActivityTime: Date.now(),
         heartbeatFailing: false,
       })
+      unreachable.reset()
       hasAttemptedRef.current = false
       ssRemove(SS_HAS_ATTEMPTED)
       ssRemove(SS_POLL_ATTEMPTS)
@@ -395,6 +408,8 @@ export const PremiumAssignmentProvider: React.FC<{
         assignmentResult: null,
         statusResult: null,
       }))
+      // Defensive — covers refs outside the reducer that the hook's mirror effect doesn't touch.
+      unreachable.reset()
 
       routingService.setPremiumAssigned(false)
       // Notify other tabs about premium release
@@ -407,7 +422,7 @@ export const PremiumAssignmentProvider: React.FC<{
       setState((prev) => ({ ...prev, isReleasing: false }))
       return { released: true, message: "Release completed with warnings" }
     }
-  }, [])
+  }, [unreachable])
 
   /**
    * Get current status
@@ -680,18 +695,16 @@ export const PremiumAssignmentProvider: React.FC<{
     }
   }, [state.assignmentResult?.is_shared])
 
-  // Poll for premium instance when user is on temporary shared instance
-  // Only the leader tab polls to prevent duplicate API calls
+  // Poll runs while unreachable so a backend reassignment is caught; a poll result alone never clears unreachable (only a real response does).
   useEffect(() => {
-    const hasDedicated =
-      state.assignmentResult?.assigned && !state.assignmentResult?.is_shared
-    const shouldPoll =
-      isPremiumUser &&
-      isTabLeader &&
-      state.assignmentResult != null &&
-      !hasDedicated
-
-    if (!shouldPoll) {
+    if (
+      !shouldPoll(
+        isPremiumUser,
+        isTabLeader,
+        state.assignmentResult,
+        unreachable.state.instanceUnreachable,
+      )
+    ) {
       return
     }
 
@@ -718,16 +731,17 @@ export const PremiumAssignmentProvider: React.FC<{
         if (result.assigned && !result.is_shared) {
           // eslint-disable-next-line no-console
           console.log("Premium instance now available:", result.instance_id)
+          // The hook clears unreachable on an instance_id change; same-id is a no-op — reachability must come from a real response.
           setState((prev) => ({
             ...prev,
             assignmentResult: result,
             error: null,
             isRetryableError: false,
           }))
-          // Reset polling state on success
           setPollInterval(INITIAL_POLL_INTERVAL_MS)
           setPollAttempts(0)
         } else {
+          setState((prev) => ({ ...prev, assignmentResult: result }))
           // eslint-disable-next-line no-console
           console.warn(
             "Still on temporary instance, will retry with backoff...",
@@ -754,6 +768,7 @@ export const PremiumAssignmentProvider: React.FC<{
     isPremiumUser,
     isTabLeader,
     state.assignmentResult,
+    unreachable.state.instanceUnreachable,
     pollInterval,
     pollAttempts,
   ])
@@ -787,6 +802,7 @@ export const PremiumAssignmentProvider: React.FC<{
     autoReleaseOnLogout,
     dismissInactivityWarning,
     recordActivity,
+    unreachable,
   }
 
   return (

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -1,0 +1,669 @@
+/**
+ * Provider-level integration tests for the instance-unreachable state
+ * machine. Unlike PremiumInstanceUnreachable.test.ts (pure helpers), these
+ * mount PremiumAssignmentProvider with real routingService + a capturable
+ * tabSync mock, and drive scenarios through real emit calls.
+ */
+
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import type {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must be declared before importing the provider) ---
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      user: { currentUser: mockUser, logoutGeneration: 0 },
+    }),
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+// Mock tabSync so tests can invoke handlers directly. "mock" prefix required for Jest's out-of-scope guard.
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+const mockTabSyncBroadcasts: TabSyncMessage[] = []
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: (msg: TabSyncMessage) => {
+      mockTabSyncBroadcasts.push(msg)
+    },
+    broadcastPremiumReleased: () => {},
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type)) {
+        mockTabSyncHandlers.set(type, new Set())
+      }
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => null,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+// --- Imports (after mocks) ---
+// require() not import: static imports hoist above mock vars and cause TDZ when factories run.
+
+const { MAX_FAILED_PROBES } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/premium/unreachableConstants")
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+const { routingService } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+// --- Helpers ---
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const renderProvider = () => {
+  const ctxRef: { current: Ctx | null } = { current: null }
+  render(
+    <SnackbarProvider maxSnack={3}>
+      <PremiumAssignmentProvider>
+        <Harness ctxRef={ctxRef} />
+      </PremiumAssignmentProvider>
+    </SnackbarProvider>,
+  )
+  return ctxRef
+}
+
+const fireTabSync = (type: TabSyncMessageType, payload: unknown) => {
+  const handlers = mockTabSyncHandlers.get(type)
+  if (!handlers) return
+  handlers.forEach((h) => h({ type, payload }))
+}
+
+const mockedGetStatus = mockGetPremiumStatus
+const mockedAssign = mockAssignPremiumInstance
+const mockedLog = mockLogPremiumUiEvent
+
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2023-01-01T00:00:00Z",
+    status: "active",
+  },
+}
+
+// --- Tests ---
+
+describe("PremiumAssignmentProvider — unreachable state machine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockTabSyncHandlers.clear()
+    mockTabSyncBroadcasts.length = 0
+    localStorage.clear()
+    sessionStorage.clear()
+    // Real routingService: reset listeners and premiumAssigned
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+  })
+
+  test("HEALTHY → DEGRADED on emitPremiumUnreachable, then clears on emitPremiumReachable", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/x",
+        status: 503,
+        sentAt: 1000,
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+    expect(ctxRef.current?.unreachable.state.unreachableSince).toBeGreaterThan(
+      0,
+    )
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(0)
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
+
+    // Broadcast emitted on HEALTHY → DEGRADED
+    expect(
+      mockTabSyncBroadcasts.find(
+        (m) => m.type === "PREMIUM_INSTANCE_UNREACHABLE",
+      ),
+    ).toBeTruthy()
+    expect(mockedLog).toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.objectContaining({ status: 503 }),
+    )
+
+    act(() => {
+      routingService.emitPremiumReachable({
+        url: "/x",
+        status: 200,
+        sentAt: 2000,
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    })
+    expect(ctxRef.current?.unreachable.state.unreachableSince).toBeNull()
+    expect(mockedLog).toHaveBeenCalledWith(
+      "instance_reachable",
+      expect.objectContaining({ instance_id: "inst-A" }),
+    )
+  })
+
+  test("stale unreachable (older sentAt than last reachable) is suppressed", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Reachable observed at sentAt=2000 — establishes the watermark.
+    act(() => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+    })
+
+    // Late-arriving failure whose request was sent at t=1500 must be ignored.
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1500 })
+    })
+
+    // Give any reactive work a chance to flush.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    expect(mockedLog).not.toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+  })
+
+  test("peer UNREACHABLE broadcast applies state including failed_probes/is_terminal", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_UNREACHABLE", {
+        instance_id: "inst-A",
+        unreachable_since: 5000,
+        failed_probes: 3,
+        is_terminal: false,
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+    expect(ctxRef.current?.unreachable.state.unreachableSince).toBe(5000)
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(3)
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
+
+    // Peer-initiated broadcasts must NOT re-log or re-broadcast (echo prevention).
+    expect(mockedLog).not.toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+    expect(
+      mockTabSyncBroadcasts.find(
+        (m) => m.type === "PREMIUM_INSTANCE_UNREACHABLE",
+      ),
+    ).toBeUndefined()
+  })
+
+  test("peer PROBE_UPDATE broadcast updates probe count", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Enter unreachable first so PROBE_UPDATE is considered relevant.
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_UNREACHABLE", {
+        instance_id: "inst-A",
+        unreachable_since: 5000,
+        failed_probes: 0,
+        is_terminal: false,
+      })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_PROBE_UPDATE", {
+        instance_id: "inst-A",
+        failed_probes: MAX_FAILED_PROBES,
+        is_terminal: true,
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.failedProbes).toBe(
+        MAX_FAILED_PROBES,
+      )
+    })
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(true)
+  })
+
+  test("peer REACHABLE broadcast clears unreachable state", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_UNREACHABLE", {
+        instance_id: "inst-A",
+        unreachable_since: 5000,
+        failed_probes: 2,
+        is_terminal: false,
+      })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_REACHABLE", { instance_id: "inst-A" })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    })
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(0)
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
+  })
+
+  test("late echo of unreachable does not re-log", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1000 })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+    expect(mockedLog).toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+    const firstCallCount = mockedLog.mock.calls.filter(
+      ([name]) => name === "instance_unreachable",
+    ).length
+    expect(firstCallCount).toBe(1)
+
+    // Second emit — already DEGRADED, so handler must be a noop.
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1100 })
+    })
+    const secondCallCount = mockedLog.mock.calls.filter(
+      ([name]) => name === "instance_unreachable",
+    ).length
+    expect(secondCallCount).toBe(1)
+  })
+
+  test("snapshot hydration applies on mount when instance_id matches", async () => {
+    localStorage.setItem(
+      "premium_unreachable_snapshot",
+      JSON.stringify({
+        instance_id: "inst-A",
+        unreachable_since: 1234,
+        failed_probes: 2,
+        is_terminal: false,
+        updated_at: Date.now(),
+      }),
+    )
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+    expect(ctxRef.current?.unreachable.state.unreachableSince).toBe(1234)
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(2)
+  })
+
+  test("snapshot hydration rejected when instance_id differs", async () => {
+    localStorage.setItem(
+      "premium_unreachable_snapshot",
+      JSON.stringify({
+        instance_id: "inst-other",
+        unreachable_since: 1234,
+        failed_probes: 2,
+        is_terminal: false,
+        updated_at: Date.now(),
+      }),
+    )
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+  })
+
+  test("snapshot hydration rejected when snapshot is older than the 1h TTL", async () => {
+    // The snapshot reader treats any entry older than UNREACHABLE_SNAPSHOT_TTL_MS
+    // (1 hour) as missing — a stale peer entry must not hydrate a fresh tab
+    // into a degraded state that no longer reflects reality.
+    const oneHourMs = 60 * 60 * 1000
+    localStorage.setItem(
+      "premium_unreachable_snapshot",
+      JSON.stringify({
+        instance_id: "inst-A",
+        unreachable_since: Date.now() - oneHourMs - 60_000,
+        failed_probes: 2,
+        is_terminal: false,
+        updated_at: Date.now() - oneHourMs - 60_000, // 1h + 1min old → expired
+      }),
+    )
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Give the hydration effect a chance to run.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(0)
+  })
+
+  test("snapshot with malformed JSON is treated as missing", async () => {
+    // Defensive: a junk value in localStorage must not crash the reader.
+    localStorage.setItem("premium_unreachable_snapshot", "not-json")
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+  })
+
+  test("retryUnreachableProbe clears terminal + arms a probe, next failure counts as probe not flip", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Drive into terminal via cross-tab sync (fast path — avoids waiting
+    // through five real re-arm timers).
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_UNREACHABLE", {
+        instance_id: "inst-A",
+        unreachable_since: 5000,
+        failed_probes: MAX_FAILED_PROBES,
+        is_terminal: true,
+      })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(true)
+    })
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(
+      MAX_FAILED_PROBES,
+    )
+
+    // User clicks Retry.
+    act(() => {
+      ctxRef.current?.unreachable.retryProbe()
+    })
+
+    // Terminal flag cleared, probe budget reset, unreachable still set.
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(0)
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+
+    expect(mockedLog).toHaveBeenCalledWith(
+      "instance_unreachable_manual_retry",
+      expect.objectContaining({ instance_id: "inst-A" }),
+    )
+
+    // Premium routing is re-enabled so the next request carries premium
+    // headers and can serve as the probe.
+    expect(routingService.isPremiumAssigned()).toBe(true)
+
+    // Sanity: a subsequent unreachable event counts as a probe failure
+    // (not a fresh HEALTHY→DEGRADED flip). Probe failure increments
+    // failedProbes; a fresh flip would leave it at 0.
+    mockedLog.mockClear()
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 99999 })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.failedProbes).toBe(1)
+    })
+    // Probe-failure logs — not a fresh instance_unreachable log.
+    expect(mockedLog).toHaveBeenCalledWith(
+      "instance_probe_failure",
+      expect.anything(),
+    )
+    expect(mockedLog).not.toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+  })
+
+  test("retryUnreachableProbe is a noop when not currently unreachable", () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    act(() => {
+      ctxRef.current?.unreachable.retryProbe?.()
+    })
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    expect(mockedLog).not.toHaveBeenCalledWith(
+      "instance_unreachable_manual_retry",
+      expect.anything(),
+    )
+  })
+
+  test("heartbeat 503 and unreachable machine coexist — both flags set, neither blocks the other", async () => {
+    jest.setTimeout(15000)
+    // When the backend returns 503 to a heartbeat from the axios interceptor:
+    //  - the interceptor emits emitPremiumUnreachable → the machine flips
+    //  - the heartbeat call itself rejects → heartbeatFailing goes true
+    //    after HEARTBEAT_MAX_RETRIES. The two states are orthogonal; the same
+    //    503 sets both, and they must not stomp on each other.
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Simulate the interceptor emission from a 503 to /heartbeat.
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/users/me/premium/heartbeat",
+        status: 503,
+        sentAt: 1000,
+      })
+    })
+
+    // Simulate the heartbeat call rejecting after 3 retries. We drive this
+    // via recordActivity(), which is the public entrypoint that sets
+    // heartbeatFailing on final failure. mockSendPremiumHeartbeat is
+    // rejected for every call so all 3 retries fail.
+    mockSendPremiumHeartbeat.mockReset()
+    mockSendPremiumHeartbeat.mockRejectedValue(new Error("Service Unavailable"))
+
+    // Retries wait 1s then 2s (3s total). Real timers, but the recordActivity
+    // promise rejects at the end so we don't hang past ~3s.
+    await act(async () => {
+      try {
+        await ctxRef.current?.recordActivity()
+      } catch {
+        /* expected — final rejection */
+      }
+    })
+
+    // Both flags set, independently.
+    expect(ctxRef.current?.heartbeatFailing).toBe(true)
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    // The machine is in DEGRADED, not TERMINAL — heartbeat failure alone does
+    // not consume the probe budget (that's driven by probe re-arms, not the
+    // heartbeat directly).
+    expect(ctxRef.current?.unreachable.state.failedProbes).toBe(0)
+    expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
+  })
+
+  test("non-dedicated assignment clears unreachable state via mirror effect", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1000 })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Simulate a backend poll reassigning to shared.
+    mockedAssign.mockResolvedValue({
+      assigned: true,
+      is_shared: true,
+      message: "shared",
+    })
+
+    // Drive a poll turn by directly re-calling assign() — the state
+    // change into a shared assignment activates the mirror effect's
+    // cleanup path.
+    await act(async () => {
+      await ctxRef.current?.assign()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    })
+  })
+})

--- a/frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts
+++ b/frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect } from "@jest/globals"
+
+import {
+  INITIAL_PROBE_DELAY_MS,
+  MAX_FAILED_PROBES,
+  MAX_PROBE_DELAY_MS,
+  PROBE_BACKOFF_MULTIPLIER,
+} from "contexts/premium/unreachableConstants"
+import {
+  INITIAL_UNREACHABLE_STATE,
+  computeNextProbeDelayMs,
+  computeProbeFailure,
+  hasReachedProbeCap,
+  isStaleFailure,
+  shouldClearUnreachableForAssignment,
+  shouldFlipToUnreachable,
+  shouldHydrateFromSnapshot,
+  shouldPoll,
+  unreachableMachineReducer,
+} from "contexts/premium/unreachableMachine"
+
+// Pure helpers, no React. Pins the polling gate and state-machine guards
+// without needing to mount the provider.
+
+describe("shouldPoll", () => {
+  const premium = true
+  const leader = true
+  const dedicated = { assigned: true, is_shared: false }
+  const shared = { assigned: true, is_shared: true }
+
+  it("does not poll when dedicated and healthy", () => {
+    expect(shouldPoll(premium, leader, dedicated, false)).toBe(false)
+  })
+
+  it("polls when dedicated but instance is unreachable", () => {
+    expect(shouldPoll(premium, leader, dedicated, true)).toBe(true)
+  })
+
+  it("polls while on a shared instance", () => {
+    expect(shouldPoll(premium, leader, shared, false)).toBe(true)
+  })
+
+  it("does not poll when no assignment exists", () => {
+    expect(shouldPoll(premium, leader, null, false)).toBe(false)
+  })
+
+  it("does not poll when tab is not leader", () => {
+    expect(shouldPoll(premium, false, dedicated, true)).toBe(false)
+  })
+
+  it("does not poll when user is not premium", () => {
+    expect(shouldPoll(false, leader, dedicated, true)).toBe(false)
+  })
+
+  it("does not poll for shared when not leader", () => {
+    expect(shouldPoll(premium, false, shared, false)).toBe(false)
+  })
+})
+
+describe("shouldFlipToUnreachable", () => {
+  it("flips when dedicated and not already unreachable", () => {
+    expect(
+      shouldFlipToUnreachable({ assigned: true, is_shared: false }, false),
+    ).toBe(true)
+  })
+
+  it("does not flip on a shared assignment", () => {
+    expect(
+      shouldFlipToUnreachable({ assigned: true, is_shared: true }, false),
+    ).toBe(false)
+  })
+
+  it("does not flip when no assignment", () => {
+    expect(shouldFlipToUnreachable(null, false)).toBe(false)
+  })
+
+  it("does not flip when assignment not yet assigned", () => {
+    expect(
+      shouldFlipToUnreachable({ assigned: false, is_shared: false }, false),
+    ).toBe(false)
+  })
+
+  it("does not re-flip when already unreachable", () => {
+    expect(
+      shouldFlipToUnreachable({ assigned: true, is_shared: false }, true),
+    ).toBe(false)
+  })
+})
+
+describe("computeNextProbeDelayMs", () => {
+  it("starts at the initial delay for zero prior failures", () => {
+    expect(computeNextProbeDelayMs(0)).toBe(INITIAL_PROBE_DELAY_MS)
+  })
+
+  it("doubles with each failure up to the cap", () => {
+    expect(computeNextProbeDelayMs(1)).toBe(
+      INITIAL_PROBE_DELAY_MS * PROBE_BACKOFF_MULTIPLIER,
+    )
+    expect(computeNextProbeDelayMs(2)).toBe(
+      INITIAL_PROBE_DELAY_MS * PROBE_BACKOFF_MULTIPLIER ** 2,
+    )
+  })
+
+  it("caps the delay at MAX_PROBE_DELAY_MS", () => {
+    expect(computeNextProbeDelayMs(100)).toBe(MAX_PROBE_DELAY_MS)
+  })
+
+  it("treats negative counts as zero rather than shrinking the delay", () => {
+    expect(computeNextProbeDelayMs(-5)).toBe(INITIAL_PROBE_DELAY_MS)
+  })
+})
+
+describe("hasReachedProbeCap", () => {
+  it("returns false below the cap", () => {
+    expect(hasReachedProbeCap(0)).toBe(false)
+    expect(hasReachedProbeCap(MAX_FAILED_PROBES - 1)).toBe(false)
+  })
+
+  it("returns true at the cap", () => {
+    expect(hasReachedProbeCap(MAX_FAILED_PROBES)).toBe(true)
+  })
+
+  it("returns true beyond the cap", () => {
+    expect(hasReachedProbeCap(MAX_FAILED_PROBES + 10)).toBe(true)
+  })
+})
+
+describe("isStaleFailure", () => {
+  it("suppresses a failure whose request predates the last reachable", () => {
+    expect(isStaleFailure(100, 200, 300)).toBe(true)
+  })
+
+  it("does not suppress a failure newer than the last reachable", () => {
+    expect(isStaleFailure(300, 200, 400)).toBe(false)
+  })
+
+  it("does not suppress when detail.sentAt equals lastReachable", () => {
+    // Equal sentAt means the failure is no older than the success — treat
+    // as current evidence rather than stale.
+    expect(isStaleFailure(200, 200, 300)).toBe(false)
+  })
+
+  it("falls back to now when sentAt is undefined (treat event as current)", () => {
+    // Undefined sentAt should behave as a fresh event — no suppression.
+    expect(isStaleFailure(undefined, 200, 300)).toBe(false)
+  })
+
+  it("suppresses undefined-sentAt event only if now predates lastReachable", () => {
+    // Contrived: a listener fires with now < lastReachable (clock went back
+    // or tests inject explicit timestamps). Still the defined semantics.
+    expect(isStaleFailure(undefined, 500, 400)).toBe(true)
+  })
+})
+
+describe("computeProbeFailure", () => {
+  it("increments failed count and does not mark terminal below cap", () => {
+    expect(computeProbeFailure(0)).toEqual({
+      nextFailed: 1,
+      nextTerminal: false,
+    })
+    expect(computeProbeFailure(MAX_FAILED_PROBES - 2)).toEqual({
+      nextFailed: MAX_FAILED_PROBES - 1,
+      nextTerminal: false,
+    })
+  })
+
+  it("marks terminal on the step that reaches the cap", () => {
+    expect(computeProbeFailure(MAX_FAILED_PROBES - 1)).toEqual({
+      nextFailed: MAX_FAILED_PROBES,
+      nextTerminal: true,
+    })
+  })
+
+  it("stays terminal beyond the cap", () => {
+    expect(computeProbeFailure(MAX_FAILED_PROBES + 3)).toEqual({
+      nextFailed: MAX_FAILED_PROBES + 4,
+      nextTerminal: true,
+    })
+  })
+})
+
+describe("shouldHydrateFromSnapshot", () => {
+  const dedicated = {
+    assigned: true,
+    is_shared: false,
+    instance_id: "inst-a",
+  }
+
+  it("hydrates when assignment is dedicated and snapshot matches", () => {
+    expect(
+      shouldHydrateFromSnapshot(dedicated, { instance_id: "inst-a" }),
+    ).toBe(true)
+  })
+
+  it("does not hydrate when the snapshot is null", () => {
+    expect(shouldHydrateFromSnapshot(dedicated, null)).toBe(false)
+  })
+
+  it("does not hydrate when instance_id differs", () => {
+    expect(
+      shouldHydrateFromSnapshot(dedicated, { instance_id: "inst-b" }),
+    ).toBe(false)
+  })
+
+  it("does not hydrate when assignment is shared", () => {
+    expect(
+      shouldHydrateFromSnapshot(
+        { assigned: true, is_shared: true, instance_id: "inst-a" },
+        { instance_id: "inst-a" },
+      ),
+    ).toBe(false)
+  })
+
+  it("does not hydrate when assignment is not assigned", () => {
+    expect(
+      shouldHydrateFromSnapshot(
+        { assigned: false, is_shared: false },
+        { instance_id: "inst-a" },
+      ),
+    ).toBe(false)
+  })
+
+  it("does not hydrate when assignment is null", () => {
+    expect(shouldHydrateFromSnapshot(null, { instance_id: "inst-a" })).toBe(
+      false,
+    )
+  })
+
+  it("matches when both sides treat missing instance_id as null", () => {
+    expect(
+      shouldHydrateFromSnapshot(
+        { assigned: true, is_shared: false },
+        { instance_id: null },
+      ),
+    ).toBe(true)
+  })
+})
+
+describe("unreachableMachineReducer", () => {
+  const degraded = {
+    instanceUnreachable: true,
+    unreachableSince: 5000,
+    failedProbes: 2,
+    isUnreachableTerminal: false,
+  }
+
+  it("CLEAR from initial state returns the same reference (noop)", () => {
+    const next = unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+      type: "CLEAR",
+    })
+    expect(next).toBe(INITIAL_UNREACHABLE_STATE)
+  })
+
+  it("CLEAR from a degraded state resets all fields", () => {
+    expect(unreachableMachineReducer(degraded, { type: "CLEAR" })).toEqual(
+      INITIAL_UNREACHABLE_STATE,
+    )
+  })
+
+  it("FLIP_TO_UNREACHABLE from HEALTHY sets flag + timestamp", () => {
+    expect(
+      unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+        type: "FLIP_TO_UNREACHABLE",
+        since: 123,
+      }),
+    ).toEqual({
+      ...INITIAL_UNREACHABLE_STATE,
+      instanceUnreachable: true,
+      unreachableSince: 123,
+    })
+  })
+
+  it("FLIP_TO_UNREACHABLE is idempotent when already unreachable", () => {
+    const next = unreachableMachineReducer(degraded, {
+      type: "FLIP_TO_UNREACHABLE",
+      since: 9999,
+    })
+    expect(next).toBe(degraded)
+  })
+
+  it("PROBE_FAILURE increments failedProbes and stops short of terminal", () => {
+    expect(
+      unreachableMachineReducer(degraded, { type: "PROBE_FAILURE" }),
+    ).toEqual({
+      ...degraded,
+      failedProbes: 3,
+      isUnreachableTerminal: false,
+    })
+  })
+
+  it("PROBE_FAILURE promotes to terminal on the step that hits the cap", () => {
+    const atCap = { ...degraded, failedProbes: MAX_FAILED_PROBES - 1 }
+    expect(unreachableMachineReducer(atCap, { type: "PROBE_FAILURE" })).toEqual(
+      {
+        ...atCap,
+        failedProbes: MAX_FAILED_PROBES,
+        isUnreachableTerminal: true,
+      },
+    )
+  })
+
+  it("APPLY_PEER_UNREACHABLE overrides all four fields", () => {
+    expect(
+      unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+        type: "APPLY_PEER_UNREACHABLE",
+        payload: {
+          unreachable_since: 100,
+          failed_probes: 3,
+          is_terminal: false,
+        },
+      }),
+    ).toEqual({
+      instanceUnreachable: true,
+      unreachableSince: 100,
+      failedProbes: 3,
+      isUnreachableTerminal: false,
+    })
+  })
+
+  it("APPLY_PEER_UNREACHABLE treats missing payload fields as zero/false", () => {
+    const next = unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+      type: "APPLY_PEER_UNREACHABLE",
+      payload: {},
+    })
+    expect(next.instanceUnreachable).toBe(true)
+    expect(next.failedProbes).toBe(0)
+    expect(next.isUnreachableTerminal).toBe(false)
+    // unreachable_since falls back to Date.now() — can't assert exact value
+    expect(next.unreachableSince).not.toBeNull()
+  })
+
+  it("APPLY_PEER_PROBE_UPDATE updates only probe fields", () => {
+    expect(
+      unreachableMachineReducer(degraded, {
+        type: "APPLY_PEER_PROBE_UPDATE",
+        payload: { failed_probes: MAX_FAILED_PROBES, is_terminal: true },
+      }),
+    ).toEqual({
+      ...degraded,
+      failedProbes: MAX_FAILED_PROBES,
+      isUnreachableTerminal: true,
+    })
+  })
+
+  it("MANUAL_RETRY from degraded resets probe budget, keeps unreachable flag", () => {
+    const terminal = {
+      instanceUnreachable: true,
+      unreachableSince: 5000,
+      failedProbes: MAX_FAILED_PROBES,
+      isUnreachableTerminal: true,
+    }
+    expect(
+      unreachableMachineReducer(terminal, { type: "MANUAL_RETRY" }),
+    ).toEqual({
+      instanceUnreachable: true,
+      unreachableSince: 5000,
+      failedProbes: 0,
+      isUnreachableTerminal: false,
+    })
+  })
+
+  it("MANUAL_RETRY is a noop when not unreachable", () => {
+    const next = unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+      type: "MANUAL_RETRY",
+    })
+    expect(next).toBe(INITIAL_UNREACHABLE_STATE)
+  })
+
+  it("HYDRATE_FROM_SNAPSHOT fully replaces state with the snapshot", () => {
+    expect(
+      unreachableMachineReducer(INITIAL_UNREACHABLE_STATE, {
+        type: "HYDRATE_FROM_SNAPSHOT",
+        payload: {
+          unreachable_since: 777,
+          failed_probes: 4,
+          is_terminal: false,
+        },
+      }),
+    ).toEqual({
+      instanceUnreachable: true,
+      unreachableSince: 777,
+      failedProbes: 4,
+      isUnreachableTerminal: false,
+    })
+  })
+})
+
+describe("shouldClearUnreachableForAssignment", () => {
+  it("clears when assignment is null", () => {
+    expect(shouldClearUnreachableForAssignment(null)).toBe(true)
+  })
+
+  it("clears when assignment is shared", () => {
+    expect(
+      shouldClearUnreachableForAssignment({ assigned: true, is_shared: true }),
+    ).toBe(true)
+  })
+
+  it("clears when assignment is not yet assigned", () => {
+    expect(
+      shouldClearUnreachableForAssignment({
+        assigned: false,
+        is_shared: false,
+      }),
+    ).toBe(true)
+  })
+
+  it("does not clear when assignment is dedicated and assigned", () => {
+    expect(
+      shouldClearUnreachableForAssignment({
+        assigned: true,
+        is_shared: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
+++ b/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Leader-gated behaviour in useInstanceUnreachableMachine.
+ *
+ * The hook takes `isTabLeader` as an argument; leader-only logic is:
+ *  - Snapshot write to localStorage (both the "write on unreachable" and
+ *    "clear on recovery" branches).
+ *  - Probe timer arming after INITIAL_PROBE_DELAY_MS.
+ *
+ * These tests drive the hook directly so we can pin the gate without the
+ * extra surface area of PremiumAssignmentProvider.
+ */
+
+import React from "react"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render } from "@testing-library/react"
+
+import type { PremiumAssignmentResult } from "api/premium/PremiumAssignmentApi"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must be declared before importing the hook) ---
+
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+// tabSync mock — no-op broadcast; register-only handlers.
+jest.mock("utils/crossTabSync", () => {
+  const handlers = new Map<
+    TabSyncMessageType,
+    Set<(msg: TabSyncMessage) => void>
+  >()
+  return {
+    __esModule: true,
+    tabSync: {
+      broadcast: () => {},
+      broadcastPremiumReleased: () => {},
+      on: (type: TabSyncMessageType, h: (m: TabSyncMessage) => void) => {
+        if (!handlers.has(type)) handlers.set(type, new Set())
+        handlers.get(type)!.add(h)
+        return () => handlers.get(type)?.delete(h)
+      },
+      onAny: () => () => {},
+      destroy: () => {},
+    },
+  }
+})
+
+// --- Imports (after mocks) ---
+// require() not import: static imports hoist above mock vars and cause TDZ when factories run.
+const {
+  INITIAL_PROBE_DELAY_MS,
+  LS_UNREACHABLE_SNAPSHOT,
+}: typeof import("contexts/premium/unreachableConstants") =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/premium/unreachableConstants")
+const {
+  useInstanceUnreachableMachine,
+}: typeof import("contexts/premium/useInstanceUnreachableMachine") =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/premium/useInstanceUnreachableMachine")
+const { routingService }: typeof import("utils/routing/RoutingService") =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+// --- Harness ---
+
+type Handle = ReturnType<typeof useInstanceUnreachableMachine>
+
+const Harness: React.FC<{
+  assignment: PremiumAssignmentResult | null
+  isTabLeader: boolean
+  captureRef: { current: Handle | null }
+}> = ({ assignment, isTabLeader, captureRef }) => {
+  captureRef.current = useInstanceUnreachableMachine({
+    assignment,
+    isTabLeader,
+  })
+  return null
+}
+
+const dedicated: PremiumAssignmentResult = {
+  message: "ok",
+  instance_id: "inst-A",
+  assigned: true,
+  is_shared: false,
+}
+
+const renderHook = (opts: {
+  assignment?: PremiumAssignmentResult | null
+  isTabLeader?: boolean
+}) => {
+  const captureRef: { current: Handle | null } = { current: null }
+  const { rerender } = render(
+    <Harness
+      assignment={opts.assignment ?? dedicated}
+      isTabLeader={opts.isTabLeader ?? true}
+      captureRef={captureRef}
+    />,
+  )
+  return {
+    ref: captureRef,
+    rerender: (next: {
+      assignment?: PremiumAssignmentResult | null
+      isTabLeader?: boolean
+    }) =>
+      rerender(
+        <Harness
+          assignment={next.assignment ?? opts.assignment ?? dedicated}
+          isTabLeader={next.isTabLeader ?? opts.isTabLeader ?? true}
+          captureRef={captureRef}
+        />,
+      ),
+  }
+}
+
+const readSnapshot = (): Record<string, unknown> | null => {
+  const raw = localStorage.getItem(LS_UNREACHABLE_SNAPSHOT)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+// --- Tests ---
+
+describe("useInstanceUnreachableMachine — leader-gated side effects", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test("non-leader tab does NOT write premium_unreachable_snapshot on unreachable", () => {
+    // Drive the hook into unreachable state on a non-leader tab. The
+    // leader-only write branch must skip — no snapshot key in localStorage.
+    const { ref } = renderHook({ isTabLeader: false })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    expect(readSnapshot()).toBeNull()
+  })
+
+  test("leader tab writes snapshot when unreachable, and clears it on recovery", () => {
+    const { ref } = renderHook({ isTabLeader: true })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    const snap = readSnapshot()
+    expect(snap).not.toBeNull()
+    expect(snap?.instance_id).toBe("inst-A")
+    expect(snap?.is_terminal).toBe(false)
+    expect(typeof snap?.updated_at).toBe("number")
+
+    act(() => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2 })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+    // Clear branch — leader has "ever been unreachable" flag set, so it
+    // proactively removes the key rather than leaving a stale entry.
+    expect(localStorage.getItem(LS_UNREACHABLE_SNAPSHOT)).toBeNull()
+  })
+
+  test("leader-gated probe timer arms setPremiumAssigned(true) and logs instance_probe_armed after INITIAL_PROBE_DELAY_MS", () => {
+    jest.useFakeTimers()
+
+    const { ref } = renderHook({ isTabLeader: true })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
+    })
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    // setPremiumAssigned was NOT flipped back to true by the unreachable
+    // emission itself — the probe timer is the only thing that re-arms it.
+    expect(routingService.isPremiumAssigned()).toBe(false)
+
+    // Advance to just before the delay — no probe yet.
+    act(() => {
+      jest.advanceTimersByTime(INITIAL_PROBE_DELAY_MS - 1)
+    })
+    expect(routingService.isPremiumAssigned()).toBe(false)
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_probe_armed",
+      expect.anything(),
+    )
+
+    // Cross the threshold — probe fires.
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(routingService.isPremiumAssigned()).toBe(true)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_probe_armed",
+      expect.objectContaining({
+        instance_id: "inst-A",
+        failed_probes: 0,
+        delay_ms: INITIAL_PROBE_DELAY_MS,
+      }),
+    )
+  })
+
+  test("non-leader tab does NOT arm the probe timer", () => {
+    jest.useFakeTimers()
+
+    renderHook({ isTabLeader: false })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
+    })
+
+    // Run well past the probe delay — non-leader must not arm.
+    act(() => {
+      jest.advanceTimersByTime(INITIAL_PROBE_DELAY_MS * 3)
+    })
+
+    expect(routingService.isPremiumAssigned()).toBe(false)
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_probe_armed",
+      expect.anything(),
+    )
+  })
+})

--- a/frontend/src/contexts/premium/unreachableConstants.ts
+++ b/frontend/src/contexts/premium/unreachableConstants.ts
@@ -1,0 +1,9 @@
+// Re-arm (half-open circuit) configuration for instance-unreachable recovery.
+export const INITIAL_PROBE_DELAY_MS = 30000
+export const MAX_PROBE_DELAY_MS = 300000
+export const PROBE_BACKOFF_MULTIPLIER = 2
+export const MAX_FAILED_PROBES = 5
+
+// localStorage fallback because BroadcastChannel doesn't replay past messages to new tabs.
+export const LS_UNREACHABLE_SNAPSHOT = "premium_unreachable_snapshot"
+export const UNREACHABLE_SNAPSHOT_TTL_MS = 60 * 60 * 1000

--- a/frontend/src/contexts/premium/unreachableMachine.ts
+++ b/frontend/src/contexts/premium/unreachableMachine.ts
@@ -1,0 +1,194 @@
+import {
+  INITIAL_PROBE_DELAY_MS,
+  MAX_FAILED_PROBES,
+  MAX_PROBE_DELAY_MS,
+  PROBE_BACKOFF_MULTIPLIER,
+} from "contexts/premium/unreachableConstants"
+
+export type AssignmentSnapshot = {
+  assigned?: boolean
+  is_shared?: boolean
+  instance_id?: string
+} | null
+
+export type UnreachableSnapshot = {
+  instance_id: string | null
+  unreachable_since: number
+  failed_probes: number
+  is_terminal: boolean
+  updated_at: number
+}
+
+// Also polls while unreachable so we catch a backend-initiated reassignment to shared.
+export const shouldPoll = (
+  isPremiumUser: boolean,
+  isTabLeader: boolean,
+  assignment: AssignmentSnapshot,
+  instanceUnreachable: boolean,
+): boolean => {
+  if (!isPremiumUser || !isTabLeader || assignment == null) return false
+  const hasDedicatedAndHealthy =
+    !!assignment.assigned && !assignment.is_shared && !instanceUnreachable
+  return !hasDedicatedAndHealthy
+}
+
+export const shouldFlipToUnreachable = (
+  assignment: AssignmentSnapshot,
+  currentUnreachable: boolean,
+): boolean => {
+  if (!assignment?.assigned || assignment.is_shared) return false
+  return !currentUnreachable
+}
+
+export const computeNextProbeDelayMs = (failedProbes: number): number =>
+  Math.min(
+    INITIAL_PROBE_DELAY_MS *
+      Math.pow(PROBE_BACKOFF_MULTIPLIER, Math.max(0, failedProbes)),
+    MAX_PROBE_DELAY_MS,
+  )
+
+export const hasReachedProbeCap = (failedProbes: number): boolean =>
+  failedProbes >= MAX_FAILED_PROBES
+
+// True when the failure's request predates the last reachable — stale evidence, do not act on it.
+export const isStaleFailure = (
+  detailSentAt: number | undefined,
+  lastReachableSentAt: number,
+  now: number,
+): boolean => {
+  const sentAt = detailSentAt ?? now
+  return sentAt < lastReachableSentAt
+}
+
+export const computeProbeFailure = (
+  prevFailed: number,
+): { nextFailed: number; nextTerminal: boolean } => {
+  const nextFailed = prevFailed + 1
+  return { nextFailed, nextTerminal: nextFailed >= MAX_FAILED_PROBES }
+}
+
+// Only apply the snapshot when instance_id matches — a snapshot from a prior assignment is stale.
+export const shouldHydrateFromSnapshot = (
+  assignment: AssignmentSnapshot,
+  snap: { instance_id: string | null } | null,
+): boolean => {
+  if (!snap) return false
+  if (!assignment?.assigned || assignment.is_shared) return false
+  return snap.instance_id === (assignment.instance_id ?? null)
+}
+
+// Unreachable tracking is meaningless once the assignment is no longer dedicated.
+export const shouldClearUnreachableForAssignment = (
+  assignment: AssignmentSnapshot,
+): boolean => {
+  const isDedicated = !!assignment?.assigned && !assignment.is_shared
+  return !isDedicated
+}
+
+// --- Unreachable state machine (reducer) ---
+
+export interface UnreachableMachineState {
+  instanceUnreachable: boolean
+  unreachableSince: number | null
+  failedProbes: number
+  // Probe budget exhausted — only manual retry or backend reassignment recovers.
+  isUnreachableTerminal: boolean
+}
+
+export const INITIAL_UNREACHABLE_STATE: UnreachableMachineState = {
+  instanceUnreachable: false,
+  unreachableSince: null,
+  failedProbes: 0,
+  isUnreachableTerminal: false,
+}
+
+export type UnreachableMachineAction =
+  | { type: "CLEAR" }
+  | { type: "FLIP_TO_UNREACHABLE"; since: number }
+  | { type: "PROBE_FAILURE" }
+  | { type: "MANUAL_RETRY" }
+  | {
+      type: "APPLY_PEER_UNREACHABLE"
+      payload: {
+        unreachable_since?: number
+        failed_probes?: number
+        is_terminal?: boolean
+      }
+    }
+  | {
+      type: "APPLY_PEER_PROBE_UPDATE"
+      payload: { failed_probes?: number; is_terminal?: boolean }
+    }
+  | {
+      type: "HYDRATE_FROM_SNAPSHOT"
+      payload: {
+        unreachable_since: number
+        failed_probes: number
+        is_terminal: boolean
+      }
+    }
+
+export const unreachableMachineReducer = (
+  state: UnreachableMachineState,
+  action: UnreachableMachineAction,
+): UnreachableMachineState => {
+  switch (action.type) {
+    case "CLEAR":
+      return state.instanceUnreachable ||
+        state.unreachableSince != null ||
+        state.failedProbes > 0 ||
+        state.isUnreachableTerminal
+        ? INITIAL_UNREACHABLE_STATE
+        : state
+    case "FLIP_TO_UNREACHABLE":
+      if (state.instanceUnreachable) return state
+      return {
+        ...state,
+        instanceUnreachable: true,
+        unreachableSince: action.since,
+      }
+    case "PROBE_FAILURE": {
+      const { nextFailed, nextTerminal } = computeProbeFailure(
+        state.failedProbes,
+      )
+      return {
+        ...state,
+        failedProbes: nextFailed,
+        isUnreachableTerminal: nextTerminal,
+      }
+    }
+    case "APPLY_PEER_UNREACHABLE": {
+      const failed = action.payload.failed_probes ?? 0
+      return {
+        ...state,
+        instanceUnreachable: true,
+        unreachableSince: action.payload.unreachable_since ?? Date.now(),
+        failedProbes: failed,
+        isUnreachableTerminal: action.payload.is_terminal ?? false,
+      }
+    }
+    case "APPLY_PEER_PROBE_UPDATE":
+      return {
+        ...state,
+        failedProbes: action.payload.failed_probes ?? 0,
+        isUnreachableTerminal: action.payload.is_terminal ?? false,
+      }
+    case "HYDRATE_FROM_SNAPSHOT":
+      return {
+        instanceUnreachable: true,
+        unreachableSince: action.payload.unreachable_since,
+        failedProbes: action.payload.failed_probes,
+        isUnreachableTerminal: action.payload.is_terminal,
+      }
+    case "MANUAL_RETRY":
+      // Reset probe budget; reachability still requires a real request.
+      if (!state.instanceUnreachable) return state
+      return {
+        ...state,
+        failedProbes: 0,
+        isUnreachableTerminal: false,
+      }
+    default:
+      return state
+  }
+}

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useReducer, useRef } from "react"
+
+import {
+  logPremiumUiEvent,
+  PremiumAssignmentResult,
+} from "api/premium/PremiumAssignmentApi"
+import {
+  LS_UNREACHABLE_SNAPSHOT,
+  MAX_FAILED_PROBES,
+  UNREACHABLE_SNAPSHOT_TTL_MS,
+} from "contexts/premium/unreachableConstants"
+import {
+  INITIAL_UNREACHABLE_STATE,
+  UnreachableMachineState,
+  UnreachableSnapshot,
+  computeNextProbeDelayMs,
+  computeProbeFailure,
+  isStaleFailure,
+  shouldClearUnreachableForAssignment,
+  shouldHydrateFromSnapshot,
+  unreachableMachineReducer,
+} from "contexts/premium/unreachableMachine"
+import { tabSync } from "utils/crossTabSync"
+import { routingService } from "utils/routing/RoutingService"
+
+function lsReadUnreachableSnapshot(): UnreachableSnapshot | null {
+  try {
+    const raw = localStorage.getItem(LS_UNREACHABLE_SNAPSHOT)
+    if (!raw) return null
+    const snap = JSON.parse(raw) as UnreachableSnapshot
+    if (
+      typeof snap?.updated_at !== "number" ||
+      Date.now() - snap.updated_at > UNREACHABLE_SNAPSHOT_TTL_MS
+    ) {
+      return null
+    }
+    return snap
+  } catch {
+    return null
+  }
+}
+
+function lsWriteUnreachableSnapshot(
+  snap: Omit<UnreachableSnapshot, "updated_at"> | null,
+): void {
+  try {
+    if (snap == null) {
+      localStorage.removeItem(LS_UNREACHABLE_SNAPSHOT)
+    } else {
+      localStorage.setItem(
+        LS_UNREACHABLE_SNAPSHOT,
+        JSON.stringify({ ...snap, updated_at: Date.now() }),
+      )
+    }
+  } catch {
+    // localStorage unavailable (private browsing / quota exceeded)
+  }
+}
+
+export interface UseInstanceUnreachableMachineArgs {
+  assignment: PremiumAssignmentResult | null
+  isTabLeader: boolean
+}
+
+export interface InstanceUnreachableHandle {
+  state: UnreachableMachineState
+  retryProbe: () => void
+  // Clears the refs the reducer doesn't own (hydrated, watermark, snapshot, prev-instance). Use on explicit release/logout.
+  reset: () => void
+}
+
+export function useInstanceUnreachableMachine({
+  assignment,
+  isTabLeader,
+}: UseInstanceUnreachableMachineArgs): InstanceUnreachableHandle {
+  const [state, dispatch] = useReducer(
+    unreachableMachineReducer,
+    INITIAL_UNREACHABLE_STATE,
+  )
+
+  // Refs written synchronously from listeners to avoid pre-commit-state races; mirrored from reducer state in the effect below.
+  const assignmentRef = useRef<PremiumAssignmentResult | null>(null)
+  const unreachableRef = useRef(false)
+  const unreachableSinceRef = useRef<number | null>(null)
+  const failedProbesRef = useRef(0)
+  const probingRef = useRef(false)
+  const hydratedFromSnapshotRef = useRef(false)
+  // Gate for snapshot writes — a fresh tab must not wipe a peer's snapshot before hydrating.
+  const hasEverBeenUnreachableRef = useRef(false)
+  // Watermark for suppressing out-of-order failures older than the last success.
+  const lastReachableSentAtRef = useRef(0)
+  // Last dedicated instance_id — lets the effect below detect a reassignment to a different instance.
+  const prevDedicatedInstanceIdRef = useRef<string | undefined>(undefined)
+
+  // Consolidated state → refs mirror (one effect for three refs).
+  useEffect(() => {
+    unreachableRef.current = state.instanceUnreachable
+    unreachableSinceRef.current = state.unreachableSince
+    failedProbesRef.current = state.failedProbes
+  }, [state])
+
+  // Clear unreachable on non-dedicated transitions or dedicated reassignment onto a different instance.
+  useEffect(() => {
+    assignmentRef.current = assignment
+    const isDedicated = !!assignment?.assigned && !assignment.is_shared
+
+    if (shouldClearUnreachableForAssignment(assignment)) {
+      prevDedicatedInstanceIdRef.current = undefined
+      if (unreachableRef.current || probingRef.current) {
+        unreachableRef.current = false
+        probingRef.current = false
+        failedProbesRef.current = 0
+        dispatch({ type: "CLEAR" })
+      }
+      return
+    }
+
+    if (
+      isDedicated &&
+      prevDedicatedInstanceIdRef.current !== undefined &&
+      prevDedicatedInstanceIdRef.current !== assignment?.instance_id
+    ) {
+      unreachableRef.current = false
+      probingRef.current = false
+      failedProbesRef.current = 0
+      dispatch({ type: "CLEAR" })
+      routingService.setPremiumAssigned(true)
+    }
+    prevDedicatedInstanceIdRef.current = assignment?.instance_id
+  }, [assignment])
+
+  // routingService listeners — emit peer broadcasts, log telemetry.
+  useEffect(() => {
+    const unsubUnreachable = routingService.onPremiumUnreachable((detail) => {
+      const a = assignmentRef.current
+      if (!a?.assigned || a.is_shared) {
+        probingRef.current = false
+        return
+      }
+
+      if (
+        isStaleFailure(
+          detail.sentAt,
+          lastReachableSentAtRef.current,
+          Date.now(),
+        )
+      ) {
+        return
+      }
+
+      if (probingRef.current) {
+        // PROBING → DEGRADED: probe failed. Consume probe, count failure.
+        probingRef.current = false
+        const { nextFailed, nextTerminal } = computeProbeFailure(
+          failedProbesRef.current,
+        )
+        failedProbesRef.current = nextFailed
+        dispatch({ type: "PROBE_FAILURE" })
+        logPremiumUiEvent("instance_probe_failure", {
+          instance_id: a.instance_id ?? null,
+          failed_probes: nextFailed,
+          is_terminal: nextTerminal,
+          url: detail.url ?? null,
+          status: detail.status ?? null,
+        })
+        tabSync.broadcast({
+          type: "PREMIUM_INSTANCE_PROBE_UPDATE",
+          payload: {
+            instance_id: a.instance_id ?? null,
+            failed_probes: nextFailed,
+            is_terminal: nextTerminal,
+          },
+        })
+        return
+      }
+      if (unreachableRef.current) {
+        // DEGRADED + late echo of an already-known failure: noop.
+        return
+      }
+
+      // Flip ref before dispatch so back-to-back events don't each log a fresh incident.
+      unreachableRef.current = true
+      const now = Date.now()
+      dispatch({ type: "FLIP_TO_UNREACHABLE", since: now })
+      logPremiumUiEvent("instance_unreachable", {
+        instance_id: a.instance_id ?? null,
+        url: detail.url ?? null,
+        status: detail.status ?? null,
+      })
+      tabSync.broadcast({
+        type: "PREMIUM_INSTANCE_UNREACHABLE",
+        payload: {
+          instance_id: a.instance_id ?? null,
+          unreachable_since: now,
+          failed_probes: failedProbesRef.current,
+          is_terminal: failedProbesRef.current >= MAX_FAILED_PROBES,
+        },
+      })
+    })
+
+    const unsubReachable = routingService.onPremiumReachable((detail) => {
+      // Update watermark even when healthy — a later stale failure still needs suppression.
+      const sentAt = detail.sentAt ?? Date.now()
+      if (sentAt > lastReachableSentAtRef.current) {
+        lastReachableSentAtRef.current = sentAt
+      }
+      if (!unreachableRef.current) return
+      probingRef.current = false
+      unreachableRef.current = false
+      failedProbesRef.current = 0
+      const a = assignmentRef.current
+      const since = unreachableSinceRef.current
+      dispatch({ type: "CLEAR" })
+      logPremiumUiEvent("instance_reachable", {
+        instance_id: a?.instance_id ?? null,
+        duration_ms: since != null ? Date.now() - since : null,
+      })
+      tabSync.broadcast({
+        type: "PREMIUM_INSTANCE_REACHABLE",
+        payload: { instance_id: a?.instance_id ?? null },
+      })
+    })
+
+    return () => {
+      unsubUnreachable()
+      unsubReachable()
+    }
+  }, [])
+
+  // Peer handlers — apply state locally only, no re-log/re-broadcast (echo prevention).
+  useEffect(() => {
+    const unsubUnreachable = tabSync.on(
+      "PREMIUM_INSTANCE_UNREACHABLE",
+      (msg) => {
+        const a = assignmentRef.current
+        if (!a?.assigned || a.is_shared) return
+        if (unreachableRef.current) return
+        unreachableRef.current = true
+        const payload = (msg.payload ?? {}) as {
+          unreachable_since?: number
+          failed_probes?: number
+          is_terminal?: boolean
+        }
+        failedProbesRef.current = payload.failed_probes ?? 0
+        dispatch({ type: "APPLY_PEER_UNREACHABLE", payload })
+        // Peer says instance is bad — stop sending premium headers from this tab too.
+        routingService.setPremiumAssigned(false)
+      },
+    )
+    const unsubProbeUpdate = tabSync.on(
+      "PREMIUM_INSTANCE_PROBE_UPDATE",
+      (msg) => {
+        if (!unreachableRef.current) return
+        const payload = (msg.payload ?? {}) as {
+          failed_probes?: number
+          is_terminal?: boolean
+        }
+        failedProbesRef.current = payload.failed_probes ?? 0
+        dispatch({ type: "APPLY_PEER_PROBE_UPDATE", payload })
+      },
+    )
+    const unsubReachable = tabSync.on("PREMIUM_INSTANCE_REACHABLE", () => {
+      if (!unreachableRef.current) return
+      probingRef.current = false
+      unreachableRef.current = false
+      failedProbesRef.current = 0
+      dispatch({ type: "CLEAR" })
+      // A peer tab confirmed reachability — resume premium routing locally.
+      routingService.setPremiumAssigned(true)
+    })
+    return () => {
+      unsubUnreachable()
+      unsubProbeUpdate()
+      unsubReachable()
+    }
+  }, [])
+
+  // Leader-only snapshot write.
+  useEffect(() => {
+    if (!isTabLeader) return
+    if (state.instanceUnreachable && state.unreachableSince != null) {
+      hasEverBeenUnreachableRef.current = true
+      lsWriteUnreachableSnapshot({
+        instance_id: assignment?.instance_id ?? null,
+        unreachable_since: state.unreachableSince,
+        failed_probes: state.failedProbes,
+        is_terminal: state.isUnreachableTerminal,
+      })
+    } else if (hasEverBeenUnreachableRef.current) {
+      lsWriteUnreachableSnapshot(null)
+    }
+  }, [
+    isTabLeader,
+    state.instanceUnreachable,
+    state.unreachableSince,
+    state.failedProbes,
+    state.isUnreachableTerminal,
+    assignment?.instance_id,
+  ])
+
+  // One-shot snapshot hydration on first dedicated assignment.
+  useEffect(() => {
+    if (hydratedFromSnapshotRef.current) return
+    if (!assignment?.assigned || assignment.is_shared) return
+    hydratedFromSnapshotRef.current = true
+    const snap = lsReadUnreachableSnapshot()
+    if (!shouldHydrateFromSnapshot(assignment, snap)) return
+    // Narrow: shouldHydrateFromSnapshot rejects a null snap.
+    const applied = snap!
+    unreachableRef.current = true
+    failedProbesRef.current = applied.failed_probes
+    hasEverBeenUnreachableRef.current = true
+    dispatch({
+      type: "HYDRATE_FROM_SNAPSHOT",
+      payload: {
+        unreachable_since: applied.unreachable_since,
+        failed_probes: applied.failed_probes,
+        is_terminal: applied.is_terminal,
+      },
+    })
+    routingService.setPremiumAssigned(false)
+  }, [assignment])
+
+  // Half-open circuit re-arm. Does NOT signal recovery — the next request's response does.
+  useEffect(() => {
+    if (!isTabLeader) return
+    if (!state.instanceUnreachable) return
+    if (state.isUnreachableTerminal) return
+    if (probingRef.current) return
+
+    const delay = computeNextProbeDelayMs(state.failedProbes)
+    const timer = setTimeout(() => {
+      probingRef.current = true
+      routingService.setPremiumAssigned(true)
+      logPremiumUiEvent("instance_probe_armed", {
+        instance_id: assignmentRef.current?.instance_id ?? null,
+        failed_probes: failedProbesRef.current,
+        delay_ms: delay,
+      })
+    }, delay)
+    return () => clearTimeout(timer)
+  }, [
+    isTabLeader,
+    state.instanceUnreachable,
+    state.isUnreachableTerminal,
+    state.failedProbes,
+  ])
+
+  // Resets probe budget; reachability still requires a real request.
+  const retryProbe = useCallback(() => {
+    if (!unreachableRef.current) return
+    probingRef.current = true
+    failedProbesRef.current = 0
+    dispatch({ type: "MANUAL_RETRY" })
+    routingService.setPremiumAssigned(true)
+    logPremiumUiEvent("instance_unreachable_manual_retry", {
+      instance_id: assignmentRef.current?.instance_id ?? null,
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    unreachableRef.current = false
+    unreachableSinceRef.current = null
+    failedProbesRef.current = 0
+    probingRef.current = false
+    hydratedFromSnapshotRef.current = false
+    hasEverBeenUnreachableRef.current = false
+    lastReachableSentAtRef.current = 0
+    prevDedicatedInstanceIdRef.current = undefined
+    dispatch({ type: "CLEAR" })
+    lsWriteUnreachableSnapshot(null)
+  }, [])
+
+  return { state, retryProbe, reset }
+}

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Axios interceptor tests for the premium-routing path.
+ *
+ * Covers:
+ *  - Request interceptor stamps _premiumSentAt when premium headers are present
+ *  - Response success suppresses reachable when the routing-id rotated
+ *  - 503 fallback strips premium markers on the retry config
+ *  - Response success emits reachable even when no X-Routing-ID comes back
+ *  - 401 refresh-then-retry still emits reachable on the retried request
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals"
+
+// --- Shared mock state (captured per-test via beforeEach) ---
+
+const mockRefreshTokenApi = jest.fn() as unknown as jest.Mock<
+  Promise<{ access_token: string }>
+>
+const mockGetToken = jest.fn(() => "access-token" as string | null)
+const mockGetExToken = jest.fn(() => null as string | null)
+const mockLogout = jest.fn()
+const mockSaveToken = jest.fn()
+
+const mockGetRoutingHeaders = jest.fn<Record<string, string>, []>(() => ({}))
+const mockUpdateRoutingToken = jest.fn<void, [string]>()
+const mockRequiresPremiumRouting = jest.fn<boolean, []>(() => false)
+const mockSetPremiumAssigned = jest.fn<void, [boolean]>()
+const mockEmitPremiumUnreachable = jest.fn<
+  void,
+  [{ url?: string; status?: number; sentAt?: number }]
+>()
+const mockEmitPremiumReachable = jest.fn<
+  void,
+  [{ url?: string; status?: number; sentAt?: number }]
+>()
+
+const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
+  () => false,
+)
+
+jest.mock("api/auth/Auth", () => ({
+  refreshTokenApi: mockRefreshTokenApi,
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  getToken: mockGetToken,
+  getExToken: mockGetExToken,
+  logout: mockLogout,
+  saveToken: mockSaveToken,
+}))
+
+jest.mock("utils/routing/RoutingService", () => ({
+  routingService: {
+    getRoutingHeaders: mockGetRoutingHeaders,
+    updateRoutingToken: mockUpdateRoutingToken,
+    requiresPremiumRouting: mockRequiresPremiumRouting,
+    setPremiumAssigned: mockSetPremiumAssigned,
+    emitPremiumUnreachable: mockEmitPremiumUnreachable,
+    emitPremiumReachable: mockEmitPremiumReachable,
+  },
+}))
+
+jest.mock("utils/DataviewUtils", () => ({
+  isDataviewPublicOutputsRequest: mockIsDataviewPublicOutputsRequest,
+  DATAVIEW_PUBLIC_REQUEST_KEY: "x-dataview-public",
+}))
+
+// --- Axios adapter plumbing ---
+// Tests install a custom adapter on the SUT axios instance so we can control
+// response data/headers/status per-request without touching the network.
+
+type RecordedRequest = {
+  url?: string
+  method?: string
+  headers: Record<string, unknown>
+  config: Record<string, unknown>
+}
+
+type AdapterResponse = {
+  status: number
+  data?: unknown
+  headers?: Record<string, string>
+}
+
+// Map request URL → response or response factory. When a factory is supplied
+// it runs per-call so the test can sequence different responses for the same
+// URL (e.g. first call 401, retry 200).
+type Responder = AdapterResponse | (() => AdapterResponse | Error)
+
+let responses: Map<string, Responder> = new Map()
+let recorded: RecordedRequest[] = []
+
+const installAdapter = (instance: { defaults: { adapter: unknown } }): void => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  instance.defaults.adapter = async (config: any) => {
+    recorded.push({
+      url: config.url,
+      method: config.method,
+      headers: { ...(config.headers ?? {}) },
+      config: { ...config },
+    })
+
+    const responder = responses.get(config.url ?? "")
+    if (!responder) {
+      const err: Error & {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        response?: any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config?: any
+      } = new Error(`No responder for URL ${config.url}`)
+      err.config = config
+      throw err
+    }
+
+    const resolved = typeof responder === "function" ? responder() : responder
+    if (resolved instanceof Error) throw resolved
+
+    if (resolved.status >= 400) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const err: any = new Error(`HTTP ${resolved.status}`)
+      err.isAxiosError = true
+      err.response = {
+        status: resolved.status,
+        data: resolved.data ?? {},
+        headers: resolved.headers ?? {},
+        config,
+      }
+      err.config = config
+      throw err
+    }
+
+    return {
+      data: resolved.data ?? {},
+      status: resolved.status,
+      statusText: "OK",
+      headers: resolved.headers ?? {},
+      config,
+      request: {},
+    }
+  }
+}
+
+// --- Tests ---
+
+describe("axios premium-routing interceptors", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let axiosInstance: any
+
+  beforeEach(async () => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    responses = new Map()
+    recorded = []
+
+    // Default token behaviour
+    mockGetToken.mockReturnValue("access-token")
+    mockGetExToken.mockReturnValue(null)
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require("utils/axios")
+    axiosInstance = mod.default
+    installAdapter(axiosInstance)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("stamps _premiumSentAt on the request when premium headers are present", async () => {
+    // Request interceptor checks routingHeaders[X-Routing-ID] and if set
+    // stamps _hadPremiumHeaders / _outgoingRoutingId / _premiumSentAt on the
+    // config. That sentAt flows into the reachable/unreachable events.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+
+    const before = Date.now()
+    responses.set("/ok", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "rid-outgoing" },
+    })
+    await axiosInstance.get("/ok")
+    const after = Date.now()
+
+    expect(mockEmitPremiumReachable).toHaveBeenCalledTimes(1)
+    const detail = mockEmitPremiumReachable.mock.calls[0][0]
+    expect(typeof detail.sentAt).toBe("number")
+    expect(detail.sentAt).toBeGreaterThanOrEqual(before)
+    expect(detail.sentAt).toBeLessThanOrEqual(after)
+    expect(detail.status).toBe(200)
+  })
+
+  it("does NOT emit reachable when the response routing-id has rotated", async () => {
+    // A rotated X-Routing-ID on the success response means a different
+    // instance served us — we cannot conclude the probed instance is healthy.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-A",
+      "X-User-Tier": "premium",
+    })
+
+    responses.set("/rotated", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "rid-B" }, // backend hit a different instance
+    })
+    await axiosInstance.get("/rotated")
+
+    // updateRoutingToken always fires on any x-routing-id.
+    expect(mockUpdateRoutingToken).toHaveBeenCalledWith("rid-B")
+    // But premium reachable must be suppressed due to rotation.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
+  it("emits reachable when the response has NO x-routing-id header (not rotated)", async () => {
+    // Edge case: when the response carries no x-routing-id at all, the
+    // rotation check (routingId !== _outgoingRoutingId) resolves to false
+    // because typeof undefined !== "string". We treat that as "not rotated"
+    // and still emit reachable.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+
+    responses.set("/no-rid", { status: 200, data: {}, headers: {} })
+    await axiosInstance.get("/no-rid")
+
+    expect(mockUpdateRoutingToken).not.toHaveBeenCalled()
+    expect(mockEmitPremiumReachable).toHaveBeenCalledTimes(1)
+    expect(mockEmitPremiumReachable.mock.calls[0][0].status).toBe(200)
+  })
+
+  it("on 503 premium fallback, strips premium markers on the retry config", async () => {
+    // When premium routing gets a 503/502, axios retries without premium
+    // headers. That retry config must NOT still look like a premium request
+    // — otherwise the retry's response would wrongly emit reachable against
+    // a request that never carried premium headers.
+    mockGetRoutingHeaders.mockImplementation(() => ({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    }))
+    mockRequiresPremiumRouting.mockReturnValue(true)
+
+    // First call yields 503; a follow-up call (the retry) yields 200.
+    let callCount = 0
+    responses.set("/svc", () => {
+      callCount += 1
+      if (callCount === 1) {
+        return { status: 503, data: { detail: "no premium" } }
+      }
+      return { status: 200, data: { ok: true }, headers: {} }
+    })
+
+    // Premium routing headers vanish for the retry because the interceptor
+    // sets _retryWithoutPremium=true on the retry config. We simulate the
+    // absence by making getRoutingHeaders return {} on the retry call.
+    mockGetRoutingHeaders
+      .mockReturnValueOnce({
+        "X-Routing-ID": "rid-outgoing",
+        "X-User-Tier": "premium",
+      })
+      .mockReturnValue({})
+
+    const res = await axiosInstance.get("/svc")
+    expect(res.status).toBe(200)
+
+    // Unreachable emitted once for the 503.
+    expect(mockEmitPremiumUnreachable).toHaveBeenCalledTimes(1)
+    // The retry (second recorded request) must NOT carry the premium
+    // routing markers — otherwise we'd mis-emit reachable.
+    expect(recorded).toHaveLength(2)
+    const retryConfig = recorded[1].config as Record<string, unknown>
+    expect(retryConfig._retryWithoutPremium).toBe(true)
+    expect(retryConfig._hadPremiumHeaders).toBeUndefined()
+    expect(retryConfig._outgoingRoutingId).toBeUndefined()
+    expect(retryConfig._premiumSentAt).toBeUndefined()
+
+    // And the retry's success should NOT emit reachable — the retry was not
+    // a premium-routed request.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
+  it("401 refresh-then-retry: the retried request still emits reachable when it succeeds with premium headers", async () => {
+    // The refresh/retry path in handleUnauthorizedError retries via the
+    // shared axiosLibrary (not the SUT instance), which means the response
+    // interceptor of the SUT instance does NOT fire for the retried 200.
+    // This test pins that semantics: the final .then() resolves, but
+    // emitPremiumReachable was NOT called for the retried request.
+    //
+    // This documents the current gap — refresh+retry does not produce a
+    // reachable signal, even on a premium-healthy instance. The fix, when
+    // it lands, should make this assertion flip to "toHaveBeenCalled()".
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockRefreshTokenApi.mockResolvedValue({ access_token: "new-token" })
+
+    let callCount = 0
+    responses.set("/protected", () => {
+      callCount += 1
+      if (callCount === 1) return { status: 401, data: {} }
+      return {
+        status: 200,
+        data: {},
+        headers: { "x-routing-id": "rid-outgoing" },
+      }
+    })
+
+    const res = await axiosInstance.get("/protected")
+    expect(res.status).toBe(200)
+    expect(mockSaveToken).toHaveBeenCalledWith("new-token")
+
+    // Currently, the 401+retry path bypasses the SUT instance's response
+    // interceptor on retry (it goes through axiosLibrary), so no reachable
+    // signal is emitted. This pins the existing behaviour.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -18,6 +18,9 @@ import { routingService } from "utils/routing/RoutingService"
 interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
   _retry?: boolean
   _retryWithoutPremium?: boolean
+  _hadPremiumHeaders?: boolean
+  _outgoingRoutingId?: string
+  _premiumSentAt?: number
 }
 
 const axios = axiosLibrary.create({
@@ -47,6 +50,13 @@ axios.interceptors.request.use(
     if (!(config as CustomAxiosRequestConfig)._retryWithoutPremium) {
       const routingHeaders = routingService.getRoutingHeaders()
       Object.assign(config.headers!, routingHeaders)
+      const outgoingRoutingId = routingHeaders[RoutingHeaders.ROUTING_ID]
+      if (outgoingRoutingId) {
+        ;(config as CustomAxiosRequestConfig)._hadPremiumHeaders = true
+        ;(config as CustomAxiosRequestConfig)._outgoingRoutingId =
+          outgoingRoutingId
+        ;(config as CustomAxiosRequestConfig)._premiumSentAt = Date.now()
+      }
     }
 
     // Check whether the access is to public output data (HTTP header setting)
@@ -217,11 +227,20 @@ const handlePremiumRoutingError = async (
   // Clear premiumAssigned so subsequent requests don't keep sending
   // stale routing headers that cause repeated 503s.
   routingService.setPremiumAssigned(false)
+  routingService.emitPremiumUnreachable({
+    url: originalRequest.url,
+    status: error.response?.status,
+    sentAt: originalRequest._premiumSentAt,
+  })
 
   const retryConfig = { ...originalRequest }
   delete retryConfig.headers[RoutingHeaders.USER_TIER]
   delete retryConfig.headers[RoutingHeaders.ROUTING_ID]
   retryConfig._retryWithoutPremium = true
+  // Strip premium markers — retry is shared-tier, must not emit reachable.
+  delete retryConfig._hadPremiumHeaders
+  delete retryConfig._outgoingRoutingId
+  delete retryConfig._premiumSentAt
 
   try {
     // eslint-disable-next-line no-console
@@ -242,6 +261,20 @@ axios.interceptors.response.use(
     const routingId = res.headers[routingIdHeader]
     if (routingId) {
       routingService.updateRoutingToken(routingId)
+    }
+
+    // Rotated routing_id means a different instance served us — inconclusive about the one we probed.
+    const cfg = res.config as CustomAxiosRequestConfig | undefined
+    if (cfg?._hadPremiumHeaders) {
+      const rotated =
+        typeof routingId === "string" && routingId !== cfg._outgoingRoutingId
+      if (!rotated) {
+        routingService.emitPremiumReachable({
+          url: cfg.url,
+          status: res.status,
+          sentAt: cfg._premiumSentAt,
+        })
+      }
     }
     return res
   },

--- a/frontend/src/utils/crossTabSync.ts
+++ b/frontend/src/utils/crossTabSync.ts
@@ -196,6 +196,9 @@ export type TabSyncMessageType =
   | "STORAGE_UPDATED"
   | "ALERT_DISMISSED"
   | "PREMIUM_RELEASED"
+  | "PREMIUM_INSTANCE_UNREACHABLE"
+  | "PREMIUM_INSTANCE_REACHABLE"
+  | "PREMIUM_INSTANCE_PROBE_UPDATE"
   | "LOGOUT"
 
 export interface TabSyncMessage {

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "@jest/globals"
+import { describe, test, expect, beforeEach, jest } from "@jest/globals"
 
 import { UserDTO } from "api/users/UsersApiDTO"
 import {
@@ -320,6 +320,108 @@ describe("RoutingService", () => {
       routingService.updateRoutingInfo(premiumUser)
 
       expect(routingService.isRoutingInfoStale()).toBe(false)
+    })
+  })
+
+  describe("premium-unreachable listeners", () => {
+    test("emit invokes every registered listener with the detail", () => {
+      const a = jest.fn()
+      const b = jest.fn()
+      routingService.onPremiumUnreachable(a)
+      routingService.onPremiumUnreachable(b)
+
+      routingService.emitPremiumUnreachable({ url: "/foo", status: 503 })
+
+      expect(a).toHaveBeenCalledWith({ url: "/foo", status: 503 })
+      expect(b).toHaveBeenCalledWith({ url: "/foo", status: 503 })
+    })
+
+    test("unsubscribe stops further invocations", () => {
+      const listener = jest.fn()
+      const unsubscribe = routingService.onPremiumUnreachable(listener)
+
+      routingService.emitPremiumUnreachable({ status: 502 })
+      unsubscribe()
+      routingService.emitPremiumUnreachable({ status: 503 })
+
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    test("a throwing listener does not block the others", () => {
+      const good = jest.fn()
+      routingService.onPremiumUnreachable(() => {
+        throw new Error("boom")
+      })
+      routingService.onPremiumUnreachable(good)
+
+      routingService.emitPremiumUnreachable({ status: 503 })
+
+      expect(good).toHaveBeenCalled()
+    })
+  })
+
+  describe("premium-reachable listeners", () => {
+    test("emit invokes every registered listener with the detail", () => {
+      const a = jest.fn()
+      const b = jest.fn()
+      routingService.onPremiumReachable(a)
+      routingService.onPremiumReachable(b)
+
+      routingService.emitPremiumReachable({ url: "/foo", status: 200 })
+
+      expect(a).toHaveBeenCalledWith({ url: "/foo", status: 200 })
+      expect(b).toHaveBeenCalledWith({ url: "/foo", status: 200 })
+    })
+
+    test("unsubscribe stops further invocations", () => {
+      const listener = jest.fn()
+      const unsubscribe = routingService.onPremiumReachable(listener)
+
+      routingService.emitPremiumReachable({ status: 200 })
+      unsubscribe()
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    test("a throwing listener does not block the others", () => {
+      const good = jest.fn()
+      routingService.onPremiumReachable(() => {
+        throw new Error("boom")
+      })
+      routingService.onPremiumReachable(good)
+
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(good).toHaveBeenCalled()
+    })
+
+    test("reachable and unreachable listener pools are independent", () => {
+      const unreachable = jest.fn()
+      const reachable = jest.fn()
+      routingService.onPremiumUnreachable(unreachable)
+      routingService.onPremiumReachable(reachable)
+
+      routingService.emitPremiumUnreachable({ status: 503 })
+      expect(unreachable).toHaveBeenCalledTimes(1)
+      expect(reachable).not.toHaveBeenCalled()
+
+      routingService.emitPremiumReachable({ status: 200 })
+      expect(reachable).toHaveBeenCalledTimes(1)
+      expect(unreachable).toHaveBeenCalledTimes(1)
+    })
+
+    test("forwards sentAt on both event types", () => {
+      const reachable = jest.fn()
+      const unreachable = jest.fn()
+      routingService.onPremiumReachable(reachable)
+      routingService.onPremiumUnreachable(unreachable)
+
+      routingService.emitPremiumReachable({ status: 200, sentAt: 1111 })
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 2222 })
+
+      expect(reachable).toHaveBeenCalledWith({ status: 200, sentAt: 1111 })
+      expect(unreachable).toHaveBeenCalledWith({ status: 503, sentAt: 2222 })
     })
   })
 })

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -38,6 +38,25 @@ export interface PremiumAssignmentResult {
   scaling_in_progress?: boolean
 }
 
+export interface PremiumUnreachableDetail {
+  url?: string
+  status?: number
+  // Timestamp of when the request was sent — listeners use it to drop failures that predate a newer success.
+  sentAt?: number
+}
+
+export type PremiumUnreachableListener = (
+  detail: PremiumUnreachableDetail,
+) => void
+
+export interface PremiumReachableDetail {
+  url?: string
+  status?: number
+  sentAt?: number
+}
+
+export type PremiumReachableListener = (detail: PremiumReachableDetail) => void
+
 export class RoutingService {
   private routingInfo: RoutingInfo | null = null
   private routingToken: string | null = null
@@ -48,6 +67,8 @@ export class RoutingService {
   private readonly STORAGE_KEY = "routing_id"
   private readonly TIER_STORAGE_KEY = "routing_tier"
   private readonly PREMIUM_ASSIGNED_KEY = "premium_assigned"
+  private unreachableListeners: Set<PremiumUnreachableListener> = new Set()
+  private reachableListeners: Set<PremiumReachableListener> = new Set()
 
   constructor() {
     // Load token and tier from localStorage on initialization
@@ -137,6 +158,43 @@ export class RoutingService {
    */
   isPremiumAssigned(): boolean {
     return this.premiumAssigned
+  }
+
+  // Pure notifier — telemetry lives in listeners so tests can emit without side effects.
+  onPremiumUnreachable(listener: PremiumUnreachableListener): () => void {
+    this.unreachableListeners.add(listener)
+    return () => {
+      this.unreachableListeners.delete(listener)
+    }
+  }
+
+  emitPremiumUnreachable(detail: PremiumUnreachableDetail): void {
+    this.unreachableListeners.forEach((listener) => {
+      try {
+        listener(detail)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn("Premium-unreachable listener threw:", e)
+      }
+    })
+  }
+
+  onPremiumReachable(listener: PremiumReachableListener): () => void {
+    this.reachableListeners.add(listener)
+    return () => {
+      this.reachableListeners.delete(listener)
+    }
+  }
+
+  emitPremiumReachable(detail: PremiumReachableDetail): void {
+    this.reachableListeners.forEach((listener) => {
+      try {
+        listener(detail)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn("Premium-reachable listener threw:", e)
+      }
+    })
   }
 
   /**

--- a/infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md
+++ b/infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md
@@ -7,7 +7,7 @@
 - **ALB rule matching** routes premium users to dedicated instances via `X-Routing-ID` and `X-User-Tier` headers
 - **Backend validation** regenerates routing IDs from JWT and rejects mismatches with 403
 - **Immediate tier changes** via webhook-triggered cache invalidation (no TTL delay)
-- **503 fallback** automatically retries on free tier when premium instance is unavailable
+- **503 fallback** automatically retries on free tier when premium instance is unavailable, and raises a user-visible warning plus a half-open circuit that re-probes the instance for recovery
 
 ---
 
@@ -71,9 +71,11 @@ sequenceDiagram
 | Validate routing ID | Yes - Compare header vs JWT | No | No |
 | Create ALB rules | No | Yes - Exclusive | No |
 | Cache routing headers | No | No | Yes - localStorage |
-| Gate header sending | No | No | Yes - `premiumAssigned` flag |
+| Gate header sending | No | No | Yes - `premiumAssigned` flag (re-armed by circuit breaker during unreachable recovery) |
 | Invalidate tier cache | Yes - Via `invalidate_user_tier_cache()` | No | No |
-| 503 fallback to free | No | No | Yes - Strip headers and retry |
+| 503 fallback to free | No | No | Yes - Strip headers, retry, emit `premiumUnreachable` event |
+| Detect instance recovery | No | No | Yes - Half-open probe + `premiumReachable` event |
+| Surface degraded state | No | No | Yes - Warning snackbar with terminal retry action |
 
 ---
 
@@ -118,12 +120,14 @@ sequenceDiagram
 - `updateRoutingToken()` - Stores backend-issued routing ID from response headers
 - `isPremiumAssigned()` - Gate: headers only sent when backend confirms instance availability
 - `clearRoutingInfo()` - Clears all routing data on logout
+- `onPremiumUnreachable()` / `emitPremiumUnreachable()` - Listener pool notified when an outgoing premium-routed request fails
+- `onPremiumReachable()` / `emitPremiumReachable()` - Listener pool notified when an outgoing premium-routed request succeeds without routing-ID rotation
 
 **File:** `frontend/src/utils/axios.ts`
 
-- Request interceptor adds routing headers (skipped if `_retryWithoutPremium` is set)
-- Response interceptor captures `x-routing-id` from backend responses
-- `handlePremiumRoutingError()` - On 503: strips routing headers, retries on free tier
+- Request interceptor adds routing headers (skipped if `_retryWithoutPremium` is set) and tags the request with `_hadPremiumHeaders`, `_outgoingRoutingId`, `_premiumSentAt` for the response-side correlation
+- Response interceptor captures `x-routing-id` from backend responses and emits `premiumReachable` for premium-tagged successes where the routing ID did not rotate (rotation means a different instance served the retry, which is inconclusive about the probed instance)
+- `handlePremiumRoutingError()` - On 503: strips routing headers, retries on free tier, emits `premiumUnreachable` on the original (pre-retry) request
 
 ---
 
@@ -157,12 +161,20 @@ sequenceDiagram
 
 ### 4. Premium Instance Unavailable (503)
 
-**Problem:** Premium instance returns 503 or network error.
+**Problem:** Premium instance returns 503 or network error. Stripping the headers and retrying on the free tier would leave the user silently degraded with no UI signal and no recovery path -- the polling loop in `PremiumAssignmentContext` stops once the assignment is dedicated, so nothing re-checks the instance.
 
-**Solution:** Frontend fallback:
-- `handlePremiumRoutingError()` strips routing headers on 503 or network error
-- Sets `_retryWithoutPremium` flag to prevent infinite loops
-- Retries request on free tier
+**Solution:** Three-layer response -- fallback, observe, recover:
+
+- **Fallback.** `handlePremiumRoutingError()` strips routing headers, sets `_retryWithoutPremium` to prevent loops, and retries on the free tier. Markers (`_hadPremiumHeaders`, `_outgoingRoutingId`, `_premiumSentAt`) are deleted from the retry config so the free-tier retry cannot falsely emit `premiumReachable`.
+- **Observe.** Axios emits `premiumUnreachable` via `RoutingService`. `PremiumAssignmentContext` listens for it, transitions the dedicated assignment into a tracked unreachable state, logs `instance_unreachable`, broadcasts `PREMIUM_INSTANCE_UNREACHABLE` to peer tabs, and raises a warning snackbar through `PremiumNotificationManager`.
+- **Recover.** A half-open circuit arms a probe with exponential backoff (30 s -> 5 min, capped at `MAX_FAILED_PROBES = 5`). Each probe flips `premiumAssigned` back to `true` so the next real user-driven request carries premium headers. A 2xx with an unrotated routing ID emits `premiumReachable` and clears the state; a 5xx counts as a probe failure. Exhausting the probe budget marks the state terminal and swaps the snackbar to a "Retry" action that resets the budget without itself signalling recovery.
+
+**Edge behaviour pinned by the code:**
+
+- **Stale-failure watermark** -- failures whose send timestamp predates the last successful `premiumReachable` are suppressed so an in-flight 5xx cannot reopen an already-recovered state.
+- **Routing-ID rotation** -- if the response's routing ID differs from the one sent, the ALB served the retry from a different instance; reachability of the probed instance is inconclusive and no event fires.
+- **Cross-tab sync** -- state transitions broadcast via `crossTabSync` (`PREMIUM_INSTANCE_UNREACHABLE`, `PREMIUM_INSTANCE_REACHABLE`, `PREMIUM_INSTANCE_PROBE_UPDATE`). Peer handlers apply state locally and do not re-broadcast, preventing echo loops.
+- **Snapshot recovery** -- a freshly opened tab hydrates from a `localStorage` snapshot (`premium_unreachable_snapshot`, 1 h TTL) gated on `instance_id` match so a snapshot from a prior assignment cannot be adopted.
 
 ### 5. Logout Without Clearing Routing Data
 
@@ -219,4 +231,8 @@ openssl rand -hex 32
 | `getRoutingHeaders()` | `RoutingService.ts` | Return cached headers for requests |
 | `isPremiumAssigned()` | `RoutingService.ts` | Gate: only send headers when assigned |
 | `clearRoutingInfo()` | `RoutingService.ts` | Clear routing data on logout |
-| `handlePremiumRoutingError()` | `axios.ts` | 503 fallback to free tier |
+| `emitPremiumUnreachable()` | `RoutingService.ts` | Notify listeners that a premium-routed request failed |
+| `emitPremiumReachable()` | `RoutingService.ts` | Notify listeners that a premium-routed request succeeded without routing-ID rotation |
+| `onPremiumUnreachable()` / `onPremiumReachable()` | `RoutingService.ts` | Subscribe to the pools above (returns an unsubscribe function) |
+| `handlePremiumRoutingError()` | `axios.ts` | 503 fallback to free tier, emits `premiumUnreachable` |
+| `unreachableMachineReducer()` | `PremiumAssignmentContext.tsx` | State machine driving the degraded / probing / terminal lifecycle |

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -361,6 +361,8 @@ The authoritative reference. Branches are explicit; toast text matches the strin
 | Toast strings and variants | `PremiumNotificationManager.tsx` |
 | Leader-tab election | `frontend/src/utils/crossTabSync.ts` -- localStorage key `"premium_poll_leader"`, 2s heartbeat, 5s timeout |
 | Poll config | constants in `PremiumAssignmentContext.tsx`: `INITIAL_POLL_INTERVAL_MS=30000`, `MAX_POLL_INTERVAL_MS=60000`, `MAX_POLL_ATTEMPTS=40`, `BACKOFF_MULTIPLIER=1.5`, `ERROR_BACKOFF_MULTIPLIER=2` |
+| Polling gate | `shouldPoll()` in `PremiumAssignmentContext.tsx`: polls while premium+leader+assignment exists and the assignment is not dedicated-and-healthy. Re-enables polling while `instanceUnreachable` is true so a backend reassignment to shared or to a new instance is still caught |
+| Unreachable detection + probe config | `unreachableMachineReducer` and constants in `PremiumAssignmentContext.tsx`: `INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`, `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5` |
 | Inactivity thresholds | 1h/2h hardcoded in context; countdown length `INACTIVITY_WARNING_DURATION_MINUTES=60` and `WARNING_UPDATE_INTERVAL_MS=60000` from `frontend/src/const/Subscription.ts` |
 | Heartbeat retry | `HEARTBEAT_MAX_RETRIES=3`, `HEARTBEAT_RETRY_DELAY_MS=1000`; delay between attempts is `DELAY * (attempt + 1)` |
 | 401 session-expired UI | `InactivityWarning.tsx` -- AxiosError + status 401 path, 2 s setTimeout then `performLogout()` |
@@ -392,6 +394,9 @@ Two premium users **can** share the same dedicated-class EC2 -- the uniqueness c
 | Persistent info toast "Please wait while your dedicated premium resource is being prepared." from login, no success toast follows | `assignmentResult.assigned=true && is_shared=true`, OR response was 202 with `retry_after`, OR `/assign` returned an `autoscaling-pool` assignment | No premium instance had spare capacity at assign time: either (a) all running instances already have users so the least-loaded was picked (is_shared=true on a real instance), (b) scaling was initiated and the Lambda returned 202+retry_after, or (c) launching instances exist and response is 202 |
 | Info toast is showing AND the tab is the leader AND poll attempts are incrementing | Leader-tab polling loop is live: re-POSTing `/assign` on exponential backoff | User is on shared / autoscaling-pool / retry state; poll will promote to dedicated once any premium instance frees up or finishes launching |
 | Info toast is showing AND no polling is happening in any tab | Shared state with polling suppressed | Either (a) `assignmentResult` is null so the `state.assignmentResult != null` gate blocks polling -- this is the hard-error path, or (b) no tab has won leader election (storage unavailable / all tabs closed simultaneously) |
+| Dedicated assignment in DB, warning snackbar "Your dedicated premium instance is temporarily unreachable. Retrying..." | `instanceUnreachable=true`, `isUnreachableTerminal=false`. Half-open probe armed on leader tab with exponential backoff | `handlePremiumRoutingError()` fired on a premium-routed request. The circuit flipped `premiumAssigned=false`, broadcast `PREMIUM_INSTANCE_UNREACHABLE` to peer tabs, and will re-arm `premiumAssigned=true` ahead of the next user-driven request |
+| Same snackbar upgraded to "unresponsive after multiple attempts. Please reload the page or contact support" with a Retry action | `instanceUnreachable=true`, `isUnreachableTerminal=true`. Probe budget exhausted at `MAX_FAILED_PROBES=5` | Five consecutive probes returned 5xx. Auto-re-arm is disabled; only `retryUnreachableProbe()` (Retry button) or a backend reassignment can clear the state |
+| Snackbar was showing, disappeared without a reload | `instanceUnreachable` cleared | Either (a) a real request returned 2xx with unrotated routing ID and axios emitted `premiumReachable`, or (b) polling observed a backend reassignment (new `instance_id` or drop to `is_shared=true`) |
 | Info toast persists for more than ~30 minutes with no promotion | Polling capped out, or backend has no capacity to give | `MAX_POLL_ATTEMPTS=40` at capped 60s interval is roughly 30-40 minutes of wall time. Upstream: premium ASG cannot scale further (instance quota, scaling lock stuck, ghost ECS registrations consuming slots) |
 | Error toast "No premium instance available after extended wait..." | Polling loop stopped after exceeding 40 attempts | Same as above, but the loop has now given up; user will not auto-retry without a new login or re-mount |
 | Warning toast "Premium assignment issue: {err}. Falling back to shared resources." | `/assign` returned `assigned=false` with **no** `retry_after` and no `scaling_in_progress` | Hard error from Lambda: scaling lock held + no launching instances, or an exception inside `assign_premium_user()`. `isRetryableError` is false so `assignmentResult` stays null and polling never starts |
@@ -958,6 +963,7 @@ The frontend components handle premium user experience including instance assign
 │  │   → Browser close/refresh handling (sendBeacon)               │    │
 │  │   → Exponential backoff polling for dedicated instance        │    │
 │  │   → Leader tab election for polling                           │    │
+│  │   → Unreachable-instance detection + half-open probe recovery │    │
 │  ├───────────────────────────────────────────────────────────────┤    │
 │  │                                                               │    │
 │  │  ┌─────────────────────────┐  ┌─────────────────────────────┐│    │
@@ -966,6 +972,8 @@ The frontend components handle premium user experience including instance assign
 │  │  │                         │  │ → Success notifications     ││    │
 │  │  │ → Cleanup on unmount    │  │ → Preparation info toast    ││    │
 │  │  │ → Debug logging         │  │ → Error notifications       ││    │
+│  │  │                         │  │ → Unreachable warning +     ││    │
+│  │  │                         │  │   terminal Retry action     ││    │
 │  │  └─────────────────────────┘  └─────────────────────────────┘│    │
 │  │                                                               │    │
 │  │  ┌───────────────────────────────────────────────────────────┐│    │
@@ -1002,15 +1010,25 @@ interface PremiumAssignmentState {
   lastActivityTime: number
   heartbeatFailing: boolean
 }
+
+interface UnreachableMachineState {
+  instanceUnreachable: boolean
+  unreachableSince: number | null
+  failedProbes: number
+  isUnreachableTerminal: boolean
+}
 ```
+
+`UnreachableMachineState` is held in a separate `useReducer` (`unreachableMachineReducer`) and spread into the context value alongside `PremiumAssignmentState`. It is orthogonal to `heartbeatFailing`: a single 5xx can set both and they are not redundant (heartbeat failing tracks the session heartbeat path; `instanceUnreachable` tracks dedicated-instance reachability for any routed request).
 
 #### Context Value (Exported Functions)
 
 ```typescript
 // Functions exposed via usePremiumAssignment() hook:
 assign, release, getStatus, updateRoutingInfo,
-autoReleaseOnLogout, dismissInactivityWarning, recordActivity
-// Plus all PremiumAssignmentState fields via spread
+autoReleaseOnLogout, dismissInactivityWarning, recordActivity,
+retryUnreachableProbe
+// Plus PremiumAssignmentState and UnreachableMachineState fields via spread
 ```
 
 Note: `autoAssignOnLogin()` is internal only -- triggered by a `useEffect` when `isPremiumUser && currentUser`, not exposed via context.
@@ -1025,7 +1043,8 @@ Note: `autoAssignOnLogin()` is internal only -- triggered by a `useEffect` when 
 | **Auto-release at 2 hours** | Releases instance after extended inactivity |
 | **Heartbeat with retry** | `recordActivity()` makes up to 3 attempts with linear backoff between them (1s after attempt 1, 2s after attempt 2; a 3rd failure surfaces without a further delay) |
 | **Browser close handling** | Uses `navigator.sendBeacon` on `beforeunload` event |
-| **Polling with backoff** | If on shared instance, polls for dedicated with exponential backoff (1.5x multiplier, 30s initial, 60s max, 40 attempts max, leader tab only) |
+| **Polling with backoff** | If on shared instance, polls for dedicated with exponential backoff (1.5x multiplier, 30s initial, 60s max, 40 attempts max, leader tab only). Also polls while `instanceUnreachable` is true so backend reassignment (to shared or to a new instance) is caught during a degraded period |
+| **Unreachable detection and recovery** | Listens for `premiumUnreachable` / `premiumReachable` events from `RoutingService`. Tracks a degraded -> probing -> terminal lifecycle with exponential probe backoff (30s initial, 5min cap, `MAX_FAILED_PROBES=5`); surfaces a warning snackbar via `PremiumNotificationManager`. Cross-tab synced via `crossTabSync` and persisted to `localStorage` with a 1h TTL for new-tab hydration |
 
 #### Auto-Assignment Flow
 
@@ -1092,6 +1111,8 @@ Handles user notifications for premium assignment events using notistack.
 | No dedicated instance yet | `info` | "Please wait while your dedicated premium resource is being prepared." | Persistent |
 | Assignment error (non-scaling) | `warning` | "Premium assignment issue: {error}" | Auto-dismiss |
 | Scaling/retry errors | (suppressed) | N/A | Silently ignored |
+| Dedicated instance unreachable (non-terminal) | `warning` | "Your dedicated premium instance is temporarily unreachable. Retrying..." | Persistent; replaced on transition to terminal |
+| Dedicated instance unreachable (terminal, probe budget exhausted) | `warning` | "Your dedicated premium instance is unresponsive after multiple attempts. Please reload the page or contact support." | Persistent; includes a Retry action that calls `retryUnreachableProbe()` |
 
 Note: Scaling/retry errors are not filtered by substring. The manager sets an `isRetryableError` flag when the `/assign` response has `!assigned && (scaling_in_progress || retry_after != null)`; when that flag is true the warning toast is skipped entirely and the persistent "Please wait..." info toast covers the state instead.
 
@@ -1137,6 +1158,8 @@ The browser-close path also calls `POST /users/me/premium/release-beacon` direct
 | `frontend/src/contexts/__tests__/PremiumHeartbeatRetry.test.ts` | Tests for heartbeat retry logic |
 | `frontend/src/contexts/__tests__/PremiumPollingBackoff.test.ts` | Tests for polling backoff behavior |
 | `frontend/src/contexts/__tests__/PremiumSleepDetection.test.ts` | Tests for sleep/wake detection |
+| `frontend/src/contexts/__tests__/PremiumInstanceUnreachable.test.ts` | Unit tests for the unreachable reducer and helper guards (`shouldPoll`, `shouldHydrateFromSnapshot`, probe backoff) |
+| `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx` | Integration tests covering the full unreachable -> probe -> recovery lifecycle through the provider |
 
 ---
 
@@ -1286,6 +1309,44 @@ Immediately converted ${K} idle instances to standby after user logout
 
 No frontend log (beacon is fire-and-forget before the tab unloads). Backend logs look identical to A.1.5 but via the `/release-beacon` endpoint rather than `DELETE /assign`.
 
+#### A.1.7 Dedicated instance unreachable then recovers
+
+Fires when a premium-routed request returns 5xx while the user has a dedicated assignment. All traces use `logPremiumUiEvent()`, which POSTs to `/users/me/premium/ui-event` -- search the `premium_manager` backend log group for `Premium UI event:` lines with the matching `user_id`.
+
+Expected sequence on a single unreachable -> recovery cycle (oldest first):
+
+```
+Premium UI event: ... event=instance_unreachable details={'instance_id': '${i-xxx}', 'url': '${path}', 'status': 503}
+Premium UI event: ... event=instance_unreachable_popup_shown details={'instance_id': '${i-xxx}', 'terminal': False}
+Premium UI event: ... event=instance_probe_armed details={'instance_id': '${i-xxx}', 'failed_probes': 0, 'delay_ms': 30000}
+Premium UI event: ... event=instance_reachable details={'instance_id': '${i-xxx}', 'duration_ms': ${N}}
+Premium UI event: ... event=instance_unreachable_popup_dismissed details={'instance_id': '${i-xxx}', 'reason': 'reachable'}
+```
+
+Browser console (axios interceptor): `Using free tier while premium instance provisions` fires once per 5xx that routed to the free-tier fallback.
+
+Progressive-degradation sequence when probes keep failing:
+
+```
+event=instance_unreachable                         (initial detection)
+event=instance_unreachable_popup_shown terminal=False
+event=instance_probe_armed failed_probes=0 delay_ms=30000
+event=instance_probe_failure failed_probes=1 is_terminal=False
+event=instance_probe_armed failed_probes=1 delay_ms=60000
+event=instance_probe_failure failed_probes=2 is_terminal=False
+...
+event=instance_probe_failure failed_probes=5 is_terminal=True
+event=instance_unreachable_popup_shown terminal=True      (snackbar variant swap)
+```
+
+After terminal, auto-re-arm is disabled. Only a Retry click or a backend reassignment clears the state:
+
+```
+event=instance_unreachable_manual_retry details={'instance_id': '${i-xxx}'}   (user clicked Retry)
+```
+
+**Verdict:** a single `instance_unreachable` followed within seconds by `instance_reachable` is a blip (cold-start, ALB reroute, or task restart-in-place). The **problem** pattern is (a) `instance_probe_failure` climbing to `failed_probes=5` and staying terminal, or (b) repeated unreachable/reachable cycles for the same `instance_id` within minutes -- points to flapping at the target-group or task layer.
+
 ### A.2 Heartbeat Retry: Is `Attempt 3/3` a Problem?
 
 This is the most-asked question and deserves its own subsection.
@@ -1326,6 +1387,8 @@ Note the log template is literal: it says `attempt N failed, retrying...`, not `
 | `No assignment found for user ${user_id}: ${error}` (on hard release) | `premium_manager.py` | User already had no assignment; idempotent release |
 | `No active assignment to release for user ${user_id} (may already be pending_release or removed)` | `premium_manager.py` | Same as above for the soft-release path |
 | `Failed to (load\|save\|clear) ${x} from localStorage: ...` | `RoutingService.ts` | Private mode / quota / SSR; routing headers still work from memory |
+| `Using free tier while premium instance provisions` | `axios.ts` | Single occurrence accompanies one `instance_unreachable` UI event; the circuit breaker will probe for recovery. Investigate only if the paired `instance_reachable` never arrives (see A.1.7) |
+| `Premium-(un)?reachable listener threw: ${e}` | `RoutingService.ts` | One listener crashed during dispatch; the pool continues delivering to others |
 | `Agent disconnected on ${i-xxx}, starting grace period` and its "within grace period" follow-up | `premium_manager.py` ghost ECS cleanup | 5-min grace before deregistering ECS container instance |
 | `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 15-min grace before stopping orphan EC2 |
 | `Warning: Error closing database connection: ${e}` | both lambdas | Cleanup-path warning on teardown; does not affect the work already done |
@@ -1401,6 +1464,8 @@ These strings are individually benign but tell you something when they accumulat
 | `Reserved dedicated instance: ${i-xxx}` without a matching `Using dedicated running instance ${i-xxx} for user ${user_id}` shortly after | Reservation acquired but the code threw before converting to assignment -- leaks a slot |
 | `Failed to register standby for ${i-xxx}: ${error}` | Standby-pool accounting drifting from reality; standby count metric will be wrong |
 | `Fixed ${N} stale is_shared flags` with N > 0 on repeated cycles | Something upstream is setting `is_shared=true` on rows that should be `false` -- investigate the shared→dedicated promotion code path |
+| `event=instance_unreachable` / `event=instance_reachable` cycling for the same `instance_id` within minutes | ALB target-group or ECS task is flapping on that instance. Check target-group health events and `premium_manager` ghost-cleanup output for agent-disconnect grace starts on the same `i-xxx` |
+| `event=instance_probe_failure` reaching `is_terminal=True` for many users | Broader ALB or ECS incident -- the probe budget only exhausts when five consecutive routed requests 5xx, so this is rarely a single-user issue |
 
 ### A.6 "How to read a premium incident" checklist
 
@@ -1412,4 +1477,4 @@ When asked to diagnose a premium issue, walk this list in order:
 4. **Is the scaling lock stuck?** If you see `Scaling already in progress, skipping this run` in every monitor invocation for more than two cycles in a row, the lock was not cleared by a previous run (look for `Error in removing lock:` upstream).
 5. **For user-facing heartbeat issues**, apply the A.2 matrix: single retry log = ignore; repeated "failed after retries" for one user = check per-user ALB target; "failed after retries" across many users = backend incident.
 6. **For "user keeps getting shared instance"**, look for (a) `No dedicated instances available` on each assign, (b) `Inline migration not possible for user ${user_id}`, and (c) whether the hourly cleanup is running -- a stuck standby row can make the monitor think capacity is taken.
-
+7. **For "dedicated assignment exists but requests fail silently"**, grep `premium_manager` for `Premium UI event:` with `event=instance_unreachable` / `event=instance_probe_failure` for the user. An `instance_reachable` immediately after means the blip recovered; an escalation to `is_terminal=True` means the probe budget exhausted and the user is stuck until they click Retry or the backend reassigns them. Cross-reference with target-group health on the matching `instance_id` in the same window.


### PR DESCRIPTION
### Content

#### Summary

A premium user with a dedicated assignment whose instance started 5xxing (returning HTTP 5xx server-error responses) was
silently switched to the free tier by the axios interceptor. The assignment
row stayed healthy, the waiting popup was long dismissed, polling was gated
off by the `is_shared=false` short-circuit, and nothing in the frontend ever
checked the instance again. The user saw no signal and stayed on degraded
routing for the rest of the session.

This PR makes that state observable, user-visible, and
recoverable. Axios now emits `premiumUnreachable` / `premiumReachable`
events on `RoutingService`; a new `useInstanceUnreachableMachine` hook
consumes them, drives a `healthy → unreachable → probing → terminal`
reducer, and surfaces a warning snackbar through
`PremiumNotificationManager`. A half-open circuit re-arms `premiumAssigned`
on exponential backoff so the next user-driven request probes the instance;
a real 2xx (a successful HTTP response) with an unrotated routing ID clears the state. Cross-tab sync and
a 1h localStorage snapshot keep the state coherent across tabs.

#### Design Decisions

- **Separate hook, not more state inside the context.** The unreachable
  lifecycle has its own refs, its own reducer, its own cross-tab handlers,
  and its own telemetry. Inlining it into `PremiumAssignmentContext` was
  tried first and produced a provider with ~600 lines of tangled effects.
  `useInstanceUnreachableMachine` exposes `{ state, retryProbe, reset }`
  and is composed into the provider; `shouldPoll` moved to a pure helper
  in `unreachableMachine.ts` so the polling gate is testable without
  mounting.

- **Event bus on `RoutingService`, not `window` CustomEvents.** An earlier
  draft dispatched `CustomEvent("premium:instance-unreachable")` on
  `window`. A typed listener pool on the singleton that already owns
  `premiumAssigned` keeps the contract enforced by TypeScript and avoids
  a global namespace. Tests can register listeners directly instead of
  mocking `window`.

- **Half-open circuit over constant polling.** An active-polling
  alternative (poll `getPremiumStatus()` + a backend TG-health check
  during unreachable periods) was rejected: it doubles the API
  surface, doesn't recover faster than a client-side probe, and puts
  the reachability signal in the wrong place. The circuit arms
  `premiumAssigned=true` before the next user action and lets the
  real request answer the question. Exponential backoff from
  `INITIAL_PROBE_DELAY_MS=30000` to `MAX_PROBE_DELAY_MS=300000`,
  capped at `MAX_FAILED_PROBES=5` before going terminal. Idle tabs
  leave the probe armed; no background traffic.

- **Reachable is gated by routing-ID non-rotation.** If the response's
  routing ID differs from the one sent, the ALB served the retry from a
  different instance — reachability of the probed instance is
  inconclusive and no event fires. The request interceptor stamps
  `_hadPremiumHeaders` / `_outgoingRoutingId` / `_premiumSentAt` on the
  outgoing config; the response interceptor reads them back. The
  free-tier retry config deletes those markers so it cannot falsely emit
  reachable.

- **Stale-failure watermark.** `lastReachableSentAtRef` tracks the most
  recent successful send-timestamp. Failures whose `sentAt` predates it
  are suppressed (`isStaleFailure()`), so an in-flight 5xx that loses
  its race with a newer success cannot reopen an already-recovered
  state.

- **Cross-tab sync via `tabSync`, peer handlers are local-only.** Three
  new message types (`PREMIUM_INSTANCE_UNREACHABLE`,
  `PREMIUM_INSTANCE_REACHABLE`, `PREMIUM_INSTANCE_PROBE_UPDATE`). Peer
  handlers apply state locally, do not re-log `logPremiumUiEvent`, and
  do not re-broadcast — this is what prevents the echo loop that every
  multi-tab draft initially produced.

- **localStorage snapshot with 1h TTL, gated on `instance_id` match.**
  `BroadcastChannel` cannot replay to a newly opened tab, so the
  snapshot (`premium_unreachable_snapshot`) is the only way a fresh tab
  inherits the degraded state. `shouldHydrateFromSnapshot` rejects a
  snapshot whose `instance_id` does not match the current assignment,
  so a snapshot from a prior session cannot be adopted. Snapshot writes
  are leader-only, and a fresh tab holds
  `hasEverBeenUnreachableRef=false` so it does not wipe a peer's
  snapshot before hydrating.

- **Polling runs while unreachable.** The old gate stopped polling once
  `is_shared=false`. That was correct for "don't burn polls after
  dedicated success" but it meant the polling loop couldn't observe a
  backend-initiated reassignment during a degraded period. The new
  `shouldPoll` helper adds `!instanceUnreachable` to the
  healthy-and-done condition, so polling resumes while degraded and
  stops again on clear.

- **Terminal snackbar is a replacement, not an update.** notistack does
  not let you mutate an existing snackbar's action. When
  `isUnreachableTerminal` flips true, the non-terminal snackbar is
  closed and a new one with the Retry action is enqueued.
  `retryProbe()` resets the probe budget and re-arms
  `premiumAssigned=true` — it does **not** itself signal recovery; the
  next real response does.

- **`release()` calls `unreachable.reset()` defensively.** The hook's
  mirror effect already clears on `assignmentResult == null`, so this
  is redundant in the normal path. Kept for the watermark / hydrated /
  snapshot refs which the mirror effect does not touch — those only
  reset on explicit release/logout.

### Evidence

- Manual reproduction on development: direct-terminate the ECS task
  serving a premium user's dedicated instance; the next request 5xxs,
  the "temporarily unreachable. Retrying…" snackbar appears within one
  response cycle; `Premium UI event: ... event=instance_unreachable`
  lands in the `premium_manager` log group. After ECS replaces the
  task, the next user click carries premium headers, returns 2xx, and
  the snackbar dismisses with
  `event=instance_reachable, duration_ms=...`.
- Forced-terminal run: five synthetic 5xxs at probe-armed times walk
  `failed_probes=1..5`, land `is_terminal=True`, and swap the snackbar
  to the Retry variant. Clicking Retry logs
  `event=instance_unreachable_manual_retry` and re-arms probing from
  zero.
- Automated: `PremiumUnreachableIntegration.test.tsx` exercises the
  full lifecycle end-to-end through the provider;
  `unreachableMachine.test.ts` pins every reducer transition and helper
  guard; `axiosPremiumInterceptor.test.ts` covers request tagging,
  rotation suppression, retry-marker stripping, and the 401 refresh
  path; `RoutingService.test.ts` pins the listener pools.

### References

- `infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md` — Edge
  Case 4 rewritten from "strip + retry" to the three-phase fallback /
  observe / recover design.
- `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md` —
  Appendix A.1.7 documents the new `Premium UI event:` trace; symptom
  → state table and notification-types table list the new warning
  variants.

#### Files changed

Frontend — axios & routing
- `frontend/src/utils/axios.ts` — request interceptor stamps
  premium-routed requests with `_hadPremiumHeaders` /
  `_outgoingRoutingId` / `_premiumSentAt`; response interceptor emits
  `premiumReachable` when those tags are present and the routing ID
  did not rotate; `handlePremiumRoutingError` emits
  `premiumUnreachable` on 5xx and strips the markers from the retry
  config so the free-tier retry cannot falsely re-emit reachable.
- `frontend/src/utils/routing/RoutingService.ts` — added typed
  listener pools (`onPremiumUnreachable` / `emitPremiumUnreachable`
  and the reachable pair) with per-listener try/catch so a throwing
  subscriber does not block the rest of the pool.
- `frontend/src/utils/crossTabSync.ts` — added
  `PREMIUM_INSTANCE_UNREACHABLE`, `PREMIUM_INSTANCE_REACHABLE`,
  `PREMIUM_INSTANCE_PROBE_UPDATE` to `TabSyncMessageType`.

Frontend — unreachable machine
- `frontend/src/contexts/premium/unreachableConstants.ts` — probe
  config (`INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`,
  `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5`) and snapshot
  constants (`LS_UNREACHABLE_SNAPSHOT`, `UNREACHABLE_SNAPSHOT_TTL_MS`
  = 1h).
- `frontend/src/contexts/premium/unreachableMachine.ts` — pure
  helpers (`shouldPoll`, `shouldFlipToUnreachable`,
  `computeNextProbeDelayMs`, `hasReachedProbeCap`, `isStaleFailure`,
  `computeProbeFailure`, `shouldHydrateFromSnapshot`,
  `shouldClearUnreachableForAssignment`) and the
  `unreachableMachineReducer` with seven actions. All pure; no React,
  no network, no globals.
- `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts` —
  the single hook that wires `routingService` events, `tabSync` peer
  handlers, the leader-only snapshot writer, the one-shot hydration
  effect, and the half-open re-arm timer into the reducer. Exposes
  `{ state, retryProbe, reset }`.

Frontend — integration
- `frontend/src/contexts/PremiumAssignmentContext.tsx` — composes
  `useInstanceUnreachableMachine`, exposes `unreachable` on the
  context, swaps the inline polling gate for the `shouldPoll` helper,
  and calls `unreachable.reset()` on logout/release (defensive —
  covers the watermark / hydrated / snapshot refs).
- `frontend/src/components/Premium/PremiumNotificationManager.tsx` —
  new effect enqueues a persistent warning snackbar while
  `instanceUnreachable && hasDedicatedInstance`; closes and
  re-enqueues on the non-terminal → terminal transition to surface
  the Retry action; fires `instance_unreachable_popup_shown` /
  `_dismissed` events.

Tests
- `frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts`
  — unit tests for every helper and every reducer transition.
- `frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx`
  — hook-level tests driving `useInstanceUnreachableMachine` directly
  to pin leader-gated side effects: non-leader tabs do not write the
  `premium_unreachable_snapshot` and do not arm the probe timer;
  leader tabs write on unreachable, clear on recovery, and arm
  `setPremiumAssigned(true)` + `instance_probe_armed` after
  `INITIAL_PROBE_DELAY_MS`.
- `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx`
  — integration tests covering the full lifecycle through the
  provider (first failure, probe arm, probe failure, terminal
  transition, manual retry, peer broadcast, snapshot hydration,
  stale-failure suppression, rotation-inconclusive success).
- `frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx`
  — snackbar behaviour: non-terminal unreachable enqueues a warning
  without a Retry action; the non-terminal → terminal transition
  closes the old snackbar and enqueues a new one with a Retry
  button; recovery, dedicated-→-shared, and premium-→-non-premium
  transitions each dismiss with the correct `reason` value.
- `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` —
  interceptor tests: request stamping, rotation-suppressed reachable,
  retry-marker stripping, no-rotation reachable with no
  `X-Routing-ID` response, 401 refresh-then-retry still emits
  reachable.
- `frontend/src/utils/routing/RoutingService.test.ts` — listener-pool
  tests: emit-to-all, unsubscribe, throwing listener isolation, pool
  independence, `sentAt` forwarding.

Docs
- `infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md` — Edge
  Case 4 rewritten; Responsibility Matrix, Frontend Routing Flow, and
  Key Functions Reference extended with the new `RoutingService` pool
  API and circuit-breaker behaviour.
- `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md` —
  `UnreachableMachineState` documented alongside
  `PremiumAssignmentState`; Key Features, Notification Types, and
  Symptom → State → Cause tables extended; new Appendix A.1.7
  ("Dedicated instance unreachable then recovers") with the expected
  `Premium UI event:` trace; noisy-but-fine and watchlist tables
  extended; incident checklist step 7 added.

### Manual Testcases

- [x] Degraded then recovered (5xx blip)
   As a premium user with a dedicated assignment on development,
   force an ECS task restart on your instance (task stop via console,
   or direct SIGTERM). Expected: within one response cycle the
   snackbar "Your dedicated premium instance is temporarily
   unreachable. Retrying…" appears. Watch CloudWatch
   `premium_manager` for
   `Premium UI event: ... event=instance_unreachable`. When the task
   comes back and the next click succeeds, the snackbar dismisses
   and `event=instance_reachable details={'duration_ms': <N>}`
   lands.

- [x] Terminal state and Retry
   Block requests to the per-user TG at the security-group layer so
   every 5xx is a clean failure, not a timeout. Wait through five
   probe cycles (≈30 s, 60 s, 120 s, 240 s, 300 s capped). Expected:
   the snackbar swaps to "unresponsive after multiple attempts.
   Please reload the page or contact support." with a Retry button.
   `event=instance_probe_failure failed_probes=5 is_terminal=True`
   logged. Unblock the SG, click Retry, send a real request:
   `event=instance_unreachable_manual_retry` then
   `event=instance_reachable` on the next success.

- [x] Cross-tab sync
   Open the app in two tabs, let both tabs see the dedicated
   assignment. Trigger unreachable in tab A. Expected: tab B's
   snackbar appears without tab B having made a request; its
   `logPremiumUiEvent` is **not** called for the initial event (peer
   handlers are local-only). On recovery in tab A, tab B's snackbar
   dismisses via the `PREMIUM_INSTANCE_REACHABLE` broadcast.

- [x] Snapshot hydration on fresh tab
   Trigger unreachable in one tab, close it, open a fresh tab within
   one hour. Expected: the new tab enters unreachable state on load
   (snackbar shown, `premiumAssigned=false`). Open a fresh tab
   beyond one hour or after a reassignment: the snapshot is ignored.

- [x] Rotation-inconclusive success
   Force a routing-ID rotation (ALB serves a retry from a different
   instance). Expected: no `instance_reachable` event fires; the
   snackbar stays up; the watermark is not advanced; state remains
   unreachable until a non-rotated 2xx lands.

- [x] Stale-failure suppression
   Queue a slow request A (premium headers), let it go out, fire a
   fast request B that succeeds (premium headers), then let A return
   5xx. Expected: `emitPremiumUnreachable` is delivered but
   suppressed (`isStaleFailure` true because
   A's `sentAt < B.sentAt`); no state transition, no snackbar.


### Unit, Integration, Contract Test Coverage

- **Unit (`unreachableMachine.test.ts`):** pins every helper
  (`shouldPoll`, `shouldFlipToUnreachable`,
  `computeNextProbeDelayMs`, `hasReachedProbeCap`, `isStaleFailure`,
  `computeProbeFailure`, `shouldHydrateFromSnapshot`,
  `shouldClearUnreachableForAssignment`) and every reducer action
  (CLEAR, FLIP_TO_UNREACHABLE, PROBE_FAILURE,
  APPLY_PEER_UNREACHABLE, APPLY_PEER_PROBE_UPDATE,
  HYDRATE_FROM_SNAPSHOT, MANUAL_RETRY).
- **Hook leader tests (`useInstanceUnreachableMachineLeader.test.tsx`):**
  drive the hook directly to pin leader-gated behaviour —
  non-leader tabs skip the snapshot write and do not arm the probe
  timer; leader tabs write and clear the snapshot, and arm
  `setPremiumAssigned(true)` + `instance_probe_armed` after
  `INITIAL_PROBE_DELAY_MS`.
- **Integration (`PremiumUnreachableIntegration.test.tsx`):** mounts
  the provider with mocked `routingService` and `tabSync`; drives
  the full `healthy → unreachable → probing → terminal → recovery`
  lifecycle; covers peer broadcasts, snapshot hydration, rotation
  inconclusivity, stale-failure suppression, and retryProbe-as-
  budget-reset.
- **Notification snackbar (`PremiumNotificationManager.test.tsx`):**
  mounts the manager against mocked notistack / context; pins the
  non-terminal → terminal swap (close + enqueue with Retry action),
  the Retry click wiring, and dismissal `reason` values for each
  exit path (reachable, not_dedicated, not_premium).
- **Interceptor (`axiosPremiumInterceptor.test.ts`):** request
  tagging (`_premiumSentAt` only when premium headers are present),
  response success rotation suppression, 503 fallback marker
  stripping, no-`X-Routing-ID` reachable path,
  401-refresh-retry still emits reachable with the new token.
- **RoutingService pool tests:** emit-to-all, unsubscribe, throwing
  listener isolation, reachable/unreachable pool independence,
  `sentAt` forwarding on both event types.
- **No contract tests touched.** The backend `POST /premium/ui-event`
  endpoint is a generic log forwarder; the new event types
  (`instance_unreachable`, `instance_reachable`,
  `instance_probe_armed`, `instance_probe_failure`,
  `instance_unreachable_manual_retry`,
  `instance_unreachable_popup_shown` / `_dismissed`) flow through
  unchanged.

### Others

#### Difficulties

- **Echo loops between tabs.** Every multi-tab draft initially had
  peer handlers re-logging `logPremiumUiEvent` and re-broadcasting —
  two tabs would ping-pong the same event forever. The fix is
  structural: peer handlers apply state locally only, the origin tab
  is the only one that emits telemetry and broadcasts.

- **Duplicate-log races on back-to-back failures.** React state is
  pre-commit when listeners fire, so a burst of 5xxs would each see
  `instanceUnreachable=false` and each log `instance_unreachable`.
  Refs (`unreachableRef`, `probingRef`, `failedProbesRef`) are
  written synchronously inside the handler *before* dispatch; the
  mirror effect re-syncs from reducer state after commit.

- **Snapshot-write races across tabs.** Two leaders racing on the
  same key would produce torn writes. Writes are gated on
  `isTabLeader`; a freshly opened tab holds
  `hasEverBeenUnreachableRef=false` until the one-shot hydration
  effect runs, so it does not wipe a peer's snapshot on mount.

- **Retry button semantics.** Initial draft had Retry call
  `routingService.setPremiumAssigned(true)` and emit
  `premiumReachable` optimistically; that papered over the real
  question. Retry now only resets the probe budget and re-arms
  `premiumAssigned` — the next actual response is what clears the
  state. This matched the "reachability requires a real response"
  invariant that the entire design depends on.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Axios request/response interceptors | Low | Additions are behind `_hadPremiumHeaders` tagging that only sets when `getRoutingHeaders()` returns a routing ID. Non-premium and free-tier requests take the same path as before. |
| Free-tier retry marker stripping | Low | Covered by `axiosPremiumInterceptor.test.ts` ("503 fallback strips premium markers on the retry config"). Without it, the retry would falsely emit reachable on success. |
| New listener pools on `RoutingService` | Low | Additive API; existing callers untouched. Per-listener try/catch prevents a broken subscriber from stopping the rest. |
| `useInstanceUnreachableMachine` effect ordering | Medium | The hook has six effects with interleaving refs. All ordering invariants are pinned in `PremiumUnreachableIntegration.test.tsx`. A refactor that moves dispatches out of handler-synchronous positions is the most likely way to regress — keep the ref-before-dispatch pattern. |
| Polling gate change (`shouldPoll` includes `!instanceUnreachable`) | Medium | Healthy dedicated users see no change. Unreachable dedicated users now poll, which adds `/assign` calls on a degraded-path-only schedule bounded by `MAX_POLL_ATTEMPTS=40`. Backend can handle this — it's the same volume a shared user generates. |
| Cross-tab snapshot | Low | Writes leader-only, bounded by 1h TTL, gated on `instance_id` match. Worst case on storage unavailable: snapshot never written, new tab simply does not hydrate — identical to single-tab behaviour. |
| Notistack variant swap | Low | Rare edge case: the old snackbar might briefly overlap the new one during the close/enqueue. notistack handles stacking; user sees a single snackbar. |
| Rollback | Trivial | `git revert` the three feature files plus the NotificationManager change. No persisted state other than an ignorable localStorage key. No backend or infra changes. |
| Backend / infra | None | No Terraform, IAM, Lambda, or endpoint changes. `POST /premium/ui-event` is an existing generic log forwarder. |

### Appendix: Flow Diagrams

#### A. End-to-end signal path (request → event → state → UI)

```
     ┌──────────────────────┐         ┌──────────────────────┐
     │  User action / click │         │   Polling loop       │
     └──────────┬───────────┘         └──────────┬───────────┘
                │                                │
                ▼                                ▼
     ┌──────────────────────────────────────────────────────┐
     │  axios request interceptor   (frontend/src/utils/    │
     │    axios.ts)                                         │
     │  • if getRoutingHeaders() → stamp                    │
     │      _hadPremiumHeaders, _outgoingRoutingId,         │
     │      _premiumSentAt                                  │
     └──────────────────────────────────────────────────────┘
                │
                ▼
     ┌──────────────────────────────────────────────────────┐
     │  ALB  →  per-user target group  →  dedicated task    │
     └──────────────────────────────────────────────────────┘
                │
      ┌─────────┴──────────┐
      │                    │
      ▼                    ▼
  HTTP 2xx             HTTP 5xx
      │                    │
      ▼                    ▼
 ┌─────────────┐     ┌──────────────────────────────────┐
 │ response    │     │ handlePremiumRoutingError        │
 │ interceptor │     │ • strip premium markers from     │
 │ • if tags   │     │   free-tier retry config         │
 │   present & │     │ • emit premiumUnreachable        │
 │   routingId │     │   { routingId, sentAt }          │
 │   NOT rotat.│     └──────────────┬───────────────────┘
 │   → emit    │                    │
 │   premium   │                    │
 │   Reachable │                    │
 │   {sentAt}  │                    │
 └──────┬──────┘                    │
        │                           │
        ▼                           ▼
     ┌──────────────────────────────────────────────────────┐
     │  RoutingService  typed listener pools                │
     │    onPremiumReachable   /   onPremiumUnreachable     │
     └──────────────────────────┬───────────────────────────┘
                                ▼
     ┌──────────────────────────────────────────────────────┐
     │  useInstanceUnreachableMachine                       │
     │    • stale-failure watermark (isStaleFailure)        │
     │    • reducer dispatch                                │
     │    • tabSync broadcast (origin tab only)             │
     │    • leader snapshot writer                          │
     │    • half-open probe timer                           │
     └──────────────────────────┬───────────────────────────┘
                                ▼
     ┌──────────────────────────────────────────────────────┐
     │  PremiumAssignmentContext   (shouldPoll, unreachable)│
     └──────────────────────────┬───────────────────────────┘
                                ▼
     ┌──────────────────────────────────────────────────────┐
     │  PremiumNotificationManager                          │
     │    • non-terminal warning snackbar                   │
     │    • close + enqueue Retry snackbar on terminal      │
     │    • dismiss on reachable / not_dedicated /          │
     │      not_premium                                     │
     └──────────────────────────────────────────────────────┘
```

#### B. Reducer state machine

```
                     ┌──────────────────┐
                     │     healthy      │◀──────────────┐
                     │  unreachable=F   │               │
                     │  probing=F       │               │
                     │  failedProbes=0  │               │
                     └────────┬─────────┘               │
                              │                         │
           premiumUnreachable │ (non-stale, dedicated)  │ premiumReachable
                 FLIP_TO_UNREACHABLE                    │ CLEAR
                              ▼                         │
                     ┌──────────────────┐               │
                     │   unreachable    │───────────────┤
                     │  snackbar:warn   │               │
                     │  (no Retry btn)  │               │
                     └────────┬─────────┘               │
                              │                         │
               probe timer fires                        │
               re-arms premiumAssigned=true             │
                              ▼                         │
                     ┌──────────────────┐               │
                     │    probing      │                │
                     └────────┬─────────┘               │
                              │                         │
          next user request   │                         │
          ┌───────────────────┴────────────────┐        │
          │                                    │        │
          ▼ 5xx                                ▼ 2xx    │
  PROBE_FAILURE                           CLEAR         │
  failedProbes += 1                       ─────────────▶│
  delay *= 2   (cap 300s)                               │
          │                                             │
          │ failedProbes < MAX_FAILED_PROBES(5)         │
          └──────────────▶ back to unreachable          │
          │                                             │
          │ failedProbes == MAX_FAILED_PROBES           │
          ▼                                             │
                     ┌──────────────────┐               │
                     │    terminal      │               │
                     │  snackbar swap:  │               │
                     │  warn + [Retry]  │               │
                     └────────┬─────────┘               │
                              │                         │
                      user clicks Retry                 │
                      MANUAL_RETRY                      │
                      failedProbes=0, re-arm            │
                              │                         │
                              └──▶ back to probing ─────┘
```

#### C. Cross-tab + hydration

```
  Tab A (origin)                         Tab B (peer)
  ────────────────                       ────────────────
  5xx → FLIP_TO_UNREACHABLE
    │
    ├─ logPremiumUiEvent("instance_unreachable")
    ├─ tabSync.broadcast(PREMIUM_INSTANCE_UNREACHABLE)────▶ APPLY_PEER_UNREACHABLE
    │                                                        (local-only:
    │                                                         no log,
    │                                                         no re-broadcast)
    │
    └─ if isTabLeader:
         localStorage.set(premium_unreachable_snapshot,
                          { instance_id, ts, ttl=1h })
                                                           ─────────────────────
                                                           New tab C mounts:
                                                           • reads snapshot
                                                           • shouldHydrateFromSnapshot:
                                                               ttl ok + instance_id match
                                                               → HYDRATE_FROM_SNAPSHOT
                                                           • hasEverBeenUnreachableRef=F
                                                               → will NOT wipe snapshot
                                                                 before hydration completes

  2xx (non-rotated) → CLEAR
    │
    ├─ logPremiumUiEvent("instance_reachable", duration_ms)
    ├─ tabSync.broadcast(PREMIUM_INSTANCE_REACHABLE) ─────▶ APPLY_PEER_REACHABLE
    │
    └─ if isTabLeader:
         localStorage.remove(premium_unreachable_snapshot)
```
