### PR TITLE
Fix: Prevent credential leak in custom AMI build pipeline

### DIFF
--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -82,6 +82,38 @@ phases:
               rm -rf /var/cache/yum
               echo "$(date): Cleanup complete"
 
+      # ---------------------------------------------------------------
+      # PlantTestCredentials + SanitizeCredentials form a paired test:
+      #   PlantTestCredentials creates dummy credential files, then
+      #   SanitizeCredentials removes them.  The subsequent
+      #   ValidateNoCredentialLeak step (in optinist-validate.yml)
+      #   confirms the removal succeeded.
+      #
+      # Without this synthetic canary, the validation step would only
+      # confirm "nothing is there when nothing was put there" — a
+      # vacuously true check that does not actually exercise the
+      # sanitization logic.
+      #
+      # The dummy values (AKIAIOSFODNN7EXAMPLE, etc.) are the
+      # well-known example keys from the AWS documentation and have
+      # no access to any real AWS resources.
+      # ---------------------------------------------------------------
+      - name: PlantTestCredentials
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "$(date): Planting dummy credentials to verify SanitizeCredentials step"
+              mkdir -p /root/.aws
+              cat > /root/.aws/credentials <<'CRED'
+              [default]
+              aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+              aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              CRED
+              echo "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE" >> /etc/environment
+              echo "$(date): Dummy credentials planted"
+
       - name: SanitizeCredentials
         action: ExecuteBash
         inputs:

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -81,3 +81,22 @@ phases:
               yum clean all
               rm -rf /var/cache/yum
               echo "$(date): Cleanup complete"
+
+      - name: SanitizeCredentials
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "$(date): Sanitizing credentials and sensitive data from AMI"
+              # Remove AWS credentials/config for all users
+              # -rf / -f: no error if files/dirs do not exist (exit code 0)
+              rm -rf /root/.aws /home/*/.aws
+              # Remove AWS credential env vars from persistent files
+              sed -i '/^AWS_ACCESS_KEY_ID/d;/^AWS_SECRET_ACCESS_KEY/d;/^AWS_SESSION_TOKEN/d;/^AWS_DEFAULT_REGION/d;/^AWS_PROFILE/d' /etc/environment 2>/dev/null || true
+              rm -f /etc/profile.d/aws-*.sh
+              # Remove shell histories (may contain secrets typed interactively)
+              rm -f /root/.bash_history /home/*/.bash_history
+              # Remove non-default SSH authorized keys
+              rm -f /root/.ssh/authorized_keys
+              echo "$(date): Credential sanitization complete"

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -89,6 +89,33 @@ phases:
                 exit 1
               fi
 
+      - name: ValidateNoCredentialLeak
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "=== Validating no credential leak in AMI ==="
+              FAILED=0
+              # Check for AWS credential/config directories
+              for dir in /root/.aws /home/*/.aws; do
+                if [ -d "$dir" ]; then
+                  echo "FAIL: AWS credential directory found: $dir"
+                  FAILED=1
+                fi
+              done
+              # Check for AWS credential env vars in persistent files
+              if grep -rq 'AWS_ACCESS_KEY_ID\|AWS_SECRET_ACCESS_KEY\|AWS_SESSION_TOKEN' \
+                 /etc/environment /etc/profile.d/ 2>/dev/null; then
+                echo "FAIL: AWS credential env vars found in system files"
+                FAILED=1
+              fi
+              if [ $FAILED -ne 0 ]; then
+                echo "Credential leak detected — aborting AMI build"
+                exit 1
+              fi
+              echo "OK: No credential leak detected"
+
   - name: test
     steps:
       - name: TestBakeMarkerPersisted
@@ -133,3 +160,30 @@ phases:
               else
                 echo "WARN: AWS CLI API call failed (expected if no instance role during test)"
               fi
+
+      - name: TestNoCredentialLeak
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "=== Testing no credential leak persisted in AMI ==="
+              FAILED=0
+              # Verify credential directories were not baked into the AMI
+              for dir in /root/.aws /home/*/.aws; do
+                if [ -d "$dir" ]; then
+                  echo "FAIL: AWS credential directory persisted in AMI: $dir"
+                  FAILED=1
+                fi
+              done
+              # Verify no credential env vars in persistent files
+              if grep -rq 'AWS_ACCESS_KEY_ID\|AWS_SECRET_ACCESS_KEY\|AWS_SESSION_TOKEN' \
+                 /etc/environment /etc/profile.d/ 2>/dev/null; then
+                echo "FAIL: AWS credential env vars persisted in AMI"
+                FAILED=1
+              fi
+              if [ $FAILED -ne 0 ]; then
+                echo "Credential leak persisted in AMI — build must be rejected"
+                exit 1
+              fi
+              echo "OK: No credential leak persisted in AMI"


### PR DESCRIPTION
## Problem

On 2026-04-30, a custom AMI (`ami-06d1436133576b7f8`) was built with AWS credentials from an unrelated account baked into the filesystem. The credentials were picked up by boto3's credential chain before the ECS task role, causing all `lambda.invoke("subscr-premium-manager")` calls to target the wrong account. AWS returned `ResourceNotFoundException` because the Lambda does not exist in an unrelated account.

**Impact:** Every `POST /users/me/premium/assign` and `GET /users/me/premium/status` failed silently for ~26 hours (803 error lines). The FastAPI handler caught the exception and returned HTTP 200 with a degraded payload, so monitoring did not detect the outage.

**Root cause:** The build pipeline had no credential sanitization or leak detection. When a developer's credentials were present on the build instance (likely via an SSM Session Manager session), EC2 Image Builder snapshotted the entire filesystem — including `/root/.aws/credentials` — into the AMI.

- The credential bake-in was **not intentional** — the build component YAML contains no `aws configure` or credential setup commands
- No AWS credentials are required during the build phase — only yum packages and the AWS CLI v2 binary are installed
- The build instance authenticates via its IAM Instance Profile, not static credentials
- This was an unintended side effect of interactive access to the build instance — most likely via SSM Session Manager, which is available because the build instance role includes `AmazonSSMManagedInstanceCore` — combined with the pipeline lacking a cleanup step for files outside its own scope

**Related issue:** #591

## Changes

### Modified files

- **`infrastructure/image_builder/components/optinist-packages.yml`** — Add `PlantTestCredentials` and `SanitizeCredentials` steps after `CleanupYumCache`:
  - `PlantTestCredentials`: Plants dummy AWS credentials (`AKIAIOSFODNN7EXAMPLE` — the well-known example key from AWS documentation, not a real key) as a synthetic canary. This step exists solely to verify that the subsequent `SanitizeCredentials` step actually works. Without it, the validation would only confirm "nothing is there when nothing was put there" — a vacuously true check.
  - `SanitizeCredentials`: Removes all credential files (including the dummy planted above), specifically:
  - `/root/.aws/` and `/home/*/.aws/` (AWS credential/config directories)
  - `AWS_*` credential env vars from `/etc/environment`
  - `/etc/profile.d/aws-*.sh` (shell profile credential persistence)
  - Shell history files (may contain interactively typed secrets)
  - `/root/.ssh/authorized_keys` (non-default SSH keys)

- **`infrastructure/image_builder/components/optinist-validate.yml`** — Add two credential leak validation steps:
  - `ValidateNoCredentialLeak` (build phase): Checks for credential directories and env vars **before** the AMI snapshot. Fails the build if any are found.
  - `TestNoCredentialLeak` (test phase): Re-checks on a **fresh instance launched from the AMI**, confirming no credentials persisted through the snapshot. Fails the build if any are found.

## Build pipeline execution order (after this change)

```
Build Phase
  ├── SystemUpdate
  ├── InstallYumPackages
  ├── InstallAWSCLIv2
  ├── EnableDockerService
  ├── CreateBakeMarker
  ├── CleanupYumCache
  ├── PlantTestCredentials         ← NEW: plant dummy credentials (canary)
  ├── SanitizeCredentials          ← NEW: remove all credentials (including dummy)
  ├── ValidateYumPackages
  ├── ValidateAWSCLIv2
  ├── ValidateDockerEnabled
  ├── ValidateBakeMarker
  ├── ValidateEFSUtils
  └── ValidateNoCredentialLeak     ← NEW: fail if credentials found
          ↓
      [AMI Snapshot]
          ↓
Test Phase (fresh instance from AMI)
  ├── TestBakeMarkerPersisted
  ├── TestDockerStarts
  ├── TestAWSCLIFunctional
  └── TestNoCredentialLeak         ← NEW: fail if credentials persisted
```

## Defense-in-depth strategy

| Layer | Mechanism | When |
|-------|-----------|------|
| 0. Canary | `PlantTestCredentials` plants dummy credentials to ensure layers 1-3 are not vacuously true | Before snapshot |
| 1. Removal | `SanitizeCredentials` deletes all credential files (real and dummy) | Before snapshot |
| 2. Pre-snapshot validation | `ValidateNoCredentialLeak` aborts build if removal missed anything | Before snapshot |
| 3. Post-snapshot validation | `TestNoCredentialLeak` confirms AMI is clean on a fresh boot | After snapshot |

Layer 0 guarantees that layers 1-3 are tested against actual credential files on every build, not just in the rare case where a developer accidentally leaves credentials behind.

## Post-merge action items

- [ ] Bump `custom_ami_version` in `terraform.tfvars` (e.g. `"1.0.0"` -> `"1.0.1"`)
- [ ] `terraform apply` to create new components/recipe
- [ ] Trigger AMI rebuild: `aws imagebuilder start-image-pipeline-execution --image-pipeline-arn <ARN>`
- [ ] Deregister the compromised AMI (`ami-06d1436133576b7f8`) and delete its snapshots
- [ ] Update SSM parameter with new AMI ID
- [ ] `terraform apply` to update launch templates

## Test plan

- [x] Trigger Image Builder pipeline execution with the updated components
- [x] Verify build completes successfully (SanitizeCredentials + ValidateNoCredentialLeak pass)
- [x] Verify test phase passes (TestNoCredentialLeak on fresh instance)
- [x] Launch an instance from the new AMI and confirm `ls /root/.aws/` returns "No such file or directory"
- [x] Confirm `aws sts get-caller-identity` on the ECS task returns valid credentials account ID (from task role, not baked credentials)
