### PR TITLE
Rename premium instances and tags

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -142,8 +142,8 @@ class PremiumInstanceConfig:
     INSTANCE_TYPE_TAG = "Premium-Instance"
     # EC2 Service tag value for premium instances
     SERVICE_TAG = "premium-tier"
-    # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-running")
-    INSTANCE_NAME_SUFFIX = "premium-running"
+    # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-dedicated")
+    INSTANCE_NAME_SUFFIX = "premium-dedicated"
 
     @classmethod
     def get_env_prefix(cls) -> str:
@@ -163,7 +163,7 @@ class PremiumInstanceConfig:
     def get_instance_name(cls) -> str:
         """Get the EC2 Name tag value for new instances.
 
-        Returns e.g. 'development-premium-running' or 'subscr-premium-running'.
+        Returns e.g. 'development-premium-dedicated' or 'subscr-premium-dedicated'.
         """
         return f"{EnvironmentConfig.get_env_prefix()}-{cls.INSTANCE_NAME_SUFFIX}"
 

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -142,7 +142,10 @@ class PremiumInstanceConfig:
     INSTANCE_TYPE_TAG = "Premium-Instance"
     # EC2 Service tag value for premium instances
     SERVICE_TAG = "premium-tier"
-    # Instance Name tag suffix (combined with env prefix: "{prefix}-premium-dedicated")
+    # Instance Name tag suffix for dynamically provisioned premium instances.
+    # Combined with env prefix: "<env_prefix>-<INSTANCE_NAME_SUFFIX>".
+    # Note: Terraform pre-provisions a separate "premium-initial" instance
+    # at deploy time — see compute.tf.
     INSTANCE_NAME_SUFFIX = "premium-dedicated"
 
     @classmethod
@@ -154,7 +157,7 @@ class PremiumInstanceConfig:
     def get_instance_name_pattern(cls) -> str:
         """Get the EC2 Name tag wildcard pattern for this environment.
 
-        Returns e.g. 'development-premium-*' or 'subscr-premium-*'.
+        Returns '<env_prefix>-premium-*'.
         Used in AWS API tag:Name filters.
         """
         return f"{EnvironmentConfig.get_env_prefix()}-{cls.INSTANCE_IDENTIFIER}-*"
@@ -163,7 +166,7 @@ class PremiumInstanceConfig:
     def get_instance_name(cls) -> str:
         """Get the EC2 Name tag value for new instances.
 
-        Returns e.g. 'development-premium-dedicated' or 'subscr-premium-dedicated'.
+        Returns '<env_prefix>-<INSTANCE_NAME_SUFFIX>'.
         """
         return f"{EnvironmentConfig.get_env_prefix()}-{cls.INSTANCE_NAME_SUFFIX}"
 

--- a/infrastructure/scripts/test_user_migration.py
+++ b/infrastructure/scripts/test_user_migration.py
@@ -217,6 +217,7 @@ def _start_premium_instance(ec2_client, instance_id: str) -> bool:
 PREMIUM_LAUNCH_TEMPLATE_PREFIX = "subscr-optinist-premium-"
 PREMIUM_INSTANCE_TYPE = "t3.large"
 PREMIUM_INSTANCE_TAGS = [
+    # Value: <env_prefix>-<INSTANCE_NAME_SUFFIX> (see PremiumInstanceConfig)
     {"Key": "Name", "Value": "subscr-premium-dedicated"},
     {"Key": "Type", "Value": "Premium-Instance"},
     {"Key": "Tier", "Value": "premium"},

--- a/infrastructure/scripts/test_user_migration.py
+++ b/infrastructure/scripts/test_user_migration.py
@@ -217,7 +217,7 @@ def _start_premium_instance(ec2_client, instance_id: str) -> bool:
 PREMIUM_LAUNCH_TEMPLATE_PREFIX = "subscr-optinist-premium-"
 PREMIUM_INSTANCE_TYPE = "t3.large"
 PREMIUM_INSTANCE_TAGS = [
-    {"Key": "Name", "Value": "subscr-premium-running"},
+    {"Key": "Name", "Value": "subscr-premium-dedicated"},
     {"Key": "Type", "Value": "Premium-Instance"},
     {"Key": "Tier", "Value": "premium"},
     {"Key": "Service", "Value": "premium-tier"},

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -521,7 +521,7 @@ resource "aws_instance" "premium" {
   disable_api_termination = false
 
   tags = {
-    Name          = "${var.environment}-premium-${count.index + 1}"
+    Name          = "${var.environment}-premium-initial"
     Type          = "Premium-Instance"
     Service       = "premium-tier"
     Tier          = "premium"

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -521,6 +521,9 @@ resource "aws_instance" "premium" {
   disable_api_termination = false
 
   tags = {
+    # Pre-provisioned at deploy time. Distinct from "premium-dedicated"
+    # instances which are dynamically created per user sign-in.
+    # See PremiumInstanceConfig.INSTANCE_NAME_SUFFIX in aws_constants.py.
     Name          = "${var.environment}-premium-initial"
     Type          = "Premium-Instance"
     Service       = "premium-tier"

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -659,12 +659,12 @@ def get_all_premium_instances_with_states():
             is_premium = name_match or tier_match or type_match
 
             # Filter by environment prefix to prevent cross-environment
-            # contamination. Instance Name tags follow the pattern:
-            # "{env_prefix}-premium-running" (e.g., "development-premium-running"
-            # vs "subscr-premium-running"). Reject instances whose Name tag
-            # doesn't start with this Lambda's ENV_PREFIX, or that have no
-            # Name tag at all (tagless instances cannot be verified as belonging
-            # to this environment).
+            # contamination. Instance Name tags follow the pattern
+            # "<env_prefix>-premium-*" (see PremiumInstanceConfig in
+            # aws_constants.py). Reject instances whose Name tag doesn't
+            # start with this Lambda's ENV_PREFIX, or that have no Name tag
+            # at all (tagless instances cannot be verified as belonging to
+            # this environment).
             if is_premium:
                 if not name_tag or not name_tag.lower().startswith(
                     env_prefix.lower()

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -908,8 +908,8 @@ def get_all_premium_instances_with_states():
 
             # Filter by environment prefix to prevent cross-environment
             # contamination. Instance Name tags follow the pattern:
-            # "{env_prefix}-premium-running" (e.g., "development-premium-running"
-            # vs "subscr-premium-running"). Reject instances whose Name tag
+            # "{env_prefix}-premium-dedicated" (e.g., "development-premium-dedicated"
+            # vs "subscr-premium-dedicated"). Reject instances whose Name tag
             # doesn't start with this Lambda's ENV_PREFIX, or that have no
             # Name tag at all (tagless instances cannot be verified as belonging
             # to this environment).

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -907,12 +907,12 @@ def get_all_premium_instances_with_states():
             is_premium = name_match or tier_match or type_match
 
             # Filter by environment prefix to prevent cross-environment
-            # contamination. Instance Name tags follow the pattern:
-            # "{env_prefix}-premium-dedicated" (e.g., "development-premium-dedicated"
-            # vs "subscr-premium-dedicated"). Reject instances whose Name tag
-            # doesn't start with this Lambda's ENV_PREFIX, or that have no
-            # Name tag at all (tagless instances cannot be verified as belonging
-            # to this environment).
+            # contamination. Instance Name tags follow the pattern
+            # "<env_prefix>-premium-*" (see PremiumInstanceConfig in
+            # aws_constants.py). Reject instances whose Name tag doesn't
+            # start with this Lambda's ENV_PREFIX, or that have no Name tag
+            # at all (tagless instances cannot be verified as belonging to
+            # this environment).
             if is_premium:
                 if not name_tag or not name_tag.lower().startswith(env_prefix.lower()):
                     print(

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -1060,7 +1060,7 @@ class TestGetAllPremiumInstancesEnvFilter:
                                 "Tags": [
                                     {
                                         "Key": "Name",
-                                        "Value": "production-premium-running",
+                                        "Value": "production-premium-dedicated",
                                     },
                                     {
                                         "Key": "Tier",

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -1060,6 +1060,8 @@ class TestGetAllPremiumInstancesEnvFilter:
                                 "Tags": [
                                     {
                                         "Key": "Name",
+                                        # <env_prefix>-<INSTANCE_NAME_SUFFIX>
+                                        # see PremiumInstanceConfig
                                         "Value": "production-premium-dedicated",
                                     },
                                     {

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1492,7 +1492,7 @@ class TestGetAllPremiumInstances:
                                 "Tags": [
                                     {
                                         "Key": "Name",
-                                        "Value": "production-premium-running",
+                                        "Value": "production-premium-dedicated",
                                     },
                                     {
                                         "Key": "Tier",

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1492,6 +1492,8 @@ class TestGetAllPremiumInstances:
                                 "Tags": [
                                     {
                                         "Key": "Name",
+                                        # <env_prefix>-<INSTANCE_NAME_SUFFIX>
+                                        # see PremiumInstanceConfig
                                         "Value": "production-premium-dedicated",
                                     },
                                     {


### PR DESCRIPTION
### Content

Rename premium instances to reduce confusion on their function. 
Todo: Update Documentation

- [x] <env>-premium-running -> <env>-premium-dedicated
- [x] <env>-premium-1 -> -premium-initial

#### Summary

#### Design Decisions

### Evidence

### References

### Files changed

### Manual Testcases

### Unit, Integration, Contract Test Coverage

### Others

#### Difficulties (if any)

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
|  |  |  |
