### PR TITLE
Fix premium UI and log viewer not reflecting assignment changes

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx
@@ -1,13 +1,3 @@
-/**
- * Regression test: useLogs must reset its log buffer and pagination offsets
- * when the premium assignment's instance_id changes.
- *
- * Without this, after a shared→dedicated migration the polling loop continues
- * to use offsets that meant something on the old instance — the new instance's
- * log file has a different offset space, so the user sees empty / garbled
- * content until they refresh.
- */
-
 import React from "react"
 
 import {
@@ -161,5 +151,57 @@ describe("useLogs — premium-assignment-driven reset", () => {
     // Without a real-timer advance, the 2 s tick won't fire on its own, so
     // any serviceLogs call here would only come from a spurious reset.
     expect(mockServiceLogs).not.toHaveBeenCalled()
+  })
+
+  test("does NOT call reset on first non-null assignment after a null start", async () => {
+    mockAssignment = null
+    const captureRef: { current: Handle | null } = { current: null }
+    const { rerender } = render(<Harness captureRef={captureRef} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    mockServiceLogs.mockClear()
+
+    // First real assignment lands — this is not a migration.
+    mockAssignment = sharedAssignment
+    await act(async () => {
+      rerender(<Harness captureRef={captureRef} />)
+      await Promise.resolve()
+    })
+
+    expect(mockServiceLogs).not.toHaveBeenCalled()
+  })
+
+  test("calls reset exactly once across 'X' → null → 'Y'", async () => {
+    mockAssignment = sharedAssignment
+    const captureRef: { current: Handle | null } = { current: null }
+    const { rerender } = render(<Harness captureRef={captureRef} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    mockServiceLogs.mockClear()
+
+    // Transient null — must not trigger reset.
+    mockAssignment = null
+    await act(async () => {
+      rerender(<Harness captureRef={captureRef} />)
+      await Promise.resolve()
+    })
+    expect(mockServiceLogs).not.toHaveBeenCalled()
+
+    // New instance arrives — reset fires exactly once.
+    mockServiceLogs.mockResolvedValue(mkResponse("i-dedicated-A"))
+    mockAssignment = dedicatedAssignment
+    await act(async () => {
+      rerender(<Harness captureRef={captureRef} />)
+      await Promise.resolve()
+    })
+
+    expect(mockServiceLogs).toHaveBeenCalled()
+    expect(captureRef.current?.logs).toEqual([])
   })
 })

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Regression test: useLogs must reset its log buffer and pagination offsets
+ * when the premium assignment's instance_id changes.
+ *
+ * Without this, after a shared→dedicated migration the polling loop continues
+ * to use offsets that meant something on the old instance — the new instance's
+ * log file has a different offset space, so the user sees empty / garbled
+ * content until they refresh.
+ */
+
+import React from "react"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render } from "@testing-library/react"
+
+import type { PremiumAssignmentResult } from "api/premium/PremiumAssignmentApi"
+
+// --- Module mocks (must be declared before importing the hook) ---
+
+const mockServiceLogs = jest.fn<
+  Promise<{
+    data: { text: string; id: string }[]
+    params: Record<string, unknown>
+    offset: { next: number; pre: number }
+    platform?: { service_name: string; task_id: string; instance_id: string }
+  }>,
+  [Record<string, unknown>]
+>()
+
+jest.mock("components/Workspace/FlowChart/ModalLogs/helpers/service", () => ({
+  __esModule: true,
+  serviceLogs: mockServiceLogs,
+  TLevelsLog: {
+    ALL: "ALL",
+    INFO: "INFO",
+    ERROR: "ERROR",
+    DEBUG: "DEBUG",
+    WARNING: "WARNING",
+    CRITICAL: "CRITICAL",
+    FRONTEND: "FRONTEND",
+  },
+}))
+
+let mockAssignment: PremiumAssignmentResult | null = null
+
+jest.mock("contexts/PremiumAssignmentContext", () => ({
+  __esModule: true,
+  usePremiumAssignment: () => ({ assignmentResult: mockAssignment }),
+}))
+
+// require() after mocks to avoid hoist-before-mock TDZ.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useLogs } = require("../useLogs")
+
+// --- Harness ---
+
+type Handle = ReturnType<typeof useLogs>
+
+const Harness: React.FC<{ captureRef: { current: Handle | null } }> = ({
+  captureRef,
+}) => {
+  captureRef.current = useLogs([], "", true)
+  return null
+}
+
+const sharedAssignment: PremiumAssignmentResult = {
+  message: "shared",
+  instance_id: "i-shared",
+  assigned: true,
+  is_shared: true,
+}
+
+const dedicatedAssignment: PremiumAssignmentResult = {
+  message: "dedicated",
+  instance_id: "i-dedicated-A",
+  assigned: true,
+  is_shared: false,
+}
+
+const mkResponse = (instanceId: string) => ({
+  data: [],
+  params: {},
+  offset: { next: 100, pre: 50 },
+  platform: {
+    service_name: instanceId.includes("dedicated")
+      ? "premium-service"
+      : "studio-service",
+    task_id: "t1",
+    instance_id: instanceId,
+  },
+})
+
+// --- Tests ---
+
+describe("useLogs — premium-assignment-driven reset", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockAssignment = null
+    mockServiceLogs.mockResolvedValue(mkResponse("i-studio"))
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("calls reset when assignmentResult.instance_id changes (shared → dedicated)", async () => {
+    mockAssignment = sharedAssignment
+    const captureRef: { current: Handle | null } = { current: null }
+    const { rerender } = render(<Harness captureRef={captureRef} />)
+
+    // Let the mount-time polling promise settle so the initial serviceLogs
+    // call is accounted for in the call counter.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    mockServiceLogs.mockClear()
+    mockServiceLogs.mockResolvedValue(mkResponse("i-dedicated-A"))
+
+    // Simulate the assignment promoting from shared to dedicated.
+    mockAssignment = dedicatedAssignment
+    await act(async () => {
+      rerender(<Harness captureRef={captureRef} />)
+      await Promise.resolve()
+    })
+
+    // reset() triggers realtimeApi() which calls serviceLogs immediately —
+    // proves we didn't wait for the 2 s tick and proves logs were cleared
+    // (state was set to []).
+    expect(mockServiceLogs).toHaveBeenCalled()
+    expect(captureRef.current?.logs).toEqual([])
+  })
+
+  test("does NOT call reset when assignmentResult.instance_id is unchanged across renders", async () => {
+    mockAssignment = dedicatedAssignment
+    const captureRef: { current: Handle | null } = { current: null }
+    const { rerender } = render(<Harness captureRef={captureRef} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    mockServiceLogs.mockClear()
+
+    // Re-render with the SAME instance_id — must not trigger a reset.
+    mockAssignment = { ...dedicatedAssignment }
+    await act(async () => {
+      rerender(<Harness captureRef={captureRef} />)
+      await Promise.resolve()
+    })
+
+    // Without a real-timer advance, the 2 s tick won't fire on its own, so
+    // any serviceLogs call here would only come from a spurious reset.
+    expect(mockServiceLogs).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
@@ -6,6 +6,7 @@ import {
   TParams,
   TPlatformInfo,
 } from "components/Workspace/FlowChart/ModalLogs/helpers/service"
+import { usePremiumAssignment } from "contexts/PremiumAssignmentContext"
 
 export type TLogs = { text: string; id: string }
 
@@ -127,6 +128,23 @@ export const useLogs = (
     else realtimeApi()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onNextSearchApi])
+
+  // Reset on premium routing change: pagination offsets are per-instance, so
+  // when the user is migrated (shared→dedicated or back) the old offsets address
+  // a log stream the next request won't reach.
+  const { assignmentResult } = usePremiumAssignment()
+  const prevAssignedInstanceRef = useRef<string | null | undefined>(undefined)
+  useEffect(() => {
+    const next = assignmentResult?.instance_id ?? null
+    if (prevAssignedInstanceRef.current === undefined) {
+      prevAssignedInstanceRef.current = next
+      return
+    }
+    if (prevAssignedInstanceRef.current !== next) {
+      prevAssignedInstanceRef.current = next
+      reset()
+    }
+  }, [assignmentResult?.instance_id, reset])
 
   return { onPrevSearchApi, onNextSearchApi, logs, isError, reset, platform }
 }

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx
@@ -129,21 +129,15 @@ export const useLogs = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onNextSearchApi])
 
-  // Reset on premium routing change: pagination offsets are per-instance, so
-  // when the user is migrated (shared→dedicated or back) the old offsets address
-  // a log stream the next request won't reach.
+  // Reset on premium routing change: pagination offsets are per-instance.
   const { assignmentResult } = usePremiumAssignment()
-  const prevAssignedInstanceRef = useRef<string | null | undefined>(undefined)
+  const lastKnownInstanceRef = useRef<string | null>(null)
   useEffect(() => {
     const next = assignmentResult?.instance_id ?? null
-    if (prevAssignedInstanceRef.current === undefined) {
-      prevAssignedInstanceRef.current = next
-      return
-    }
-    if (prevAssignedInstanceRef.current !== next) {
-      prevAssignedInstanceRef.current = next
-      reset()
-    }
+    if (next == null) return
+    const prev = lastKnownInstanceRef.current
+    lastKnownInstanceRef.current = next
+    if (prev != null && prev !== next) reset()
   }, [assignmentResult?.instance_id, reset])
 
   return { onPrevSearchApi, onNextSearchApi, logs, isError, reset, platform }

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -61,7 +61,7 @@ const ERROR_BACKOFF_MULTIPLIER = 2
 // sessionStorage keys — per-tab persistence across page refreshes.
 // Clears automatically when the tab closes.
 const SS_HAS_ATTEMPTED = "premium_hasAttempted"
-const SS_POLL_ATTEMPTS = "premium_pollAttempts"
+export const SS_POLL_ATTEMPTS = "premium_pollAttempts"
 
 function ssRead(key: string): string | null {
   try {
@@ -708,7 +708,8 @@ export const PremiumAssignmentProvider: React.FC<{
       return
     }
 
-    // While the user holds a shared assignment, keep polling — they're already consuming premium budget, so a long migration stall is better than a stuck UI only a reload can fix.
+    // Shared assignments still burn premium budget — keep polling past the cap
+    // so a long migration doesn't strand the UI on a state only a reload can fix.
     const isOnShared = state.assignmentResult?.is_shared === true
     if (pollAttempts >= MAX_POLL_ATTEMPTS && !isOnShared) {
       // eslint-disable-next-line no-console
@@ -763,17 +764,26 @@ export const PremiumAssignmentProvider: React.FC<{
           setPollAttempts(0)
         } else {
           if (assignment) {
-            const result: PremiumAssignmentResult = {
-              message: "Premium instance assignment (shared)",
-              instance_id: assignment.instance_id,
-              assigned: true,
-              is_shared: assignment.is_shared,
-            }
-            setState((prev) => ({
-              ...prev,
-              assignmentResult: result,
-              statusResult: status,
-            }))
+            setState((prev) => {
+              const cur = prev.assignmentResult
+              if (
+                cur &&
+                cur.instance_id === assignment.instance_id &&
+                cur.is_shared === assignment.is_shared
+              ) {
+                return { ...prev, statusResult: status }
+              }
+              return {
+                ...prev,
+                assignmentResult: {
+                  message: "Premium instance assignment (shared)",
+                  instance_id: assignment.instance_id,
+                  assigned: true,
+                  is_shared: assignment.is_shared,
+                },
+                statusResult: status,
+              }
+            })
           } else {
             setState((prev) => ({ ...prev, statusResult: status }))
           }
@@ -781,7 +791,10 @@ export const PremiumAssignmentProvider: React.FC<{
           console.warn(
             "Still on temporary instance, will retry with backoff...",
           )
-          setPollAttempts((prev) => prev + 1)
+          const isOnShared = assignment?.is_shared === true
+          if (!isOnShared) {
+            setPollAttempts((prev) => prev + 1)
+          }
           // Exponential backoff capped at MAX_POLL_INTERVAL_MS
           setPollInterval((prev) =>
             Math.min(prev * BACKOFF_MULTIPLIER, MAX_POLL_INTERVAL_MS),

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -23,6 +23,7 @@ import {
   getRoutingInfo,
   releasePremiumInstance,
   sendPremiumHeartbeat,
+  PremiumAssignment,
   PremiumAssignmentResult,
   PremiumStatusResult,
   RoutingInfo,
@@ -62,6 +63,19 @@ const ERROR_BACKOFF_MULTIPLIER = 2
 // Clears automatically when the tab closes.
 const SS_HAS_ATTEMPTED = "premium_hasAttempted"
 export const SS_POLL_ATTEMPTS = "premium_pollAttempts"
+
+// Canonical PremiumAssignment (from /status) → PremiumAssignmentResult shape
+// consumed by the rest of the provider. Fields absent from /status
+// (retry_after, scaling_in_progress, assignment_source) stay undefined.
+const statusToAssignmentResult = (
+  assignment: PremiumAssignment,
+  message: string,
+): PremiumAssignmentResult => ({
+  message,
+  instance_id: assignment.instance_id,
+  assigned: true,
+  is_shared: assignment.is_shared,
+})
 
 function ssRead(key: string): string | null {
   try {
@@ -479,13 +493,10 @@ export const PremiumAssignmentProvider: React.FC<{
       }
       if (statusResponse?.assignment) {
         // User already has an assignment - update state immediately so notifications trigger
-        // Convert PremiumAssignment to PremiumAssignmentResult format
-        const assignmentResult: PremiumAssignmentResult = {
-          message: "Premium instance already assigned",
-          instance_id: statusResponse.assignment.instance_id,
-          assigned: true,
-          is_shared: statusResponse.assignment.is_shared,
-        }
+        const assignmentResult = statusToAssignmentResult(
+          statusResponse.assignment,
+          "Premium instance already assigned",
+        )
         setState((prev) => ({
           ...prev,
           assignmentResult,
@@ -732,6 +743,8 @@ export const PremiumAssignmentProvider: React.FC<{
         const status = await getPremiumStatus()
 
         if (status?.error) {
+          // eslint-disable-next-line no-console
+          console.warn("Premium status poll returned error:", status.error)
           setPollAttempts((prev) => prev + 1)
           setPollInterval((prev) =>
             Math.min(prev * ERROR_BACKOFF_MULTIPLIER, MAX_POLL_INTERVAL_MS),
@@ -744,12 +757,10 @@ export const PremiumAssignmentProvider: React.FC<{
         if (assignment && !assignment.is_shared) {
           // eslint-disable-next-line no-console
           console.log("Premium instance now available:", assignment.instance_id)
-          const result: PremiumAssignmentResult = {
-            message: "Premium instance now available",
-            instance_id: assignment.instance_id,
-            assigned: true,
-            is_shared: false,
-          }
+          const result = statusToAssignmentResult(
+            assignment,
+            "Premium instance now available",
+          )
           // The hook clears unreachable on an instance_id change; same-id is a no-op — reachability must come from a real response.
           setState((prev) => ({
             ...prev,
@@ -775,12 +786,10 @@ export const PremiumAssignmentProvider: React.FC<{
               }
               return {
                 ...prev,
-                assignmentResult: {
-                  message: "Premium instance assignment (shared)",
-                  instance_id: assignment.instance_id,
-                  assigned: true,
-                  is_shared: assignment.is_shared,
-                },
+                assignmentResult: statusToAssignmentResult(
+                  assignment,
+                  "Premium instance assignment (shared)",
+                ),
                 statusResult: status,
               }
             })

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -738,6 +738,8 @@ export const PremiumAssignmentProvider: React.FC<{
             error: null,
             isRetryableError: false,
           }))
+          // Restore routing: an earlier 502/503 may have flipped premiumAssigned off.
+          routingService.setPremiumAssigned(true)
           setPollInterval(INITIAL_POLL_INTERVAL_MS)
           setPollAttempts(0)
         } else {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -708,8 +708,9 @@ export const PremiumAssignmentProvider: React.FC<{
       return
     }
 
-    // Check if we've exceeded max attempts
-    if (pollAttempts >= MAX_POLL_ATTEMPTS) {
+    // While the user holds a shared assignment, keep polling — they're already consuming premium budget, so a long migration stall is better than a stuck UI only a reload can fix.
+    const isOnShared = state.assignmentResult?.is_shared === true
+    if (pollAttempts >= MAX_POLL_ATTEMPTS && !isOnShared) {
       // eslint-disable-next-line no-console
       console.warn(
         `Max poll attempts (${MAX_POLL_ATTEMPTS}) reached. Stopping polling.`,
@@ -726,15 +727,33 @@ export const PremiumAssignmentProvider: React.FC<{
 
     const timeoutId = setTimeout(async () => {
       try {
-        const result = await assignPremiumInstance()
+        // /status reads the canonical assignment row; /assign could return shared even after migration completed.
+        const status = await getPremiumStatus()
 
-        if (result.assigned && !result.is_shared) {
+        if (status?.error) {
+          setPollAttempts((prev) => prev + 1)
+          setPollInterval((prev) =>
+            Math.min(prev * ERROR_BACKOFF_MULTIPLIER, MAX_POLL_INTERVAL_MS),
+          )
+          return
+        }
+
+        const assignment = status?.assignment ?? null
+
+        if (assignment && !assignment.is_shared) {
           // eslint-disable-next-line no-console
-          console.log("Premium instance now available:", result.instance_id)
+          console.log("Premium instance now available:", assignment.instance_id)
+          const result: PremiumAssignmentResult = {
+            message: "Premium instance now available",
+            instance_id: assignment.instance_id,
+            assigned: true,
+            is_shared: false,
+          }
           // The hook clears unreachable on an instance_id change; same-id is a no-op — reachability must come from a real response.
           setState((prev) => ({
             ...prev,
             assignmentResult: result,
+            statusResult: status,
             error: null,
             isRetryableError: false,
           }))
@@ -743,7 +762,21 @@ export const PremiumAssignmentProvider: React.FC<{
           setPollInterval(INITIAL_POLL_INTERVAL_MS)
           setPollAttempts(0)
         } else {
-          setState((prev) => ({ ...prev, assignmentResult: result }))
+          if (assignment) {
+            const result: PremiumAssignmentResult = {
+              message: "Premium instance assignment (shared)",
+              instance_id: assignment.instance_id,
+              assigned: true,
+              is_shared: assignment.is_shared,
+            }
+            setState((prev) => ({
+              ...prev,
+              assignmentResult: result,
+              statusResult: status,
+            }))
+          } else {
+            setState((prev) => ({ ...prev, statusResult: status }))
+          }
           // eslint-disable-next-line no-console
           console.warn(
             "Still on temporary instance, will retry with backoff...",

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Regression test: polling success must re-enable premium routing.
+ *
+ * When the polling effect catches a shared → dedicated promotion, it must
+ * call routingService.setPremiumAssigned(true). Otherwise a prior 502/503
+ * in this tab (which strips routing via handlePremiumRoutingError) leaves
+ * the tab silently demoted to free-tier even though the UI shows dedicated.
+ */
+
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import type {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must precede provider import) ---
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: () => {},
+    broadcastPremiumReleased: () => {},
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type))
+        mockTabSyncHandlers.set(type, new Set())
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => null,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+// require() not import — static imports hoist above the mock vars.
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+const { routingService } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+// --- Helpers ---
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const renderProvider = () => {
+  const ctxRef: { current: Ctx | null } = { current: null }
+  render(
+    <SnackbarProvider maxSnack={3}>
+      <PremiumAssignmentProvider>
+        <Harness ctxRef={ctxRef} />
+      </PremiumAssignmentProvider>
+    </SnackbarProvider>,
+  )
+  return ctxRef
+}
+
+const sharedAssignment: PremiumAssignmentResult = {
+  message: "shared",
+  instance_id: "inst-shared",
+  assigned: true,
+  is_shared: true,
+  assignment_source: "shared",
+}
+
+const dedicatedAssignment: PremiumAssignmentResult = {
+  message: "dedicated",
+  instance_id: "inst-A",
+  assigned: true,
+  is_shared: false,
+  assignment_source: "existing",
+}
+
+const sharedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-shared",
+    is_shared: true,
+    assigned_at: "2026-05-12T00:00:00Z",
+    status: "active",
+  },
+}
+
+// --- Tests ---
+
+describe("PremiumAssignmentProvider — polling routing restore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockTabSyncHandlers.clear()
+    localStorage.clear()
+    sessionStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("polling success on dedicated restores premiumAssigned=true after a prior 502/503 stripped it", async () => {
+    // Stage 1: autoAssignOnLogin sees an existing SHARED assignment via
+    // GET /status — provider adopts it and polling begins.
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+    // Stage 2: the first poll's /assign returns DEDICATED.
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    // Wait until the provider has adopted the shared status (mount + autoAssign).
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    // Simulate the failure mode: a prior 502/503 in this tab fired
+    // handlePremiumRoutingError, which strips routing.
+    act(() => {
+      routingService.setPremiumAssigned(false)
+    })
+    expect(routingService.isPremiumAssigned()).toBe(false)
+
+    // Advance through the polling timer; the first poll returns dedicated.
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+
+    // The regression: without the fix, premiumAssigned stays false here.
+    expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+})

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -294,4 +294,40 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
     // Regression: without fix (B), the terminal "No premium instance available" error fires here.
     expect(ctxRef.current?.error).toBeNull()
   })
+
+  test("polling fires via unreachable path on dedicated assignment, uses /status not /assign", async () => {
+    // Models the live scenario the bundle-inspection check substituted for: dedicated EC2
+    // dies, axios.handlePremiumRoutingError emits emitPremiumUnreachable, the unreachable
+    // machine flips, shouldPoll returns true via the unreachable path (not the shared
+    // path), and the polling tick must call /status — not /assign.
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/some/premium-routed/endpoint",
+        status: 503,
+        sentAt: 1000,
+      })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    mockGetPremiumStatus.mockClear()
+    mockAssignPremiumInstance.mockClear()
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    expect(mockGetPremiumStatus).toHaveBeenCalled()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -171,6 +171,18 @@ const sharedStatus: PremiumStatusResult = {
   },
 }
 
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2026-05-12T00:00:00Z",
+    status: "active",
+  },
+}
+
 // --- Tests ---
 
 describe("PremiumAssignmentProvider — polling routing restore", () => {
@@ -192,9 +204,10 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
   test("polling success on dedicated restores premiumAssigned=true after a prior 502/503 stripped it", async () => {
     // Stage 1: autoAssignOnLogin sees an existing SHARED assignment via
     // GET /status — provider adopts it and polling begins.
-    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
-    // Stage 2: the first poll's /assign returns DEDICATED.
-    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+    // Stage 2: the next /status poll returns DEDICATED.
+    mockGetPremiumStatus
+      .mockResolvedValueOnce(sharedStatus)
+      .mockResolvedValue(dedicatedStatus)
 
     const ctxRef = renderProvider()
 
@@ -222,5 +235,63 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
 
     // The regression: without the fix, premiumAssigned stays false here.
     expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+
+  test("polling uses /status — converges to dedicated even if /assign would still return shared", async () => {
+    // Models ISSUE_2 candidate (3): the canonical row is dedicated, but a hypothetical
+    // /assign call would still return shared. /status reads the canonical row, so
+    // polling must converge to dedicated within one cycle without a reload.
+    mockGetPremiumStatus
+      .mockResolvedValueOnce(sharedStatus)
+      .mockResolvedValue(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(sharedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+    expect(ctxRef.current?.assignmentResult?.instance_id).toBe(
+      dedicatedAssignment.instance_id,
+    )
+    // /assign must NOT have been called by the polling effect.
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+  })
+
+  test("polling does not terminate at MAX_POLL_ATTEMPTS while on shared — converges to dedicated post-cap", async () => {
+    // Models ISSUE_2 candidate (1): migration completes after the 40-attempt cap.
+    // pollAttempts is restored from sessionStorage on mount, so a long-running tab
+    // can come up already past the cap.
+    sessionStorage.setItem("premium_pollAttempts", "41")
+
+    mockGetPremiumStatus
+      .mockResolvedValueOnce(sharedStatus)
+      .mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+    // Regression: without fix (B), the terminal "No premium instance available" error fires here.
+    expect(ctxRef.current?.error).toBeNull()
   })
 })

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -1,12 +1,3 @@
-/**
- * Regression test: polling success must re-enable premium routing.
- *
- * When the polling effect catches a shared → dedicated promotion, it must
- * call routingService.setPremiumAssigned(true). Otherwise a prior 502/503
- * in this tab (which strips routing via handlePremiumRoutingError) leaves
- * the tab silently demoted to free-tier even though the UI shows dedicated.
- */
-
 import React from "react"
 
 import { SnackbarProvider } from "notistack"
@@ -115,7 +106,7 @@ jest.mock("utils/crossTabSync", () => ({
 }))
 
 // require() not import — static imports hoist above the mock vars.
-const { PremiumAssignmentProvider, usePremiumAssignment } =
+const { PremiumAssignmentProvider, usePremiumAssignment, SS_POLL_ATTEMPTS } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   require("contexts/PremiumAssignmentContext")
 const { routingService } =
@@ -268,10 +259,9 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
   })
 
   test("polling does not terminate at MAX_POLL_ATTEMPTS while on shared — converges to dedicated post-cap", async () => {
-    // Models ISSUE_2 candidate (1): migration completes after the 40-attempt cap.
     // pollAttempts is restored from sessionStorage on mount, so a long-running tab
     // can come up already past the cap.
-    sessionStorage.setItem("premium_pollAttempts", "41")
+    sessionStorage.setItem(SS_POLL_ATTEMPTS, "41")
 
     mockGetPremiumStatus
       .mockResolvedValueOnce(sharedStatus)
@@ -291,8 +281,56 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
     await waitFor(() => {
       expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
     })
-    // Regression: without fix (B), the terminal "No premium instance available" error fires here.
     expect(ctxRef.current?.error).toBeNull()
+  })
+
+  test("polling on shared neither terminates nor increments pollAttempts", async () => {
+    // Isolates the cap-bypass + counter-freeze: across multiple shared polls,
+    // error must stay null and pollAttempts must not be persisted (the provider
+    // only writes the SS key when the counter is >0, so a null read proves no
+    // increment occurred).
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(120_000)
+        await Promise.resolve()
+      })
+    }
+
+    expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    expect(ctxRef.current?.error).toBeNull()
+    expect(sessionStorage.getItem(SS_POLL_ATTEMPTS)).toBeNull()
+  })
+
+  test("repeated shared-status polls do not churn assignmentResult identity", async () => {
+    // Guards the value-equality short-circuit: when /status returns the same
+    // shared row, the provider must keep assignmentResult reference-stable so
+    // downstream consumers (useLogs, etc.) don't re-render or reset.
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    const firstRef = ctxRef.current?.assignmentResult
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(120_000)
+        await Promise.resolve()
+      })
+    }
+
+    expect(ctxRef.current?.assignmentResult).toBe(firstRef)
   })
 
   test("polling fires via unreachable path on dedicated assignment, uses /status not /assign", async () => {

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -5,6 +5,8 @@ This module defines constants for AWS service statuses to ensure consistency
 across the codebase and prevent typos.
 """
 
+import os
+
 
 class ECSTaskStatus:
     """
@@ -152,6 +154,11 @@ class PremiumInstanceConfig:
     def get_env_prefix(cls) -> str:
         """Delegate to EnvironmentConfig.get_env_prefix for convenience."""
         return EnvironmentConfig.get_env_prefix()
+
+    @classmethod
+    def get_backend_port(cls) -> int:
+        """TCP port the FastAPI service listens on inside premium instances."""
+        return int(os.environ.get("BACKEND_PORT", "8000"))
 
     @classmethod
     def get_instance_name_pattern(cls) -> str:

--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -157,8 +157,11 @@ class PremiumInstanceConfig:
 
     @classmethod
     def get_backend_port(cls) -> int:
-        """TCP port the FastAPI service listens on inside premium instances."""
-        return int(os.environ.get("BACKEND_PORT", "8000"))
+        raw = os.environ.get("BACKEND_PORT", "8000")
+        port = int(raw)
+        if not 1 <= port <= 65535:
+            raise ValueError(f"BACKEND_PORT out of range: {raw}")
+        return port
 
     @classmethod
     def get_instance_name_pattern(cls) -> str:

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -1362,10 +1362,11 @@ def migrate_user(
                 }
 
             # Swap instance in target group
+            backend_port = PremiumInstanceConfig.get_backend_port()
             try:
                 elbv2.deregister_targets(
                     TargetGroupArn=tg_arn,
-                    Targets=[{"Id": source, "Port": 8000}],
+                    Targets=[{"Id": source, "Port": backend_port}],
                 )
                 print(f"Deregistered {source} from {tg_arn}")
             except Exception as e:
@@ -1373,7 +1374,7 @@ def migrate_user(
 
             elbv2.register_targets(
                 TargetGroupArn=tg_arn,
-                Targets=[{"Id": target_instance_id, "Port": 8000}],
+                Targets=[{"Id": target_instance_id, "Port": backend_port}],
             )
             print(f"Registered {target_instance_id} in {tg_arn}")
 

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -41,6 +41,8 @@ resource "aws_lambda_function" "premium_manager" {
       # Environment prefix for dynamic resource naming
       ENV_PREFIX = var.environment
 
+      BACKEND_PORT = "8000"
+
       # Internal API configuration for experiment sync after migration
       ALB_DNS_NAME        = aws_lb.autoscaling.dns_name
       INTERNAL_API_SECRET = random_password.internal_api_secret.result
@@ -276,7 +278,8 @@ resource "aws_lambda_function" "premium_cleanup" {
       RDS_USER                   = var.mysql_user
       RDS_PASSWORD               = var.mysql_password
       RDS_DATABASE               = var.mysql_database
-      ENV_PREFIX                 = var.environment
+      ENV_PREFIX   = var.environment
+      BACKEND_PORT = "8000"
       # Cleanup-specific settings
       PREMIUM_IDLE_TIMEOUT_HOURS = "3"
     }

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -278,8 +278,8 @@ resource "aws_lambda_function" "premium_cleanup" {
       RDS_USER                   = var.mysql_user
       RDS_PASSWORD               = var.mysql_password
       RDS_DATABASE               = var.mysql_database
-      ENV_PREFIX   = var.environment
-      BACKEND_PORT = "8000"
+      ENV_PREFIX                 = var.environment
+      BACKEND_PORT               = "8000"
       # Cleanup-specific settings
       PREMIUM_IDLE_TIMEOUT_HOURS = "3"
     }

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2678,6 +2678,7 @@ def assign_premium_user(
 
     ec2: "EC2Client" = boto3.client("ec2")
     elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+    backend_port = PremiumInstanceConfig.get_backend_port()
 
     try:
         vpc_id = get_required_env_var("VPC_ID")
@@ -3388,7 +3389,7 @@ def assign_premium_user(
             target_group_response = elbv2.create_target_group(
                 Name=tg_name,
                 Protocol="HTTP",
-                Port=PremiumInstanceConfig.get_backend_port(),
+                Port=backend_port,
                 VpcId=vpc_id,
                 HealthCheckPath="/health",
                 HealthCheckProtocol="HTTP",
@@ -3414,16 +3415,11 @@ def assign_premium_user(
                 f"[premium-tg-mutate] site=assign action=register "
                 f"user={user_id} instance={instance_id} "
                 f"tg={target_group_arn} "
-                f"port={PremiumInstanceConfig.get_backend_port()}"
+                f"port={backend_port}"
             )
             elbv2.register_targets(
                 TargetGroupArn=target_group_arn,
-                Targets=[
-                    {
-                        "Id": instance_id,
-                        "Port": PremiumInstanceConfig.get_backend_port(),
-                    }
-                ],
+                Targets=[{"Id": instance_id, "Port": backend_port}],
             )
 
         # Create ALB listener rule for user routing
@@ -4187,6 +4183,8 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
     # Import the utility function
     from premium_user_utils import can_migrate_user
 
+    backend_port = PremiumInstanceConfig.get_backend_port()
+
     # Check if user can be safely migrated (no active workflows)
     if not can_migrate_user(user_id):
         print(
@@ -4250,16 +4248,11 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         f"action=register user={user_id} "
                         f"instance={new_instance_id} "
                         f"tg={new_target_group_arn} "
-                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                        f"port={backend_port}"
                     )
                     elbv2.register_targets(
                         TargetGroupArn=new_target_group_arn,
-                        Targets=[
-                            {
-                                "Id": new_instance_id,
-                                "Port": PremiumInstanceConfig.get_backend_port(),
-                            }
-                        ],
+                        Targets=[{"Id": new_instance_id, "Port": backend_port}],
                     )
 
                     # Check if old ALB rule exists, create new one if not
@@ -4365,16 +4358,11 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         f"action=deregister user={user_id} "
                         f"instance={old_instance_id} "
                         f"tg={old_target_group_arn} "
-                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                        f"port={backend_port}"
                     )
                     elbv2.deregister_targets(
                         TargetGroupArn=old_target_group_arn,
-                        Targets=[
-                            {
-                                "Id": old_instance_id,
-                                "Port": PremiumInstanceConfig.get_backend_port(),
-                            }
-                        ],
+                        Targets=[{"Id": old_instance_id, "Port": backend_port}],
                     )
 
                     # Register to new instance (same target group)
@@ -4383,16 +4371,11 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         f"action=register user={user_id} "
                         f"instance={new_instance_id} "
                         f"tg={old_target_group_arn} "
-                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                        f"port={backend_port}"
                     )
                     elbv2.register_targets(
                         TargetGroupArn=old_target_group_arn,
-                        Targets=[
-                            {
-                                "Id": new_instance_id,
-                                "Port": PremiumInstanceConfig.get_backend_port(),
-                            }
-                        ],
+                        Targets=[{"Id": new_instance_id, "Port": backend_port}],
                     )
 
                     # Update RDS assignment

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -772,8 +772,8 @@ def _finalize_expired_pending_releases_transaction(connection):
                 (uid, PremiumAssignment.PENDING_RELEASE),
             )
             print(
-                f"Finalized pending_release: deleted user {uid} -> "
-                f"instance {assignment['instance_id']}"
+                f"[premium-trace] finalize-deleted user={uid} "
+                f"instance={assignment['instance_id']}"
             )
 
     return expired
@@ -2541,7 +2541,7 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
         response = elbv2.create_target_group(
             Name=target_group_name,
             Protocol="HTTP",
-            Port=8000,
+            Port=PremiumInstanceConfig.get_backend_port(),
             VpcId=vpc_id,
             HealthCheckPath="/health",
             HealthCheckProtocol="HTTP",
@@ -3388,7 +3388,7 @@ def assign_premium_user(
             target_group_response = elbv2.create_target_group(
                 Name=tg_name,
                 Protocol="HTTP",
-                Port=8000,
+                Port=PremiumInstanceConfig.get_backend_port(),
                 VpcId=vpc_id,
                 HealthCheckPath="/health",
                 HealthCheckProtocol="HTTP",
@@ -3410,9 +3410,20 @@ def assign_premium_user(
             _enable_sticky_sessions(elbv2, target_group_arn)
 
             # 8. Register instance to target group
+            print(
+                f"[premium-tg-mutate] site=assign action=register "
+                f"user={user_id} instance={instance_id} "
+                f"tg={target_group_arn} "
+                f"port={PremiumInstanceConfig.get_backend_port()}"
+            )
             elbv2.register_targets(
                 TargetGroupArn=target_group_arn,
-                Targets=[{"Id": instance_id, "Port": 8000}],
+                Targets=[
+                    {
+                        "Id": instance_id,
+                        "Port": PremiumInstanceConfig.get_backend_port(),
+                    }
+                ],
             )
 
         # Create ALB listener rule for user routing
@@ -3781,6 +3792,11 @@ def get_ecs_container_instance_id(
 
         if not container_instance_arns:
             print(f"No premium container instances found in cluster {cluster_name}")
+            print(
+                f"[premium-ecs-map] ec2={ec2_instance_id} "
+                f"cluster={cluster_name} result=None "
+                f"reason=no_premium_container_instances"
+            )
             return None
 
         print(
@@ -3797,13 +3813,29 @@ def get_ecs_container_instance_id(
             if container_instance.get("ec2InstanceId") == ec2_instance_id:
                 container_instance_id = container_instance.get("containerInstanceArn")
                 print(f" Found ECS container instance: {container_instance_id}")
+                print(
+                    f"[premium-ecs-map] ec2={ec2_instance_id} "
+                    f"cluster={cluster_name} "
+                    f"result={container_instance_id} reason=found"
+                )
                 return container_instance_id
 
         print(f"No ECS container instance found for EC2 instance " f"{ec2_instance_id}")
+        print(
+            f"[premium-ecs-map] ec2={ec2_instance_id} "
+            f"cluster={cluster_name} result=None "
+            f"reason=no_matching_ec2_in_premium_set "
+            f"premium_count={len(container_instance_arns)}"
+        )
         return None
 
     except Exception as e:
         print(f"Error mapping EC2 to ECS container instance: {str(e)}")
+        print(
+            f"[premium-ecs-map] ec2={ec2_instance_id} "
+            f"cluster={cluster_name} result=None "
+            f"reason=exception error={str(e)}"
+        )
         return None
 
 
@@ -4213,9 +4245,21 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                     new_target_group_arn = create_or_get_target_group(user_id, vpc_id)
 
                     # Register new instance to new target group
+                    print(
+                        f"[premium-tg-mutate] site=migrate.autoscaling "
+                        f"action=register user={user_id} "
+                        f"instance={new_instance_id} "
+                        f"tg={new_target_group_arn} "
+                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                    )
                     elbv2.register_targets(
                         TargetGroupArn=new_target_group_arn,
-                        Targets=[{"Id": new_instance_id, "Port": 8000}],
+                        Targets=[
+                            {
+                                "Id": new_instance_id,
+                                "Port": PremiumInstanceConfig.get_backend_port(),
+                            }
+                        ],
                     )
 
                     # Check if old ALB rule exists, create new one if not
@@ -4316,15 +4360,39 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                             user_id, vpc_id
                         )
 
+                    print(
+                        f"[premium-tg-mutate] site=migrate.dedicated "
+                        f"action=deregister user={user_id} "
+                        f"instance={old_instance_id} "
+                        f"tg={old_target_group_arn} "
+                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                    )
                     elbv2.deregister_targets(
                         TargetGroupArn=old_target_group_arn,
-                        Targets=[{"Id": old_instance_id, "Port": 8000}],
+                        Targets=[
+                            {
+                                "Id": old_instance_id,
+                                "Port": PremiumInstanceConfig.get_backend_port(),
+                            }
+                        ],
                     )
 
                     # Register to new instance (same target group)
+                    print(
+                        f"[premium-tg-mutate] site=migrate.dedicated "
+                        f"action=register user={user_id} "
+                        f"instance={new_instance_id} "
+                        f"tg={old_target_group_arn} "
+                        f"port={PremiumInstanceConfig.get_backend_port()}"
+                    )
                     elbv2.register_targets(
                         TargetGroupArn=old_target_group_arn,
-                        Targets=[{"Id": new_instance_id, "Port": 8000}],
+                        Targets=[
+                            {
+                                "Id": new_instance_id,
+                                "Port": PremiumInstanceConfig.get_backend_port(),
+                            }
+                        ],
                     )
 
                     # Update RDS assignment

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -94,10 +94,13 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
             current_user.id, current_user.uid
         )
 
-        logger.debug(f"Assignment service result: {result}")
-        logger.debug(f"is_shared from service: {result.get('is_shared')}")
-        logger.debug(
-            f"assignment_source from service: {result.get('assignment_source')}"
+        logger.info(
+            "[premium-assign] user=%s assigned=%s is_shared=%s instance=%s source=%s",
+            current_user.id,
+            result.get("success"),
+            result.get("is_shared"),
+            result.get("instance_id"),
+            result.get("assignment_source"),
         )
 
         if result["success"]:
@@ -222,7 +225,11 @@ async def release_premium_beacon(request: Request, db: Session = Depends(get_db)
             user_id=user.id, user_uid=user_uid
         )
 
-        logger.info(f"Beacon release for user {user.id}: " f"{result.get('message')}")
+        logger.info(
+            f"[premium-trace] beacon-released user={user.id} "
+            f"instance={result.get('released_instance')} "
+            f"message={result.get('message')}"
+        )
         return {
             "success": True,
             "message": result.get("message", "Release processed"),
@@ -319,8 +326,8 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
             current_user.id, current_user.uid
         )
 
-        logger.debug(
-            "Premium status for user %s: " "assigned=%s, is_shared=%s, instance=%s",
+        logger.info(
+            "[premium-status] user=%s assigned=%s is_shared=%s instance=%s",
             current_user.id,
             status_info is not None,
             status_info.get("is_shared") if status_info else None,


### PR DESCRIPTION
### Content

#### Summary
Premium users could stay stuck on shared/waiting in the UI after the backend migrated them to dedicated — DB row `active`, container `RUNNING, HEALTHY`, tab still serving shared until reload. Two mechanisms: the polling effect called `POST /assign` (which could return `is_shared: true` even after the canonical row had been promoted) instead of `GET /status`, and gave up after 40 attempts (~39 min); separately, the log viewer's offset pagination kept addressing the old instance's log file after migration, so the platform banner went stale until refresh. Three commits land here.

#### Design Decisions

- **Poll `/status` instead of `/assign`.** `/status` is idempotent and reads the canonical row; `/assign` can lag the row, which is the only candidate root cause from issue #593 consistent with "reload always fixes it."

- **Unbounded poll while shared.** The 40-attempt cap pre-dated PRs #563 / #571 / #586 which lengthened migration latency. A user on shared is already consuming premium budget — keep polling at the capped 60 s cadence rather than terminate. Cap still fires when no assignment is held.

- **Restore `premiumAssigned` flag on polling promotion.** A prior 502/503 strips the routing flag via `handlePremiumRoutingError`. Without an explicit restore, polling flips the UI to dedicated but subsequent requests still route free-tier.

- **Treat `status.error` as transient.** Increment attempts, exponential backoff — same shape as the thrown-exception branch.

- **`BACKEND_PORT` env var, default `8000`.** Functional no-op; removes hardcoded `8000` from five callsites so a future port change is one env edit.

- **Structured log tags.** `[premium-assign]`, `[premium-status]`, `[premium-trace]`, `[premium-tg-mutate]`, `[premium-ecs-map]` across `users_me.py` and the Lambdas, so a single migration chain can be CloudWatch-filtered. `debug → info` on the assign/status handlers.

- **Reset log viewer on assignment change.** `useLogs`'s offset-based pagination is keyed implicitly to whichever instance answered the last `/logs` request — after migration, those offsets address a different log file. Subscribe to `usePremiumAssignment` and call the existing `reset()` when `assignmentResult?.instance_id` changes. A first-observation guard avoids clobbering logs captured pre-assignment. Triggered by the assignment, not by `platform.instance_id` on the response, so reset fires immediately rather than waiting up to one 2 s polling tick.

### References

- Issue #593 — *Premium assignment status not reflected in frontend until browser reload*
- Migration-flow changes that lengthened latency: #563, #571, #586
- Grep anchors: `PremiumAssignmentProvider`, `handlePremiumRoutingError`, `get_premium_user_status`, `migrate_user_to_dedicated_instance`, `useLogs`

#### Files changed

**Frontend**
- `frontend/src/contexts/PremiumAssignmentContext.tsx` — polling effect calls `getPremiumStatus()`, converts canonical row to `PremiumAssignmentResult`; cap gated on `!is_shared`; `setPremiumAssigned(true)` on dedicated success; `status.error` triggers backoff.
- `frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx` *(new)* — 4 regression tests: routing-flag restore; `/status` divergence; post-cap shared convergence; polling via the unreachable path.
- `frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/useLogs.tsx` — subscribes to `usePremiumAssignment`; calls existing `reset()` on `instance_id` change after baseline.
- `frontend/src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx` *(new)* — 2 regression tests: reset fires on instance_id change; no spurious reset on unchanged renders.

**Backend (FastAPI)**
- `studio/app/common/routers/users_me.py` — `[premium-assign]`, `[premium-status]`, `[premium-trace]` tags; `debug → info`.

**Infrastructure (Lambda + Terraform)**
- `infrastructure/aws_constants.py` — `PremiumInstanceConfig.get_backend_port()` reading `BACKEND_PORT` env.
- `infrastructure/terraform/premium_manager.tf` — `BACKEND_PORT = "8000"` on both Lambda env blocks.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — hardcoded `Port=8000` → `get_backend_port()` in 3 TG calls; `[premium-tg-mutate]` and `[premium-ecs-map]` tags.
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` — same hardcoded-port replacement in `migrate_user`.

### Manual Testcases

1. **Premium login auto-converges (golden path).** Sign in fresh. UI shows shared briefly, then dedicated within ≤ 60 s, no reload.
2. **Long-running migration past the legacy cap.** Pause `handle_check_capacity_and_migrate` for > 30 min, then unblock. UI flips to dedicated within one poll cycle after migration completes; no terminal error.
3. **Premium routing restored after 502/503.** Kill the dedicated instance. After polling reassigns, subsequent requests carry premium routing headers (verify in DevTools Network panel).
4. **Log viewer banner switches on migration.** Open log modal while on shared. After backend promotes to dedicated, the platform banner switches from `Service: ...-cloud-service` (white check) to `Service: ...-premium-...` (yellow premium icon) within milliseconds. Log content resumes against the new log file with no blank/stale gap.

End with: `cd frontend && CI=true yarn test --testPathPattern='Premium|useLogs' --no-coverage` → 10 suites, 135 tests pass.

### Test evidence

```
$ cd frontend && CI=true yarn test --testPathPattern='Premium|useLogs' --no-coverage
PASS src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
  PremiumAssignmentProvider — polling routing restore
    ✓ polling success on dedicated restores premiumAssigned=true after a prior 502/503 stripped it
    ✓ polling uses /status — converges to dedicated even if /assign would still return shared
    ✓ polling does not terminate at MAX_POLL_ATTEMPTS while on shared — converges to dedicated post-cap
    ✓ polling fires via unreachable path on dedicated assignment, uses /status not /assign
PASS src/components/Workspace/FlowChart/ModalLogs/helpers/__tests__/useLogs.test.tsx
  useLogs — premium-assignment-driven reset
    ✓ calls reset when assignmentResult.instance_id changes (shared → dedicated)
    ✓ does NOT call reset when assignmentResult.instance_id is unchanged across renders

Test Suites: 10 passed, 10 total
Tests:       135 passed, 135 total
```

**Deployed-bundle inspection** (`main.8524f9ac.js` on dev ALB):
- Fix (A): bundle around `"Still on temporary instance"` shows the new `statusResult` setState + the assignment-present / no-assignment split — only the new code produces that shape. Literal `"Premium instance assignment (shared)"` (new string) appears exactly once.
- Fix (B): cap gate is `if(h>=40 && !t)` — `&& !t` is `!isOnShared`; pre-fix was `if(h>=40)`.
- Backend tags (`[premium-status]`, `[premium-assign]`, `[premium-trace]`) appear live in `/ecs/development-optinist-cloud-taskdef`.

**Live verification — development, 2026-05-13.** Premium user 10 logged in with 0 dedicated premium instances available. The full shared → dedicated migration was traced end-to-end in CloudWatch and the log-modal swap was confirmed visually.

```
09:42:39  Premium UI event: user=10 event=waiting_popup_shown
            details={'is_assigning': True, 'has_assignment': False, 'is_shared': None, 'instance_id': None}
09:42:52  EC2 i-051220f8a6118c391 launched (Name=development-premium-dedicated, Tier=premium)
09:42:55  [premium-assign] user=10 assigned=True is_shared=True instance=autoscaling-pool source=autoscaling_temp
09:43:26  Frontend /premium/status → assignment=null  (canonical row not yet populated for shared)
09:49:38  Premium ECS task db1acba44a placed on i-051220f8a6118c391
09:49:48  [premium-tg-mutate] site=migrate.autoscaling action=register user=10 instance=i-051220f8a6118c391
            tg=…/targetgroup/premium-10-tg/96af13cd2e5756e1 port=8000
09:49:48  Migrated user 10 from autoscaling-pool to i-051220f8a6118c391
09:50:19  [premium-status] user=10 assigned=True is_shared=False instance=i-051220f8a6118c391
09:53:38  GET /logs?offset=… → 200 (first /logs request from this browser on the new dedicated task)
```

Frontend `/users/me/premium/status` payload after the flip (captured via DevTools):
```json
{
  "user_id": "Yw9YYbrlQ9ev1MJ3JjjKnd0fvvU2",
  "is_premium": true,
  "assignment": {
    "user_id": 10,
    "instance_id": "i-051220f8a6118c391",
    "target_group_arn": ".../targetgroup/premium-10-tg/96af13cd2e5756e1",
    "status": "active",
    "is_shared": false
  }
}
```

Covers manual testcases #1 and #4: the polling effect caught the canonical row transition on the next `/status` tick (`is_shared: true → false` within one poll cycle of the DB write), and `useLogs` re-pointed its pagination at the dedicated task without a reload. Sustained `GET /logs?offset=…` requests on premium task `db1acba44a` from 09:53:38 onward, offsets climbing monotonically — i.e. the modal is following the new instance's log stream, not stuck on the old one.

**Not live-tested.** Manual testcase #2 (real > 25-min Lambda block) wasn't executed end-to-end — covered by the post-cap regression test + the `&&!t` bundle gate. Manual testcase #3 (live polling cadence via unreachable path) was attempted but short-circuited: an earlier listener-rule cleanup meant premium-routed requests fell through to the ALB default rule, so no 502/503 fired. The 4th regression test (`polling fires via unreachable path…`) closes that with unit coverage.

### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Polling endpoint switch | Medium | Behavioural change in `PremiumAssignmentProvider`. 4 regression tests; shape conversion mirrors existing `autoAssignOnLogin`. Rollback: revert commit 2. |
| Unbounded poll while shared | Low | Adds load only when stuck on shared. `/status` is one Lambda+RDS read per minute per stuck tab. |
| `BACKEND_PORT` consolidation | Low | Functional no-op; defaults preserve `8000`. Rollback: revert commit 1's Terraform + Lambda hunks. |
| Increased CloudWatch log volume | Low-Medium | `debug → info` on assign/status. The `awslogs` driver on `subscr-premium-optinist-cloud-taskdef:58` is `non-blocking` (25 MB buffer) and silently drops on overflow — tracked separately. |
| Structured log tags | Low | Additive; parsers that don't recognise them ignore them. |
| Log viewer reset | Low | Surgical. `useLogs` is only consumed by `ModalLogs`; reset gated on a real `instance_id` transition. No effect when modal closed. |
