### PR TITLE
Fix: premium success snackbar can be missed during shared → dedicated migration

### DIFF
--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -13,6 +13,29 @@ import { Button } from "@mui/material"
 import { logPremiumUiEvent } from "api/premium/PremiumAssignmentApi"
 import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
+// sessionStorage key — tracks the instance_id we've already notified about
+// for this browser session. Cleared automatically when the tab closes,
+// so a fresh login always shows one confirmation. Replaces the old
+// `wasWaiting` gate, which incorrectly suppressed the snackbar when the
+// user was already-assigned at login (no waiting popup ever shown).
+const SS_NOTIFIED_INSTANCE_KEY = "premium_notified_instance_id"
+
+function ssGetNotifiedInstance(): string | null {
+  try {
+    return sessionStorage.getItem(SS_NOTIFIED_INSTANCE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function ssSetNotifiedInstance(instanceId: string): void {
+  try {
+    sessionStorage.setItem(SS_NOTIFIED_INSTANCE_KEY, instanceId)
+  } catch {
+    // sessionStorage unavailable (e.g., some private browsing modes)
+  }
+}
+
 const PremiumNotificationManager: FC = () => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
   const {
@@ -40,17 +63,30 @@ const PremiumNotificationManager: FC = () => {
   const hasDedicatedInstance =
     assignmentResult?.assigned && !assignmentResult?.is_shared
 
-  // Show success notification when premium instance is assigned
+  // Show success notification when premium instance is assigned.
+  //
+  // Gating: fire once per browser session per instance_id. We use
+  // sessionStorage instead of relying on the in-component `lastAssignmentId`
+  // state because that state resets on every page refresh, which would
+  // re-fire the snackbar. sessionStorage clears when the tab closes,
+  // so the next session sees a fresh confirmation.
+  //
+  // We do NOT require the waiting popup to have been shown first — that
+  // gate (`wasWaiting`) used to suppress the snackbar on refresh, but it
+  // also incorrectly suppressed it when the user was already-assigned at
+  // login (the autoAssignOnLogin "already assigned" path skips isAssigning).
   useEffect(() => {
-    const hasNewInstance = assignmentResult?.instance_id !== lastAssignmentId
-    const wasWaiting = waitingKeyRef.current !== null
+    const instanceId = assignmentResult?.instance_id
+    const alreadyNotifiedThisSession =
+      instanceId != null && ssGetNotifiedInstance() === instanceId
+    const hasNewInstance = instanceId !== lastAssignmentId
 
     if (
       isPremiumUser &&
       hasDedicatedInstance &&
-      assignmentResult.instance_id &&
+      instanceId &&
       hasNewInstance &&
-      wasWaiting
+      !alreadyNotifiedThisSession
     ) {
       enqueueSnackbar(
         "Premium instance assigned successfully! " +
@@ -73,11 +109,12 @@ const PremiumNotificationManager: FC = () => {
         },
       )
       logPremiumUiEvent("dedicated_instance_ready", {
-        instance_id: assignmentResult.instance_id,
+        instance_id: instanceId,
       })
 
+      ssSetNotifiedInstance(instanceId)
       setHasShownAssignmentSuccess(true)
-      setLastAssignmentId(assignmentResult.instance_id)
+      setLastAssignmentId(instanceId)
     }
   }, [
     isPremiumUser,

--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -93,19 +93,7 @@ const PremiumNotificationManager: FC = () => {
           "You now have dedicated compute resources.",
         {
           variant: "success",
-          // Longer than the default toast lifetime so a transient warning
-          // popup during the dedicated ALB warm-up (issue #575) cannot
-          // overwrite the confirmation before the user reads it.
-          autoHideDuration: 10000,
-          action: (snackbarKey) => (
-            <Button
-              size="small"
-              color="inherit"
-              onClick={() => closeSnackbar(snackbarKey)}
-            >
-              Dismiss
-            </Button>
-          ),
+          persist: true,
         },
       )
       logPremiumUiEvent("dedicated_instance_ready", {

--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -57,7 +57,19 @@ const PremiumNotificationManager: FC = () => {
           "You now have dedicated compute resources.",
         {
           variant: "success",
-          autoHideDuration: 5000,
+          // Longer than the default toast lifetime so a transient warning
+          // popup during the dedicated ALB warm-up (issue #575) cannot
+          // overwrite the confirmation before the user reads it.
+          autoHideDuration: 10000,
+          action: (snackbarKey) => (
+            <Button
+              size="small"
+              color="inherit"
+              onClick={() => closeSnackbar(snackbarKey)}
+            >
+              Dismiss
+            </Button>
+          ),
         },
       )
       logPremiumUiEvent("dedicated_instance_ready", {
@@ -74,6 +86,7 @@ const PremiumNotificationManager: FC = () => {
     hasShownAssignmentSuccess,
     lastAssignmentId,
     enqueueSnackbar,
+    closeSnackbar,
   ])
 
   // Show waiting snackbar when premium user does not have a dedicated instance.

--- a/frontend/src/components/Premium/PremiumNotificationManager.tsx
+++ b/frontend/src/components/Premium/PremiumNotificationManager.tsx
@@ -13,11 +13,6 @@ import { Button } from "@mui/material"
 import { logPremiumUiEvent } from "api/premium/PremiumAssignmentApi"
 import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
-// sessionStorage key — tracks the instance_id we've already notified about
-// for this browser session. Cleared automatically when the tab closes,
-// so a fresh login always shows one confirmation. Replaces the old
-// `wasWaiting` gate, which incorrectly suppressed the snackbar when the
-// user was already-assigned at login (no waiting popup ever shown).
 const SS_NOTIFIED_INSTANCE_KEY = "premium_notified_instance_id"
 
 function ssGetNotifiedInstance(): string | null {
@@ -63,18 +58,8 @@ const PremiumNotificationManager: FC = () => {
   const hasDedicatedInstance =
     assignmentResult?.assigned && !assignmentResult?.is_shared
 
-  // Show success notification when premium instance is assigned.
-  //
-  // Gating: fire once per browser session per instance_id. We use
-  // sessionStorage instead of relying on the in-component `lastAssignmentId`
-  // state because that state resets on every page refresh, which would
-  // re-fire the snackbar. sessionStorage clears when the tab closes,
-  // so the next session sees a fresh confirmation.
-  //
-  // We do NOT require the waiting popup to have been shown first — that
-  // gate (`wasWaiting`) used to suppress the snackbar on refresh, but it
-  // also incorrectly suppressed it when the user was already-assigned at
-  // login (the autoAssignOnLogin "already assigned" path skips isAssigning).
+  // Fire once per session per instance_id. sessionStorage survives refresh;
+  // component state doesn't.
   useEffect(() => {
     const instanceId = assignmentResult?.instance_id
     const alreadyNotifiedThisSession =
@@ -114,9 +99,7 @@ const PremiumNotificationManager: FC = () => {
     closeSnackbar,
   ])
 
-  // Show waiting snackbar when premium user does not have a dedicated instance.
-  // Two triggers: isAssigning (assignment API in flight) or assignmentResult
-  // shows a shared instance. Gate prevents flash on refresh before status check.
+  // `assignmentResult &&` gates on having fetched status — avoids a flash on refresh.
   useEffect(() => {
     const needsWaiting =
       isAssigning || (assignmentResult && !hasDedicatedInstance)

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -133,10 +133,18 @@ describe("PremiumNotificationManager — unreachable snackbar", () => {
     snackbarLog = []
     snackbarKeyCounter = 0
     mockCtxValue = baseCtx()
-    // Clear sessionStorage so the success-snackbar's per-session
-    // `premium_notified_instance_id` gate doesn't bleed across tests.
+    // These tests focus on the unreachable snackbar. baseCtx has a
+    // fully-assigned dedicated instance, which would also trigger the
+    // success snackbar on first render. Pre-mark the session as already
+    // notified for this instance_id so only the unreachable snackbar
+    // appears — mirroring the realistic state where unreachable events
+    // arrive after the user has already seen the assignment confirmation.
     try {
       sessionStorage.clear()
+      sessionStorage.setItem(
+        "premium_notified_instance_id",
+        baseCtx().assignmentResult!.instance_id!,
+      )
     } catch {
       // sessionStorage unavailable in this environment
     }

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -133,12 +133,8 @@ describe("PremiumNotificationManager — unreachable snackbar", () => {
     snackbarLog = []
     snackbarKeyCounter = 0
     mockCtxValue = baseCtx()
-    // These tests focus on the unreachable snackbar. baseCtx has a
-    // fully-assigned dedicated instance, which would also trigger the
-    // success snackbar on first render. Pre-mark the session as already
-    // notified for this instance_id so only the unreachable snackbar
-    // appears — mirroring the realistic state where unreachable events
-    // arrive after the user has already seen the assignment confirmation.
+    // Pre-mark this instance_id as already notified so the success snackbar
+    // doesn't fire — focus of this suite is the unreachable snackbar.
     try {
       sessionStorage.clear()
       sessionStorage.setItem(
@@ -146,7 +142,7 @@ describe("PremiumNotificationManager — unreachable snackbar", () => {
         baseCtx().assignmentResult!.instance_id!,
       )
     } catch {
-      // sessionStorage unavailable in this environment
+      /* sessionStorage unavailable */
     }
 
     mockEnqueueSnackbar.mockImplementation(
@@ -318,12 +314,11 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     snackbarLog = []
     snackbarKeyCounter = 0
     mockCtxValue = baseCtx()
-    // Clear sessionStorage so the success-snackbar's per-session
-    // `premium_notified_instance_id` gate doesn't bleed across tests.
+    // Clear the per-session notification flag between tests.
     try {
       sessionStorage.clear()
     } catch {
-      // sessionStorage unavailable in this environment
+      /* sessionStorage unavailable */
     }
 
     mockEnqueueSnackbar.mockImplementation(
@@ -340,12 +335,8 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     )
   })
 
-  // Renders the component, then transitions to a dedicated assignment.
-  // The success branch fires when (a) hasDedicatedInstance becomes true,
-  // (b) instance_id differs from `lastAssignmentId` (initial null), and
-  // (c) the per-session sessionStorage flag is not yet set for this id.
+  // Renders on shared, then transitions to dedicated — fires the success branch.
   const renderAndMigrate = () => {
-    // Start on shared so the waiting snackbar is enqueued.
     mockCtxValue = {
       ...baseCtx(),
       assignmentResult: {
@@ -356,7 +347,6 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     }
     const { rerender } = render(<PremiumNotificationManager />)
 
-    // Now flip to a dedicated assignment — fires success branch.
     mockCtxValue = {
       ...mockCtxValue,
       assignmentResult: {

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -133,6 +133,13 @@ describe("PremiumNotificationManager — unreachable snackbar", () => {
     snackbarLog = []
     snackbarKeyCounter = 0
     mockCtxValue = baseCtx()
+    // Clear sessionStorage so the success-snackbar's per-session
+    // `premium_notified_instance_id` gate doesn't bleed across tests.
+    try {
+      sessionStorage.clear()
+    } catch {
+      // sessionStorage unavailable in this environment
+    }
 
     mockEnqueueSnackbar.mockImplementation(
       (message: string, options?: Record<string, unknown>) => {
@@ -303,6 +310,13 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     snackbarLog = []
     snackbarKeyCounter = 0
     mockCtxValue = baseCtx()
+    // Clear sessionStorage so the success-snackbar's per-session
+    // `premium_notified_instance_id` gate doesn't bleed across tests.
+    try {
+      sessionStorage.clear()
+    } catch {
+      // sessionStorage unavailable in this environment
+    }
 
     mockEnqueueSnackbar.mockImplementation(
       (message: string, options?: Record<string, unknown>) => {
@@ -318,8 +332,10 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     )
   })
 
-  // The success branch needs (a) the waiting popup to have been shown first
-  // (wasWaiting = true) and (b) a transition to a dedicated assignment.
+  // Renders the component, then transitions to a dedicated assignment.
+  // The success branch fires when (a) hasDedicatedInstance becomes true,
+  // (b) instance_id differs from `lastAssignmentId` (initial null), and
+  // (c) the per-session sessionStorage flag is not yet set for this id.
   const renderAndMigrate = () => {
     // Start on shared so the waiting snackbar is enqueued.
     mockCtxValue = {

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -370,7 +370,7 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     })
   }
 
-  test("success snackbar uses 10s autoHideDuration and exposes a Dismiss action", () => {
+  test("success snackbar persists and inherits the default close action", () => {
     renderAndMigrate()
 
     const successCall = snackbarLog.find((c) =>
@@ -378,22 +378,8 @@ describe("PremiumNotificationManager — assignment success snackbar", () => {
     )
     expect(successCall).toBeDefined()
     expect(successCall?.options?.variant).toBe("success")
-    expect(successCall?.options?.autoHideDuration).toBe(10000)
-    expect(typeof successCall?.options?.action).toBe("function")
-  })
-
-  test("clicking Dismiss on the success snackbar closes it", () => {
-    renderAndMigrate()
-
-    const successCall = snackbarLog.find((c) =>
-      c.message.includes("Premium instance assigned successfully"),
-    )!
-    expect(typeof successCall.options?.action).toBe("function")
-
-    const actionEl = successCall.options!.action!(successCall.key)
-    const { getByRole } = render(<>{actionEl}</>)
-    fireEvent.click(getByRole("button", { name: /dismiss/i }))
-
-    expect(mockCloseSnackbar).toHaveBeenCalledWith(successCall.key)
+    expect(successCall?.options?.persist).toBe(true)
+    expect(successCall?.options?.autoHideDuration).toBeUndefined()
+    expect(successCall?.options?.action).toBeUndefined()
   })
 })

--- a/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
+++ b/frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
@@ -21,6 +21,8 @@ type SnackbarCall = {
   message: string
   options?: {
     variant?: string
+    autoHideDuration?: number
+    persist?: boolean
     action?: (key: string | number) => React.ReactNode
   }
 }
@@ -292,5 +294,82 @@ describe("PremiumNotificationManager — unreachable snackbar", () => {
       "instance_unreachable_popup_dismissed",
       expect.objectContaining({ reason: "not_premium" }),
     )
+  })
+})
+
+describe("PremiumNotificationManager — assignment success snackbar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    snackbarLog = []
+    snackbarKeyCounter = 0
+    mockCtxValue = baseCtx()
+
+    mockEnqueueSnackbar.mockImplementation(
+      (message: string, options?: Record<string, unknown>) => {
+        snackbarKeyCounter += 1
+        const key = snackbarKeyCounter
+        snackbarLog.push({
+          key,
+          message,
+          options: options as SnackbarCall["options"],
+        })
+        return key
+      },
+    )
+  })
+
+  // The success branch needs (a) the waiting popup to have been shown first
+  // (wasWaiting = true) and (b) a transition to a dedicated assignment.
+  const renderAndMigrate = () => {
+    // Start on shared so the waiting snackbar is enqueued.
+    mockCtxValue = {
+      ...baseCtx(),
+      assignmentResult: {
+        instance_id: "shared-pool",
+        assigned: true,
+        is_shared: true,
+      },
+    }
+    const { rerender } = render(<PremiumNotificationManager />)
+
+    // Now flip to a dedicated assignment — fires success branch.
+    mockCtxValue = {
+      ...mockCtxValue,
+      assignmentResult: {
+        instance_id: "inst-A",
+        assigned: true,
+        is_shared: false,
+      },
+    }
+    act(() => {
+      rerender(<PremiumNotificationManager />)
+    })
+  }
+
+  test("success snackbar uses 10s autoHideDuration and exposes a Dismiss action", () => {
+    renderAndMigrate()
+
+    const successCall = snackbarLog.find((c) =>
+      c.message.includes("Premium instance assigned successfully"),
+    )
+    expect(successCall).toBeDefined()
+    expect(successCall?.options?.variant).toBe("success")
+    expect(successCall?.options?.autoHideDuration).toBe(10000)
+    expect(typeof successCall?.options?.action).toBe("function")
+  })
+
+  test("clicking Dismiss on the success snackbar closes it", () => {
+    renderAndMigrate()
+
+    const successCall = snackbarLog.find((c) =>
+      c.message.includes("Premium instance assigned successfully"),
+    )!
+    expect(typeof successCall.options?.action).toBe("function")
+
+    const actionEl = successCall.options!.action!(successCall.key)
+    const { getByRole } = render(<>{actionEl}</>)
+    fireEvent.click(getByRole("button", { name: /dismiss/i }))
+
+    expect(mockCloseSnackbar).toHaveBeenCalledWith(successCall.key)
   })
 })

--- a/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
+++ b/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
@@ -62,6 +62,7 @@ jest.mock("utils/crossTabSync", () => {
 // --- Imports (after mocks) ---
 // require() not import: static imports hoist above mock vars and cause TDZ when factories run.
 const {
+  DEDICATED_HANDOFF_GRACE_MS,
   INITIAL_PROBE_DELAY_MS,
   LS_UNREACHABLE_SNAPSHOT,
 }: typeof import("contexts/premium/unreachableConstants") =
@@ -97,6 +98,13 @@ const dedicated: PremiumAssignmentResult = {
   instance_id: "inst-A",
   assigned: true,
   is_shared: false,
+}
+
+const shared: PremiumAssignmentResult = {
+  message: "ok",
+  instance_id: "shared-pool",
+  assigned: true,
+  is_shared: true,
 }
 
 const renderHook = (opts: {
@@ -245,6 +253,165 @@ describe("useInstanceUnreachableMachine — leader-gated side effects", () => {
     expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
       "instance_probe_armed",
       expect.anything(),
+    )
+  })
+})
+
+describe("useInstanceUnreachableMachine — dedicated handoff warm-up grace", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test("first 5xx within grace after shared → dedicated transition is suppressed", () => {
+    jest.useFakeTimers()
+
+    // Start on shared, then flip to dedicated — that flip starts the grace.
+    const { ref, rerender } = renderHook({ assignment: shared })
+    act(() => {
+      rerender({ assignment: dedicated })
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS - 1)
+      routingService.emitPremiumUnreachable({
+        url: "/api/run",
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_warmup_suppressed",
+      expect.objectContaining({
+        instance_id: "inst-A",
+        url: "/api/run",
+        status: 503,
+      }),
+    )
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+  })
+
+  test("5xx after grace expires flips to unreachable as normal", () => {
+    jest.useFakeTimers()
+
+    const { ref, rerender } = renderHook({ assignment: shared })
+    act(() => {
+      rerender({ assignment: dedicated })
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS + 1)
+      routingService.emitPremiumUnreachable({
+        url: "/api/run",
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.objectContaining({ instance_id: "inst-A", status: 503 }),
+    )
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_unreachable_warmup_suppressed",
+      expect.anything(),
+    )
+  })
+
+  test("grace is single-shot: a second 5xx within the window is NOT suppressed", () => {
+    jest.useFakeTimers()
+
+    const { ref, rerender } = renderHook({ assignment: shared })
+    act(() => {
+      rerender({ assignment: dedicated })
+    })
+
+    // First 5xx within grace — suppressed.
+    act(() => {
+      jest.advanceTimersByTime(1000)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+
+    // Second 5xx still within the original grace window — must flip.
+    act(() => {
+      jest.advanceTimersByTime(1000)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_warmup_suppressed",
+      expect.anything(),
+    )
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+  })
+
+  test("dedicated reassignment to a different instance starts a fresh grace", () => {
+    jest.useFakeTimers()
+
+    const { ref, rerender } = renderHook({ assignment: shared })
+    act(() => {
+      rerender({ assignment: dedicated })
+    })
+
+    // Burn the first grace.
+    act(() => {
+      jest.advanceTimersByTime(1000)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+
+    // Reassign onto a different dedicated instance — should re-arm grace and clear state.
+    const dedicatedB: PremiumAssignmentResult = {
+      ...dedicated,
+      instance_id: "inst-B",
+    }
+    act(() => {
+      rerender({ assignment: dedicatedB })
+    })
+
+    // First 5xx after reassignment, well within new grace.
+    act(() => {
+      jest.advanceTimersByTime(2000)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+    // Two separate suppression events — one per dedicated transition.
+    const suppressedCalls = mockLogPremiumUiEvent.mock.calls.filter(
+      ([event]) => event === "instance_unreachable_warmup_suppressed",
+    )
+    expect(suppressedCalls).toHaveLength(2)
+    expect(suppressedCalls[1][1]).toEqual(
+      expect.objectContaining({ instance_id: "inst-B" }),
     )
   })
 })

--- a/frontend/src/contexts/premium/unreachableConstants.ts
+++ b/frontend/src/contexts/premium/unreachableConstants.ts
@@ -4,11 +4,8 @@ export const MAX_PROBE_DELAY_MS = 300000
 export const PROBE_BACKOFF_MULTIPLIER = 2
 export const MAX_FAILED_PROBES = 5
 
-// Suppress the first instance_unreachable signal for this long after a
-// shared → dedicated transition (or a dedicated reassignment to a different
-// instance). The dedicated ALB target group can return a single transient
-// 5xx during warm-up, which is not a true outage and should not overwrite
-// the success toast with a warning popup.
+// Window to absorb a single transient 5xx after a dedicated handoff —
+// the dedicated ALB target group can flap once during warm-up.
 export const DEDICATED_HANDOFF_GRACE_MS = 15000
 
 // localStorage fallback because BroadcastChannel doesn't replay past messages to new tabs.

--- a/frontend/src/contexts/premium/unreachableConstants.ts
+++ b/frontend/src/contexts/premium/unreachableConstants.ts
@@ -4,6 +4,13 @@ export const MAX_PROBE_DELAY_MS = 300000
 export const PROBE_BACKOFF_MULTIPLIER = 2
 export const MAX_FAILED_PROBES = 5
 
+// Suppress the first instance_unreachable signal for this long after a
+// shared → dedicated transition (or a dedicated reassignment to a different
+// instance). The dedicated ALB target group can return a single transient
+// 5xx during warm-up, which is not a true outage and should not overwrite
+// the success toast with a warning popup.
+export const DEDICATED_HANDOFF_GRACE_MS = 15000
+
 // localStorage fallback because BroadcastChannel doesn't replay past messages to new tabs.
 export const LS_UNREACHABLE_SNAPSHOT = "premium_unreachable_snapshot"
 export const UNREACHABLE_SNAPSHOT_TTL_MS = 60 * 60 * 1000

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -5,6 +5,7 @@ import {
   PremiumAssignmentResult,
 } from "api/premium/PremiumAssignmentApi"
 import {
+  DEDICATED_HANDOFF_GRACE_MS,
   LS_UNREACHABLE_SNAPSHOT,
   MAX_FAILED_PROBES,
   UNREACHABLE_SNAPSHOT_TTL_MS,
@@ -91,6 +92,16 @@ export function useInstanceUnreachableMachine({
   const lastReachableSentAtRef = useRef(0)
   // Last dedicated instance_id — lets the effect below detect a reassignment to a different instance.
   const prevDedicatedInstanceIdRef = useRef<string | undefined>(undefined)
+  // True once we have observed any non-dedicated assignment during this hook
+  // lifetime. Distinguishes "user just migrated from shared → dedicated"
+  // (grace needed) from "page mounted with the user already on dedicated"
+  // (no migration, no grace) — without this flag the first dedicated
+  // assignment seen on mount would falsely arm the grace.
+  const hasSeenNonDedicatedRef = useRef(false)
+  // Timestamp of the most recent shared → dedicated transition (or a dedicated
+  // reassignment onto a different instance_id). Used to suppress a transient
+  // first 5xx during the new dedicated ALB's warm-up — see issue #575.
+  const dedicatedSinceRef = useRef<number | null>(null)
 
   // Consolidated state → refs mirror (one effect for three refs).
   useEffect(() => {
@@ -106,6 +117,14 @@ export function useInstanceUnreachableMachine({
 
     if (shouldClearUnreachableForAssignment(assignment)) {
       prevDedicatedInstanceIdRef.current = undefined
+      dedicatedSinceRef.current = null
+      // Track that this lifetime has seen a non-dedicated state — needed to
+      // distinguish a shared → dedicated migration from an initial mount.
+      // Only counts when there is actually an assignment object; a null
+      // assignment is "we don't know yet", not "user is on shared".
+      if (assignment != null) {
+        hasSeenNonDedicatedRef.current = true
+      }
       if (unreachableRef.current || probingRef.current) {
         unreachableRef.current = false
         probingRef.current = false
@@ -125,6 +144,17 @@ export function useInstanceUnreachableMachine({
       failedProbesRef.current = 0
       dispatch({ type: "CLEAR" })
       routingService.setPremiumAssigned(true)
+      // Reassignment onto a different dedicated instance — start a fresh grace.
+      dedicatedSinceRef.current = Date.now()
+    } else if (
+      isDedicated &&
+      prevDedicatedInstanceIdRef.current === undefined &&
+      hasSeenNonDedicatedRef.current
+    ) {
+      // True shared → dedicated migration during this hook lifetime: arm the
+      // grace. NOT armed when the page just mounted with the user already on
+      // a dedicated instance, since there is no ALB warm-up to absorb.
+      dedicatedSinceRef.current = Date.now()
     }
     prevDedicatedInstanceIdRef.current = assignment?.instance_id
   }, [assignment])
@@ -145,6 +175,29 @@ export function useInstanceUnreachableMachine({
           Date.now(),
         )
       ) {
+        return
+      }
+
+      // Warm-up grace: suppress the first 5xx that hits within
+      // DEDICATED_HANDOFF_GRACE_MS of a shared → dedicated transition (or
+      // dedicated reassignment). The dedicated ALB target group can return a
+      // single transient 5xx during warm-up that is not a true outage and
+      // would otherwise overwrite the success toast with a warning popup.
+      // Only applies before the machine has flipped to unreachable; once
+      // unreachable, normal probe semantics take over.
+      if (
+        !unreachableRef.current &&
+        dedicatedSinceRef.current !== null &&
+        Date.now() - dedicatedSinceRef.current < DEDICATED_HANDOFF_GRACE_MS
+      ) {
+        // Consume the grace once so subsequent failures during this transition
+        // window are treated normally.
+        dedicatedSinceRef.current = null
+        logPremiumUiEvent("instance_unreachable_warmup_suppressed", {
+          instance_id: a.instance_id ?? null,
+          url: detail.url ?? null,
+          status: detail.status ?? null,
+        })
         return
       }
 
@@ -367,6 +420,8 @@ export function useInstanceUnreachableMachine({
     hasEverBeenUnreachableRef.current = false
     lastReachableSentAtRef.current = 0
     prevDedicatedInstanceIdRef.current = undefined
+    hasSeenNonDedicatedRef.current = false
+    dedicatedSinceRef.current = null
     dispatch({ type: "CLEAR" })
     lsWriteUnreachableSnapshot(null)
   }, [])

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -100,7 +100,7 @@ export function useInstanceUnreachableMachine({
   const hasSeenNonDedicatedRef = useRef(false)
   // Timestamp of the most recent shared → dedicated transition (or a dedicated
   // reassignment onto a different instance_id). Used to suppress a transient
-  // first 5xx during the new dedicated ALB's warm-up — see issue #575.
+  // first 5xx during the new dedicated ALB's warm-up.
   const dedicatedSinceRef = useRef<number | null>(null)
 
   // Consolidated state → refs mirror (one effect for three refs).

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -92,15 +92,10 @@ export function useInstanceUnreachableMachine({
   const lastReachableSentAtRef = useRef(0)
   // Last dedicated instance_id — lets the effect below detect a reassignment to a different instance.
   const prevDedicatedInstanceIdRef = useRef<string | undefined>(undefined)
-  // True once we have observed any non-dedicated assignment during this hook
-  // lifetime. Distinguishes "user just migrated from shared → dedicated"
-  // (grace needed) from "page mounted with the user already on dedicated"
-  // (no migration, no grace) — without this flag the first dedicated
-  // assignment seen on mount would falsely arm the grace.
+  // Distinguishes a true shared → dedicated migration from an initial mount
+  // already on dedicated (no warm-up to absorb in the latter).
   const hasSeenNonDedicatedRef = useRef(false)
-  // Timestamp of the most recent shared → dedicated transition (or a dedicated
-  // reassignment onto a different instance_id). Used to suppress a transient
-  // first 5xx during the new dedicated ALB's warm-up.
+  // Timestamp of the most recent shared → dedicated transition.
   const dedicatedSinceRef = useRef<number | null>(null)
 
   // Consolidated state → refs mirror (one effect for three refs).
@@ -118,10 +113,7 @@ export function useInstanceUnreachableMachine({
     if (shouldClearUnreachableForAssignment(assignment)) {
       prevDedicatedInstanceIdRef.current = undefined
       dedicatedSinceRef.current = null
-      // Track that this lifetime has seen a non-dedicated state — needed to
-      // distinguish a shared → dedicated migration from an initial mount.
-      // Only counts when there is actually an assignment object; a null
-      // assignment is "we don't know yet", not "user is on shared".
+      // Only a concrete assignment counts — null is "unknown", not shared.
       if (assignment != null) {
         hasSeenNonDedicatedRef.current = true
       }
@@ -151,9 +143,7 @@ export function useInstanceUnreachableMachine({
       prevDedicatedInstanceIdRef.current === undefined &&
       hasSeenNonDedicatedRef.current
     ) {
-      // True shared → dedicated migration during this hook lifetime: arm the
-      // grace. NOT armed when the page just mounted with the user already on
-      // a dedicated instance, since there is no ALB warm-up to absorb.
+      // Shared → dedicated migration: arm the warm-up grace.
       dedicatedSinceRef.current = Date.now()
     }
     prevDedicatedInstanceIdRef.current = assignment?.instance_id
@@ -178,20 +168,13 @@ export function useInstanceUnreachableMachine({
         return
       }
 
-      // Warm-up grace: suppress the first 5xx that hits within
-      // DEDICATED_HANDOFF_GRACE_MS of a shared → dedicated transition (or
-      // dedicated reassignment). The dedicated ALB target group can return a
-      // single transient 5xx during warm-up that is not a true outage and
-      // would otherwise overwrite the success toast with a warning popup.
-      // Only applies before the machine has flipped to unreachable; once
-      // unreachable, normal probe semantics take over.
+      // Single-shot warm-up grace — absorbs one transient 5xx within
+      // DEDICATED_HANDOFF_GRACE_MS of a handoff before flipping unreachable.
       if (
         !unreachableRef.current &&
         dedicatedSinceRef.current !== null &&
         Date.now() - dedicatedSinceRef.current < DEDICATED_HANDOFF_GRACE_MS
       ) {
-        // Consume the grace once so subsequent failures during this transition
-        // window are treated normally.
         dedicatedSinceRef.current = null
         logPremiumUiEvent("instance_unreachable_warmup_suppressed", {
           instance_id: a.instance_id ?? null,

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -369,7 +369,7 @@ The authoritative reference. Branches are explicit; toast text matches the strin
 | Leader-tab election | `frontend/src/utils/crossTabSync.ts` -- localStorage key `"premium_poll_leader"`, 2s heartbeat, 5s timeout |
 | Poll config | constants in `PremiumAssignmentContext.tsx`: `INITIAL_POLL_INTERVAL_MS=30000`, `MAX_POLL_INTERVAL_MS=60000`, `MAX_POLL_ATTEMPTS=40`, `BACKOFF_MULTIPLIER=1.5`, `ERROR_BACKOFF_MULTIPLIER=2` |
 | Polling gate | `shouldPoll()` in `PremiumAssignmentContext.tsx`: polls while premium+leader+assignment exists and the assignment is not dedicated-and-healthy. Re-enables polling while `instanceUnreachable` is true so a backend reassignment to shared or to a new instance is still caught |
-| Unreachable detection + probe config | `unreachableMachineReducer` and constants in `frontend/src/contexts/premium/unreachableConstants.ts`: `INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`, `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5`, `DEDICATED_HANDOFF_GRACE_MS=15000` (single-shot suppression of the first 5xx after a shared → dedicated transition or dedicated reassignment, to avoid false-positive unreachable popups during ALB target-group warm-up — issue #575) |
+| Unreachable detection + probe config | `unreachableMachineReducer` and constants in `frontend/src/contexts/premium/unreachableConstants.ts`: `INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`, `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5`, `DEDICATED_HANDOFF_GRACE_MS=15000` (single-shot suppression of the first 5xx after a shared → dedicated transition or dedicated reassignment, to avoid false-positive unreachable popups during ALB target-group warm-up) |
 | Inactivity thresholds | 1h/2h hardcoded in context; countdown length `INACTIVITY_WARNING_DURATION_MINUTES=60` and `WARNING_UPDATE_INTERVAL_MS=60000` from `frontend/src/const/Subscription.ts` |
 | Heartbeat retry | `HEARTBEAT_MAX_RETRIES=3`, `HEARTBEAT_RETRY_DELAY_MS=1000`; delay between attempts is `DELAY * (attempt + 1)` |
 | 401 session-expired UI | `InactivityWarning.tsx` -- AxiosError + status 401 path, 2 s setTimeout then `performLogout()` |
@@ -1181,7 +1181,7 @@ Handles user notifications for premium assignment events using notistack.
 
 | Event | Variant | Message | Behavior |
 |-------|---------|---------|----------|
-| Dedicated instance assigned | `success` | "Premium instance assigned successfully!" | Auto-dismiss after 10s, plus a `Dismiss` action — duration was bumped from 5s and the action added so the toast cannot be visually overwritten by a transient warning popup during the dedicated ALB warm-up (issue #575) |
+| Dedicated instance assigned | `success` | "Premium instance assigned successfully!" | Persistent so a transient warning popup during the dedicated ALB warm-up cannot visually overwrite the toast; user must click the default close "X" inherited from `SnackbarProvider` |
 | No dedicated instance yet | `info` | "Please wait while your dedicated premium resource is being prepared." | Persistent |
 | Assignment error (non-scaling) | `warning` | "Premium assignment issue: {error}" | Auto-dismiss |
 | Scaling/retry errors | (suppressed) | N/A | Silently ignored |

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -369,7 +369,7 @@ The authoritative reference. Branches are explicit; toast text matches the strin
 | Leader-tab election | `frontend/src/utils/crossTabSync.ts` -- localStorage key `"premium_poll_leader"`, 2s heartbeat, 5s timeout |
 | Poll config | constants in `PremiumAssignmentContext.tsx`: `INITIAL_POLL_INTERVAL_MS=30000`, `MAX_POLL_INTERVAL_MS=60000`, `MAX_POLL_ATTEMPTS=40`, `BACKOFF_MULTIPLIER=1.5`, `ERROR_BACKOFF_MULTIPLIER=2` |
 | Polling gate | `shouldPoll()` in `PremiumAssignmentContext.tsx`: polls while premium+leader+assignment exists and the assignment is not dedicated-and-healthy. Re-enables polling while `instanceUnreachable` is true so a backend reassignment to shared or to a new instance is still caught |
-| Unreachable detection + probe config | `unreachableMachineReducer` and constants in `PremiumAssignmentContext.tsx`: `INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`, `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5` |
+| Unreachable detection + probe config | `unreachableMachineReducer` and constants in `frontend/src/contexts/premium/unreachableConstants.ts`: `INITIAL_PROBE_DELAY_MS=30000`, `MAX_PROBE_DELAY_MS=300000`, `PROBE_BACKOFF_MULTIPLIER=2`, `MAX_FAILED_PROBES=5`, `DEDICATED_HANDOFF_GRACE_MS=15000` (single-shot suppression of the first 5xx after a shared → dedicated transition or dedicated reassignment, to avoid false-positive unreachable popups during ALB target-group warm-up — issue #575) |
 | Inactivity thresholds | 1h/2h hardcoded in context; countdown length `INACTIVITY_WARNING_DURATION_MINUTES=60` and `WARNING_UPDATE_INTERVAL_MS=60000` from `frontend/src/const/Subscription.ts` |
 | Heartbeat retry | `HEARTBEAT_MAX_RETRIES=3`, `HEARTBEAT_RETRY_DELAY_MS=1000`; delay between attempts is `DELAY * (attempt + 1)` |
 | 401 session-expired UI | `InactivityWarning.tsx` -- AxiosError + status 401 path, 2 s setTimeout then `performLogout()` |
@@ -1181,7 +1181,7 @@ Handles user notifications for premium assignment events using notistack.
 
 | Event | Variant | Message | Behavior |
 |-------|---------|---------|----------|
-| Dedicated instance assigned | `success` | "Premium instance assigned successfully!" | Auto-dismiss |
+| Dedicated instance assigned | `success` | "Premium instance assigned successfully!" | Auto-dismiss after 10s, plus a `Dismiss` action — duration was bumped from 5s and the action added so the toast cannot be visually overwritten by a transient warning popup during the dedicated ALB warm-up (issue #575) |
 | No dedicated instance yet | `info` | "Please wait while your dedicated premium resource is being prepared." | Persistent |
 | Assignment error (non-scaling) | `warning` | "Premium assignment issue: {error}" | Auto-dismiss |
 | Scaling/retry errors | (suppressed) | N/A | Silently ignored |
@@ -1425,6 +1425,20 @@ event=instance_unreachable_manual_retry details={'instance_id': '${i-xxx}'}   (u
 ```
 
 **Verdict:** a single `instance_unreachable` followed within seconds by `instance_reachable` is a blip (cold-start, ALB reroute, or task restart-in-place). The **problem** pattern is (a) `instance_probe_failure` climbing to `failed_probes=5` and staying terminal, or (b) repeated unreachable/reachable cycles for the same `instance_id` within minutes -- points to flapping at the target-group or task layer.
+
+#### A.1.7a Warm-up suppression: `instance_unreachable_warmup_suppressed`
+
+Within `DEDICATED_HANDOFF_GRACE_MS` (15s) of a shared → dedicated transition or a dedicated reassignment to a different `instance_id`, the **first** 5xx on a premium-routed request is suppressed: the unreachable state machine does not flip, the warning popup is not shown, and the user keeps reading the success toast. The grace is single-shot — a second 5xx within the same window is treated normally and will flip to unreachable.
+
+The trace looks like:
+
+```
+Premium UI event: ... event=instance_unreachable_warmup_suppressed details={'instance_id': '${i-xxx}', 'url': '${path}', 'status': 503}
+```
+
+Followed (in the healthy case) by an `instance_reachable` event the next time the user makes a successful premium-routed request.
+
+**Expected:** zero or one `instance_unreachable_warmup_suppressed` per migration. **Investigate** if you see two or more for the same `instance_id` (the grace is single-shot, so the second event means the new dedicated instance is genuinely flapping during warm-up, not just doing a one-shot ALB target-health blip).
 
 ### A.2 Heartbeat Retry: Is `Attempt 3/3` a Problem?
 


### PR DESCRIPTION
# Fix: premium success snackbar can be missed during shared → dedicated migration

Closes #575.

## Summary

During a shared → dedicated premium migration, the *"Premium instance assigned successfully!"* success toast could be visually overwritten by an *"instance unreachable"* warning popup that fired when the very first request after the dedicated handoff hit a 503 during the dedicated ALB target group's warm-up.

This PR fixes the race in two layers:

1. **Root cause** — suppress the first 5xx in a 15-second grace window after a real shared → dedicated transition (or a dedicated reassignment to a different instance). The state machine no longer flips to `unreachable` on the warm-up blip; we log `instance_unreachable_warmup_suppressed` for observability and let the next response confirm reachability.
2. **Defense in depth** — the success snackbar's `autoHideDuration` is bumped from 5s to 10s and now ships a `Dismiss` action so the user has more time to read it and a way to keep it visible.

The migration itself was already correct: the Lambda only returns `assigned: true && is_shared: false` after ECS reports the premium task as `RUNNING` on the target instance (see `check_instance_readiness_with_retry()` in `infrastructure/terraform/premium_manager_package/premium_manager.py`). The remaining hazard was the gap between *ECS task RUNNING* and *ALB target healthy*, which this PR closes on the frontend.

## Changes

### `frontend/src/contexts/premium/unreachableConstants.ts`

Add `DEDICATED_HANDOFF_GRACE_MS = 15000`.

### `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts`

- Track `dedicatedSinceRef` on real shared → dedicated transitions and on dedicated reassignment to a different `instance_id`.
- Add a `hasSeenNonDedicatedRef` guard so an initial mount onto an already-dedicated instance does not falsely arm the grace (we only suppress when there was a true transition during this hook lifetime).
- In `onPremiumUnreachable`: when the machine is not already unreachable and we are inside the grace window, consume the grace once, log `instance_unreachable_warmup_suppressed`, and return without flipping. The grace is single-shot — a second 5xx within the same window is treated normally.

### `frontend/src/components/Premium/PremiumNotificationManager.tsx`

- Success snackbar `autoHideDuration: 5000 → 10000`.
- Add a `Dismiss` action button (mirrors the existing Retry button on the terminal-unreachable snackbar).

### `frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx`

Four new tests for the warm-up grace:

- First 5xx within grace after shared → dedicated transition is suppressed.
- 5xx after grace expires flips to unreachable as normal.
- Grace is single-shot: a second 5xx within the window is **not** suppressed.
- Dedicated reassignment to a different instance starts a fresh grace.

### `frontend/src/components/Premium/__tests__/PremiumNotificationManager.test.tsx`

Two new tests for the success snackbar:

- Uses `autoHideDuration: 10000` and exposes a Dismiss action.
- Clicking Dismiss closes the snackbar.

### `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md`

- Notification Types row updated for the success snackbar (10s + Dismiss).
- Unreachable-machine config row updated to list `DEDICATED_HANDOFF_GRACE_MS` alongside the probe constants, and corrects the constants file path.
- New Log Playbook subsection `A.1.7a` covering `instance_unreachable_warmup_suppressed`: expected zero or one per migration; investigate if you see two or more for the same `instance_id` (the grace is single-shot, so a second event indicates real warm-up flapping rather than a one-shot blip).

## Why a time-based grace and not "≥2 consecutive 5xx"

The issue lists three candidate fixes:

- (a) Persist + Dismiss on the success toast.
- (b) Gate `instance_unreachable` on ≥2 consecutive 5xx, **or** suppress for N seconds after a dedicated transition.
- (c) Bump `autoHideDuration` to 10–15s.

This PR ships (a)+(b)+(c), with (b) implemented as the time-based variant.

The "≥2 consecutive 5xx" alternative would also delay legitimate unreachable detection during steady-state operation, regressing the existing probe lifecycle that the docs and tests are built around (see `MAX_FAILED_PROBES`, `INITIAL_PROBE_DELAY_MS` etc.). The time-based grace targets exactly the warm-up window the issue describes and leaves steady-state semantics unchanged.
