### PR TITLE
Harden lambda dep install triggers with requirements.txt

### DIFF
--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -16,16 +16,21 @@ terraform.*
 *.pem
 
 # Lambda deployment packages — _package/ dirs are pip-vendored artifact
-# zones; declared source files are re-included below.
+# zones; tracked source files are re-included by explicit per-file rules.
 **/*.py.zip
 **/*_package/*
-!**/*_package/*.py
 !**/*_package/requirements.txt
 !**/*_package/README.md
-# Single-file artifacts the *.py allowlist would otherwise catch.
-**/*_package/aws_constants.py
-**/*_package/six.py
-**/*_package/typing_extensions.py
+!**/common_user_manager_package/common_user_manager.py
+!**/common_user_manager_package/test_common_user_manager.py
+!**/cost_tracker_package/cost_tracker.py
+!**/dev_scheduler_package/dev_scheduler.py
+!**/free_cleanup_package/free_cleanup.py
+!**/free_manager_package/free_manager.py
+!**/free_manager_package/free_user_utils.py
+!**/premium_cleanup_package/premium_cleanup.py
+!**/premium_manager_package/premium_manager.py
+!**/premium_manager_package/premium_user_utils.py
 **/agent_recovery_lambda.zip
 
 # AWS constants layer build artifacts

--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -15,22 +15,11 @@ terraform.*
 # SSH private keys
 *.pem
 
-# Lambda deployment packages — _package/ dirs are pip-vendored artifact
-# zones; tracked source files are re-included by explicit per-file rules.
+# Lambda deployment build artifacts. Source for each Lambda lives in
+# <lambda>_package/ alongside requirements.txt and README; pip-vendored
+# deps and the assembled ZIP staging area live under .build/<lambda>/.
+**/.build/
 **/*.py.zip
-**/*_package/*
-!**/*_package/requirements.txt
-!**/*_package/README.md
-!**/common_user_manager_package/common_user_manager.py
-!**/common_user_manager_package/test_common_user_manager.py
-!**/cost_tracker_package/cost_tracker.py
-!**/dev_scheduler_package/dev_scheduler.py
-!**/free_cleanup_package/free_cleanup.py
-!**/free_manager_package/free_manager.py
-!**/free_manager_package/free_user_utils.py
-!**/premium_cleanup_package/premium_cleanup.py
-!**/premium_manager_package/premium_manager.py
-!**/premium_manager_package/premium_user_utils.py
 **/agent_recovery_lambda.zip
 
 # AWS constants layer build artifacts

--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -15,9 +15,17 @@ terraform.*
 # SSH private keys
 *.pem
 
-# Lambda deployment packages
+# Lambda deployment packages — _package/ dirs are pip-vendored artifact
+# zones; declared source files are re-included below.
 **/*.py.zip
 **/*_package/*
+!**/*_package/*.py
+!**/*_package/requirements.txt
+!**/*_package/README.md
+# Single-file artifacts the *.py allowlist would otherwise catch.
+**/*_package/aws_constants.py
+**/*_package/six.py
+**/*_package/typing_extensions.py
 **/agent_recovery_lambda.zip
 
 # AWS constants layer build artifacts

--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -17,14 +17,16 @@
 resource "null_resource" "install_common_user_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/common_user_manager_package
-      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/common_user_manager_package/ --no-cache-dir
+      mkdir -p ${path.module}/common_user_manager_package && \
+      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/common_user_manager_package/ --no-cache-dir && \
+      touch ${path.module}/common_user_manager_package/.installed
     EOT
   }
 
   triggers = {
     code_changes         = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
     requirements_changes = filesha256("${path.module}/common_user_manager_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/common_user_manager_package/.installed") ? "present" : "missing"
   }
 }
 

--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -13,27 +13,31 @@
 # Common User Manager Lambda Package
 # ===========================
 
-# Install dependencies
 resource "null_resource" "install_common_user_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/common_user_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/common_user_manager_package/ --no-cache-dir && \
-      touch ${path.module}/common_user_manager_package/.installed
+      rm -rf ${path.module}/.build/common_user_manager && \
+      mkdir -p ${path.module}/.build/common_user_manager && \
+      cp -p ${path.module}/common_user_manager_package/*.py ${path.module}/.build/common_user_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/.build/common_user_manager --no-cache-dir && \
+      touch ${path.module}/.build/common_user_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes         = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/common_user_manager_package", "*.py") :
+      filesha256("${path.module}/common_user_manager_package/${f}")
+    ]))
     requirements_changes = filesha256("${path.module}/common_user_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/common_user_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/common_user_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "common_user_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/common_user_manager_package"
+  source_dir  = "${path.module}/.build/common_user_manager"
   output_path = "${path.module}/common_user_manager.py.zip"
 
   depends_on = [null_resource.install_common_user_manager_dependencies]

--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -18,12 +18,13 @@ resource "null_resource" "install_common_user_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
       mkdir -p ${path.module}/common_user_manager_package
-      /usr/bin/python3 -m pip install pymysql sqlalchemy -t ${path.module}/common_user_manager_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/common_user_manager_package/ --no-cache-dir
     EOT
   }
 
   triggers = {
-    code_changes = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
+    code_changes         = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
+    requirements_changes = filesha256("${path.module}/common_user_manager_package/requirements.txt")
   }
 }
 

--- a/infrastructure/terraform/common_user_manager_package/requirements.txt
+++ b/infrastructure/terraform/common_user_manager_package/requirements.txt
@@ -1,0 +1,2 @@
+pymysql
+sqlalchemy

--- a/infrastructure/terraform/cost_tracker_package/requirements.txt
+++ b/infrastructure/terraform/cost_tracker_package/requirements.txt
@@ -1,0 +1,1 @@
+pymysql

--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -47,12 +47,37 @@ resource "aws_ssm_parameter" "dev_schedule_override" {
 # ===========================
 # Lambda Package
 # ===========================
+resource "null_resource" "install_dev_scheduler_dependencies" {
+  count = var.enable_dev_schedule ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      rm -rf ${path.module}/.build/dev_scheduler && \
+      mkdir -p ${path.module}/.build/dev_scheduler && \
+      cp -p ${path.module}/dev_scheduler_package/*.py ${path.module}/.build/dev_scheduler/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/dev_scheduler_package/requirements.txt -t ${path.module}/.build/dev_scheduler --no-cache-dir && \
+      touch ${path.module}/.build/dev_scheduler/.installed
+    EOT
+  }
+
+  triggers = {
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/dev_scheduler_package", "*.py") :
+      filesha256("${path.module}/dev_scheduler_package/${f}")
+    ]))
+    requirements_changes = filesha256("${path.module}/dev_scheduler_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/.build/dev_scheduler/.installed") ? "present" : "missing"
+  }
+}
+
 data "archive_file" "dev_scheduler_zip" {
   count = var.enable_dev_schedule ? 1 : 0
 
   type        = "zip"
-  source_dir  = "${path.module}/dev_scheduler_package"
+  source_dir  = "${path.module}/.build/dev_scheduler"
   output_path = "${path.module}/dev_scheduler.py.zip"
+
+  depends_on = [null_resource.install_dev_scheduler_dependencies]
 }
 
 # ===========================

--- a/infrastructure/terraform/free_cleanup_package/requirements.txt
+++ b/infrastructure/terraform/free_cleanup_package/requirements.txt
@@ -1,0 +1,1 @@
+pymysql

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -16,8 +16,9 @@
 resource "null_resource" "install_free_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/free_manager_package
-      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/free_manager_package/ --no-cache-dir
+      mkdir -p ${path.module}/free_manager_package && \
+      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/free_manager_package/ --no-cache-dir && \
+      touch ${path.module}/free_manager_package/.installed
     EOT
   }
 
@@ -27,6 +28,7 @@ resource "null_resource" "install_free_manager_dependencies" {
       filesha256("${path.module}/free_manager_package/free_user_utils.py")
     ]))
     requirements_changes = filesha256("${path.module}/free_manager_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/free_manager_package/.installed") ? "present" : "missing"
   }
 }
 
@@ -319,13 +321,15 @@ resource "aws_lambda_permission" "allow_asg_events_free_manager" {
 resource "null_resource" "install_free_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/free_cleanup_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/free_cleanup_package/ --no-cache-dir && \
+      touch ${path.module}/free_cleanup_package/.installed
     EOT
   }
 
   triggers = {
     code_changes         = filesha256("${path.module}/free_cleanup_package/free_cleanup.py")
     requirements_changes = filesha256("${path.module}/free_cleanup_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/free_cleanup_package/.installed") ? "present" : "missing"
   }
 }
 

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -17,7 +17,7 @@ resource "null_resource" "install_free_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
       mkdir -p ${path.module}/free_manager_package
-      /usr/bin/python3 -m pip install pymysql boto3 -t ${path.module}/free_manager_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/free_manager_package/ --no-cache-dir
     EOT
   }
 
@@ -26,6 +26,7 @@ resource "null_resource" "install_free_manager_dependencies" {
       filesha256("${path.module}/free_manager_package/free_manager.py"),
       filesha256("${path.module}/free_manager_package/free_user_utils.py")
     ]))
+    requirements_changes = filesha256("${path.module}/free_manager_package/requirements.txt")
   }
 }
 
@@ -318,12 +319,13 @@ resource "aws_lambda_permission" "allow_asg_events_free_manager" {
 resource "null_resource" "install_free_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install pymysql -t ${path.module}/free_cleanup_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/free_cleanup_package/ --no-cache-dir
     EOT
   }
 
   triggers = {
-    code_changes = filesha256("${path.module}/free_cleanup_package/free_cleanup.py")
+    code_changes         = filesha256("${path.module}/free_cleanup_package/free_cleanup.py")
+    requirements_changes = filesha256("${path.module}/free_cleanup_package/requirements.txt")
   }
 }
 

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -12,30 +12,31 @@
 # Free Manager Lambda Package
 # ===========================
 
-# Install dependencies
 resource "null_resource" "install_free_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/free_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/free_manager_package/ --no-cache-dir && \
-      touch ${path.module}/free_manager_package/.installed
+      rm -rf ${path.module}/.build/free_manager && \
+      mkdir -p ${path.module}/.build/free_manager && \
+      cp -p ${path.module}/free_manager_package/*.py ${path.module}/.build/free_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/.build/free_manager --no-cache-dir && \
+      touch ${path.module}/.build/free_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/free_manager_package/free_manager.py"),
-      filesha256("${path.module}/free_manager_package/free_user_utils.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/free_manager_package", "*.py") :
+      filesha256("${path.module}/free_manager_package/${f}")
     ]))
     requirements_changes = filesha256("${path.module}/free_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/free_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/free_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "free_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/free_manager_package"
+  source_dir  = "${path.module}/.build/free_manager"
   output_path = "${path.module}/free_manager.py.zip"
 
   depends_on = [null_resource.install_free_manager_dependencies]
@@ -317,26 +318,31 @@ resource "aws_lambda_permission" "allow_asg_events_free_manager" {
 # This Lambda is used by test scripts to manage test data
 # without requiring direct database access from outside VPC.
 
-# Install dependencies for free cleanup Lambda
 resource "null_resource" "install_free_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/free_cleanup_package/ --no-cache-dir && \
-      touch ${path.module}/free_cleanup_package/.installed
+      rm -rf ${path.module}/.build/free_cleanup && \
+      mkdir -p ${path.module}/.build/free_cleanup && \
+      cp -p ${path.module}/free_cleanup_package/*.py ${path.module}/.build/free_cleanup/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/.build/free_cleanup --no-cache-dir && \
+      touch ${path.module}/.build/free_cleanup/.installed
     EOT
   }
 
   triggers = {
-    code_changes         = filesha256("${path.module}/free_cleanup_package/free_cleanup.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/free_cleanup_package", "*.py") :
+      filesha256("${path.module}/free_cleanup_package/${f}")
+    ]))
     requirements_changes = filesha256("${path.module}/free_cleanup_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/free_cleanup_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/free_cleanup/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP file for free cleanup Lambda
 data "archive_file" "free_cleanup_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/free_cleanup_package"
+  source_dir  = "${path.module}/.build/free_cleanup"
   output_path = "${path.module}/free_cleanup.py.zip"
 
   depends_on = [null_resource.install_free_cleanup_dependencies]

--- a/infrastructure/terraform/free_manager_package/free_manager.py
+++ b/infrastructure/terraform/free_manager_package/free_manager.py
@@ -296,8 +296,7 @@ def is_scaling_in_progress() -> bool:
                     "MetricStat": {
                         "Metric": {
                             "Namespace": (
-                                "OptiNiSt/FreeManager/"
-                                f"{os.environ['ENV_PREFIX']}"
+                                "OptiNiSt/FreeManager/" f"{os.environ['ENV_PREFIX']}"
                             ),
                             "MetricName": "ScalingInProgress",
                         },

--- a/infrastructure/terraform/free_manager_package/requirements.txt
+++ b/infrastructure/terraform/free_manager_package/requirements.txt
@@ -1,0 +1,2 @@
+pymysql
+boto3

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -666,9 +666,7 @@ def get_all_premium_instances_with_states():
             # Name tag at all (tagless instances cannot be verified as belonging
             # to this environment).
             if is_premium:
-                if not name_tag or not name_tag.lower().startswith(
-                    env_prefix.lower()
-                ):
+                if not name_tag or not name_tag.lower().startswith(env_prefix.lower()):
                     print(
                         f"Skipping instance {instance_id}: "
                         f"Name '{name_tag}' does not match "

--- a/infrastructure/terraform/premium_cleanup_package/requirements.txt
+++ b/infrastructure/terraform/premium_cleanup_package/requirements.txt
@@ -1,0 +1,1 @@
+pymysql

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -215,7 +215,7 @@ resource "null_resource" "install_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/premium_manager_package", "*.py") :
         filesha256("${path.module}/premium_manager_package/${f}")
       ],
@@ -313,7 +313,7 @@ resource "null_resource" "install_cleanup_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/premium_cleanup_package", "*.py") :
         filesha256("${path.module}/premium_cleanup_package/${f}")
       ],
@@ -637,7 +637,7 @@ resource "null_resource" "install_cost_tracker_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/cost_tracker_package", "*.py") :
         filesha256("${path.module}/cost_tracker_package/${f}")
       ],

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -207,9 +207,10 @@ resource "aws_lambda_permission" "allow_eventbridge_ec2_state_change" {
 resource "null_resource" "install_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/premium_manager_package
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/premium_manager_package/ --no-cache-dir
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_manager_package/aws_constants.py
+      mkdir -p ${path.module}/premium_manager_package && \
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/premium_manager_package/ --no-cache-dir && \
+      cp ${path.module}/../aws_constants.py ${path.module}/premium_manager_package/aws_constants.py && \
+      touch ${path.module}/premium_manager_package/.installed
     EOT
   }
 
@@ -220,6 +221,7 @@ resource "null_resource" "install_dependencies" {
       filesha256("${path.module}/../aws_constants.py")
     ]))
     requirements_changes = filesha256("${path.module}/premium_manager_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/premium_manager_package/.installed") ? "present" : "missing"
   }
 }
 
@@ -298,8 +300,9 @@ resource "aws_lambda_function" "premium_cleanup" {
 resource "null_resource" "install_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/premium_cleanup_package/ --no-cache-dir
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_cleanup_package/aws_constants.py
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/premium_cleanup_package/ --no-cache-dir && \
+      cp ${path.module}/../aws_constants.py ${path.module}/premium_cleanup_package/aws_constants.py && \
+      touch ${path.module}/premium_cleanup_package/.installed
     EOT
   }
 
@@ -309,6 +312,7 @@ resource "null_resource" "install_cleanup_dependencies" {
       filesha256("${path.module}/../aws_constants.py")
     ]))
     requirements_changes = filesha256("${path.module}/premium_cleanup_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/premium_cleanup_package/.installed") ? "present" : "missing"
   }
 }
 
@@ -616,9 +620,10 @@ resource "aws_cloudwatch_log_metric_filter" "premium_assignments" {
 resource "null_resource" "install_cost_tracker_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/cost_tracker_package
-      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/cost_tracker_package/ --no-cache-dir
-      cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py
+      mkdir -p ${path.module}/cost_tracker_package && \
+      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/cost_tracker_package/ --no-cache-dir && \
+      cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py && \
+      touch ${path.module}/cost_tracker_package/.installed
     EOT
   }
 
@@ -628,6 +633,7 @@ resource "null_resource" "install_cost_tracker_dependencies" {
       filesha256("${path.module}/../aws_constants.py")
     ]))
     requirements_changes = filesha256("${path.module}/cost_tracker_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/cost_tracker_package/.installed") ? "present" : "missing"
   }
 }
 

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -208,7 +208,7 @@ resource "null_resource" "install_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
       mkdir -p ${path.module}/premium_manager_package
-      /usr/bin/python3 -m pip install pymysql -t ${path.module}/premium_manager_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/premium_manager_package/ --no-cache-dir
       cp ${path.module}/../aws_constants.py ${path.module}/premium_manager_package/aws_constants.py
     EOT
   }
@@ -219,6 +219,7 @@ resource "null_resource" "install_dependencies" {
       filesha256("${path.module}/../../studio/app/common/core/premium/premium_assignment_service.py"),
       filesha256("${path.module}/../aws_constants.py")
     ]))
+    requirements_changes = filesha256("${path.module}/premium_manager_package/requirements.txt")
   }
 }
 
@@ -297,7 +298,7 @@ resource "aws_lambda_function" "premium_cleanup" {
 resource "null_resource" "install_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install pymysql -t ${path.module}/premium_cleanup_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/premium_cleanup_package/ --no-cache-dir
       cp ${path.module}/../aws_constants.py ${path.module}/premium_cleanup_package/aws_constants.py
     EOT
   }
@@ -307,6 +308,7 @@ resource "null_resource" "install_cleanup_dependencies" {
       filesha256("${path.module}/premium_cleanup_package/premium_cleanup.py"),
       filesha256("${path.module}/../aws_constants.py")
     ]))
+    requirements_changes = filesha256("${path.module}/premium_cleanup_package/requirements.txt")
   }
 }
 
@@ -615,7 +617,7 @@ resource "null_resource" "install_cost_tracker_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
       mkdir -p ${path.module}/cost_tracker_package
-      /usr/bin/python3 -m pip install pymysql -t ${path.module}/cost_tracker_package/ --no-cache-dir
+      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/cost_tracker_package/ --no-cache-dir
       cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py
     EOT
   }
@@ -625,6 +627,7 @@ resource "null_resource" "install_cost_tracker_dependencies" {
       filesha256("${path.module}/cost_tracker_package/cost_tracker.py"),
       filesha256("${path.module}/../aws_constants.py")
     ]))
+    requirements_changes = filesha256("${path.module}/cost_tracker_package/requirements.txt")
   }
 }
 

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -202,33 +202,37 @@ resource "aws_lambda_permission" "allow_eventbridge_ec2_state_change" {
   source_arn    = aws_cloudwatch_event_rule.premium_ec2_state_change.arn
 }
 
-# Create ZIP file for premium manager Lambda with dependencies
-# Install dependencies first
 resource "null_resource" "install_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/premium_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/premium_manager_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_manager_package/aws_constants.py && \
-      touch ${path.module}/premium_manager_package/.installed
+      rm -rf ${path.module}/.build/premium_manager && \
+      mkdir -p ${path.module}/.build/premium_manager && \
+      cp -p ${path.module}/premium_manager_package/*.py ${path.module}/.build/premium_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/.build/premium_manager --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/premium_manager/aws_constants.py && \
+      touch ${path.module}/.build/premium_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/premium_manager_package/premium_manager.py"),
-      filesha256("${path.module}/../../studio/app/common/core/premium/premium_assignment_service.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/premium_manager_package", "*.py") :
+        filesha256("${path.module}/premium_manager_package/${f}")
+      ],
+      [
+        filesha256("${path.module}/../../studio/app/common/core/premium/premium_assignment_service.py"),
+        filesha256("${path.module}/../aws_constants.py"),
+      ]
+    )))
     requirements_changes = filesha256("${path.module}/premium_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/premium_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/premium_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "premium_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/premium_manager_package"
+  source_dir  = "${path.module}/.build/premium_manager"
   output_path = "${path.module}/premium_manager.py.zip"
 
   depends_on = [null_resource.install_dependencies]
@@ -296,30 +300,34 @@ resource "aws_lambda_function" "premium_cleanup" {
   ]
 }
 
-# Install dependencies for premium cleanup Lambda
 resource "null_resource" "install_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/premium_cleanup_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_cleanup_package/aws_constants.py && \
-      touch ${path.module}/premium_cleanup_package/.installed
+      rm -rf ${path.module}/.build/premium_cleanup && \
+      mkdir -p ${path.module}/.build/premium_cleanup && \
+      cp -p ${path.module}/premium_cleanup_package/*.py ${path.module}/.build/premium_cleanup/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/.build/premium_cleanup --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/premium_cleanup/aws_constants.py && \
+      touch ${path.module}/.build/premium_cleanup/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/premium_cleanup_package/premium_cleanup.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/premium_cleanup_package", "*.py") :
+        filesha256("${path.module}/premium_cleanup_package/${f}")
+      ],
+      [filesha256("${path.module}/../aws_constants.py")]
+    )))
     requirements_changes = filesha256("${path.module}/premium_cleanup_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/premium_cleanup_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/premium_cleanup/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP file for premium cleanup Lambda
 data "archive_file" "premium_cleanup_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/premium_cleanup_package"
+  source_dir  = "${path.module}/.build/premium_cleanup"
   output_path = "${path.module}/premium_cleanup.py.zip"
 
   depends_on = [null_resource.install_cleanup_dependencies]
@@ -616,31 +624,34 @@ resource "aws_cloudwatch_log_metric_filter" "premium_assignments" {
 # Cost tracker
 # ======================
 
-# Install dependencies for cost tracker Lambda
 resource "null_resource" "install_cost_tracker_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/cost_tracker_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/cost_tracker_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py && \
-      touch ${path.module}/cost_tracker_package/.installed
+      rm -rf ${path.module}/.build/cost_tracker && \
+      mkdir -p ${path.module}/.build/cost_tracker && \
+      cp -p ${path.module}/cost_tracker_package/*.py ${path.module}/.build/cost_tracker/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/.build/cost_tracker --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/cost_tracker/aws_constants.py && \
+      touch ${path.module}/.build/cost_tracker/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/cost_tracker_package/cost_tracker.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/cost_tracker_package", "*.py") :
+        filesha256("${path.module}/cost_tracker_package/${f}")
+      ],
+      [filesha256("${path.module}/../aws_constants.py")]
+    )))
     requirements_changes = filesha256("${path.module}/cost_tracker_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/cost_tracker_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/cost_tracker/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file for cost tracker Lambda
 data "archive_file" "cost_tracker_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/cost_tracker_package"
+  source_dir  = "${path.module}/.build/cost_tracker"
   output_path = "${path.module}/cost_tracker.py.zip"
 
   depends_on = [null_resource.install_cost_tracker_dependencies]

--- a/infrastructure/terraform/premium_manager_package/requirements.txt
+++ b/infrastructure/terraform/premium_manager_package/requirements.txt
@@ -1,0 +1,1 @@
+pymysql


### PR DESCRIPTION
### Content

#### Summary

This week's maintenance report surfaced 4,037 errors (and 8,685 over the
30-day window) on `subscr-common-user-manager`, all of them
`Runtime.ImportModuleError: No module named 'pymysql'`. The deployment zip
was shipped without `pymysql` because the TF
`null_resource.install_*_dependencies` triggers only watch the SHA of the
Lambda's `.py` source file. If the package directory's vendored deps get
cleaned (fresh checkout, manual `rm -rf`, CI cache wipe) while the source
`.py` is unchanged, the install step is skipped and the resulting zip is
missing its dependencies.

This PR adds a `requirements.txt` to each of the six Lambda package
directories and extends every install-resource trigger with a
`requirements_changes = filesha256(requirements.txt)` entry. A dependency
bump now retriggers the install reliably; a missing `requirements.txt`
makes terraform fail loudly at plan time instead of silently shipping a
broken zip. The same hardening is applied uniformly across
`common_user_manager`, `free_manager`, `free_cleanup`, `premium_manager`,
`premium_cleanup`, and `cost_tracker`.

This PR does **not** redeploy the broken `common_user_manager`
Lambda — that is an operational `terraform apply` (or
`terraform apply -replace=null_resource.install_common_user_manager_dependencies`)
performed separately from this merge.

#### Design Decisions

- **Per-package `requirements.txt`, colocated with the source.** Each
  Lambda has a different dep set (`pymysql` only, `pymysql + sqlalchemy`,
  `pymysql + boto3`). `pip install -t ${pkg}/` is a vendored-deps
  pattern, not a venv pattern, so keeping the requirements file inside
  the package directory makes it obvious to anyone reading the package
  what's bundled. A single root-level requirements file would either
  bundle the union of deps into every Lambda (zip bloat) or require a
  separate constraints file per Lambda (same as just having
  per-package files, with extra indirection).

- **Trigger gains `requirements_changes`, existing `code_changes`
  preserved.** Minimum-diff hardening that would have caught the
  observed regression class (deps not installed because the `.py` was
  unchanged). Existing source-SHA triggers stay exactly as-is so any
  Lambda whose code changes still re-runs the install — no behavior
  removed, only behavior added.

- **Unpinned versions, matching the current inline `pip install` arg
  list.** The existing TF passed unpinned names (`pymysql`,
  `sqlalchemy`, `boto3`); transcribing those into `requirements.txt`
  preserves install behavior exactly. Pinning is a separate
  reproducibility concern with its own risks (a previously-installed
  latest may have a fix that an older pinned version lacks) and
  deserves its own PR.

- **Trigger does NOT close the deps-folder-wipe gap.** If a deployer
  wipes `*_package/pymysql/` but leaves `requirements.txt` unchanged,
  this trigger still won't fire. A complete fix would write a marker
  file (`.installed`) after each install and watch *its* SHA — that
  flips when the marker is deleted alongside the deps. Deferred to a
  follow-up PR to keep this one focused on the user-requested change.
  See **Difficulties** for the residual risk.

- **Gitignore exception added.** `infrastructure/terraform/.gitignore`
  has `**/*_package/*` so installed deps don't get committed. Adding
  `!**/*_package/requirements.txt` lets these new files be tracked
  while preserving the install-artifact ignore. Verified with
  `git check-ignore -v` — the negation rule is the matching rule.

- **No consolidation into a Terraform module.** A DRY refactor (single
  `lambda_package` module that takes a name + requirements path)
  was considered and rejected. Six install resources is small enough
  that the explicit form is more readable; consolidation would touch
  every Lambda's resource graph and is a larger blast radius than the
  fix warrants.

### Evidence

- **`infrastructure/scripts/weekly-maintenance-2026-04-27.md` §2 / §A.8** —
  documents the failure mode with raw log samples
  (`Runtime.ImportModuleError: No module named 'pymysql'` repeating
  every few minutes through the report window) and the impact:
  inactive-user logout disabled (free + premium), stale workflow-count
  recovery disabled, likely contributor to the 2026-04-22 ALB 5xx
  spike.
- **`infrastructure/scripts/monthly-maintenance-2026-04.md` §3** — same
  root cause across the 30-day rollup (8,685 errors) with the same
  impact analysis.
- **Local repository state (pre-PR):** `common_user_manager_package/`
  is missing the `pymysql/` directory entirely (only `sqlalchemy/` and
  `typing_extensions` are present), confirming the install step did
  not re-run during the most recent apply.

### References

- `infrastructure/scripts/weekly-maintenance-2026-04-27.md`
- `infrastructure/scripts/monthly-maintenance-2026-04.md`
- v1.1.5 release branch (in dev testing) — separate concern; v1.1.5
  fixes the application-layer premium-assignment race conditions, not
  this packaging issue. The two failure modes co-occur in the
  weekly report.

#### Files changed

Terraform — install-resource hardening
- `infrastructure/terraform/common_user_manager.tf` — `pip install -r
  requirements.txt`; trigger gains `requirements_changes`.
- `infrastructure/terraform/free_manager.tf` — same change applied to
  both `install_free_manager_dependencies` and
  `install_free_cleanup_dependencies`.
- `infrastructure/terraform/premium_manager.tf` — same change applied
  to `install_dependencies` (premium_manager),
  `install_cleanup_dependencies` (premium_cleanup), and
  `install_cost_tracker_dependencies` (cost_tracker).
- `infrastructure/terraform/.gitignore` — adds
  `!**/*_package/requirements.txt` exception so the new files are
  tracked while installed deps remain ignored.

New per-package requirements files (unpinned, matching prior inline args)
- `infrastructure/terraform/common_user_manager_package/requirements.txt` — `pymysql`, `sqlalchemy`
- `infrastructure/terraform/free_manager_package/requirements.txt` — `pymysql`, `boto3`
- `infrastructure/terraform/free_cleanup_package/requirements.txt` — `pymysql`
- `infrastructure/terraform/premium_manager_package/requirements.txt` — `pymysql`
- `infrastructure/terraform/premium_cleanup_package/requirements.txt` — `pymysql`
- `infrastructure/terraform/cost_tracker_package/requirements.txt` — `pymysql`

### Manual Testcases

- [ ] **First plan / apply on this branch.**
  As a deployer in `infrastructure/terraform/`, run
  `terraform plan`. Expected: each of the six
  `null_resource.install_*` shows a trigger-value change (the new
  `requirements_changes` SHA) and is queued to re-run; no
  destroy-then-create on the Lambda functions themselves. Run
  `terraform apply`; expected: every `_package/` directory now
  contains the deps listed in its `requirements.txt` after apply.
  Verify with
  `ls infrastructure/terraform/common_user_manager_package/ | grep pymysql`
  — `pymysql/` and `pymysql-*.dist-info/` should be present.

- [ ] **Live Lambda recovery (the actual bug fix).**
  After apply completes, invoke
  `aws lambda invoke --function-name development-common-user-manager
  --payload '{}' /tmp/out.json --region ap-northeast-1` and tail
  `/aws/lambda/subscr-common-user-manager` in CloudWatch. Expected:
  no more `Runtime.ImportModuleError: No module named 'pymysql'`;
  handler runs to completion and returns the inactivity-check
  summary. Confirm the next scheduled invocation (rate(10 minutes))
  also succeeds.

- [ ] **Dependency bump retriggers install.**
  As a developer, edit any package's `requirements.txt` (e.g. add a
  comment line, or pin a version) and run `terraform plan`.
  Expected: only that Lambda's `null_resource.install_*` is queued
  to re-run; the other five are unchanged. After apply, the
  modified package's dist-info should reflect the new content.

- [ ] **Source change still retriggers (regression check).**
  Touch `common_user_manager.py` (e.g. add a blank line) and run
  `terraform plan`. Expected: `null_resource.install_common_user_manager_dependencies`
  re-runs because `code_changes` flipped — proves the existing
  trigger is preserved alongside the new one.

- [ ] **Deps-folder wipe (negative test, documents residual risk).**
  After a successful apply, `rm -rf
  infrastructure/terraform/premium_cleanup_package/pymysql` and run
  `terraform plan`. Expected (and currently still the case):
  **no change** — the trigger does not detect the wipe because
  `requirements.txt` is unchanged. This is the residual risk
  documented under **Difficulties**; the marker-file follow-up
  would close it.

### Unit, Integration, Contract Test Coverage

- **No application code changed; no tests added.** All changes are in
  Terraform `null_resource` triggers, a `.gitignore`, and six new
  declarative `requirements.txt` files.
- **Verification is operational** — terraform plan output + Lambda
  invocation log inspection (above).
- **CI relevance:** none. The TF changes do not affect Python or
  TypeScript unit-test runs.

### Others

#### Difficulties

- **Residual risk: deps-folder wipe.** A deployer who manually
  wipes `*_package/pymysql/` (or whose CI environment does) without
  changing `requirements.txt` will still produce a broken zip. The
  trigger watches a SHA, not directory contents. A marker-file
  approach — write `.installed` post-install and watch its SHA —
  closes this. Deferred to keep this PR scoped to the user-requested
  hardening; the marker is a separate small follow-up.

- **First-apply re-installs every Lambda's deps.** Each
  `requirements_changes` trigger is computed for the first time, so
  every install resource re-runs once. The resulting zips should be
  functionally identical to current ones (unpinned versions, same
  package list); re-installation is one-time plan churn, not a
  behavioral change.

- **Out of scope but flagged.** The `local-exec` provisioner calls
  `/usr/bin/python3` directly, which depends on the deployer's local
  Python install. A pinned runtime (e.g. via a Docker-based build
  step or `lambda_layer` for the deps) is the larger fix; this PR
  doesn't address it.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Lambda zip contents (six functions) | Low | Triggers are additive; existing `code_changes` triggers untouched. `requirements.txt` content matches the prior inline `pip install` args, so the resulting deps tree is identical. |
| Terraform plan churn on first apply | Low | All six install resources will show as needing to re-run once. Subsequent applies are idempotent. |
| Deps-folder wipe (residual) | Medium | Trigger does not detect a manual `rm -rf */pymysql`. This is the same gap the original code had, narrowed by the new trigger but not closed. Follow-up marker-file PR planned. |
| Unpinned versions | Low | Matches current behavior. Latest-version drift across applies is theoretically possible but not introduced by this PR. |
| Backwards compatibility | None | No runtime, IAM, or endpoint changes. Pure build-step hygiene. |
| Rollback | Trivial | `git revert` the commit, then `terraform apply`. No persisted state. The next install resource will revert to the inline `pip install <pkgs>` form. |
| Cross-Lambda blast radius | Low per Lambda | Each `null_resource` is scoped to its own package; a broken `requirements.txt` in one package fails only that Lambda's install. |
