### PR TITLE
CloudWatch log streams stalled fix

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -801,8 +801,7 @@ resource "aws_ecs_task_definition" "autoscaling" {
         logDriver = "awslogs"
         options = {
           "awslogs-group"             = "/ecs/${local.env_prefix}-cloud-taskdef"
-          "mode"                      = "non-blocking"
-          "awslogs-multiline-pattern" = "^\\[\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
+          "awslogs-multiline-pattern" = "^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
           "max-buffer-size"           = "25m"
           "awslogs-region"            = var.aws_region
           "awslogs-create-group"      = "true"
@@ -1045,7 +1044,7 @@ resource "aws_ecs_task_definition" "premium" {
         logDriver = "awslogs"
         options = {
           "awslogs-group"             = "/ecs/${var.environment}-premium-optinist-cloud-taskdef"
-          "awslogs-multiline-pattern" = "^\\[\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
+          "awslogs-multiline-pattern" = "^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
           "max-buffer-size"           = "25m"
           "awslogs-region"            = var.aws_region
           "awslogs-create-group"      = "true"


### PR DESCRIPTION
## Summary

Fixes #565 — CloudWatch log streams stalled for tens of minutes at a time. Root cause: `awslogs-multiline-pattern` required a leading `[` that the app's log format never emits, so the awslogs driver buffered indefinitely.

## Changes

`infrastructure/terraform/compute.tf`:

- Drop `\[` from the multiline pattern in both task definitions so it anchors on the emitted timestamp.
- Remove the duplicate `"mode" = "non-blocking"` key on the free-tier `logConfiguration.options` map.

```diff
- "awslogs-multiline-pattern" = "^\\[\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
+ "awslogs-multiline-pattern" = "^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}"
```

## Test plan

- `terraform fmt -check && terraform validate`
- `terraform plan` against development — diff limited to the two task definition revisions.
- Apply to development, force a new ECS deployment.
- Trigger 20+ `Premium UI event:` lines and confirm they land in CloudWatch within 60 s.
- Force a Python traceback and confirm it arrives as a single CloudWatch event.
- Repeat on production.

## Risk

Low. Task definition revision bump only — no IAM, networking, or volume changes. Rollback is `--task-definition <previous-revision>` on the service.
