### PR TITLE
Fix S3 region handling on ECS tasks and add error diagnostics

### DIFF
--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -124,6 +124,10 @@ resource "aws_ecs_task_definition" "background" {
           value = var.environment
         },
         {
+          name  = "AWS_DEFAULT_REGION"
+          value = var.aws_region
+        },
+        {
           name  = "CLOUDWATCH_LOG_GROUP"
           value = "/ecs/${var.environment}-background-optinist-cloud-taskdef"
         },

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -613,6 +613,10 @@ resource "aws_ecs_task_definition" "autoscaling" {
           value = var.environment
         },
         {
+          name  = "AWS_DEFAULT_REGION"
+          value = var.aws_region
+        },
+        {
           name  = "CLOUDWATCH_LOG_GROUP"
           value = "/ecs/${local.env_prefix}-cloud-taskdef"
         },
@@ -872,6 +876,10 @@ resource "aws_ecs_task_definition" "premium" {
         {
           name  = "ENV_PREFIX"
           value = var.environment
+        },
+        {
+          name  = "AWS_DEFAULT_REGION"
+          value = var.aws_region
         },
         {
           name  = "CLOUDWATCH_LOG_GROUP"

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -65,10 +65,12 @@ class S3StorageController(BaseRemoteStorageController):
         logger.debug(f"Init S3StorageController: {bucket_name=}")
 
     def __get_s3_client(self):
-        return aioboto3.Session().client("s3")
+        region = os.environ.get("AWS_DEFAULT_REGION")
+        return aioboto3.Session().client("s3", region_name=region)
 
     def __get_s3_resource(self):
-        return aioboto3.Session().resource("s3")
+        region = os.environ.get("AWS_DEFAULT_REGION")
+        return aioboto3.Session().resource("s3", region_name=region)
 
     def _make_input_data_local_path(self, workspace_id: str, filename: str) -> str:
         input_data_local_path = join_filepath(
@@ -497,6 +499,14 @@ class S3StorageController(BaseRemoteStorageController):
             if is_no_such_bucket_error(e):
                 logger.warning(f"Bucket does not exist: {self.bucket_name}")
                 raise RemoteStorageBucketNotFoundError(self.bucket_name) from e
+            logger.error(
+                "S3 list_objects_v2 failed: bucket=%s, prefix=%s, "
+                "region=%s, error=%s",
+                self.bucket_name,
+                __class__.make_s3_output_prefix(),
+                os.environ.get("AWS_DEFAULT_REGION", "(not set)"),
+                e,
+            )
             raise
 
         if "CommonPrefixes" not in workspaces_response:


### PR DESCRIPTION
## Pull Request

### Summary

- Add explicit `AWS_DEFAULT_REGION` environment variable to all ECS task definitions (regular, premium, background)
- Pass `region_name` explicitly to aioboto3 S3 client/resource constructors
- Add enhanced error logging for `list_objects_v2` failures (bucket, prefix, region)

### Background

An `AccessDenied` error was observed on `ListObjectsV2` for a specific premium-tier user's S3 bucket. The error occurred in `s3_storage_controller.py` via `aiobotocore` (async S3 client). Premium ECS tasks rely on ECS Task Role credentials (no IAM User env vars injected), and `AWS_DEFAULT_REGION` was not set in any task definition.

Thorough investigation (see below) ruled out IAM permissions, bucket configuration, and SDK-level differences as root causes. The error is **100% reproducible** for the affected user (user 71) across all premium ECS task instances, yet a diagnostic script (including aioboto3 async tests) passes on the same task. The root cause remains unidentified, but the lack of explicit region configuration is a latent risk, and the enhanced error logging is essential for further diagnosis.

### Changes

**`infrastructure/terraform/compute.tf`**
- Add `AWS_DEFAULT_REGION = var.aws_region` to regular (autoscaling) task definition
- Add `AWS_DEFAULT_REGION = var.aws_region` to premium task definition

**`infrastructure/terraform/background_service.tf`**
- Add `AWS_DEFAULT_REGION = var.aws_region` to background service task definition

**`studio/app/common/core/storage/s3_storage_controller.py`**
- `__get_s3_client()`: Pass `region_name` explicitly to `aioboto3.Session().client("s3")`
- `__get_s3_resource()`: Pass `region_name` explicitly to `aioboto3.Session().resource("s3")`
- Add detailed error logging on `list_objects_v2` failure (bucket name, prefix, region)

### Test plan

- [ ] Verify `AWS_DEFAULT_REGION` is set in ECS task environment after `terraform apply`
- [ ] Confirm experiment list loads for previously affected user (user 71)
- [ ] Confirm experiment list loads for other premium users (users 72, 73)
- [ ] Confirm regular (autoscaling) task S3 operations are unaffected
- [ ] If error recurs, verify enhanced logging captures bucket/prefix/region in CloudWatch

---

## Investigation Report

### 1. Problem Statement

A premium-tier user experiences `AccessDenied` on `ListObjectsV2` when loading the experiment list in the browser. The error is **100% reproducible** and occurs only under a specific combination of conditions:

| User | Regular (autoscaling) task | Premium task |
|---|---|---|
| User 71 | **OK** | **FAIL (100%)** |
| User 72 | OK | OK |
| User 73 | OK | OK |

- The error occurs on **any** premium ECS task instance (not instance-specific)
- User 71 successfully loads experiments when temporarily assigned to a regular task (before premium assignment completes)
- The same user's bucket is accessible from the premium task via a diagnostic script (both boto3 and aioboto3)

**Symptoms**:
- Browser requests to experiment list / workflow endpoints return HTTP 500
- CloudWatch: `botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied`
- Error source: `s3_storage_controller.py` line 491 via `aiobotocore`
- Affected endpoints: `experiment.py:109` (`get_experiments`), `workflow.py:71` (`fetch_last_experiment`)
- First observed: 2025-05-07, still occurring as of 2025-05-12
- **Not transient**: Reproduces on every request for the affected user on premium tasks

**Affected user**:
- User 71: bucket `optinist-user-71-233c55563a`
- Working users on same infrastructure: user 72 (`optinist-user-72-d1eda2701d`), user 73 (`optinist-user-73-d8d9d3fc21`)

**Key difference between regular and premium tasks**:
- Regular task: S3 client uses **IAM User credentials** (injected via `AWS_ACCESS_KEY_ID`/`SECRET` env vars)
- Premium task: S3 client uses **ECS Task Role** (no credential env vars; resolved via container credentials)

### 2. CloudWatch Error Traceback

Two errors logged at `2025-05-07T17:42:21` (same timestamp):

```
File "/app/studio/app/common/routers/experiment.py", line 109, in get_experiments
    await remote_storage_controller.download_all_experiments_metas(
File "/app/studio/app/common/core/storage/s3_storage_controller.py", line 486, in download_all_experiments_metas
    result = await self.__download_all_experiments_metas_via_boto3(
File "/app/studio/app/common/core/storage/s3_storage_controller.py", line 491, in __download_all_experiments_metas_via_boto3
    workspaces_response = await __s3_client.list_objects_v2(
File "/usr/local/lib/python3.11/site-packages/aiobotocore/client.py", line 424, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
```

### 3. Architecture Context

#### Premium vs Regular ECS Tasks

| Aspect | Regular Task | Premium Task |
|---|---|---|
| AWS Credentials | IAM User (via `secrets` env vars) | ECS Task Role (no env vars) |
| `AWS_ACCESS_KEY_ID` | Set (from Secrets Manager) | **Not set** |
| `AWS_SECRET_ACCESS_KEY` | Set (from Secrets Manager) | **Not set** |
| `AWS_DEFAULT_REGION` | **Not set** (pre-fix) | **Not set** (pre-fix) |
| Credential chain | env vars → config → container | Container credentials only |
| Task Role | `subscr-optinist-cloud-task-role` | `subscr-optinist-cloud-task-role` |

#### Application S3 Client (pre-fix)

```python
# s3_storage_controller.py — deployed version
def __get_s3_client(self):
    return aioboto3.Session().client("s3")
    # No region_name → SDK falls back to us-east-1
```

#### S3 Operations Flow

```
Browser → FastAPI endpoint
  → Depends(get_user_remote_bucket_name) → DB lookup → bucket name
  → RemoteStorageSimpleReader(bucket_name) → __get_s3_client()
  → aioboto3 list_objects_v2(Bucket=bucket_name, Prefix=..., Delimiter="/")
```

### 4. Diagnostic Results

Ran [583_sub4_diagnose_s3_access.py](https://github.com/user-attachments/files/27626453/583_sub4_diagnose_s3_access.py) on the **actual production premium ECS task** (`subscr-premium-optinist-cloud-service`) for user 71's bucket.

#### Environment

```
AWS_ACCESS_KEY_ID    : (not set)    ← premium task uses Task Role
AWS_SECRET_ACCESS_KEY: (not set)
AWS_DEFAULT_REGION   : None
AWS_REGION           : None
AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credential_provider/...
```

#### Test Results

| Test | Method | Description | Result |
|---|---|---|---|
| A | boto3 (sync) | `list_objects_v2` | **PASS** — found 4 workspace prefixes |
| C | boto3 (sync) | `head_bucket` | **PASS** — bucket exists |
| D | boto3 (sync) | `get_bucket_location` | **PASS** — `ap-northeast-1` |
| E | aioboto3 (async) | `list_objects_v2` (mirrors app code) | **PASS** — found 4 workspace prefixes |
| F | aioboto3 (async) | `sts:GetCallerIdentity` | **PASS** — same Task Role identity |
| STS | boto3 (sync) | `sts:GetCallerIdentity` | **PASS** — `subscr-optinist-cloud-task-role` |

All tests passed — both synchronous `boto3` and asynchronous `aioboto3` successfully access the bucket from the same ECS task.

**Critical paradox**: The diagnostic script (including async aioboto3) succeeds, yet the application fails **100% of the time** for this user. Something in the application runtime context differs from the diagnostic script that has not yet been identified.

### 5. Hypotheses

| # | Hypothesis | Status | Evidence |
|---|---|---|---|
| 1 | IAM permission issue | **Ruled out** | Diagnostic script succeeds with same Task Role |
| 2 | DB bucket name mismatch | **Ruled out** | DB confirmed: `remote_bucket_name = optinist-user-71-233c55563a` |
| 3 | Bucket policy blocking access | **Ruled out** | `NoSuchBucketPolicy` — no bucket policy exists |
| 4 | Bucket encryption difference | **Ruled out** | Both user 71 and 72 buckets: identical AES256 SSE |
| 5 | aioboto3 vs boto3 behavior | **Ruled out** | Test E (aioboto3) passes on same task |
| 6 | Async credential chain issue | **Ruled out** | Test F confirms same identity via aioboto3 |
| 7 | FastAPI process stale state | **Ruled out** | Error occurs on freshly created ECS tasks |
| 8 | Public Access Block difference | **Ruled out** | Both user 71 and 72: identical (all four flags `true`) |
| 9 | App runtime parameters differ from diagnostic | **Open** | See section 6 |

### 6. Open Investigation

The root cause remains **unidentified**. All infrastructure and bucket-level causes have been exhaustively ruled out. The critical finding is:

- User 71 **succeeds** on regular tasks (IAM User credentials via env vars)
- User 71 **fails 100%** on premium tasks (Task Role credentials)
- The diagnostic script (aioboto3, same Task Role) **succeeds** on premium tasks

This means the issue is **not** the Task Role permissions themselves, but something about how the **application** uses credentials on premium tasks specifically for user 71. The diagnostic script bypasses the application's initialization and request handling, which is why it succeeds.

The remaining gap is: **we cannot verify the actual parameters the application passes to S3 at runtime** (bucket name, prefix, region) because the enhanced error logging has not been deployed yet.

Areas to investigate after deploying enhanced logging:

1. **Actual runtime parameters** (highest priority) — The enhanced error logging will capture the exact `bucket_name`, `prefix`, and `region` at failure time. If any parameter differs from what the diagnostic script tested, that identifies the root cause.
2. **App initialization side effects** — The application performs module-level initialization (e.g., `platform_metadata.py` creates `boto3.client("ecs")` at import time) that the diagnostic script does not. On premium tasks without `AWS_DEFAULT_REGION`, this could affect the credential chain or session state used by subsequent aioboto3 calls.
3. **S3 Server Access Logs** — Enabling logging on the affected bucket would reveal the actual request received by S3, including signing region and credential identity.

### 7. Conclusion

The error is **not transient** — it is 100% reproducible, specific to the combination of user 71 + premium task, and environment-independent. The root cause is not yet identified. The prepared fix (explicit `AWS_DEFAULT_REGION` + `region_name`) and enhanced error logging should be deployed as the **immediate next step** to:

- Potentially resolve the issue if implicit region resolution is the cause (given that regular tasks with explicit IAM User credentials work, adding explicit region may similarly stabilize premium task behavior)
- Capture exact runtime parameters (bucket, prefix, region) on failure for further diagnosis
- Narrow down whether the issue is in the S3 request parameters or in the credential/signing context

### 8. Diff Summary

```diff
# infrastructure/terraform/compute.tf (regular + premium task definitions)
+        {
+          name  = "AWS_DEFAULT_REGION"
+          value = var.aws_region
+        },

# infrastructure/terraform/background_service.tf
+        {
+          name  = "AWS_DEFAULT_REGION"
+          value = var.aws_region
+        },

# studio/app/common/core/storage/s3_storage_controller.py
  def __get_s3_client(self):
-     return aioboto3.Session().client("s3")
+     region = os.environ.get("AWS_DEFAULT_REGION")
+     return aioboto3.Session().client("s3", region_name=region)

  def __get_s3_resource(self):
-     return aioboto3.Session().resource("s3")
+     region = os.environ.get("AWS_DEFAULT_REGION")
+     return aioboto3.Session().resource("s3", region_name=region)

  # Enhanced error logging on list_objects_v2 failure:
+     logger.error(
+         "S3 list_objects_v2 failed: bucket=%s, prefix=%s, region=%s, error=%s",
+         self.bucket_name,
+         __class__.make_s3_output_prefix(),
+         os.environ.get("AWS_DEFAULT_REGION", "(not set)"),
+         e,
+     )
```
