### PR TITLE
Move Lambda pip vendoring out of _package/ into .build/

### DIFF
--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -15,22 +15,11 @@ terraform.*
 # SSH private keys
 *.pem
 
-# Lambda deployment packages — _package/ dirs are pip-vendored artifact
-# zones; tracked source files are re-included by explicit per-file rules.
+# Lambda deployment build artifacts. Source for each Lambda lives in
+# <lambda>_package/ alongside requirements.txt and README; pip-vendored
+# deps and the assembled ZIP staging area live under .build/<lambda>/.
+**/.build/
 **/*.py.zip
-**/*_package/*
-!**/*_package/requirements.txt
-!**/*_package/README.md
-!**/common_user_manager_package/common_user_manager.py
-!**/common_user_manager_package/test_common_user_manager.py
-!**/cost_tracker_package/cost_tracker.py
-!**/dev_scheduler_package/dev_scheduler.py
-!**/free_cleanup_package/free_cleanup.py
-!**/free_manager_package/free_manager.py
-!**/free_manager_package/free_user_utils.py
-!**/premium_cleanup_package/premium_cleanup.py
-!**/premium_manager_package/premium_manager.py
-!**/premium_manager_package/premium_user_utils.py
 **/agent_recovery_lambda.zip
 
 # AWS constants layer build artifacts

--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -13,27 +13,31 @@
 # Common User Manager Lambda Package
 # ===========================
 
-# Install dependencies
 resource "null_resource" "install_common_user_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/common_user_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/common_user_manager_package/ --no-cache-dir && \
-      touch ${path.module}/common_user_manager_package/.installed
+      rm -rf ${path.module}/.build/common_user_manager && \
+      mkdir -p ${path.module}/.build/common_user_manager && \
+      cp -p ${path.module}/common_user_manager_package/*.py ${path.module}/.build/common_user_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/common_user_manager_package/requirements.txt -t ${path.module}/.build/common_user_manager --no-cache-dir && \
+      touch ${path.module}/.build/common_user_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes         = filesha256("${path.module}/common_user_manager_package/common_user_manager.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/common_user_manager_package", "*.py") :
+      filesha256("${path.module}/common_user_manager_package/${f}")
+    ]))
     requirements_changes = filesha256("${path.module}/common_user_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/common_user_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/common_user_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "common_user_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/common_user_manager_package"
+  source_dir  = "${path.module}/.build/common_user_manager"
   output_path = "${path.module}/common_user_manager.py.zip"
 
   depends_on = [null_resource.install_common_user_manager_dependencies]

--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -47,12 +47,37 @@ resource "aws_ssm_parameter" "dev_schedule_override" {
 # ===========================
 # Lambda Package
 # ===========================
+resource "null_resource" "install_dev_scheduler_dependencies" {
+  count = var.enable_dev_schedule ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      rm -rf ${path.module}/.build/dev_scheduler && \
+      mkdir -p ${path.module}/.build/dev_scheduler && \
+      cp -p ${path.module}/dev_scheduler_package/*.py ${path.module}/.build/dev_scheduler/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/dev_scheduler_package/requirements.txt -t ${path.module}/.build/dev_scheduler --no-cache-dir && \
+      touch ${path.module}/.build/dev_scheduler/.installed
+    EOT
+  }
+
+  triggers = {
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/dev_scheduler_package", "*.py") :
+      filesha256("${path.module}/dev_scheduler_package/${f}")
+    ]))
+    requirements_changes = filesha256("${path.module}/dev_scheduler_package/requirements.txt")
+    installed_marker     = fileexists("${path.module}/.build/dev_scheduler/.installed") ? "present" : "missing"
+  }
+}
+
 data "archive_file" "dev_scheduler_zip" {
   count = var.enable_dev_schedule ? 1 : 0
 
   type        = "zip"
-  source_dir  = "${path.module}/dev_scheduler_package"
+  source_dir  = "${path.module}/.build/dev_scheduler"
   output_path = "${path.module}/dev_scheduler.py.zip"
+
+  depends_on = [null_resource.install_dev_scheduler_dependencies]
 }
 
 # ===========================

--- a/infrastructure/terraform/free_manager.tf
+++ b/infrastructure/terraform/free_manager.tf
@@ -12,30 +12,31 @@
 # Free Manager Lambda Package
 # ===========================
 
-# Install dependencies
 resource "null_resource" "install_free_manager_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/free_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/free_manager_package/ --no-cache-dir && \
-      touch ${path.module}/free_manager_package/.installed
+      rm -rf ${path.module}/.build/free_manager && \
+      mkdir -p ${path.module}/.build/free_manager && \
+      cp -p ${path.module}/free_manager_package/*.py ${path.module}/.build/free_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/free_manager_package/requirements.txt -t ${path.module}/.build/free_manager --no-cache-dir && \
+      touch ${path.module}/.build/free_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/free_manager_package/free_manager.py"),
-      filesha256("${path.module}/free_manager_package/free_user_utils.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/free_manager_package", "*.py") :
+      filesha256("${path.module}/free_manager_package/${f}")
     ]))
     requirements_changes = filesha256("${path.module}/free_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/free_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/free_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "free_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/free_manager_package"
+  source_dir  = "${path.module}/.build/free_manager"
   output_path = "${path.module}/free_manager.py.zip"
 
   depends_on = [null_resource.install_free_manager_dependencies]
@@ -317,26 +318,31 @@ resource "aws_lambda_permission" "allow_asg_events_free_manager" {
 # This Lambda is used by test scripts to manage test data
 # without requiring direct database access from outside VPC.
 
-# Install dependencies for free cleanup Lambda
 resource "null_resource" "install_free_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/free_cleanup_package/ --no-cache-dir && \
-      touch ${path.module}/free_cleanup_package/.installed
+      rm -rf ${path.module}/.build/free_cleanup && \
+      mkdir -p ${path.module}/.build/free_cleanup && \
+      cp -p ${path.module}/free_cleanup_package/*.py ${path.module}/.build/free_cleanup/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/free_cleanup_package/requirements.txt -t ${path.module}/.build/free_cleanup --no-cache-dir && \
+      touch ${path.module}/.build/free_cleanup/.installed
     EOT
   }
 
   triggers = {
-    code_changes         = filesha256("${path.module}/free_cleanup_package/free_cleanup.py")
+    code_changes = sha256(join("", [
+      for f in fileset("${path.module}/free_cleanup_package", "*.py") :
+      filesha256("${path.module}/free_cleanup_package/${f}")
+    ]))
     requirements_changes = filesha256("${path.module}/free_cleanup_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/free_cleanup_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/free_cleanup/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP file for free cleanup Lambda
 data "archive_file" "free_cleanup_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/free_cleanup_package"
+  source_dir  = "${path.module}/.build/free_cleanup"
   output_path = "${path.module}/free_cleanup.py.zip"
 
   depends_on = [null_resource.install_free_cleanup_dependencies]

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -215,7 +215,7 @@ resource "null_resource" "install_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/premium_manager_package", "*.py") :
         filesha256("${path.module}/premium_manager_package/${f}")
       ],
@@ -313,7 +313,7 @@ resource "null_resource" "install_cleanup_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/premium_cleanup_package", "*.py") :
         filesha256("${path.module}/premium_cleanup_package/${f}")
       ],
@@ -637,7 +637,7 @@ resource "null_resource" "install_cost_tracker_dependencies" {
   }
 
   triggers = {
-    code_changes = md5(join("", concat(
+    code_changes = sha256(join("", concat(
       [for f in fileset("${path.module}/cost_tracker_package", "*.py") :
         filesha256("${path.module}/cost_tracker_package/${f}")
       ],

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -202,33 +202,37 @@ resource "aws_lambda_permission" "allow_eventbridge_ec2_state_change" {
   source_arn    = aws_cloudwatch_event_rule.premium_ec2_state_change.arn
 }
 
-# Create ZIP file for premium manager Lambda with dependencies
-# Install dependencies first
 resource "null_resource" "install_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/premium_manager_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/premium_manager_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_manager_package/aws_constants.py && \
-      touch ${path.module}/premium_manager_package/.installed
+      rm -rf ${path.module}/.build/premium_manager && \
+      mkdir -p ${path.module}/.build/premium_manager && \
+      cp -p ${path.module}/premium_manager_package/*.py ${path.module}/.build/premium_manager/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_manager_package/requirements.txt -t ${path.module}/.build/premium_manager --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/premium_manager/aws_constants.py && \
+      touch ${path.module}/.build/premium_manager/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/premium_manager_package/premium_manager.py"),
-      filesha256("${path.module}/../../studio/app/common/core/premium/premium_assignment_service.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/premium_manager_package", "*.py") :
+        filesha256("${path.module}/premium_manager_package/${f}")
+      ],
+      [
+        filesha256("${path.module}/../../studio/app/common/core/premium/premium_assignment_service.py"),
+        filesha256("${path.module}/../aws_constants.py"),
+      ]
+    )))
     requirements_changes = filesha256("${path.module}/premium_manager_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/premium_manager_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/premium_manager/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file
 data "archive_file" "premium_manager_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/premium_manager_package"
+  source_dir  = "${path.module}/.build/premium_manager"
   output_path = "${path.module}/premium_manager.py.zip"
 
   depends_on = [null_resource.install_dependencies]
@@ -296,30 +300,34 @@ resource "aws_lambda_function" "premium_cleanup" {
   ]
 }
 
-# Install dependencies for premium cleanup Lambda
 resource "null_resource" "install_cleanup_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/premium_cleanup_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/premium_cleanup_package/aws_constants.py && \
-      touch ${path.module}/premium_cleanup_package/.installed
+      rm -rf ${path.module}/.build/premium_cleanup && \
+      mkdir -p ${path.module}/.build/premium_cleanup && \
+      cp -p ${path.module}/premium_cleanup_package/*.py ${path.module}/.build/premium_cleanup/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/premium_cleanup_package/requirements.txt -t ${path.module}/.build/premium_cleanup --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/premium_cleanup/aws_constants.py && \
+      touch ${path.module}/.build/premium_cleanup/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/premium_cleanup_package/premium_cleanup.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/premium_cleanup_package", "*.py") :
+        filesha256("${path.module}/premium_cleanup_package/${f}")
+      ],
+      [filesha256("${path.module}/../aws_constants.py")]
+    )))
     requirements_changes = filesha256("${path.module}/premium_cleanup_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/premium_cleanup_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/premium_cleanup/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP file for premium cleanup Lambda
 data "archive_file" "premium_cleanup_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/premium_cleanup_package"
+  source_dir  = "${path.module}/.build/premium_cleanup"
   output_path = "${path.module}/premium_cleanup.py.zip"
 
   depends_on = [null_resource.install_cleanup_dependencies]
@@ -616,31 +624,34 @@ resource "aws_cloudwatch_log_metric_filter" "premium_assignments" {
 # Cost tracker
 # ======================
 
-# Install dependencies for cost tracker Lambda
 resource "null_resource" "install_cost_tracker_dependencies" {
   provisioner "local-exec" {
     command = <<-EOT
-      mkdir -p ${path.module}/cost_tracker_package && \
-      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/cost_tracker_package/ --no-cache-dir && \
-      cp ${path.module}/../aws_constants.py ${path.module}/cost_tracker_package/aws_constants.py && \
-      touch ${path.module}/cost_tracker_package/.installed
+      rm -rf ${path.module}/.build/cost_tracker && \
+      mkdir -p ${path.module}/.build/cost_tracker && \
+      cp -p ${path.module}/cost_tracker_package/*.py ${path.module}/.build/cost_tracker/ && \
+      /usr/bin/python3 -m pip install -r ${path.module}/cost_tracker_package/requirements.txt -t ${path.module}/.build/cost_tracker --no-cache-dir && \
+      cp -p ${path.module}/../aws_constants.py ${path.module}/.build/cost_tracker/aws_constants.py && \
+      touch ${path.module}/.build/cost_tracker/.installed
     EOT
   }
 
   triggers = {
-    code_changes = md5(join("", [
-      filesha256("${path.module}/cost_tracker_package/cost_tracker.py"),
-      filesha256("${path.module}/../aws_constants.py")
-    ]))
+    code_changes = md5(join("", concat(
+      [for f in fileset("${path.module}/cost_tracker_package", "*.py") :
+        filesha256("${path.module}/cost_tracker_package/${f}")
+      ],
+      [filesha256("${path.module}/../aws_constants.py")]
+    )))
     requirements_changes = filesha256("${path.module}/cost_tracker_package/requirements.txt")
-    installed_marker     = fileexists("${path.module}/cost_tracker_package/.installed") ? "present" : "missing"
+    installed_marker     = fileexists("${path.module}/.build/cost_tracker/.installed") ? "present" : "missing"
   }
 }
 
 # Create ZIP using archive_file for cost tracker Lambda
 data "archive_file" "cost_tracker_zip" {
   type        = "zip"
-  source_dir  = "${path.module}/cost_tracker_package"
+  source_dir  = "${path.module}/.build/cost_tracker"
   output_path = "${path.module}/cost_tracker.py.zip"
 
   depends_on = [null_resource.install_cost_tracker_dependencies]


### PR DESCRIPTION
### Content

#### Summary

PR #573 hardened the Lambda dep-install triggers, but it was
flagged a follow-on maintainability risk in c176b28: the per-file
`.gitignore` allowlist (one `!**/<pkg>/<source>.py` line per tracked
source file, sitting on top of `**/*_package/*`) is fragile. Adding a
new `.py` file to any `_package/` dir without remembering to update
`.gitignore` means git silently drops the file from `git status`,
`git clone`, and the deployed zip — reproducing the same
"works on my machine" class that the original PR was created to fix,
just one layer up. See
https://github.com/arayabrain/araya-optinist/pull/573#discussion_r3198772273.

This PR addresses that medium-term risk by separating source from
vendored deps. Each Lambda now builds into a sibling
`infrastructure/terraform/.build/<lambda>/` directory: source `.py`
files are copied in, `pip install -t .build/<lambda>/` vendors the
deps, and `archive_file` zips `.build/<lambda>/`. `<lambda>_package/`
stays source-only. The `.gitignore` allowlist (16 lines) collapses to
a single `**/.build/` rule.

Triggers are also refactored to `fileset(...)` + `filesha256` so a
new `.py` source file rebuilds without manual trigger maintenance —
and incidentally fixes a pre-existing miss in the `premium_manager`
trigger which did not hash `premium_user_utils.py`, so content edits
to that file would not have rebuilt the zip.

#### Design Decisions

- **Approach: `_package/` source-only, `.build/<lambda>/` for vendored
  deps.** The reviewer's literal suggestion was `_package/src/` +
  `_package/lib/`. Equivalent goal, slightly different layout. Picked
  `.build/` because (a) `_package/` dirs already exist on disk in the
  source-mixed-with-deps form, so keeping source there is a no-rename
  refactor — test scripts and developer mental models are
  undisturbed; (b) `archive_file` needs a single `source_dir` for the
  zip, so `_package/src/` + `_package/lib/` would still require a
  build-merge step anyway. With `.build/<lambda>/` we get a clean
  source-only `_package/` and a clean vendored-only build dir with
  no remaining mixed directory.

- **Lambda Layers rejected.** Considered moving vendored deps to
  per-Lambda Lambda Layers. Cleanest separation conceptually but:
  five-layer-per-function cap, layer storage cost per version,
  per-Lambda duplication of `pymysql` (unless coordinated via a
  shared "common deps" layer), and bigger AWS-resource footprint.
  Heavier than the problem warrants for a build-hygiene fix.

- **`cp -p` to preserve mtime.** Without `-p`, every
  `terraform apply` would update mtimes on the copied source files,
  which would change the zip bytes and flip `source_code_hash` →
  spurious Lambda redeploys on every apply. With `-p`, the build
  dir's mtime tracks the source's, so when source content is
  unchanged the zip is byte-stable. macOS and GNU `cp` both honor
  `-p`. See the second-apply manual testcase for verification.

- **`rm -rf .build/<lambda>` at the top of each build.** Renames and
  deletions handled deterministically — a removed source file
  doesn't linger in `.build/` and ship as stale code in the zip.
  pip-install is the slow part and runs whenever its trigger fires
  anyway, so the per-apply `rm -rf` cost is negligible.

- **Triggers refactored to `fileset(...)` + `filesha256`.** Existing
  triggers enumerate each source file by name. With `_package/` now
  source-only, we can hash *all* `*.py` files in the package via
  `fileset(...)`. Concrete benefits: (a) a new `.py` source file
  added to a package automatically retriggers install (no `.tf`
  edit needed), (b) fixes the pre-existing miss in
  `premium_manager`'s trigger which only hashed `premium_manager.py`
  and missed `premium_user_utils.py`. External-file triggers
  (`aws_constants.py` for three Lambdas, the studio cross-reference
  `premium_assignment_service.py` for premium_manager) are preserved
  as explicit entries.

- **`aws_constants.py` cp preserved as-is.** Three Lambdas
  (`premium_manager`, `premium_cleanup`, `cost_tracker`) `cp`
  `aws_constants.py` into the build dir even though they also
  attach the `aws_constants` Lambda Layer. The cp is *probably*
  runtime-redundant (three other Lambdas import the same module
  via layer-only with no cp) but the introducing commits weren't
  git-blamed during this refactor, so removing it would be
  unjustified scope creep. Only the cp *target* changed
  (`<pkg>/aws_constants.py` → `.build/<lambda>/aws_constants.py`).

- **`null_resource` added for `dev_scheduler`.** Previously this
  Lambda had no `null_resource` because no `requirements.txt`
  existed (no deps). Created an empty `requirements.txt` and wired
  up the same build pipeline so adding a dep later is just a
  one-line edit. `pip install -r empty.txt -t .build/...` is a
  harmless no-op. Uniform pipeline across all 7 Lambdas.

- **Source files not moved.** Considered relocating source out of
  `<lambda>_package/` to a sibling like `<lambda>_src/` to fully
  eliminate the directory's history. Rejected — `_package/`
  becomes source-only after the one-time cleanup (see
  **Migration**), so no remaining mix to address, and a rename
  would touch every test script that does
  `sys.path.insert(0, lambda_package_dir)`.

### References

- PR #573 (`fix/lambda-deps-trigger`) — base branch; this PR
  addresses the medium-term suggestion in
  https://github.com/arayabrain/araya-optinist/pull/573#discussion_r3198772273.
- `infrastructure/terraform/<lambda>_package/README.md` — existing
  per-Lambda READMEs (untouched).

#### Files changed

Terraform — build pipeline restructure
- `infrastructure/terraform/.gitignore` — replaces 16-line
  `**/*_package/*` block + 11 per-source `!` allowlist lines with a
  single `**/.build/` rule.
- `infrastructure/terraform/common_user_manager.tf` — `null_resource`
  builds into `.build/common_user_manager/`; `archive_file.source_dir`
  retargeted; trigger uses `fileset("*.py")` + `installed_marker`
  pointing at the new path.
- `infrastructure/terraform/dev_schedule.tf` — adds
  `null_resource.install_dev_scheduler_dependencies` (was missing);
  `archive_file.source_dir` retargeted to `.build/dev_scheduler/`.
- `infrastructure/terraform/free_manager.tf` — same change applied
  to `install_free_manager_dependencies` and
  `install_free_cleanup_dependencies`.
- `infrastructure/terraform/premium_manager.tf` — same change applied
  to `install_dependencies` (premium_manager),
  `install_cleanup_dependencies` (premium_cleanup), and
  `install_cost_tracker_dependencies` (cost_tracker);
  `aws_constants.py` cp retargeted to `.build/<lambda>/`.

New file
- `infrastructure/terraform/dev_scheduler_package/requirements.txt` —
  empty; keeps the build pattern uniform across all 7 Lambdas.

#### Migration: one-time local cleanup

If you have previously run `terraform apply` against this repo, your
local `<lambda>_package/` directories contain stale pip-installed
artifacts that the old `.gitignore` allowlist kept hidden. After
pulling this branch they surface as untracked (≈2,500 files, mostly
under `free_manager_package/boto3*` and
`common_user_manager_package/sqlalchemy*`). Run:

```
git -C infrastructure/terraform clean -fd \
  common_user_manager_package free_manager_package free_cleanup_package \
  premium_manager_package premium_cleanup_package cost_tracker_package \
  dev_scheduler_package
```

This removes the untracked vendored deps from each `_package/` dir
without touching tracked source files or anything covered by
`.gitignore` (e.g. `__pycache__/`). Future builds install into
`.build/<lambda>/` instead, which is fully ignored — so this cleanup
is only needed once. Fresh clones after merge don't need it.

### Manual Testcases

- [ ] **First plan / apply on this branch.**
  As a deployer in `infrastructure/terraform/`, run
  `terraform plan`. Expected: each of the 7 `null_resource.install_*`
  shows a trigger-value change (`installed_marker = missing` because
  `.build/<lambda>/` doesn't exist yet) and is queued to re-run; no
  destroy-then-create on the Lambda functions themselves. Run
  `terraform apply`; expected: every `.build/<lambda>/` directory
  now contains source files plus the deps from its
  `requirements.txt`. Verify with
  `ls infrastructure/terraform/.build/common_user_manager/` —
  should show `common_user_manager.py`, `pymysql/`, `sqlalchemy/`,
  `.installed`, etc.

- [ ] **Idempotent second apply.**
  Immediately re-run `terraform apply`. Expected: 0 changes. The
  `.installed` marker exists, source SHAs are unchanged,
  `requirements.txt` hashes are unchanged — no `null_resource`
  fires, no `source_code_hash` flips, no Lambda redeploys.
  This also implicitly verifies `cp -p` is preserving mtime on
  the deployment runner.

- [ ] **`_package/` stays source-only.**
  After a successful apply, `ls
  infrastructure/terraform/free_manager_package/` should show only
  `free_manager.py`, `free_user_utils.py`, `requirements.txt`,
  `README.md` (and possibly `__pycache__/` from local imports).
  No `boto3/`, no `*.dist-info/`.

- [ ] **Source change retriggers install + redeploys Lambda.**
  Touch `infrastructure/terraform/premium_manager_package/premium_user_utils.py`
  (e.g. add a blank line) and run `terraform plan`. Expected:
  `null_resource.install_dependencies` re-runs because
  `code_changes` flipped — this is the bug fix; the old trigger
  only hashed `premium_manager.py`. `aws_lambda_function.premium_manager`
  shows a `source_code_hash` change. After apply, the new code is
  live.

- [ ] **New source file is auto-tracked and auto-triggered.**
  As a developer, add a no-op
  `infrastructure/terraform/free_manager_package/_test_extra.py`
  with a single `pass`. `git status` should show it as
  untracked-but-not-ignored (no allowlist edit needed). Run
  `terraform plan`: `null_resource.install_free_manager_dependencies`
  should re-run because the `fileset("*.py")` hash flipped. After
  apply, the file is in the deployed zip. Discard the file
  (`git clean -f infrastructure/terraform/free_manager_package/_test_extra.py`)
  when done.

- [ ] **Build-dir wipe self-heals.**
  `rm -rf infrastructure/terraform/.build/common_user_manager` and
  run `terraform plan`. Expected: `installed_marker` flips to
  `"missing"`, `null_resource` re-runs, deps reinstalled.
  Confirms the `.installed` marker fix from PR #573 carries over to
  the new build dir.

- [ ] **Source rename does not leave stale file in zip.**
  Rename `free_manager_package/free_user_utils.py` to
  `free_manager_package/free_user_helpers.py`, update its single
  reference in `free_manager.py`, and run `terraform apply`.
  Verify that `.build/free_manager/` contains
  `free_user_helpers.py` and **not** `free_user_utils.py` (the
  `rm -rf` at the top of the build script handles this). Revert
  the rename when done.

### Unit, Integration, Contract Test Coverage

- **No application code changed; no tests added.** All changes are
  in Terraform `null_resource` build scripts, `archive_file`
  source_dir values, one `.gitignore`, and one new empty
  `requirements.txt`.
- **Test scripts in `infrastructure/scripts/`** that
  `sys.path.insert(0, lambda_package_dir)` (e.g.
  `test_premium_lambda.py`, `test_premium_migration_edge_cases.py`,
  `test_safe_environment_variables.py`,
  `test_standby_integration.py`) are unaffected: source modules
  still live at `<lambda>_package/<source>.py`, and these scripts
  import `boto3`/`pymysql` from the runtime venv at the top of
  each file (before any `sys.path` manipulation), not from the
  `_package/` vendored deps.
- **Verification is operational** — `terraform plan/apply` output
  + `ls .build/<lambda>/` + Lambda invocation log (above).
- **CI relevance:** none. The TF changes do not affect Python or
  TypeScript unit-test runs.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Lambda zip contents (7 functions) | Low | Same source files, same vendored deps (unpinned, identical `requirements.txt`), same Python runtime. Build artifact functionally identical to the prior `_package/` zip; only the source path differs. |
| Terraform plan churn on first apply | Low | All 7 `null_resource.install_*` re-run once because `installed_marker` is `"missing"` (no `.build/` exists yet). Subsequent applies are idempotent assuming `cp -p` preserves mtime. |
| `cp -p` mtime on the build runner | Medium | If the runner's `cp` doesn't preserve mtime, every apply re-deploys every Lambda. No correctness impact; cosmetic + slow. Detect via the second-apply test in **Manual Testcases**; mitigate with `touch -d` if needed. |
| Local working-tree noise post-pull | Low | ≈2,555 stale untracked files surface until the developer runs `git clean -fd <pkg dirs>`. Documented in **Migration**. No correctness impact. |
| Test scripts that `sys.path.insert(_package_dir)` | None | Verified — they import vendored deps from the test venv (top-of-file imports run before sys.path manipulation), not from `_package/`. Source modules still live at the same path. |
| Trigger completeness | Low | `fileset("*.py")` is strictly broader than the prior per-file enumeration (captures the previously-missed `premium_user_utils.py`). External cross-references kept as explicit entries. |
| Allowlist regression | None | The rule the reviewer flagged is fully removed, not narrowed — single-line `**/.build/` replaces 16 lines. Any new `.py` source file in `_package/` is tracked by default. |
| Backwards compatibility | None | No runtime, IAM, or endpoint changes. Pure build-step refactor. |
| Rollback | Trivial | `git revert` the merge commit, then `terraform apply`. Resources keep their TF addresses (only their internals changed), so no state migration. Local `.build/` dirs become orphaned but harmless. |
| Cross-Lambda blast radius | Low per Lambda | Each `null_resource` is scoped to its own package + build dir; a broken build script for one Lambda fails only that Lambda's pipeline. |
