### PR TITLE
Unify naming under araya-optinist (tags, logical resources, prose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Araya-OptiNiSt Cloud <img src="docs/_static/optinist.png" width="77" title="optinist" alt="optinist" align="right" vspace = "50"><img src="docs/_static/araya_logo.png" width="200" title="araya" alt="araya" align="right" vspace = "50">
+# Araya OptiNiSt <img src="docs/_static/optinist.png" width="77" title="optinist" alt="optinist" align="right" vspace = "50"><img src="docs/_static/araya_logo.png" width="200" title="araya" alt="araya" align="right" vspace = "50">
 
 <p align="center">
     <a>
@@ -27,9 +27,9 @@
     </a>
 </p>
 
-**Araya-OptiNiSt Cloud** allows researchers to process and visualize their calcium imaging data entirely online. It was built by [Araya Inc.](https://www.araya.org/en/) on top of [OptiNiSt](https://github.com/oist/optinist), an open-source calcium imaging pipeline tool originally developed in collaboration with [OIST](https://www.oist.jp/).
+**Araya OptiNiSt** allows researchers to process and visualize their calcium imaging data entirely online. It was built by [Araya Inc.](https://www.araya.org/en/) on top of [OptiNiSt](https://github.com/oist/optinist), an open-source calcium imaging pipeline tool originally developed in collaboration with [OIST](https://www.oist.jp/).
 
-We believe in open, reproducible science and in making it easy to share results between labs. Araya-OptiNiSt Cloud is built around these principles:
+We believe in open, reproducible science and in making it easy to share results between labs. Araya OptiNiSt is built around these principles:
 
 - **Public Data Sharing**: Publish your experiments to the [public page](https://www.araya-optinist.com/public), where anyone can view your results and reproduce your workflows without needing an account.
 - **Cloud Computing**: Run analysis pipelines on cloud infrastructure without managing local hardware.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 
 # -- Project information -----------------------------------------------------
-project = "Araya-OptiNiSt Cloud"
+project = "Araya OptiNiSt"
 copyright = f"{datetime.now().year}, Araya Inc., OIST"
 author = "Araya Inc."
 release = "1.1.4"

--- a/docs/gui_guide/workflow.md
+++ b/docs/gui_guide/workflow.md
@@ -388,7 +388,7 @@ Filtered data will be saved to the output NWB file once `RUN` has been performed
 (DirectorySettings)=
 ## Cloud Storage
 
-Araya-OptiNiSt Cloud stores your data in S3-backed cloud storage. You do not need to manage local directories.
+Araya OptiNiSt stores your data in S3-backed cloud storage. You do not need to manage local directories.
 
 To add data, upload files via the GUI by clicking the image icon on a data node. Choosing a folder makes all the TIFF files in the shown sequence an input set of continuous frames.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,13 @@
 .. meta::
-   :description: Araya-OptiNiSt Cloud – a no-code cloud platform for calcium imaging data analysis. Build visual pipelines, ensure reproducibility, and collaborate with NWB-compatible workflows.
+   :description: Araya OptiNiSt – a no-code cloud platform for calcium imaging data analysis. Build visual pipelines, ensure reproducibility, and collaborate with NWB-compatible workflows.
    :keywords: OptiNiSt, Araya, calcium imaging, neuroscience, data analysis, no-code, NWB, Neurodata Without Borders, visual workflow, pipeline builder, ROI analysis, cloud computing, reproducible science, OIST, microscopy, open science
 
-Araya-OptiNiSt Cloud
+Araya OptiNiSt
 ==========================================
 
-**Araya-OptiNiSt Cloud** allows researchers to process and visualize their calcium imaging data entirely online. It was built by `Araya Inc. <https://www.araya.org/en/>`_ on top of `OptiNiSt <https://github.com/oist/optinist>`_, an open-source calcium imaging pipeline tool originally developed in collaboration with `OIST <https://www.oist.jp/>`_.
+**Araya OptiNiSt** allows researchers to process and visualize their calcium imaging data entirely online. It was built by `Araya Inc. <https://www.araya.org/en/>`_ on top of `OptiNiSt <https://github.com/oist/optinist>`_, an open-source calcium imaging pipeline tool originally developed in collaboration with `OIST <https://www.oist.jp/>`_.
 
-We believe in open, reproducible science and in making it easy to share results between labs. Araya-OptiNiSt Cloud is built around these principles:
+We believe in open, reproducible science and in making it easy to share results between labs. Araya OptiNiSt is built around these principles:
 
 - **Public Data Sharing**: Publish your experiments to the `public page <https://www.araya-optinist.com/public>`_, where anyone can view your results and reproduce your workflows without needing an account.
 - **Cloud Computing**: Run analysis pipelines on cloud infrastructure without managing local hardware.

--- a/docs/specifications/add_algorithm.md
+++ b/docs/specifications/add_algorithm.md
@@ -6,7 +6,7 @@ Add your algorithm
 :depth: 3
 ```
 
-Additional algorithms can be added to Araya-OptiNiSt Cloud on request. Delivery is greatly sped up if requests include code for new nodes. This guide explains the format for adding new nodes.
+Additional algorithms can be added to Araya OptiNiSt on request. Delivery is greatly sped up if requests include code for new nodes. This guide explains the format for adding new nodes.
 
 ## Example of Algorithm Addition Procedure
 

--- a/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
@@ -1,6 +1,6 @@
-# OptiNiSt Cloud Deployment Procedure
+# Araya OptiNiSt Deployment Procedure
 
-This document describes how to deploy OptiNiSt to AWS infrastructure. There are two deployment methods depending on your level of access.
+This document describes how to deploy Araya OptiNiSt to AWS infrastructure. There are two deployment methods depending on your level of access.
 
 **Production URL:** `https://araya-optinist.com`
 

--- a/infrastructure/documentation/DEV_SCHEDULE_GUIDE.md
+++ b/infrastructure/documentation/DEV_SCHEDULE_GUIDE.md
@@ -103,7 +103,7 @@ stop will be skipped. Clear it first if you want to force a stop:
 
 ```bash
 aws ssm put-parameter \
-  --name /development/optinist/schedule-override \
+  --name /development/araya-optinist/schedule-override \
   --value off \
   --type String \
   --overwrite \
@@ -130,7 +130,7 @@ The value is a UTC expiry timestamp (e.g., `2026-03-18T16:00:00Z`) or `off`:
 
 ```bash
 aws ssm get-parameter \
-  --name /development/optinist/schedule-override \
+  --name /development/araya-optinist/schedule-override \
   --query 'Parameter.Value' \
   --region ap-northeast-1 \
   --output text

--- a/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
@@ -321,7 +321,7 @@ terraform output alb_dns_name
 terraform output rds_endpoint
 
 # Sensitive output
-terraform output -raw optinist_cloud_user_secret_access_key
+terraform output -raw araya_optinist_cloud_user_secret_access_key
 ```
 
 ### Update a Single Resource

--- a/infrastructure/documentation/INFRA_SECURITY_MODEL.md
+++ b/infrastructure/documentation/INFRA_SECURITY_MODEL.md
@@ -134,7 +134,7 @@ All resources are tagged automatically via `default_tags`:
 | ------------- | ------------------------- | ----------------------------------------------------------- |
 | `Environment` | `subscr` or `development` | Identify which environment owns the resource                |
 | `ManagedBy`   | `terraform`               | Distinguish Terraform-managed vs manually-created resources |
-| `Project`     | `optinist-cloud`          | Filter across all OptiNiSt resources                        |
+| `Project`     | `araya-optinist`          | Filter across all Araya OptiNiSt resources                  |
 
 **Filter in AWS Console**: Use `Environment = development` to see only dev resources.
 

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -1,6 +1,6 @@
-# OptiNiSt Cloud Maintenance Procedures
+# Araya OptiNiSt Maintenance Procedures
 
-This document defines the roles, responsibilities, and periodic maintenance tasks required to keep the OptiNiSt Cloud production environment healthy and reliable.
+This document defines the roles, responsibilities, and periodic maintenance tasks required to keep the Araya OptiNiSt production environment healthy and reliable.
 
 Weekly and monthly checks are automated by maintenance scripts that collect data from AWS and produce a markdown report. **Always use the scripts** — do not run the underlying CLI commands manually unless you are debugging a specific issue.
 

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -124,7 +124,7 @@ resource "aws_launch_template" "ecs" {
   name_prefix   = "${local.env_prefix}-ecs-"
   image_id      = data.aws_ami.ecs_optimized.id
   instance_type = var.free_instance_type
-  key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
+  key_name      = aws_key_pair.araya_optinist_cloud_key_pair.key_name
 
   vpc_security_group_ids = [aws_security_group.ecs.id]
 
@@ -344,7 +344,7 @@ resource "aws_launch_template" "premium" {
   name_prefix   = "${local.env_prefix}-premium-"
   image_id      = data.aws_ami.ecs_optimized.id
   instance_type = var.premium_instance_type
-  key_name      = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
+  key_name      = aws_key_pair.araya_optinist_cloud_key_pair.key_name
 
   vpc_security_group_ids = [aws_security_group.ecs.id]
 

--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -15,7 +15,7 @@
 #
 # Manual override (skip next scheduled stop):
 #   aws ssm put-parameter \
-#     --name /<env>/optinist/schedule-override \
+#     --name /<env>/araya-optinist/schedule-override \
 #     --value on --type String --overwrite
 #
 # Manual start (after-hours / weekends):
@@ -30,7 +30,7 @@
 resource "aws_ssm_parameter" "dev_schedule_override" {
   count = var.enable_dev_schedule ? 1 : 0
 
-  name  = "/${var.environment}/optinist/schedule-override"
+  name  = "/${var.environment}/araya-optinist/schedule-override"
   type  = "String"
   value = "off"
 
@@ -87,7 +87,7 @@ resource "aws_lambda_function" "dev_scheduler" {
       ASG_MAX_SIZE                  = tostring(var.asg_max_size)
       ASG_DESIRED_CAPACITY          = tostring(var.asg_desired_capacity)
       CLUSTER_NAME                  = aws_ecs_cluster.main.name
-      OVERRIDE_PARAM_NAME           = "/${var.environment}/optinist/schedule-override"
+      OVERRIDE_PARAM_NAME           = "/${var.environment}/araya-optinist/schedule-override"
       ALARM_PREFIX                  = "${var.environment}-"
       PREMIUM_MANAGER_FUNCTION_NAME = aws_lambda_function.premium_manager.function_name
       DEFAULT_STOP_MODE             = var.dev_schedule_stop_mode
@@ -294,7 +294,7 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
           "ssm:GetParameter",
           "ssm:PutParameter",
         ]
-        Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment}/optinist/schedule-override"
+        Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment}/araya-optinist/schedule-override"
       },
       # Invoke premium_manager to clean up dynamic instances before stop
       {
@@ -502,7 +502,7 @@ output "dev_schedule_info" {
     stop_time      = "22:00 JST (13:00 UTC) Mon-Fri"
     stop_mode      = var.dev_schedule_stop_mode
     weekends       = "Stopped (Fri 22:00 -> Mon 08:00 JST)"
-    override       = "aws ssm put-parameter --name /${var.environment}/optinist/schedule-override --value on --type String --overwrite"
+    override       = "aws ssm put-parameter --name /${var.environment}/araya-optinist/schedule-override --value on --type String --overwrite"
     manual_start   = "aws lambda invoke --function-name ${var.environment}-dev-scheduler --payload '{\"action\":\"start\"}' /dev/stdout"
     manual_stop    = "aws lambda invoke --function-name ${var.environment}-dev-scheduler --payload '{\"action\":\"stop\",\"stop_mode\":\"stop\"}' /dev/stdout"
     manual_destroy = "aws lambda invoke --function-name ${var.environment}-dev-scheduler --payload '{\"action\":\"stop\",\"stop_mode\":\"destroy\"}' /dev/stdout"

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
     tags = {
       Environment = local.environment_label
       ManagedBy   = "terraform"
-      Project     = "optinist-cloud"
+      Project     = "araya-optinist"
     }
   }
 }
@@ -441,7 +441,7 @@ output "backend_config" {
 # Output the key information
 output "ssh_key_name" {
   description = "Name of the generated SSH key pair"
-  value       = aws_key_pair.subscr_optinist_cloud_key_pair.key_name
+  value       = aws_key_pair.araya_optinist_cloud_key_pair.key_name
 }
 
 output "ssh_private_key_path" {
@@ -455,14 +455,14 @@ output "ssh_command" {
 }
 
 # Output the access key credentials
-output "optinist_cloud_user_access_key_id" {
-  description = "Access Key ID for subscr-optinist-cloud-user"
-  value       = aws_iam_access_key.subscr_optinist_cloud_user_access_key.id
+output "araya_optinist_cloud_user_access_key_id" {
+  description = "Access Key ID for the araya-optinist IAM user"
+  value       = aws_iam_access_key.araya_optinist_cloud_user_access_key.id
 }
 
-output "optinist_cloud_user_secret_access_key" {
-  description = "Secret Access Key for subscr-optinist-cloud-user"
-  value       = aws_iam_access_key.subscr_optinist_cloud_user_access_key.secret
+output "araya_optinist_cloud_user_secret_access_key" {
+  description = "Secret Access Key for the araya-optinist IAM user"
+  value       = aws_iam_access_key.araya_optinist_cloud_user_access_key.secret
   sensitive   = true
 }
 

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -439,16 +439,16 @@ resource "aws_iam_role_policy" "ecs_instance_detailed_monitoring" {
   })
 }
 
-# IAM User for this OptiNiSt Cloud project (separate from other webapps)
-resource "aws_iam_user" "subscr_optinist_cloud_user" {
+# IAM User for this Araya OptiNiSt project (separate from other webapps)
+resource "aws_iam_user" "araya_optinist_cloud_user" {
   name = "${local.env_prefix}-cloud-user"
   path = "/"
 }
 
-# IAM Policy for this OptiNiSt Cloud User
-resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
+# IAM Policy for this Araya OptiNiSt User
+resource "aws_iam_policy" "araya_optinist_cloud_user_policy" {
   name        = "${local.env_prefix}-cloud-user-policy"
-  description = "Policy for this OptiNiSt Cloud project"
+  description = "Policy for this Araya OptiNiSt project"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -577,14 +577,14 @@ resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
 }
 
 # Attach policy to user
-resource "aws_iam_user_policy_attachment" "subscr_optinist_cloud_user_policy_attachment" {
-  user       = aws_iam_user.subscr_optinist_cloud_user.name
-  policy_arn = aws_iam_policy.subscr_optinist_cloud_user_policy.arn
+resource "aws_iam_user_policy_attachment" "araya_optinist_cloud_user_policy_attachment" {
+  user       = aws_iam_user.araya_optinist_cloud_user.name
+  policy_arn = aws_iam_policy.araya_optinist_cloud_user_policy.arn
 }
 
 # Create access key for the user
-resource "aws_iam_access_key" "subscr_optinist_cloud_user_access_key" {
-  user = aws_iam_user.subscr_optinist_cloud_user.name
+resource "aws_iam_access_key" "araya_optinist_cloud_user_access_key" {
+  user = aws_iam_user.araya_optinist_cloud_user.name
 }
 
 # S3 access for ECS tasks (scoped to app storage bucket)
@@ -963,8 +963,8 @@ resource "aws_secretsmanager_secret" "aws_credentials" {
 resource "aws_secretsmanager_secret_version" "aws_credentials" {
   secret_id = aws_secretsmanager_secret.aws_credentials.id
   secret_string = jsonencode({
-    AWS_ACCESS_KEY_ID     = aws_iam_access_key.subscr_optinist_cloud_user_access_key.id
-    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.subscr_optinist_cloud_user_access_key.secret
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.araya_optinist_cloud_user_access_key.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.araya_optinist_cloud_user_access_key.secret
   })
 }
 
@@ -1132,15 +1132,15 @@ locals {
 }
 
 # Generate SSH key pair
-resource "tls_private_key" "subscr_optinist_cloud_key" {
+resource "tls_private_key" "araya_optinist_cloud_key" {
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
 # Create AWS key pair
-resource "aws_key_pair" "subscr_optinist_cloud_key_pair" {
+resource "aws_key_pair" "araya_optinist_cloud_key_pair" {
   key_name   = local.key_name
-  public_key = tls_private_key.subscr_optinist_cloud_key.public_key_openssh # Fixed reference
+  public_key = tls_private_key.araya_optinist_cloud_key.public_key_openssh # Fixed reference
 
   tags = {
     Name = "${local.env_prefix}-cloud-key"
@@ -1149,7 +1149,7 @@ resource "aws_key_pair" "subscr_optinist_cloud_key_pair" {
 
 # Save private key to local file
 resource "local_file" "private_key" {
-  content         = tls_private_key.subscr_optinist_cloud_key.private_key_pem # Fixed reference
+  content         = tls_private_key.araya_optinist_cloud_key.private_key_pem # Fixed reference
   filename        = "${path.module}/${local.env_prefix}-cloud-private-key.pem"
   file_permission = "0400"
 }

--- a/studio/scripts/run_data_cleanup.py
+++ b/studio/scripts/run_data_cleanup.py
@@ -10,7 +10,7 @@ Usage:
 
 Cron example (every hour):
     0 * * * * cd /path/to/optinist-for-cloud &&
-    python studio/scripts/run_data_cleanup.py >> /var/log/optinist/cleanup_job.log 2>&1
+    python studio/scripts/run_data_cleanup.py >> /var/log/araya-optinist/cleanup_job.log 2>&1
 """
 
 import asyncio

--- a/studio/scripts/run_published_experiment_sync.py
+++ b/studio/scripts/run_published_experiment_sync.py
@@ -11,7 +11,7 @@ Usage:
 Cron example (every 5 minutes):
     */5 * * * * cd /path/to/optinist-for-cloud &&
     python studio/scripts/run_published_experiment_sync.py
-    >> /var/log/optinist/sync_job.log 2>&1
+    >> /var/log/araya-optinist/sync_job.log 2>&1
 """
 
 import asyncio

--- a/studio/scripts/run_storage_reconciliation.py
+++ b/studio/scripts/run_storage_reconciliation.py
@@ -11,7 +11,7 @@ Usage:
 Cron example (every hour):
     0 * * * * cd /path/to/optinist-for-cloud &&
     python studio/scripts/run_storage_reconciliation.py
-    >> /var/log/optinist/reconciliation_job.log 2>&1
+    >> /var/log/araya-optinist/reconciliation_job.log 2>&1
 """
 
 import asyncio


### PR DESCRIPTION
## Summary
 
Standardizes on **`araya-optinist`** across Terraform tags, logical identifiers, output names, container-internal log paths, one dev-only SSM parameter path, and user-facing prose. **No physical AWS resource is renamed** (ECS cluster, RDS, ALB, S3, IAM user/role *physical* names, Secrets Manager secrets, CloudWatch log groups, KMS aliases all keep their current `{env}-optinist-cloud-*` names).
 
17 files changed, 52 insertions / 52 deletions — the diff is balanced because every change is a rename of an existing token.
 
## What changed
 
**Terraform (4 files)**
 
- `main.tf` — `default_tags.Project` tag value `"optinist-cloud"` → `"araya-optinist"`; renamed two outputs (`optinist_cloud_user_access_key_id` / `_secret_access_key` → `araya_optinist_cloud_user_*`); updated references to the renamed logical resources.
- `security.tf` — renamed logical identifiers on IAM user / policy / attachment / access-key / TLS private key / AWS key pair (`subscr_optinist_cloud_*` → `araya_optinist_cloud_*`). All `name = "${local.env_prefix}-cloud-*"` attributes and ARN patterns are unchanged.
- `compute.tf` — updated `aws_key_pair` reference to the new logical name.
- `dev_schedule.tf` — SSM parameter `name = /${var.environment}/optinist/schedule-override` → `/${var.environment}/araya-optinist/schedule-override` (4 occurrences incl. IAM policy resource ARN and inline runbook comment).
**Scripts (3 files)**
 
- `studio/scripts/run_data_cleanup.py`, `run_published_experiment_sync.py`, `run_storage_reconciliation.py` — cron-example log paths `/var/log/optinist/*.log` → `/var/log/araya-optinist/*.log`. These paths are inside the container and take effect on next deployment.
**Documentation (7 files)**
 
- `README.md`, `docs/conf.py`, `docs/index.rst`, `docs/gui_guide/workflow.md`, `docs/specifications/add_algorithm.md` — brand prose "Araya-OptiNiSt Cloud" → "Araya OptiNiSt".
- `infrastructure/documentation/DEPLOYMENT_PROCEDURE.md` — title + intro.
- `infrastructure/documentation/MAINTENANCE_PROCEDURES.md` — title + intro.
- `infrastructure/documentation/INFRA_SECURITY_MODEL.md` — `Project` tag value row in the tagging table.
- `infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md` — updated `terraform output -raw <name>` example.
- `infrastructure/documentation/DEV_SCHEDULE_GUIDE.md` — updated SSM path examples.
## Pre-apply: `terraform state mv` commands
 
Run these **once per backend** (dev and prod) before `terraform apply`. Without them, Terraform will plan destroy + create for the renamed logical resources.
 
```bash
terraform state mv aws_iam_user.subscr_optinist_cloud_user aws_iam_user.araya_optinist_cloud_user
terraform state mv aws_iam_policy.subscr_optinist_cloud_user_policy aws_iam_policy.araya_optinist_cloud_user_policy
terraform state mv aws_iam_user_policy_attachment.subscr_optinist_cloud_user_policy_attachment aws_iam_user_policy_attachment.araya_optinist_cloud_user_policy_attachment
terraform state mv aws_iam_access_key.subscr_optinist_cloud_user_access_key aws_iam_access_key.araya_optinist_cloud_user_access_key
terraform state mv tls_private_key.subscr_optinist_cloud_key tls_private_key.araya_optinist_cloud_key
terraform state mv aws_key_pair.subscr_optinist_cloud_key_pair aws_key_pair.araya_optinist_cloud_key_pair
```
 
## Expected `terraform plan` diff
 
After the state moves, `plan` should show **only**:
 
- Tag-value diffs on every resource: `Project: "optinist-cloud" → "araya-optinist"`.
- IAM policy `description` update (cosmetic).
- Two output-name changes (`+ araya_optinist_cloud_user_access_key_id`, `- optinist_cloud_user_access_key_id` and secret-access-key counterpart).
- **Dev only:** `aws_ssm_parameter.dev_schedule_override` — old path destroyed, new path created. Safe: the parameter stores a throwaway override string (`on`/`off`/timestamp), re-written on next `dev_scheduler` Lambda run.
**Stop and review before applying** if the plan shows any `+ create / - destroy` on ECS, RDS, ALB, S3, IAM users/policies (beyond the logical moves), log groups, or anything else.
 
## Why this is safe
 
- AWS tags are free-form metadata — changing the `Project` tag value modifies no resource.
- Logical renames paired with `terraform state mv` keep the *physical* AWS resource untouched.
- Output renames only affect `terraform output <name>` callers — the only consumer in this repo is `INFRA_DEPLOYMENT_PROCEDURE.md`, updated in the same PR.
- Log paths are inside the container. Old log files on EFS remain readable.
- SSM parameter change is the one non-cosmetic diff but affects only dev and only a disposable override value.
- Prose updates have no functional impact.
## Test plan
 
- [ ] `terraform init -backend-config=backends/development.hcl -reconfigure` succeeds.
- [ ] After running the 6 `state mv` commands, `terraform plan -var-file=environments/development.tfvars` shows only the diffs listed above — no unexpected `+ create / - destroy` pairs.
- [ ] `terraform apply` on dev completes cleanly.
- [ ] `terraform output araya_optinist_cloud_user_access_key_id` returns a non-empty value; `terraform output optinist_cloud_user_access_key_id` no longer exists.
- [ ] Dev ECS task runs successfully with the new tag values (verify in AWS Console: Resources → filter by `Project = araya-optinist`).
- [ ] `dev_scheduler` Lambda runs once on schedule; confirm new SSM parameter `/development/araya-optinist/schedule-override` is read/written correctly.
- [ ] Background jobs (cleanup / sync / reconciliation) emit logs to `/var/log/araya-optinist/` on next container deployment.
- [ ] Repeat the above against production backend.
## Rollback
 
Revert this PR. Then on each backend:
 
```bash
# Reverse the state moves
terraform state mv aws_iam_user.araya_optinist_cloud_user aws_iam_user.subscr_optinist_cloud_user
terraform state mv aws_iam_policy.araya_optinist_cloud_user_policy aws_iam_policy.subscr_optinist_cloud_user_policy
terraform state mv aws_iam_user_policy_attachment.araya_optinist_cloud_user_policy_attachment aws_iam_user_policy_attachment.subscr_optinist_cloud_user_policy_attachment
terraform state mv aws_iam_access_key.araya_optinist_cloud_user_access_key aws_iam_access_key.subscr_optinist_cloud_user_access_key
terraform state mv tls_private_key.araya_optinist_cloud_key tls_private_key.subscr_optinist_cloud_key
terraform state mv aws_key_pair.araya_optinist_cloud_key_pair aws_key_pair.subscr_optinist_cloud_key_pair
terraform apply -var-file=environments/<env>.tfvars
```
 
Tags flip back, logical identifiers move back, outputs rename back, SSM parameter recreates at the old path. No physical resource was ever destroyed, so nothing to rebuild.
 
## Out of scope
 
Physical AWS resource renames (ECS cluster, RDS, ALB, S3 buckets, IAM *physical* names, log groups, ECR repo) are **not in this PR**. They require a blue/green migration and are tracked separately.
 
Upstream OIST OptiNiSt package paths (`studio/app/optinist/`, `github.com/oist/optinist`, `pyproject.toml` package entries) are carved out and remain unchanged.