### PR TITLE
Fix: Premium release-beacon & Multi-tab contamination

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,5 +131,6 @@
       "react-dnd-html5-backend": "react-dnd-html5-backend-cjs",
       "dnd-core": "dnd-core-cjs"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/frontend/src/api/premium/PremiumAssignmentApi.ts
+++ b/frontend/src/api/premium/PremiumAssignmentApi.ts
@@ -35,6 +35,7 @@ export interface PremiumAssignment {
   assigned_at: string
   status: string
   is_shared: boolean
+  assignment_source?: string
 }
 
 export interface PremiumStatusResult {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -804,7 +804,7 @@ export const PremiumAssignmentProvider: React.FC<{
     // synchronously-computed value derived from currentUser. Closes the
     // logout race where the mirror effect hasn't propagated yet on a
     // same-tab sign-out → sign-in flow, causing useLogout's gate to bail
-    // with stale state.isPremiumUser=false (ISSUE_5).
+    // with stale state.isPremiumUser=false
     isPremiumUser,
     assign,
     release,

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -485,6 +485,8 @@ export const PremiumAssignmentProvider: React.FC<{
           instance_id: statusResponse.assignment.instance_id,
           assigned: true,
           is_shared: statusResponse.assignment.is_shared,
+          assignment_source:
+            statusResponse.assignment.assignment_source ?? "existing",
         }
         setState((prev) => ({
           ...prev,
@@ -665,6 +667,9 @@ export const PremiumAssignmentProvider: React.FC<{
   // Listen for premium release events from other tabs (Cases 54-56)
   useEffect(() => {
     const unsubscribe = tabSync.on("PREMIUM_RELEASED", () => {
+      // Backend has already released this assignment; drop the local token
+      // so a later logout/beforeunload doesn't beacon a now-invalid token.
+      beaconTokenRef.current = null
       setState((prev) => ({
         ...prev,
         assignmentResult: null,
@@ -795,6 +800,12 @@ export const PremiumAssignmentProvider: React.FC<{
 
   const contextValue: PremiumAssignmentContextType = {
     ...state,
+    // Override state.isPremiumUser (mirror-effect-driven) with the
+    // synchronously-computed value derived from currentUser. Closes the
+    // logout race where the mirror effect hasn't propagated yet on a
+    // same-tab sign-out → sign-in flow, causing useLogout's gate to bail
+    // with stale state.isPremiumUser=false (ISSUE_5).
+    isPremiumUser,
     assign,
     release,
     getStatus,

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -6,6 +6,7 @@ import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 import { logout } from "store/slice/User/UserSlice"
 import { setLoggingOut } from "utils/axios"
 import { tabSync } from "utils/crossTabSync"
+import { flushErrors } from "utils/errorReporter"
 
 export const useLogout = () => {
   const dispatch = useDispatch()
@@ -23,6 +24,8 @@ export const useLogout = () => {
       if (broadcast) {
         tabSync.broadcastLogout()
       }
+
+      flushErrors()
 
       dispatch(logout())
       navigate("/login")

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -772,8 +772,8 @@ def _finalize_expired_pending_releases_transaction(connection):
                 (uid, PremiumAssignment.PENDING_RELEASE),
             )
             print(
-                f"Finalized pending_release: deleted user {uid} -> "
-                f"instance {assignment['instance_id']}"
+                f"[premium-trace] finalize-deleted user={uid} "
+                f"instance={assignment['instance_id']}"
             )
 
     return expired
@@ -5672,15 +5672,40 @@ def fix_incorrect_is_shared_flags(connection) -> Dict[str, Any]:
 
 @with_transaction
 def update_user_activity_timestamp(connection, user_id: int) -> bool:
-    """Update activity timestamp for a user with proper transaction isolation"""
+    """Update activity timestamp for a user with proper transaction isolation.
+
+    Also restores a row from `pending_release` back to `active` so an explicit
+    heartbeat from one tab heals a soft-release triggered by another tab's
+    close. Mirrors the user_activity_middleware behaviour. The instance_state
+    guard preserves the dead-EC2 escape valve.
+    """
     with connection.cursor() as cursor:
         cursor.execute(
             """
             UPDATE premium_user_assignments
-            SET last_activity = CURRENT_TIMESTAMP
-            WHERE user_id = %s AND is_standby = 0
-        """,
-            (user_id,),
+            SET last_activity = CURRENT_TIMESTAMP,
+                status = CASE
+                    WHEN status = %s THEN %s
+                    ELSE status
+                END
+            WHERE user_id = %s
+            AND status IN (%s, %s)
+            AND is_standby = 0
+            AND (
+                status = %s
+                OR instance_state IS NULL
+                OR instance_state NOT IN
+                    ('terminated','shutting-down','stopped','stopping')
+            )
+            """,
+            (
+                PremiumAssignment.PENDING_RELEASE,
+                PremiumAssignment.ACTIVE,
+                user_id,
+                PremiumAssignment.ACTIVE,
+                PremiumAssignment.PENDING_RELEASE,
+                PremiumAssignment.ACTIVE,
+            ),
         )
         return cursor.rowcount > 0
 

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -568,16 +568,26 @@ def _update_premium_user_activity_sync(user_id: int) -> bool:
         with session_scope() as session:
             now = datetime.now(timezone.utc)
 
-            # Update last_activity and reset heartbeat_failures
-            # Uses raw SQL for efficiency (no need to load full ORM object)
+            # Update last_activity and reset heartbeat_failures.
+            # Also restores a row from `terminating` (= PENDING_RELEASE) back to
+            # `active` so multi-tab close on Tab A doesn't silently finalize
+            # Tab B's still-active session during the 120s grace window.
             result = session.execute(
                 text(
                     """
                 UPDATE premium_user_assignments
-                SET last_activity = :now, heartbeat_failures = 0
+                SET last_activity = :now,
+                    status = 'active',
+                    heartbeat_failures = 0
                 WHERE user_id = :user_id
-                AND status = 'active'
+                AND status IN ('active', 'terminating')
                 AND is_standby = 0
+                AND (
+                    status = 'active'
+                    OR instance_state IS NULL
+                    OR instance_state NOT IN
+                        ('terminated','shutting-down','stopped','stopping')
+                )
                 """
                 ),
                 {"now": now, "user_id": user_id},

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -94,10 +94,14 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
             current_user.id, current_user.uid
         )
 
-        logger.debug(f"Assignment service result: {result}")
-        logger.debug(f"is_shared from service: {result.get('is_shared')}")
-        logger.debug(
-            f"assignment_source from service: {result.get('assignment_source')}"
+        logger.info(
+            "[premium-assign] user=%s assigned=%s is_shared=%s "
+            "instance=%s source=%s",
+            current_user.id,
+            result.get("success"),
+            result.get("is_shared"),
+            result.get("instance_id"),
+            result.get("assignment_source"),
         )
 
         if result["success"]:
@@ -108,7 +112,6 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
                 "is_shared": result.get("is_shared", False),
                 "assignment_source": result.get("assignment_source"),
             }
-            logger.debug(f"API response: {response}")
             return response
         elif result.get("requires_retry"):
             # Return 202 for scaling in progress
@@ -222,7 +225,12 @@ async def release_premium_beacon(request: Request, db: Session = Depends(get_db)
             user_id=user.id, user_uid=user_uid
         )
 
-        logger.info(f"Beacon release for user {user.id}: " f"{result.get('message')}")
+        logger.info(
+            "[premium-trace] beacon-released user=%s instance=%s message=%s",
+            user.id,
+            result.get("released_instance"),
+            result.get("message"),
+        )
         return {
             "success": True,
             "message": result.get("message", "Release processed"),
@@ -319,8 +327,8 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
             current_user.id, current_user.uid
         )
 
-        logger.debug(
-            "Premium status for user %s: " "assigned=%s, is_shared=%s, instance=%s",
+        logger.info(
+            "[premium-status] user=%s assigned=%s is_shared=%s instance=%s",
             current_user.id,
             status_info is not None,
             status_info.get("is_shared") if status_info else None,

--- a/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
@@ -813,7 +813,7 @@ class TestHeartbeatFailureTracking:
 class TestPremiumActivityRestoresPendingRelease:
     """SQL widening — heartbeat restores `terminating` rows back to `active`.
 
-    These assertions guard PLAN_5-1's multi-tab close fix. The unit harness
+    These assertions guard the multi-tab close fix. The unit harness
     mocks `session_scope`, so semantic SQL behaviour (which rows actually
     match) is not exercised — that's covered by integration tests. Here we
     assert the SQL shape itself, since the shape encodes the behaviour.

--- a/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
@@ -808,3 +808,81 @@ class TestHeartbeatFailureTracking:
             call_args = mock_session.execute.call_args
             sql_text = str(call_args[0][0])
             assert "heartbeat_failures = 0" in sql_text
+
+
+class TestPremiumActivityRestoresPendingRelease:
+    """SQL widening — heartbeat restores `terminating` rows back to `active`.
+
+    These assertions guard PLAN_5-1's multi-tab close fix. The unit harness
+    mocks `session_scope`, so semantic SQL behaviour (which rows actually
+    match) is not exercised — that's covered by integration tests. Here we
+    assert the SQL shape itself, since the shape encodes the behaviour.
+    """
+
+    def setup_method(self):
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _logged_out_users,
+        )
+
+        _logged_out_users.clear()
+
+    def _execute_sync_update(self, rowcount=1):
+        """Run _update_premium_user_activity_sync under a mocked session.
+
+        Returns (result, sql_text). The mocked rowcount drives the boolean
+        return; sql_text is the raw textual SQL passed to session.execute.
+        """
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _update_premium_user_activity_sync,
+        )
+
+        mock_result = MagicMock()
+        mock_result.rowcount = rowcount
+
+        mock_session = MagicMock()
+        mock_session.execute.return_value = mock_result
+
+        mw_path = "studio.app.common.core.middleware.user_activity_middleware"
+        with patch(f"{mw_path}.session_scope") as mock_session_scope:
+            mock_session_scope.return_value.__enter__.return_value = mock_session
+
+            result = _update_premium_user_activity_sync(TEST_USER_ID)
+            sql_text = str(mock_session.execute.call_args[0][0])
+            return result, sql_text
+
+    def test_update_matches_active_and_terminating(self):
+        """Filter widened from `status='active'` to IN ('active','terminating')."""
+        _, sql_text = self._execute_sync_update()
+        assert "status IN ('active', 'terminating')" in sql_text
+
+    def test_update_writes_active_to_restore_pending_release(self):
+        """SET clause writes status='active' so terminating rows flip back."""
+        _, sql_text = self._execute_sync_update()
+        # The SET-clause assignment, not the WHERE-clause comparison.
+        assert "SET last_activity = :now" in sql_text
+        assert "status = 'active'" in sql_text
+
+    def test_update_guards_against_known_dead_instance_states(self):
+        """instance_state guard prevents restoring known-dead rows
+        (preserves the existing dead-EC2 escape valve)."""
+        _, sql_text = self._execute_sync_update()
+        assert "instance_state NOT IN" in sql_text
+        for dead_state in ("terminated", "shutting-down", "stopped", "stopping"):
+            assert dead_state in sql_text
+
+    def test_update_allows_active_rows_unconditionally(self):
+        """OR-branch on `status = 'active'` skips the instance_state guard
+        for already-active rows (frontend handles instance-unreachable)."""
+        _, sql_text = self._execute_sync_update()
+        # The full OR-branch — the guard is gated only on terminating rows.
+        assert "OR instance_state IS NULL" in sql_text
+
+    def test_returns_true_when_row_matched(self):
+        """rowcount > 0 → returns True (row was updated or restored)."""
+        result, _ = self._execute_sync_update(rowcount=1)
+        assert result is True
+
+    def test_returns_false_when_no_row_matched(self):
+        """rowcount == 0 → returns False (no row, or escape valve blocked)."""
+        result, _ = self._execute_sync_update(rowcount=0)
+        assert result is False

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1402,6 +1402,97 @@ class TestDatabaseCommits:
             mock_connection.commit.assert_called()
 
 
+class TestHeartbeatRestoresPendingRelease:
+    """SQL widening — heartbeat restores `pending_release` rows back to `active`.
+
+    Mirrors the user_activity_middleware behaviour so explicit /heartbeat
+    calls heal a soft-release triggered by another tab's close. Guards
+    PLAN_5-1's multi-tab fix on the lambda side.
+
+    The unit harness mocks `pymysql.connect`, so semantic row-matching is
+    not exercised — that's covered by integration tests. Here we assert the
+    SQL shape and parameter binding, since they encode the behaviour.
+    """
+
+    def _execute_timestamp_update(self, mock_env_vars_premium, rowcount=1):
+        """Run update_user_activity_timestamp under a mocked DB connection.
+
+        Returns (result, mock_cursor, sql_text, sql_params). The cursor is
+        returned so caller can inspect both the SQL text and the parameter
+        tuple passed to execute().
+        """
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "pymysql.connect"
+        ) as mock_pymysql:
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            mock_cursor.rowcount = rowcount
+
+            from premium_manager import update_user_activity_timestamp
+
+            result = update_user_activity_timestamp(42)
+
+            execute_call = mock_cursor.execute.call_args
+            sql_text = execute_call[0][0]
+            sql_params = execute_call[0][1] if len(execute_call[0]) > 1 else ()
+            return result, mock_connection, sql_text, sql_params
+
+    def test_sql_matches_active_and_pending_release(self, mock_env_vars_premium):
+        """Filter widened from is_standby=0 only to IN (active, pending_release)."""
+        _, _, sql_text, _ = self._execute_timestamp_update(mock_env_vars_premium)
+        assert "status IN" in sql_text
+
+    def test_sql_uses_premium_assignment_status_constants(self, mock_env_vars_premium):
+        """Parameter binding uses PremiumAssignment.ACTIVE / PENDING_RELEASE
+        constants, not raw strings — protects against the
+        'terminating' / 'pending_release' aliasing footgun in aws_constants."""
+        from aws_constants import PremiumAssignment
+
+        _, _, _, sql_params = self._execute_timestamp_update(mock_env_vars_premium)
+        # CASE WHEN status = PENDING_RELEASE THEN ACTIVE, then user_id,
+        # then IN(ACTIVE, PENDING_RELEASE), then OR-branch status = ACTIVE.
+        assert PremiumAssignment.PENDING_RELEASE in sql_params
+        assert PremiumAssignment.ACTIVE in sql_params
+        # Active appears in three places (THEN clause, IN list, OR branch).
+        assert sql_params.count(PremiumAssignment.ACTIVE) == 3
+        # Pending_release appears in two places (CASE WHEN, IN list).
+        assert sql_params.count(PremiumAssignment.PENDING_RELEASE) == 2
+
+    def test_sql_flips_pending_release_to_active_via_case(self, mock_env_vars_premium):
+        """CASE expression restores pending_release rows to active."""
+        _, _, sql_text, _ = self._execute_timestamp_update(mock_env_vars_premium)
+        assert "CASE" in sql_text
+        assert "WHEN status = %s THEN %s" in sql_text
+
+    def test_sql_guards_against_known_dead_instance_states(self, mock_env_vars_premium):
+        """instance_state guard prevents restoring known-dead rows."""
+        _, _, sql_text, _ = self._execute_timestamp_update(mock_env_vars_premium)
+        assert "instance_state NOT IN" in sql_text
+        for dead_state in ("terminated", "shutting-down", "stopped", "stopping"):
+            assert dead_state in sql_text
+
+    def test_returns_true_when_row_matched(self, mock_env_vars_premium):
+        """rowcount > 0 → returns True (row was updated or restored)."""
+        result, _, _, _ = self._execute_timestamp_update(
+            mock_env_vars_premium, rowcount=1
+        )
+        assert result is True
+
+    def test_returns_false_when_no_row_matched(self, mock_env_vars_premium):
+        """rowcount == 0 → returns False (no row, or escape valve blocked)."""
+        result, _, _, _ = self._execute_timestamp_update(
+            mock_env_vars_premium, rowcount=0
+        )
+        assert result is False
+
+    def test_commits_after_update(self, mock_env_vars_premium):
+        """@with_transaction decorator commits on success."""
+        _, mock_connection, _, _ = self._execute_timestamp_update(mock_env_vars_premium)
+        mock_connection.commit.assert_called()
+
+
 class TestGetAllPremiumInstances:
     """get_all_premium_instances tests."""
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -1407,7 +1407,7 @@ class TestHeartbeatRestoresPendingRelease:
 
     Mirrors the user_activity_middleware behaviour so explicit /heartbeat
     calls heal a soft-release triggered by another tab's close. Guards
-    PLAN_5-1's multi-tab fix on the lambda side.
+    the multi-tab fix on the lambda side.
 
     The unit harness mocks `pymysql.connect`, so semantic row-matching is
     not exercised — that's covered by integration tests. Here we assert the


### PR DESCRIPTION
### Content

#### Summary

- Premium release-beacon was silently bailing on Sign Out — gate at `useLogout.ts` read `state.isPremiumUser=false` from the context-value spread, never reaching `autoReleaseOnLogout`. Reproduced on the autoscaling-pool path in dev on 2026-05-11.
- Multi-tab close was leaking dedicated assignments — Tab A's `beforeunload` beacon soft-released the row to `terminating`; Tab B's middleware activity UPDATEs filtered `WHERE status='active'` and silently skipped the terminating row, so `last_activity` never advanced and `finalize_expired_pending_releases` deleted the row 120 s later despite Tab B being a fully-active session. Also reproduced in dev on 2026-05-11.
- Adds two surgical fixes (one-line frontend override + middleware/lambda SQL widening), supporting bug fixes (`flushErrors` race, cross-tab phantom-beacon prevention), permanent operational logging (`[premium-trace]`, `[premium-assign]`, `[premium-status]`), and 13 new unit tests.
- All diagnostic-only probes from the investigation branch (`[premium-release]`, `[premium-poll]`, `TAB_LOG_ID`, beforeunload attach/detach logs) are excluded from this PR.

#### Design Decisions

- **`isPremiumUser` override after the `...state` spread in `contextValue`.** The structural concern was first identified on 2026-04-27 and deprioritised on 2026-05-08 as "less likely" because the pattern had been latent for 5 months. 2026-05-11 reproduction proved it IS the cause on the same-tab sign-out → sign-in flow (no full page reload — the post-logout state reset competes with the mirror effect and the local computation diverges from the mirrored value). Alternative considered: remove the state mirror entirely. Rejected — the mirror is still a useful stable-across-renders read for other consumers; the override is one line, narrow, and reversible.
- **Widen middleware UPDATE to match `status IN ('active','terminating')` and flip `terminating` rows back to `active`.** The `instance_state` guard preserves the dead-EC2 escape valve: known-dead rows are not restored, so `finalize_expired_pending_releases` still cleans them up. Alternative considered: separate "restore-on-activity" function that runs after the main UPDATE. Rejected — extra DB roundtrip per request; the SQL widening is one UPDATE with no perf impact.
- **Mirror the same change in the lambda `update_user_activity_timestamp`** so explicit `/heartbeat` POSTs heal soft-releases identically to the middleware path. Uses parameterised `PremiumAssignment.ACTIVE` / `PremiumAssignment.PENDING_RELEASE` constants to guard against the `'terminating'` aliasing footgun documented in `aws_constants.py:206-214`.
- **Edge-case hardenings deferred.** The 2026-05-11 trace showed `hasToken=true, tokenLen=192` consistently — the token path was clean. Token-fetch retry, two-round-trip race elimination, and migration-path token refetch remain valid defense-in-depth but are not required to close the bug. Tracked as follow-ups.
- **`[premium-trace]` correlation tags retained.** `beacon-released` (FastAPI) and `finalize-deleted` (lambda) tags pair every released assignment so CloudWatch Logs Insights can classify: paired = multi-tab leak path; unpaired `finalize-deleted` = no-beacon path. Useful operationally; ~zero noise (low-volume events).
- **`[premium-assign]` / `[premium-status]` single info-level lines** replace three previous debug lines each. Trade-off: shifts from debug to info severity (one log line per call). Net effect is fewer total lines and queryable structure.
- **Defensive: null `beaconTokenRef.current` in cross-tab `PREMIUM_RELEASED` handler.** Previously, if Tab B released, Tab A cleared its assignment state but kept the now-stale beacon token. A later logout/`beforeunload` in Tab A would beacon a token the backend already invalidated — silent but wasted. Behaviour change beyond the headline fix; safe (failing to send a beacon is correct in this state) and surfaces no new edge cases.

### Evidence

**Gate-A reproduction (2026-05-11 16:36 dev session, autoscaling-pool path):**

```
16:36:35  token fetched   site=autoAssign.freshAssign
                          instance=autoscaling-pool hasToken=true tokenLen=192
16:36:56  performLogout entered  tabId=dbj7kv  isPremiumUser=false  broadcast=true
16:36:56  gate-A                 tabId=dbj7kv  isPremiumUser=false  willCall=false  ← BAIL
          (no gate-B, no sendBeacon, no [premium-trace] beacon-released)
```

Token present (gate B would have passed); gate A bailed because `state.isPremiumUser=false`.

**Healthy path (2026-05-11 16:07 dev session, dedicated/existing):**

```
gate-A   willCall=true  →  gate-B  hasToken=true  →  sendBeacon queued=true
backend: [premium-trace] beacon-released user=12 instance=i-0435a5b8...
```

End-to-end release worked when the state mirror happened to be fresh.

**Multi-tab leak reproduction (2026-05-11 600-10 test, dedicated `i-005362c4bf824b3ac`):**

- T0 = 16:54:58 UTC — Tab A close → `[premium-trace] beacon-released user=12 instance=i-005362c4bf824b3ac` → soft-release.
- T0+10 s — `status='terminating'`, `last_activity=07:54:58`.
- T0+45 s — `status='terminating'`, `last_activity=07:54:58` (unchanged; Tab B actively clicking).
- T0+>60 s — `status='terminating'`, `last_activity=07:54:58` (unchanged). Row eligible for `finalize_expired_pending_releases` despite Tab B being a fully-active session.

### References

- https://github.com/arayabrain/araya-optinist/issues/576 — original bug report, re-investigation history, and 2026-05-11 dev-session findings.
- System Test Cases sheet 06.2: 600-7 (autoscaling-pool precondition), 600-3 (UI logout), 600-9 (grace + finalize), 600-10 (multi-tab close), 600-11 (multi-tab logout).

#### Files changed

**Frontend (release-beacon fix + supporting changes):**

- `frontend/src/api/premium/PremiumAssignmentApi.ts` — added optional `assignment_source?: string` to `PremiumAssignment` interface so the adopt-existing-assignment path can carry the field forward when the lambda starts returning it.
- `frontend/src/contexts/PremiumAssignmentContext.tsx` — three changes: (1) override `isPremiumUser` after the `...state` spread in `contextValue` (the headline release-beacon fix); (2) null `beaconTokenRef.current` in the `tabSync.on("PREMIUM_RELEASED")` handler to prevent phantom beacons after a sibling tab released; (3) synthesize `assignment_source: "existing"` (or the lambda's value if returned) on the `autoAssign.alreadyAssigned` reconstruction so the field isn't `undefined` on adopted assignments.
- `frontend/src/hooks/useLogout.ts` — synchronously call `flushErrors()` before `dispatch(logout)` so the frontend-error reporter drains its queue while the auth token is still valid. Previously, all `console.warn` lines fired during logout (gate probes, sendBeacon results) were dropped because the next reporter flush ran after `dispatch(logout)` cleared the token.

**Backend operational logging (kept permanently):**

- `studio/app/common/routers/users_me.py` — three log refinements: (1) `[premium-assign] user=… assigned=… is_shared=… instance=… source=…` single info line on `assign_premium_instance` (replaces three debug lines); (2) `[premium-status] user=… assigned=… is_shared=… instance=…` info line on `get_premium_assignment_status`; (3) `[premium-trace] beacon-released user=… instance=… message=…` on `release_premium_beacon` (pairs with the lambda finalize tag for CloudWatch Insights correlation).
- `infrastructure/terraform/premium_manager_package/premium_manager.py` (logging only) — `[premium-trace] finalize-deleted user=… instance=…` print in `_finalize_expired_pending_releases_transaction`.

**Backend (middleware + lambda heartbeat widening — multi-tab restore):**

- `studio/app/common/core/middleware/user_activity_middleware.py` — `_update_premium_user_activity_sync` UPDATE widened to match `status IN ('active','terminating')` and flip `terminating` rows back to `active`, gated on `instance_state NOT IN ('terminated','shutting-down','stopped','stopping')`. Preserves the dead-EC2 escape valve.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — `update_user_activity_timestamp` (lambda `/heartbeat`) matching change for symmetry. Uses parameterised `PremiumAssignment.ACTIVE` and `PremiumAssignment.PENDING_RELEASE` constants.

**Tests:**

- `studio/tests/app/common/core/middleware/test_user_activity_middleware.py` — added class `TestPremiumActivityRestoresPendingRelease` with 6 tests covering the widened SQL shape (filter, SET clause, dead-EC2 guard, OR-branch) and rowcount-driven return semantics.
- `studio/tests/infrastructure/test_premium_manager.py` — added class `TestHeartbeatRestoresPendingRelease` with 7 tests covering the lambda's matching SQL shape, constant binding, `CASE` expression, dead-EC2 guard, return semantics, and `@with_transaction` commit.

### Manual Testcases

**1. 600-7 + 600-3 — autoscaling-pool logout (the silent-bail repro).**
- Tester: drain dev premium fleet (delete `premium_user_assignments` rows, delete dev ALB rule + `premium-*-tg`, terminate dev premium EC2). Sign in as user 12. Confirm DB shows `instance_id='autoscaling-pool'`, `is_shared=1`, `assignment_source='autoscaling_temp'`. Click Sign Out within 30 s (before migration to dedicated).
- Expected: CloudWatch `/ecs/development-optinist-cloud-taskdef` shows `[premium-trace] beacon-released user=12 instance=autoscaling-pool`. DB row transitions to `status='terminating'`, then finalised on next monitor cycle. Pre-fix: no `beacon-released` line, no DB transition, row leaks.

**2. 600-10 — multi-tab close (the multi-tab leak repro).**
- Tester: sign in user 12 on dedicated assignment (`is_shared=0`), open two tabs (duplicate tab in same browser profile). Click in Tab B once to prime heartbeat path. Close one tab; keep clicking in the remaining tab every 15 s for 2 min. Don't reload.
- Expected: at T+10 s, DB shows `status='terminating'`; at T+30–60 s, `status` flips back to `active` and `last_activity` advances on Tab B's next heartbeat. Pre-fix: `status` stays `terminating`, `last_activity` stuck at T0, finalize at next monitor cycle.

**3. 600-9 — single tab close + grace expiry (sanity baseline).**
- Tester: sign in single tab, close it, wait > 120 s, then wait for next 15-min monitor cycle, then sign back in.
- Expected: CloudWatch shows `[premium-trace] beacon-released` for the user followed by `[premium-trace] finalize-deleted` for the same user+instance within 16 min. Re-login creates a fresh assignment.

**4. 600-11 — multi-tab UI logout (cross-tab broadcast).**
- Tester: sign in, open Tabs A, B, C on the same user. Click Sign Out in Tab A.
- Expected: all three tabs redirect to `/login`. Exactly one `[premium-trace] beacon-released` in CloudWatch (from Tab A only). Tabs B and C clear `beaconTokenRef` via the cross-tab listener and do not independently beacon.

**Automated verification:**

```
pytest studio/tests/app/common/core/middleware/test_user_activity_middleware.py studio/tests/infrastructure/test_premium_manager.py -- all 51+ tests pass
```

Local run: 44 existing middleware tests + 6 new = 50 pass; existing lambda commit/heartbeat tests + 7 new = 11 pass; combined: full test files green.

### Unit, Integration, Contract Test Coverage

**Added (13 tests, all passing):**

- `TestPremiumActivityRestoresPendingRelease` (6 tests) — middleware SQL shape and return semantics.
- `TestHeartbeatRestoresPendingRelease` (7 tests) — lambda heartbeat SQL shape, constant binding, CASE expression, commit.

The tests assert SQL shape (filter clauses, SET assignments, guard fragments, parameter binding) rather than row-matching against a real DB. Both target functions use mocked `session_scope` / `pymysql.connect`, so semantic row-matching is exercised by integration tests rather than unit tests. Shape-level assertions catch the most common regression class — someone reverting the widening or removing the `instance_state` guard — without an integration DB.

**Not added (deferred, low priority):**

- Frontend `useLogout` test asserting `flushErrors()` is called before `dispatch(logout)`. Would require mocking `usePremiumAssignment`, `useDispatch`, `useNavigate`, `flushErrors`. Listed as a follow-up; not a blocker since the fix is one line and the manual repro covers it.
- Context-shape assertion that `contextValue.isPremiumUser` equals the locally-computed value when it differs from `state.isPremiumUser`. Same setup cost. Listed as a follow-up.
- Integration test against a real DB for the middleware/lambda widening. Out of scope for this PR; SQL shape assertions cover most regression classes.

**Existing coverage validated:**

- 44 existing middleware tests pass alongside the new class.
- `test_heartbeat_event` and `test_update_user_activity_commits` still pass (the latter targets a different function, `update_user_activity`, not `update_user_activity_timestamp`).
- Frontend typecheck clean on the three modified files (`PremiumAssignmentContext.tsx`, `useLogout.ts`, `PremiumAssignmentApi.ts`).

### Others

#### Difficulties

- The 2026-05-08 re-investigation had deprioritised the gate-A hypothesis as "less likely". The 2026-05-11 reproduction required deploying instrumentation, draining the dev premium fleet to force the autoscaling-pool path, and observing the gate-A bail in CloudWatch before the fix could be confirmed. The diagnostic-only logging from that effort lives in `experiments/additonal-logging` and is intentionally not included here.
- The frontend `errorReporter` was silently dropping `console.warn` lines during logout (the `_queue` survived `dispatch(logout)` but the next flush early-returned at `!getToken()`). This masked all premium probe output for the first reproduction attempt. The `flushErrors()` call in `useLogout.ts` is a permanent fix for the underlying race — it would have affected any logout-time diagnostic logging, not just the premium probes.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Frontend context override | Low | One-line addition after `...state` spread. Consumers that read `isPremiumUser` from `usePremiumAssignment()` now see the synchronously-computed value. `state.isPremiumUser` still exists for stable-across-renders reads. Reversible. |
| Middleware UPDATE widening | Medium | Runs on every authed request from a premium user. Wider WHERE clause + restore-via-SET. Guarded by `instance_state` allowlist for dead-EC2 escape valve. Behavioural change is strict superset of prior (previously-no-op UPDATEs on terminating rows now succeed under the guard). No callers branch on rowcount-zero. |
| Lambda heartbeat widening | Low | Mirrors middleware on the explicit `/heartbeat` path. Lower traffic than middleware. Uses parameterised constants. |
| Cross-tab beacon-token clear | Low | Defensive: prevents stale-token beacon. Failing to send a beacon in this state is the correct outcome. No new edge cases. |
| `flushErrors()` in useLogout | Low | Drains an in-memory queue using `keepalive: true` fetch. Fire-and-forget; non-blocking. Errors silently swallowed by the reporter. No data loss path. |
| `[premium-trace] / [premium-assign] / [premium-status]` info-level logs | Low | Promotion from debug to info adds one info line per assign + per status check + per beacon release. Volume bounded by user actions; cost is negligible compared to existing access logs. CloudWatch Insights queries become trivial. |
| Removal of three debug lines in `assign_premium_instance` | Low | Replaced by one `[premium-assign]` info line. Anyone grepping the old text will not find matches; the new tag is documented in this PR. No tests asserted on the old debug strings. |
