### PR TITLE
Fix _get_ecs_instance_id would returning "none"

### DIFF
--- a/studio/app/common/core/platform_metadata.py
+++ b/studio/app/common/core/platform_metadata.py
@@ -74,9 +74,14 @@ def _get_ecs_instance_id() -> str:
         if not task_arn or not cluster_arn:
             return NO_ECS_INSTANCE_DEFAULT
 
+        # Extract region from the task ARN
+        # (arn:aws:ecs:region:account:task/cluster/id)
+        arn_parts = task_arn.split(":")
+        region = arn_parts[3] if len(arn_parts) > 3 else None
+
         import boto3
 
-        ecs = boto3.client("ecs")
+        ecs = boto3.client("ecs", region_name=region)
         tasks_resp = ecs.describe_tasks(cluster=cluster_arn, tasks=[task_arn])
         tasks = tasks_resp.get("tasks", [])
         if not tasks:


### PR DESCRIPTION
## Problem

`_get_ecs_instance_id()` in `studio/app/common/core/platform_metadata.py` always
returned `"none"` under a specific environment condition:

| Environment | Tier | ECS Service Name | Result |
|---|---|---|---|
| development | free | `development-optinist-cloud-service` | OK |
| development | premium | `development-premium-optinist-cloud-service` | OK |
| production | free | `subscr-optinist-cloud-service` | OK |
| **production** | **premium** | `subscr-premium-optinist-cloud-service` | **NG** |

The issue appeared after the v1.1.5 release, which introduced the
`_get_ecs_instance_id()` function.

## Root Cause

**`botocore.exceptions.NoRegionError: You must specify a region.`**

The function calls `boto3.client("ecs")` without specifying a region. boto3
determines the region through a credential provider chain that depends on
environment variables (`AWS_DEFAULT_REGION`), config files, or EC2 instance
metadata (IMDS). In the production premium container, none of these sources
were available:

1. **No `AWS_DEFAULT_REGION` env var** -- Neither the free nor premium ECS task
   definitions set this variable.
2. **No IMDS access** -- The EC2 Instance Metadata Service was unreachable from
   the container (likely due to IMDSv2 hop-limit restrictions on the bridge
   network).

The broad `except Exception` handler (line 97) silently swallowed the
`NoRegionError` and returned `"none"`, making the failure invisible in logs.

### Why did free tasks work?

The free ECS task definition injects explicit IAM User credentials via
Secrets Manager (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`). When these
environment variables are present, boto3 uses a different credential provider
chain path that resolves the region through IMDS or another fallback
successfully.

The premium task definition does **not** have a `secrets` block -- it relies
on the ECS Task Role via the Container Credential Provider, which does not
provide region information.

### Why did development premium work?

The development EC2 instances allowed IMDS access from within the container
(hop-limit or network configuration difference), so boto3 could resolve the
region as a fallback. Production premium instances did not have this fallback
available.

## Investigation Steps Taken

1. Used `aws ecs execute-command` to access the production premium container.
2. Ran `python3 -c "import boto3; print(boto3.session.Session().region_name)"`
   -- confirmed output was `None`.
3. Ran the `_get_ecs_instance_id` logic step-by-step with `traceback.print_exc()`
   -- confirmed `botocore.exceptions.NoRegionError` at `boto3.client("ecs")`.

## Fix

Extract the AWS region from the TaskARN (already fetched from the ECS metadata
endpoint) and pass it explicitly to `boto3.client()`.

The TaskARN format is `arn:aws:ecs:<region>:<account>:task/<cluster>/<id>`,
so the region is always available as the 4th colon-delimited field.

```diff
         task_arn = data.get("TaskARN", "")
         cluster_arn = data.get("Cluster", "")
         if not task_arn or not cluster_arn:
             return NO_ECS_INSTANCE_DEFAULT

+        # Extract region from the task ARN
+        # (arn:aws:ecs:region:account:task/cluster/id)
+        arn_parts = task_arn.split(":")
+        region = arn_parts[3] if len(arn_parts) > 3 else None
+
         import boto3

-        ecs = boto3.client("ecs")
+        ecs = boto3.client("ecs", region_name=region)
```

This eliminates the dependency on environment variables and IMDS for region
resolution, using data that is already available from the metadata endpoint.

## Files Changed

- `studio/app/common/core/platform_metadata.py` -- Extract region from TaskARN
  and pass to `boto3.client("ecs", region_name=region)`.

## Test case

Run the following test script in each environment to confirm that the EC2 instance ID can be obtained.
\*This is a production environment issue and cannot be confirmed without deployment, so the above script is used to perform a simulated pre-check.

- Test script
  - [597_verify_get_ecs_instance_id.py](https://github.com/user-attachments/files/27615639/597_verify_get_ecs_instance_id.py)
  - Execute the above script within the target ECS task.

- Check
  - [x] Production + Free instance
  - [x] Production + Premium instance

## Note: Architectural inconsistency (out of scope)

The free and premium task definitions use different AWS credential strategies:

- **Free**: Injects static IAM User credentials via Secrets Manager `secrets` block
- **Premium**: Uses ECS Task Role (AWS recommended approach)

Both task definitions specify the same `task_role_arn`, so the free task's
`secrets` block is redundant and could be removed to unify on the Task Role
approach. This is a separate cleanup effort and not addressed in this PR.
