### PR TITLE
Updated documentation related to premium user assignments

### DIFF
--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -1109,6 +1109,14 @@ from the backend cleanup timeout (3 hours). The frontend
 acts as the primary mechanism; the backend cleanup is a
 safety net.
 
+The `last_activity` column in `premium_user_assignments` is updated by:
+
+| # | Path | Function | Timing |
+|---|---|---|---|
+| 1 | Heartbeat API | `handle_activity_update()` → `update_user_activity_timestamp()` | On each `recordActivity()` call from frontend (user interaction / "Stay Active" click) |
+| 2 | API middleware | `_update_premium_user_activity_sync()` | On each authenticated API request from a premium user |
+| 3 | Schema default | `ON UPDATE CURRENT_TIMESTAMP` | Implicit; any row modification auto-updates the column |
+
 ### PremiumNotificationManager
 
 **File:** `frontend/src/components/Premium/PremiumNotificationManager.tsx`

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -94,7 +94,7 @@ graph TB
 | Tier | Source | Wait Time | User Experience | Cost | Use Case | Reachability |
 |------|--------|-----------|-----------------|------|----------|--------------|
 | 1 | Dedicated Running | 0s | Best (exclusive) | Highest | Active user pool | Reachable |
-| 2 | Shared Instance | 0s | Good (shared) | Medium | Burst capacity | Reachable |
+| 2 | Shared Instance | 0s | Good (shared, migrates) | Medium | Burst capacity | Reachable |
 | 3 | Standby (Stopped) | 5-15s | Good (warming) | Low | Premium provisioning / re-login | Reachable |
 | 3.5 | Autoscaling Pool | 0s | Temporary (migrates) | Low | Last-resort fallback (no standby) | Reachable (always succeeds when reached -- see Precedence & Reachability Notes below) |
 | 4 | AWS Stopped | 60s-6min | Acceptable | Low | Defensive fallback | **Unreachable on the happy path** -- `register_orphaned_stopped_instances()` absorbs stopped instances into Tier 3 before the cascade runs |
@@ -830,8 +830,9 @@ are both untracked in the standby pool and unassigned to any user.
 ### 4. Shared-to-Dedicated Migration
 
 Migration moves users from shared assignments (`is_shared = true`) to
-dedicated instances (`is_shared = false`). It is triggered by three
-paths:
+dedicated instances (`is_shared = false`). Both Tier 2 (shared EC2) and
+Tier 3.5 (autoscaling pool) produce `is_shared = true` rows and are
+targets of this migration. It is triggered by three paths:
 
 | # | Path | Trigger | Timing |
 |---|---|---|---|

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -27,7 +27,7 @@
 2. **User Experience First**
    - Users get dedicated instance from standby pool when available (5-15s)
    - Falls back to autoscaling pool only when no standby instances exist
-   - Background migration to dedicated premium instance from shared/pool
+   - Async migration to dedicated premium instance from shared/pool
    - No user-visible delays or retry loops
 
 3. **Standby Pool Management**
@@ -60,7 +60,7 @@ graph TB
 
         C1 --> D[Create Target Group + ALB Rule]
         C2 --> E[Background Scaling Triggered]
-        C3 --> F[Background Scaling + Migration Queued]
+        C3 --> F[Scaling + Shared-to-Dedicated Migration Queued]
         C4 --> G[Replenish Standby Pool]
         C5 --> D
         C6 --> H[Wait for Instance Ready]
@@ -138,7 +138,7 @@ This document covers one Lambda -- the Premium Manager -- acting across several 
 | Real-time user assignment            | Assignment handler                            | `assign_premium_user()`, `try_reserve_instance()`, `store_user_assignment()`            |
 | Standby pool lifecycle               | Standby pool management                       | `create_and_stop_standby_instance()`, `start_standby_instance()`, `register_orphaned_stopped_instances()` |
 | Capacity scaling (up)                | Scaling system                                | `scale_premium_instances_if_needed()`, `_create_running_instances_locked()`             |
-| Shared-to-dedicated migration        | Background migration                          | `process_shared_instance_optimization()`, `migrate_user_to_dedicated_instance()`, `invoke_migration_async()` |
+| Shared-to-dedicated migration        | Shared-to-dedicated migration                 | `process_shared_instance_optimization()`, `migrate_user_to_dedicated_instance()`, `invoke_migration_async()` |
 | Concurrency / race prevention        | Locking                                       | `distributed_lock()` (MySQL `GET_LOCK`), `try_reserve_instance_transaction()` (`SELECT FOR UPDATE`), `is_creation_lock_held()` |
 | Scale-down + ghost / orphan cleanup  | Scheduled monitoring (see [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)) | `handle_scheduled_monitoring()`, [`scale_down_if_possible()`](./PREMIUM_MANAGER_ARCHITECTURE.md#scale-down-scale_down_if_possible) |
 | Stale assignment + ALB rule hygiene  | Premium Cleanup Lambda (separate)             | See [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md)               |
@@ -221,11 +221,11 @@ sequenceDiagram
     end
 ```
 
-### Background Migration Flow
+### Shared-to-Dedicated Migration Flow
 
 ```mermaid
 graph TB
-    subgraph "Background Migration (invoke_migration_async)"
+    subgraph "Shared-to-Dedicated Migration (invoke_migration_async)"
         A[User on autoscaling-pool or shared] --> AA{Migration lock held?}
         AA -->|Yes| AB[Skip - another Lambda migrating]
         AA -->|No| B{Available dedicated instance?}
@@ -300,19 +300,24 @@ A **shared assignment** is a premium user assignment where the user is
 co-located on a real premium EC2 instance with one or more other premium
 users, or routed through the free-tier autoscaling pool. The state is
 recorded by `is_shared = true` in `premium_user_assignments` and is
-always **temporary** — the Background Migration System
+always **temporary** — the Shared-to-Dedicated Migration
 (`process_shared_instance_optimization()`) moves the user to a dedicated
 instance as soon as one becomes available.
 
 The `is_shared` column records the sharing state at assignment time
 (default: `false`). Its transitions are:
 
-| Transition | Function | Caller / trigger | Timing |
-|---|---|---|---|
-| Set to `false` (initial) | `store_user_assignment()` | Tier 1, 3, 4, 5 assignment (dedicated) | On-demand (user `/assign`) |
-| Set to `true` | `store_user_assignment()` | Tier 2 (shared) or Tier 3.5 (autoscaling pool) assignment | On-demand (user `/assign`) |
-| Set to `false` | `migrate_user_to_dedicated_instance()` | Migration to dedicated instance completes | Immediately after assign + every 15 min (monitor) |
-| Preserved | `restore_pending_release()` | Pending-release row resumed | On-demand (user `/assign`) |
+| Path | Value | Function | Caller / trigger | Timing |
+|---|---|---|---|---|
+| Creation (dedicated) | `→ false` | `store_user_assignment()` | Tier 1, 3, 4, 5 assignment | On-demand (user `/assign`) |
+| Creation (shared) | `→ true` | `store_user_assignment()` | Tier 2 or Tier 3.5 assignment | On-demand (user `/assign`) |
+| Migration | `true → false` | `migrate_user_to_dedicated_instance()` | Migration to dedicated instance completes | Immediately after assign + every 15 min (monitor) |
+| Pending-release resume | Preserved | `restore_pending_release()` | Pending-release row resumed | On-demand (user `/assign`) |
+
+> \* For Tier 1, `try_reserve_instance_transaction()` INSERTs a temporary
+> reservation row (`is_shared = 0`) before `store_user_assignment()`. This
+> row is DELETEd within the same Lambda invocation (see § Atomic Instance
+> Reservation).
 
 Unlike `is_standby` (which uses DELETE + INSERT and never updates
 in-place), `is_shared` transitions via ordinary UPDATE on the same row.
@@ -822,7 +827,7 @@ Called at the start of every `assign_premium_user()` invocation to
 ensure maximum standby availability. Only registers instances that
 are both untracked in the standby pool and unassigned to any user.
 
-### 4. Background Migration System
+### 4. Shared-to-Dedicated Migration
 
 Migration moves users from shared assignments (`is_shared = true`) to
 dedicated instances (`is_shared = false`). It is triggered by three

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -294,6 +294,29 @@ Autoscaling Pool routes through the free-tier ASG target group. The toast
 copy collapses them, but infra-layer behaviour (scaling triggers, migration
 paths, routing) differs.
 
+### Shared assignment (`is_shared`)
+
+A **shared assignment** is a premium user assignment where the user is
+co-located on a real premium EC2 instance with one or more other premium
+users, or routed through the free-tier autoscaling pool. The state is
+recorded by `is_shared = true` in `premium_user_assignments` and is
+always **temporary** — the Background Migration System
+(`process_shared_instance_optimization()`) moves the user to a dedicated
+instance as soon as one becomes available.
+
+The `is_shared` column records the sharing state at assignment time
+(default: `false`). Its transitions are:
+
+| Transition | Function | Caller / trigger | Timing |
+|---|---|---|---|
+| Set to `false` (initial) | `store_user_assignment()` | Tier 1, 3, 4, 5 assignment (dedicated) | On-demand (user `/assign`) |
+| Set to `true` | `store_user_assignment()` | Tier 2 (shared) or Tier 3.5 (autoscaling pool) assignment | On-demand (user `/assign`) |
+| Set to `false` | `migrate_user_to_dedicated_instance()` | Migration to dedicated instance completes | Immediately after assign + every 15 min (monitor) |
+| Preserved | `restore_pending_release()` | Pending-release row resumed | On-demand (user `/assign`) |
+
+Unlike `is_standby` (which uses DELETE + INSERT and never updates
+in-place), `is_shared` transitions via ordinary UPDATE on the same row.
+
 ### Standby pool
 
 The **standby pool** is a set of stopped EC2 instances maintained solely to
@@ -620,11 +643,11 @@ There are **three** ways a standby placeholder row ever gets into
 `premium_user_assignments`. All three funnel through `store_user_assignment()`
 with `is_standby=True, user_id=NULL`.
 
-| # | Function | Caller / trigger | EC2 action | DB action |
-|---|---|---|---|---|
-| 1 | `create_and_stop_standby_instance()` | `handle_scheduled_monitoring()` replenish, and Tier 3 backfill immediately after a standby is consumed | `run_instances` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped', target_group_arn='standby', alb_rule_arn='standby', standby_created_at=NOW()` |
-| 2 | `register_orphaned_stopped_instances()` | `handle_scheduled_monitoring()` step that runs after `scale_down_if_possible()` | None (only adopts an existing stopped EC2) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` for every AWS-stopped premium instance with zero rows in `premium_user_assignments` |
-| 3 | `convert_idle_instances_to_standby_immediate()` | Called from inside `scale_down_if_possible()` -- the scheduled monitor path, and also runs when the last user releases on an instance | `deregister_from_ecs` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` on the just-idled instance |
+| # | Function | Caller / trigger | Timing | EC2 action | DB action |
+|---|---|---|---|---|---|
+| 1 | `create_and_stop_standby_instance()` | `handle_scheduled_monitoring()` replenish, and Tier 3 backfill immediately after a standby is consumed | Every 15 min (replenish) + immediately (Tier 3 backfill) | `run_instances` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped', target_group_arn='standby', alb_rule_arn='standby', standby_created_at=NOW()` |
+| 2 | `register_orphaned_stopped_instances()` | `handle_scheduled_monitoring()` step that runs after `scale_down_if_possible()` | Every `/assign` call + every 15 min | None (only adopts an existing stopped EC2) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` for every AWS-stopped premium instance with zero rows in `premium_user_assignments` |
+| 3 | `convert_idle_instances_to_standby_immediate()` | Called from inside `scale_down_if_possible()` -- the scheduled monitor path, and also runs when the last user releases on an instance | Every 15 min (monitor) + immediately (on last-user release) | `deregister_from_ecs` → `stop_instances` (waits for stopped) | INSERT `is_standby=1, user_id=NULL, instance_state='stopped'` on the just-idled instance |
 
 The invariant is that the table never holds more than one `is_standby=1`
 row per `instance_id`: (1) and (3) create fresh rows, while (2) only
@@ -632,14 +655,14 @@ adopts instances that have no existing row at all.
 
 #### Exit paths: how an `is_standby = 1` row is consumed or removed
 
-| Path | Function | Caller / trigger | DB action | EC2 action |
-|---|---|---|---|---|
-| **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (the inline DELETE/INSERT lives in the Tier 3 block of `assign_premium_user()`) | `start_instances` (via `start_standby_instance()`) |
-| **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | DELETE the `is_standby=1` row (inline DELETE inside `try_reserve_instance_for_migration()`), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
-| **Terminated (aged)** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | DELETE the row | `terminate_instances` |
-| **Terminated (excess)** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | DELETE the row | `terminate_instances` |
-| **Cleaned up** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
-| **Cleared** | `ensure_standby_pool_capacity()` [**Cleanup Lambda**] | Hourly cleanup schedule, when `standby_stopped > target_stopped` | UPDATE `is_standby = 0` on the oldest excess rows (ordered by `last_activity DESC` keep-the-newest) | None (row becomes a normal stopped-instance row; Manager will reclaim via scale-down) |
+| Path | Function | Caller / trigger | Timing | DB action | EC2 action |
+|---|---|---|---|---|---|
+| **Assigned** (Tier 3 happy path) | inline SQL inside `assign_premium_user()` Tier 3 | User `/assign` picks this standby | On-demand (user `/assign`) | DELETE the `is_standby=1` row, then INSERT a new `is_standby=0` user row (the inline DELETE/INSERT lives in the Tier 3 block of `assign_premium_user()`) | `start_instances` (via `start_standby_instance()`) |
+| **Migrated** (displaces a standby for migration) | DELETE inside `try_reserve_instance_for_migration()` | `process_shared_instance_optimization()` picks this instance to relocate a shared / autoscaling-pool user | On-demand (migration) | DELETE the `is_standby=1` row (inline DELETE inside `try_reserve_instance_for_migration()`), reservation row is inserted separately | `start_instances` (via `start_standby_instance()` from the migration path) |
+| **Terminated (aged)** | `terminate_aged_stopped_instances()` → `terminate_standby_instance()` | Scheduled monitor, hourly-style check | Every 15 min (monitor); age > `PREMIUM_STOPPED_MAX_AGE_HOURS` | DELETE the row | `terminate_instances` |
+| **Terminated (excess)** | `cleanup_excess_standby_instances()` → `terminate_standby_instance()` | Scheduled monitor when `get_standby_count() > PREMIUM_STANDBY_POOL_SIZE`; selects **oldest `standby_created_at` first** | Every 15 min (monitor) | DELETE the row | `terminate_instances` |
+| **Cleaned up** | `cleanup_failed_standby_instances()` | Scheduled monitor, first standby step | Every 15 min (monitor) | DELETE the row | None (EC2 already gone from AWS; this is pure DB orphan cleanup) |
+| **Cleared** | `ensure_standby_pool_capacity()` [**Cleanup Lambda**] | Hourly cleanup schedule, when `standby_stopped > target_stopped` | Hourly (Cleanup Lambda) | UPDATE `is_standby = 0` on the oldest excess rows (ordered by `last_activity DESC` keep-the-newest) | None (row becomes a normal stopped-instance row; Manager will reclaim via scale-down) |
 
 #### `convert_idle_instances_to_standby_immediate()`
 
@@ -800,6 +823,21 @@ ensure maximum standby availability. Only registers instances that
 are both untracked in the standby pool and unassigned to any user.
 
 ### 4. Background Migration System
+
+Migration moves users from shared assignments (`is_shared = true`) to
+dedicated instances (`is_shared = false`). It is triggered by three
+paths:
+
+| # | Path | Trigger | Timing |
+|---|---|---|---|
+| 1 | Async Lambda | `invoke_migration_async()` fired immediately after a Tier 2 or Tier 3.5 assignment | Immediately after `/assign` |
+| 2 | Scheduled monitor | `handle_scheduled_monitoring()` calls `process_shared_instance_optimization()` | Every 15 min |
+| 3 | Inline migration | `assign_premium_user()` Pre-assignment Step 2 — when a shared/autoscaling user re-calls `/assign`, an inline migration is attempted before falling back to path 1 | On-demand (user re-login) |
+
+All three paths converge on the same function:
+`process_shared_instance_optimization()` (paths 1 and 2) or its inline
+equivalent in `assign_premium_user()` (path 3). If no dedicated instance
+is ready, migration is deferred to the next trigger.
 
 #### process_shared_instance_optimization()
 


### PR DESCRIPTION
## Summary

`PREMIUM_USER_ASSIGNMENT.md` documented the `is_standby` and `is_shared` update paths but lacked explicit timing/interval information, making it difficult to answer "when does this happen?" at a glance.
This PR adds structured timing data and a new glossary entry for shared assignments.

## Changes

### 1. Add Timing column to `is_standby` Entry/Exit paths tables

The existing Entry paths and Exit paths tables for `is_standby` had columns for Function, Caller/trigger, EC2 action, and DB action — but no explicit timing.
A new **Timing** column was added to both tables, documenting the frequency or trigger cadence for each path
(e.g.  "Every 15 min (monitor)", "On-demand (user `/assign`)", "Immediately (on last-user release)").

### 2. Add Glossary section: Shared assignment (`is_shared`)

Previously, `is_shared` had no dedicated glossary entry — its semantics were scattered across the 4-state table, migration sections, and edge case notes.
A new `### Shared assignment (is_shared)` glossary section was added with:

- **Conceptual definition:** what a shared assignment is, its temporary nature, and the migration system that resolves it
- **Transition table:** all `is_shared` state changes with Function, Caller/trigger, and Timing columns (aligned with the `is_standby` table structure)
- **Default value:** explicitly documents `false` as the initial value
- **UPDATE vs DELETE+INSERT note:** contrasts with `is_standby`'s row-replacement invariant

### 3. Add migration trigger summary to Background Migration System

The "4. Background Migration System" section previously jumped straight into function specs.
A new introductory block was added with a table documenting the three migration trigger paths:

### 4. Document `last_activity` update paths in Architecture doc

`PREMIUM_MANAGER_ARCHITECTURE.md` documented the heartbeat mechanism (frontend → API → Lambda) and inactivity detection,
but never explicitly stated that these operations update the `last_activity` column in the DB.
A concise 3-row table was added after the Inactivity Monitoring section:

## Design decisions

- **Timing as a separate column** (not inline in Caller/trigger): keeps the existing Caller/trigger text unchanged and allows quick scanning of timing values down a single column
- **No new section for `is_shared`** Entry/Exit paths: `is_shared` has only 4 transitions (vs 9 for `is_standby`), so a full Entry/Exit split would be unnecessarily heavy. A single transition table suffices.
- **Column alignment across tables:** `is_shared` and migration trigger tables reuse the same column names (Function, Caller/trigger, Timing) as the `is_standby` tables for consistency

## Files changed

- `infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md`
- `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md`
