### PR TITLE
Fix/stuck  premium ecs service deployment

### DIFF
--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -494,6 +494,60 @@ Guards:
 > For the scale-up / scale-down asymmetry comparison, see
 > [PREMIUM_USER_ASSIGNMENT.md → 5. Scaling System (scale-up and scale-down)](./PREMIUM_USER_ASSIGNMENT.md#5-scaling-system-scale-up-and-scale-down).
 
+#### ECS Service Desired Count Sync (`update_premium_service_desired_count`)
+
+**File:** `infrastructure/terraform/premium_manager_package/premium_manager.py`
+**Purpose:** Keep the ECS service's `desiredCount` in sync with the actual
+number of premium EC2 instances that should be running ECS tasks.
+**Input:** None (reads state from ECS and EC2 APIs)
+**Output:** Calls `ecs.update_service()` when `desiredCount` diverges from the
+computed target; no-op when already in sync.
+**Calls:** `ecs.describe_services()` → `_list_premium_ecs_registered_ec2_ids()`
+→ `_list_premium_ec2_instances_running()` → `ecs.update_service()`
+
+**Why manual control instead of ECS Auto Scaling:**
+The premium tier uses Lambda-driven scaling (`scale_premium_instances_if_needed`,
+`scale_down_if_possible`) rather than ECS Application Auto Scaling. The ECS
+Auto Scaling target is commented out in `compute.tf`. Because EC2 instance
+start/stop decisions are made by the Lambda based on user assignment demand
+(not task-level metrics), the ECS service's `desiredCount` must be
+explicitly synchronized after every scaling action to match reality.
+
+**Desired count formula:**
+
+```
+desiredCount = registered_count + booting_count
+```
+
+| Component | Definition |
+|---|---|
+| `registered_count` | Number of EC2 instances currently registered as ECS container instances in the premium cluster (via `_list_premium_ecs_registered_ec2_ids()`) |
+| `booting_count` | Number of running premium EC2 instances that are **not yet** registered in ECS but were launched less than `ORPHAN_GRACE_PERIOD_MINUTES` (10 min) ago |
+
+The boot grace period prevents a race condition: when a stopped standby
+instance is started (Tier 3) or a new instance is created (Tier 5), there
+is a gap between the EC2 reaching `running` state and the ECS agent
+registering with the cluster. If `desiredCount` were dropped during this
+gap, ECS would cancel the pending task placement and never re-fire it once
+the agent registers — leaving the instance with no premium task and the
+user stuck on the waiting popup. The 10-minute grace is symmetric with
+`cleanup_orphaned_ec2_instances()`, which uses the same threshold before
+treating an unregistered instance as orphaned.
+
+**Call sites (5 locations):**
+
+| # | Caller | Context |
+|---|---|---|
+| 1 | `handle_scheduled_monitoring()` step 6 | After `scale_down_if_possible()` in the 15-min cycle |
+| 2 | `scale_down_if_possible()` | After stopping idle instances and converting to standby |
+| 3 | `scale_premium_instances_if_needed()` (success path) | After starting stopped instances or creating new ones |
+| 4 | `scale_premium_instances_if_needed()` (lock-held path) | When scaling was blocked by an existing lock |
+| 5 | `_handle_migrate_shared_users()` | Before each migration attempt in the retry loop, to ensure ECS has the correct task count for readiness checks |
+
+**Idempotency:** The function compares `running_premium_count` to the
+current `desiredCount` and only issues `update_service` when they differ,
+so repeated calls within the same cycle are safe.
+
 #### Terraform Configuration
 
 ```hcl
@@ -918,7 +972,7 @@ All resource names are prefixed with the Terraform `environment` variable (shown
 | `scale_premium_instances_if_needed()` | Scale up by starting stopped or creating new instances when `running_count < active_users` |
 | `_create_running_instances_locked()` | Create running instances under distributed lock (called by `scale_premium_instances_if_needed()`) |
 | `scale_down_if_possible()` | Conservative scale-down: requires `running_count > max(1, active_users + 1)` AND `idle_instances >= 2` |
-| `update_premium_service_desired_count()` | Sync ECS desired count |
+| `update_premium_service_desired_count()` | Sync ECS `desiredCount` to `registered + booting` instance count ([details](#ecs-service-desired-count-sync-update_premium_service_desired_count)) |
 | `assign_premium_user()` | Real-time user assignment (API) - 5-tier priority: dedicated > shared > standby > autoscaling pool > stopped > new |
 | `release_premium_user()` | Real-time user release (API) |
 | `handle_activity_update()` | Heartbeat/activity timestamp update (API) |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -922,6 +922,11 @@ subscribers.
 - Always calls `invoke_migration_async()` and
   `update_premium_service_desired_count()` after scaling
 
+> For the full specification of `update_premium_service_desired_count()` —
+> desired count formula, boot grace period, call sites, and the rationale
+> for manual ECS control instead of Auto Scaling — see
+> [PREMIUM_MANAGER_ARCHITECTURE.md → ECS Service Desired Count Sync](./PREMIUM_MANAGER_ARCHITECTURE.md#ecs-service-desired-count-sync-update_premium_service_desired_count).
+
 #### Scale-down (`scale_down_if_possible`)
 
 Runs as step 5 of `handle_scheduled_monitoring()` (the 15-minute cycle).
@@ -1377,7 +1382,7 @@ Shared instance optimization complete: 1 users migrated
 | `scale_premium_instances_if_needed()` | Start stopped or create new instances |
 | `_create_running_instances_locked()` | Create running instances under lock |
 | `create_running_instance()` | Create and leave running for assignment |
-| `update_premium_service_desired_count()` | Sync ECS desired count |
+| `update_premium_service_desired_count()` | Sync ECS `desiredCount` (see [PREMIUM_MANAGER_ARCHITECTURE.md](./PREMIUM_MANAGER_ARCHITECTURE.md#ecs-service-desired-count-sync-update_premium_service_desired_count)) |
 | `trigger_experiment_sync()` | Sync experiment metadata after migration |
 
 > For locking primitives (`distributed_lock()`, `try_reserve_instance_transaction()`, etc.)

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -352,7 +352,7 @@ resource "aws_ecs_service" "premium" {
   task_definition                    = aws_ecs_task_definition.premium.arn
   desired_count                      = 1
   deployment_maximum_percent         = 200
-  deployment_minimum_healthy_percent = 50
+  deployment_minimum_healthy_percent = 0
   launch_type                        = "EC2"
 
   enable_execute_command = true


### PR DESCRIPTION
## Problem

The premium ECS service (`*-premium-optinist-cloud-service`) frequently experiences
deployment failures (status: stopped) with extremely long durations — some exceeding
24 hours. During these stalled deployments, ECS reports:

```
was unable to place a task because no container instance met all of its requirements.
The closest matching container instance has insufficient CPU units available.
```

Manually stopping the old ECS task unblocks the stalled deployment, confirming
that the old task is holding resources that the new task needs.

The free-tier ECS service does not exhibit this problem — deployments complete
in 10-20 minutes consistently.

## Root Cause

A resource deadlock caused by the combination of three configuration values
on the premium ECS service:

| Setting | Value | Effect |
|---|---|---|
| `deployment_minimum_healthy_percent` | `50` | With `desiredCount=1`: `ceil(1 * 0.5) = 1` — ECS must keep the old task running |
| `deployment_maximum_percent` | `200` | Allows up to 2 tasks, but no physical capacity for a 2nd |
| Instance type (`t3.large`) | 2048 CPU units | Task definition requires 2048 CPU — exactly 100% of instance capacity |

**Deadlock cycle:**
1. ECS creates a new deployment (e.g. task definition update via `terraform apply`)
2. ECS tries to place a new task but the instance has 0 free CPU (old task uses all 2048 units)
3. ECS cannot stop the old task because `minimum_healthy_percent=50` requires 1 task to stay healthy
4. Deployment stalls indefinitely

This deadlock is specific to `desiredCount=1`, which is the most common premium
state (single user or idle with standby). At `desiredCount >= 2`, ECS can rotate
through instances because `ceil(N * 0.5) < N`.

The free-tier service uses `deployment_minimum_healthy_percent = 0`, which allows
ECS to stop all old tasks before placing new ones, avoiding the deadlock entirely.

## Fix

Change `deployment_minimum_healthy_percent` from `50` to `0` for the premium
ECS service, matching the free-tier configuration.

```hcl
# infrastructure/terraform/compute.tf — aws_ecs_service.premium
deployment_minimum_healthy_percent = 0   # was: 50
```

With `0`, ECS is allowed to stop the old task first, freeing CPU capacity on the
instance, then place the new task. This eliminates the deadlock at any `desiredCount`.

## Risk Assessment

| Concern | Assessment |
|---|---|
| Brief task downtime during deploy | Yes — the old task stops before the new one starts (~30-90s gap). Affects only the user on that specific instance. Acceptable because deployments are manual (`terraform apply` or `--force-new-deployment`), not automatic |
| Active workflow interruption | Possible if a user has a running workflow during deployment. Mitigated by scheduling deployments outside business hours |
| Lambda `update_service` calls | Safe — `update_premium_service_desired_count()` does not pass `forceNewDeployment`, so the 15-min monitoring cycle does not trigger new deployments |
| Standby pool operations | No impact — all standby lifecycle operations (create, start, stop, register, terminate) are Lambda-driven via direct EC2/ECS API calls, not managed by the ECS deployment controller. `deployment_minimum_healthy_percent` is only consulted during rolling deployments, which are never triggered by standby pool code. A standby instance started during an active deployment receives a task from the PRIMARY (newest) deployment regardless of this setting |

## Test Plan

1. Start 1 premium instance with 1 running ECS task (`desiredCount = 1`)
2. Run `aws ecs update-service --force-new-deployment` on the premium service
3. Verify deployment completes within 10-20 minutes (not hours/days)
4. Verify the new task revision is running and healthy after deployment
