### PR TITLE
Fix: Premium tg host port - edge case

### DIFF
--- a/infrastructure/aws_constants.py
+++ b/infrastructure/aws_constants.py
@@ -27,6 +27,18 @@ class ECSTaskStatus:
     STOPPED = "STOPPED"
 
 
+class EphemeralPortConfig:
+    """Tuning constants for resolving an ECS task's host port via
+    describe_tasks → networkBindings.
+
+    The poll exists because networkBindings is briefly empty while the
+    task is RUNNING but Docker port mappings are still propagating.
+    """
+
+    RESOLVE_MAX_ATTEMPTS = 10
+    RESOLVE_DELAY_SECONDS = 3.0
+
+
 class InstanceState:
     """
     Instance state constants for premium EC2 instances.

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -865,9 +865,9 @@ resource "aws_ecs_task_definition" "premium" {
 
       portMappings = [
         {
-          name          = "${var.environment}-premium-optinist-cloud-container-port-8000"
-          containerPort = 8000
-          hostPort      = 8000
+          name          = "${var.environment}-premium-optinist-cloud-container-port-${var.premium_backend_port}"
+          containerPort = var.premium_backend_port
+          hostPort      = var.premium_backend_port
           protocol      = "tcp"
         }
       ]
@@ -927,7 +927,7 @@ resource "aws_ecs_task_definition" "premium" {
         },
         {
           name  = "BACKEND_PORT"
-          value = "8000"
+          value = tostring(var.premium_backend_port)
         },
         {
           name  = "FRONTEND_SERVER_HOST"
@@ -1041,7 +1041,7 @@ resource "aws_ecs_task_definition" "premium" {
       ]
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+        command     = ["CMD-SHELL", "curl -f http://localhost:${var.premium_backend_port}/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -233,6 +233,12 @@ variable "premium_instance_type" {
   default     = "t3.large"
 }
 
+variable "reconcile_premium_tg_ports_enabled" {
+  description = "Kill-switch for the premium target-group port reconciler in handle_scheduled_monitoring. Set false to disable without redeploying code."
+  type        = bool
+  default     = true
+}
+
 variable "background_instance_type" {
   description = "Instance type for background service instance"
   type        = string

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -233,6 +233,12 @@ variable "premium_instance_type" {
   default     = "t3.large"
 }
 
+variable "premium_backend_port" {
+  description = "Premium studio container listen port. Single source of truth for the premium task def's containerPort/hostPort/BACKEND_PORT and the premium_manager/cleanup Lambdas' BACKEND_PORT env, so the reconciler's networkBindings filter cannot drift from the live port mapping."
+  type        = number
+  default     = 8000
+}
+
 variable "reconcile_premium_tg_ports_enabled" {
   description = "Kill-switch for the premium target-group port reconciler in handle_scheduled_monitoring. Set false to disable without redeploying code."
   type        = bool

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -46,6 +46,10 @@ resource "aws_lambda_function" "premium_manager" {
       # Internal API configuration for experiment sync after migration
       ALB_DNS_NAME        = aws_lb.autoscaling.dns_name
       INTERNAL_API_SECRET = random_password.internal_api_secret.result
+
+      # Kill-switch for the per-user TG host-port reconciler. Set to
+      # "false" via terraform var to disable without redeploying code.
+      RECONCILE_PREMIUM_TG_PORTS_ENABLED = tostring(var.reconcile_premium_tg_ports_enabled)
     }
   }
 
@@ -492,6 +496,7 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Effect = "Allow"
         Action = [
           "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetHealth",
           "elasticloadbalancing:DescribeRules"
         ]
         Resource = "*"

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "premium_manager" {
       # Environment prefix for dynamic resource naming
       ENV_PREFIX = var.environment
 
-      BACKEND_PORT = "8000"
+      BACKEND_PORT = tostring(var.premium_backend_port)
 
       # Internal API configuration for experiment sync after migration
       ALB_DNS_NAME        = aws_lb.autoscaling.dns_name
@@ -283,7 +283,7 @@ resource "aws_lambda_function" "premium_cleanup" {
       RDS_PASSWORD               = var.mysql_password
       RDS_DATABASE               = var.mysql_database
       ENV_PREFIX                 = var.environment
-      BACKEND_PORT               = "8000"
+      BACKEND_PORT               = tostring(var.premium_backend_port)
       # Cleanup-specific settings
       PREMIUM_IDLE_TIMEOUT_HOURS = "3"
     }

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -41,7 +41,7 @@ import os
 import re
 import time
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import boto3
 import pymysql
@@ -51,6 +51,7 @@ from aws_constants import (
     DatabaseConfig,
     ECSTaskStatus,
     EnvironmentConfig,
+    EphemeralPortConfig,
     InstanceState,
     PremiumAssignment,
     PremiumInstanceConfig,
@@ -82,6 +83,10 @@ MIGRATION_INITIAL_DELAY_SECONDS = 60
 
 STANDBY_READINESS_TIMEOUT_SECONDS = 120
 STANDBY_READINESS_RETRY_INTERVAL_SECONDS = 10
+
+# Skip TG reconciliation for rows whose write paths touched them within this
+# window — avoids racing in-flight assign/migrate work.
+RECONCILE_RECENT_MUTATION_SECONDS = 30
 
 
 def generate_routing_id(uid: str, secret_key: str) -> str:
@@ -1951,7 +1956,12 @@ def get_premium_user_status(user_id: int) -> Dict[str, Any]:
 
 
 def publish_premium_metrics(
-    active_users: int, idle_users: int, running_instances: int, idle_instances: int
+    active_users: int,
+    idle_users: int,
+    running_instances: int,
+    idle_instances: int,
+    tg_port_drift_detected: int = 0,
+    tg_port_drift_fixed: int = 0,
 ) -> None:
     """
     Publish premium tier monitoring metrics to CloudWatch.
@@ -1961,6 +1971,8 @@ def publish_premium_metrics(
     - IdlePremiumUsers: Count of users with inactive/no assignments
     - RunningInstances: Count of running EC2 instances
     - IdleInstances: Count of instances with no assigned users
+    - TargetGroupPortDriftDetected: drifting per-user TGs observed this cycle
+    - TargetGroupPortDriftFixed: drifting per-user TGs converged this cycle
     """
     cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
 
@@ -1994,11 +2006,25 @@ def publish_premium_metrics(
                     "Unit": "Count",
                     "Timestamp": datetime.now(timezone.utc),
                 },
+                {
+                    "MetricName": "TargetGroupPortDriftDetected",
+                    "Value": tg_port_drift_detected,
+                    "Unit": "Count",
+                    "Timestamp": datetime.now(timezone.utc),
+                },
+                {
+                    "MetricName": "TargetGroupPortDriftFixed",
+                    "Value": tg_port_drift_fixed,
+                    "Unit": "Count",
+                    "Timestamp": datetime.now(timezone.utc),
+                },
             ],
         )
         print(
             f"Published metrics: active_users={active_users}, idle_users={idle_users}, "
-            f"running_instances={running_instances}, idle_instances={idle_instances}"
+            f"running_instances={running_instances}, idle_instances={idle_instances}, "
+            f"tg_port_drift_detected={tg_port_drift_detected}, "
+            f"tg_port_drift_fixed={tg_port_drift_fixed}"
         )
 
     except Exception as e:
@@ -2064,14 +2090,6 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                 f"{idle_instances} idle instances"
             )
 
-            # 4. Publish metrics to CloudWatch
-            publish_premium_metrics(
-                active_users=active_users,
-                idle_users=total_premium_users - active_users,
-                running_instances=len(running_instances),
-                idle_instances=idle_instances,
-            )
-
             # 5. Call existing scaling logic to stop idle instances
             scale_down_if_possible()
 
@@ -2132,6 +2150,30 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # 10b. Cleanup ghost ECS container instance registrations
             # (deregister container instances where EC2 is stopped/terminated)
             cleanup_ghost_ecs_registrations()
+
+            # 10c. Reconcile per-user TG host ports against actual container
+            # bindings. Closes the same-instance task-restart drift class.
+            # Idempotent under fixed host ports; non-trivial only when
+            # ephemeral ports are re-introduced.
+            try:
+                reconcile_summary = reconcile_premium_target_group_ports()
+            except Exception:
+                print("WARNING: reconcile_premium_target_group_ports() failed")
+                import traceback
+
+                traceback.print_exc()
+                reconcile_summary = {"errors": 1}
+
+            # 10d. Publish metrics to CloudWatch (after reconcile so drift
+            # counters are populated in the same cycle).
+            publish_premium_metrics(
+                active_users=active_users,
+                idle_users=total_premium_users - active_users,
+                running_instances=len(running_instances),
+                idle_instances=idle_instances,
+                tg_port_drift_detected=reconcile_summary.get("drift_detected", 0),
+                tg_port_drift_fixed=reconcile_summary.get("drift_fixed", 0),
+            )
 
             # 11. Stop orphaned EC2 instances not in ECS cluster
             cleanup_orphaned_ec2_instances()
@@ -4341,8 +4383,11 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                         ),
                     )
                 else:
-                    # Normal migration: deregister from old, register to new
-                    # First verify target group exists
+                    # Normal migration: register new, then deregister old.
+                    # Register-before-deregister keeps the TG non-empty across
+                    # the swap; reversing the order leaves a brief window where
+                    # ALB has zero targets and falls through to the free-tier
+                    # default action.
                     if not target_group_exists(old_target_group_arn):
                         print(
                             f"Target group {old_target_group_arn} not found, "
@@ -4355,19 +4400,6 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
 
                     print(
                         f"[premium-tg-mutate] site=migrate.dedicated "
-                        f"action=deregister user={user_id} "
-                        f"instance={old_instance_id} "
-                        f"tg={old_target_group_arn} "
-                        f"port={backend_port}"
-                    )
-                    elbv2.deregister_targets(
-                        TargetGroupArn=old_target_group_arn,
-                        Targets=[{"Id": old_instance_id, "Port": backend_port}],
-                    )
-
-                    # Register to new instance (same target group)
-                    print(
-                        f"[premium-tg-mutate] site=migrate.dedicated "
                         f"action=register user={user_id} "
                         f"instance={new_instance_id} "
                         f"tg={old_target_group_arn} "
@@ -4376,6 +4408,18 @@ def migrate_user_to_dedicated_instance(user_id: int, new_instance_id: str) -> bo
                     elbv2.register_targets(
                         TargetGroupArn=old_target_group_arn,
                         Targets=[{"Id": new_instance_id, "Port": backend_port}],
+                    )
+
+                    print(
+                        f"[premium-tg-mutate] site=migrate.dedicated "
+                        f"action=deregister user={user_id} "
+                        f"instance={old_instance_id} "
+                        f"tg={old_target_group_arn} "
+                        f"port={backend_port}"
+                    )
+                    elbv2.deregister_targets(
+                        TargetGroupArn=old_target_group_arn,
+                        Targets=[{"Id": old_instance_id, "Port": backend_port}],
                     )
 
                     # Update RDS assignment
@@ -5061,6 +5105,203 @@ def cleanup_failed_standby_instances():
 
 _DISCONNECT_TAG_KEY = "optinist:agent-disconnected-at"
 _AGENT_DISCONNECT_GRACE_SECONDS = 300
+
+
+def get_host_port_for_instance(
+    instance_id: str,
+    max_attempts: int = EphemeralPortConfig.RESOLVE_MAX_ATTEMPTS,
+    delay: float = EphemeralPortConfig.RESOLVE_DELAY_SECONDS,
+) -> Optional[int]:
+    """Resolve the host port bound to the studio container on instance_id.
+
+    Returns None (soft-fail; caller skips this row) if the port cannot be
+    resolved within the poll window. networkBindings is briefly empty
+    while lastStatus == RUNNING, so we poll. Filters the binding by the
+    container's listen port to stay unambiguous if a future task def
+    adds a second port mapping.
+    """
+    cluster_name = get_required_env_var("CLUSTER_NAME")
+    container_port = PremiumInstanceConfig.get_backend_port()
+    ecs_client: "ECSClient" = boto3.client("ecs")
+
+    last_err: Optional[str] = None
+    for _ in range(max_attempts):
+        try:
+            ecs_container_instance_id = get_ecs_container_instance_id(
+                instance_id, cluster_name
+            )
+            if not ecs_container_instance_id:
+                last_err = "no ECS container instance mapping"
+                time.sleep(delay)
+                continue
+
+            task_arns = ecs_client.list_tasks(
+                cluster=cluster_name,
+                containerInstance=ecs_container_instance_id,
+            ).get("taskArns", [])
+            if not task_arns:
+                last_err = "no tasks on container instance"
+                time.sleep(delay)
+                continue
+
+            task_details = ecs_client.describe_tasks(
+                cluster=cluster_name, tasks=task_arns
+            )
+            for task in task_details.get("tasks", []):
+                if task.get("lastStatus") != ECSTaskStatus.RUNNING:
+                    continue
+                for container in task.get("containers", []):
+                    match = next(
+                        (
+                            b
+                            for b in (container.get("networkBindings") or [])
+                            if b.get("containerPort") == container_port
+                        ),
+                        None,
+                    )
+                    if match and match.get("hostPort"):
+                        return int(match["hostPort"])
+            last_err = "task running but networkBindings still empty"
+        except Exception as e:
+            last_err = str(e)
+        time.sleep(delay)
+
+    print(
+        f"get_host_port_for_instance: could not resolve port for "
+        f"{instance_id} after {max_attempts} attempts: {last_err}"
+    )
+    return None
+
+
+def get_registered_ports_for_instance(
+    target_group_arn: str, instance_id: str
+) -> List[int]:
+    """Return every port currently registered for instance_id in
+    target_group_arn.
+
+    Plural because partial-fix scenarios can leave both the stale and the
+    current port registered simultaneously; the reconciler needs the
+    full set to deregister all stale entries.
+    """
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+    response = elbv2.describe_target_health(TargetGroupArn=target_group_arn)
+    return [
+        int(desc["Target"]["Port"])
+        for desc in response.get("TargetHealthDescriptions", [])
+        if (desc.get("Target") or {}).get("Id") == instance_id
+        and (desc.get("Target") or {}).get("Port") is not None
+    ]
+
+
+def reconcile_premium_target_group_ports() -> Dict[str, Any]:
+    """Reconcile per-user premium target groups so each registered
+    (Id, Port) pair matches the studio container's actual host port on
+    that instance.
+
+    Idempotent. Under fixed-port deployments every comparison resolves
+    equal and the function is a no-op apart from the read calls. Called
+    every 15 minutes by handle_scheduled_monitoring under
+    PREMIUM_SCALING_LOCK.
+    """
+    if os.environ.get("RECONCILE_PREMIUM_TG_PORTS_ENABLED", "true").lower() != "true":
+        print("reconcile_premium_target_group_ports: disabled via kill-switch")
+        return {"disabled": True}
+
+    elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+
+    summary: Dict[str, Any] = {
+        "assignments_scanned": 0,
+        "drift_detected": 0,
+        "drift_fixed": 0,
+        "skipped_no_host_port": 0,
+        "skipped_missing_tg": 0,
+        "errors": 0,
+    }
+
+    try:
+        with get_db_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """SELECT user_id, instance_id, target_group_arn
+                       FROM premium_user_assignments
+                       WHERE status IN (%s, %s)
+                         AND is_standby = 0
+                         AND instance_id <> %s
+                         AND target_group_arn IS NOT NULL
+                         AND target_group_arn <> ''
+                         AND target_group_arn NOT IN (%s, %s)
+                         AND last_state_check < (NOW() - INTERVAL %s SECOND)""",
+                    (
+                        PremiumAssignment.ACTIVE,
+                        PremiumAssignment.PENDING_RELEASE,
+                        PremiumAssignment.AUTOSCALING_POOL,
+                        PremiumAssignment.STANDBY,
+                        PremiumAssignment.RESERVING,
+                        RECONCILE_RECENT_MUTATION_SECONDS,
+                    ),
+                )
+                assignments = cursor.fetchall()
+    except Exception as e:
+        print(f"reconcile_premium_target_group_ports: DB read failed: {e}")
+        summary["errors"] += 1
+        return summary
+
+    for row in assignments:
+        summary["assignments_scanned"] += 1
+        user_id = row["user_id"]
+        instance_id = row["instance_id"]
+        tg_arn = row["target_group_arn"]
+
+        try:
+            if not target_group_exists(tg_arn):
+                summary["skipped_missing_tg"] += 1
+                print(f"reconcile: user {user_id} TG {tg_arn} gone — skipping")
+                continue
+
+            actual_port = get_host_port_for_instance(instance_id)
+            if actual_port is None:
+                summary["skipped_no_host_port"] += 1
+                continue
+
+            registered_ports = get_registered_ports_for_instance(tg_arn, instance_id)
+            stale_ports = [p for p in registered_ports if p != actual_port]
+            current_registered = actual_port in registered_ports
+
+            if not stale_ports and current_registered:
+                continue
+
+            summary["drift_detected"] += 1
+            print(
+                f"reconcile: user {user_id} instance {instance_id} drift "
+                f"detected — registered={registered_ports}, "
+                f"actual_host_port={actual_port}, tg={tg_arn}"
+            )
+
+            # Register first (additive), then deregister stale, so the TG
+            # always has at least one entry across the transition.
+            if not current_registered:
+                elbv2.register_targets(
+                    TargetGroupArn=tg_arn,
+                    Targets=[{"Id": instance_id, "Port": actual_port}],
+                )
+            for stale in stale_ports:
+                elbv2.deregister_targets(
+                    TargetGroupArn=tg_arn,
+                    Targets=[{"Id": instance_id, "Port": stale}],
+                )
+
+            summary["drift_fixed"] += 1
+            print(
+                f"reconcile: user {user_id} converged TG {tg_arn} to port "
+                f"{actual_port} (removed stale {stale_ports})"
+            )
+        except Exception as e:
+            summary["errors"] += 1
+            print(f"reconcile: user {user_id} instance {instance_id} " f"failed: {e}")
+            continue
+
+    print(f"reconcile_premium_target_group_ports summary: {summary}")
+    return summary
 
 
 def cleanup_ghost_ecs_registrations():

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -5112,19 +5112,19 @@ def get_host_port_for_instance(
     max_attempts: int = EphemeralPortConfig.RESOLVE_MAX_ATTEMPTS,
     delay: float = EphemeralPortConfig.RESOLVE_DELAY_SECONDS,
 ) -> Optional[int]:
-    """Resolve the host port bound to the studio container on instance_id.
+    """Resolve the studio container's host port on instance_id.
 
-    Returns None (soft-fail; caller skips this row) if the port cannot be
-    resolved within the poll window. networkBindings is briefly empty
-    while lastStatus == RUNNING, so we poll. Filters the binding by the
-    container's listen port to stay unambiguous if a future task def
-    adds a second port mapping.
+    Returns None if not resolvable within the poll window (networkBindings
+    is briefly empty after a task starts). Raises if bindings exist but
+    none match the expected containerPort — permanent config drift, not
+    transient.
     """
     cluster_name = get_required_env_var("CLUSTER_NAME")
     container_port = PremiumInstanceConfig.get_backend_port()
     ecs_client: "ECSClient" = boto3.client("ecs")
 
     last_err: Optional[str] = None
+    mismatch_error: Optional[str] = None
     for _ in range(max_attempts):
         try:
             ecs_container_instance_id = get_ecs_container_instance_id(
@@ -5147,24 +5147,37 @@ def get_host_port_for_instance(
             task_details = ecs_client.describe_tasks(
                 cluster=cluster_name, tasks=task_arns
             )
+            observed_container_ports: List[Any] = []
             for task in task_details.get("tasks", []):
                 if task.get("lastStatus") != ECSTaskStatus.RUNNING:
                     continue
                 for container in task.get("containers", []):
+                    bindings = container.get("networkBindings") or []
+                    for b in bindings:
+                        observed_container_ports.append(b.get("containerPort"))
                     match = next(
                         (
                             b
-                            for b in (container.get("networkBindings") or [])
+                            for b in bindings
                             if b.get("containerPort") == container_port
                         ),
                         None,
                     )
                     if match and match.get("hostPort"):
                         return int(match["hostPort"])
+            if observed_container_ports:
+                mismatch_error = (
+                    f"containerPort mismatch on {instance_id}: expected "
+                    f"{container_port}, got {observed_container_ports}"
+                )
+                break
             last_err = "task running but networkBindings still empty"
         except Exception as e:
             last_err = str(e)
         time.sleep(delay)
+
+    if mismatch_error:
+        raise RuntimeError(mismatch_error)
 
     print(
         f"get_host_port_for_instance: could not resolve port for "

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -3528,6 +3528,42 @@ class TestGetHostPortForInstance:
 
             assert get_host_port_for_instance("i-test") == 32769
 
+    def test_raises_on_container_port_mismatch(self, mock_env_vars_premium):
+        """Bindings present but none matching the expected containerPort is
+        permanent config drift — must raise so the caller counts an error
+        rather than silently skipping every row."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "lastStatus": "RUNNING",
+                        "containers": [
+                            {
+                                "networkBindings": [
+                                    {"containerPort": 9000, "hostPort": 32700},
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            from premium_manager import get_host_port_for_instance
+
+            with pytest.raises(RuntimeError, match="containerPort mismatch"):
+                get_host_port_for_instance("i-test")
+            # Must stop polling on first observation; not loop max_attempts.
+            assert mock_ecs.describe_tasks.call_count == 1
+
     def test_skips_non_running_task(self, mock_env_vars_premium):
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "boto3.client"

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -3380,3 +3380,774 @@ class TestCleanupGhostECSRegistrations:
                 force=True,
             )
             mock_ec2.describe_instances.assert_not_called()
+
+
+class TestGetHostPortForInstance:
+    """get_host_port_for_instance polls describe_tasks → networkBindings,
+    filters by CONTAINER_PORT, and soft-fails to None."""
+
+    def _ecs_client(self, mock_boto3):
+        mock_ecs = MagicMock()
+
+        def client_factory(service):
+            if service == "ecs":
+                return mock_ecs
+            return MagicMock()
+
+        mock_boto3.side_effect = client_factory
+        return mock_ecs
+
+    def test_returns_host_port_on_first_attempt(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "lastStatus": "RUNNING",
+                        "containers": [
+                            {
+                                "networkBindings": [
+                                    {"containerPort": 8000, "hostPort": 32769}
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-test") == 32769
+            mock_ecs.describe_tasks.assert_called_once()
+
+    def test_polls_through_empty_bindings(self, mock_env_vars_premium):
+        """First call returns empty networkBindings; second returns populated."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ) as mock_sleep:
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1"]}
+            mock_ecs.describe_tasks.side_effect = [
+                {
+                    "tasks": [
+                        {
+                            "lastStatus": "RUNNING",
+                            "containers": [{"networkBindings": []}],
+                        }
+                    ]
+                },
+                {
+                    "tasks": [
+                        {
+                            "lastStatus": "RUNNING",
+                            "containers": [
+                                {
+                                    "networkBindings": [
+                                        {"containerPort": 8000, "hostPort": 32770}
+                                    ]
+                                }
+                            ],
+                        }
+                    ]
+                },
+            ]
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-test") == 32770
+            assert mock_ecs.describe_tasks.call_count == 2
+            mock_sleep.assert_called()
+
+    def test_returns_none_after_max_attempts(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "lastStatus": "RUNNING",
+                        "containers": [{"networkBindings": []}],
+                    }
+                ]
+            }
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-test", max_attempts=3) is None
+            assert mock_ecs.describe_tasks.call_count == 3
+
+    def test_filters_by_container_port(self, mock_env_vars_premium):
+        """A second port mapping that is NOT containerPort 8000 must be ignored."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "lastStatus": "RUNNING",
+                        "containers": [
+                            {
+                                "networkBindings": [
+                                    {"containerPort": 9000, "hostPort": 32700},
+                                    {"containerPort": 8000, "hostPort": 32769},
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-test") == 32769
+
+    def test_skips_non_running_task(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value="ci-arn",
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            mock_ecs = self._ecs_client(mock_boto3)
+            mock_ecs.list_tasks.return_value = {"taskArns": ["t1", "t2"]}
+            mock_ecs.describe_tasks.return_value = {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "containers": [
+                            {
+                                "networkBindings": [
+                                    {"containerPort": 8000, "hostPort": 99999}
+                                ]
+                            }
+                        ],
+                    },
+                    {
+                        "lastStatus": "RUNNING",
+                        "containers": [
+                            {
+                                "networkBindings": [
+                                    {"containerPort": 8000, "hostPort": 32777}
+                                ]
+                            }
+                        ],
+                    },
+                ]
+            }
+
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-test") == 32777
+
+    def test_returns_none_when_no_container_instance_mapping(
+        self, mock_env_vars_premium
+    ):
+        """get_ecs_container_instance_id returning None (e.g. terminated EC2)
+        should drain attempts and return None, not raise."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ), patch(
+            "premium_manager.get_ecs_container_instance_id",
+            return_value=None,
+        ), patch(
+            "premium_manager.time.sleep"
+        ):
+            from premium_manager import get_host_port_for_instance
+
+            assert get_host_port_for_instance("i-gone", max_attempts=2) is None
+
+
+class TestGetRegisteredPortsForInstance:
+    """get_registered_ports_for_instance returns the full set of (Port)
+    entries for instance_id in target_group_arn."""
+
+    def test_returns_all_ports_for_instance(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": [
+                    {"Target": {"Id": "i-test", "Port": 32768}},
+                    {"Target": {"Id": "i-test", "Port": 32769}},
+                    {"Target": {"Id": "i-test", "Port": 32770}},
+                ]
+            }
+
+            from premium_manager import get_registered_ports_for_instance
+
+            ports = get_registered_ports_for_instance("tg-arn", "i-test")
+            assert sorted(ports) == [32768, 32769, 32770]
+
+    def test_filters_other_instances(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+            mock_elbv2.describe_target_health.return_value = {
+                "TargetHealthDescriptions": [
+                    {"Target": {"Id": "i-test", "Port": 32768}},
+                    {"Target": {"Id": "i-other", "Port": 32769}},
+                ]
+            }
+
+            from premium_manager import get_registered_ports_for_instance
+
+            assert get_registered_ports_for_instance("tg-arn", "i-test") == [32768]
+
+
+class TestReconcilePremiumTargetGroupPorts:
+    """reconcile_premium_target_group_ports compares each per-user TG's
+    registered ports against the actual host port and converges drift."""
+
+    def _make_row(self, user_id, instance_id, tg_arn):
+        return MockRow(
+            {
+                "user_id": user_id,
+                "instance_id": instance_id,
+                "target_group_arn": tg_arn,
+            }
+        )
+
+    def test_disabled_via_kill_switch(self, mock_env_vars_premium):
+        env = {**mock_env_vars_premium, "RECONCILE_PREMIUM_TG_PORTS_ENABLED": "false"}
+        with patch.dict("os.environ", env, clear=False), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_conn, patch("boto3.client") as mock_boto3:
+            from premium_manager import reconcile_premium_target_group_ports
+
+            result = reconcile_premium_target_group_ports()
+
+            assert result == {"disabled": True}
+            mock_conn.assert_not_called()
+            mock_boto3.assert_not_called()
+
+    def test_converged_no_drift_is_noop(self, mock_env_vars_premium):
+        """registered == actual_port: zero register/deregister calls."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=8000
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            return_value=[8000],
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["assignments_scanned"] == 1
+            assert summary["drift_detected"] == 0
+            assert summary["drift_fixed"] == 0
+            mock_elbv2.register_targets.assert_not_called()
+            mock_elbv2.deregister_targets.assert_not_called()
+
+    def test_drift_detected_and_fixed(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=32769
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            return_value=[32768],
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["drift_detected"] == 1
+            assert summary["drift_fixed"] == 1
+            mock_elbv2.register_targets.assert_called_once_with(
+                TargetGroupArn="arn:tg/premium-12-tg",
+                Targets=[{"Id": "i-aaa", "Port": 32769}],
+            )
+            mock_elbv2.deregister_targets.assert_called_once_with(
+                TargetGroupArn="arn:tg/premium-12-tg",
+                Targets=[{"Id": "i-aaa", "Port": 32768}],
+            )
+
+    def test_register_then_deregister_order(self, mock_env_vars_premium):
+        """The reconciler must register first, then deregister, so the TG
+        is never empty mid-transition."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=32769
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            return_value=[32768],
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            reconcile_premium_target_group_ports()
+
+            method_names = [call[0] for call in mock_elbv2.method_calls]
+            register_idx = method_names.index("register_targets")
+            deregister_idx = method_names.index("deregister_targets")
+            assert register_idx < deregister_idx
+
+    def test_partial_fix_both_ports_registered(self, mock_env_vars_premium):
+        """registered=[old, new], actual=new: no extra register; only
+        deregister old."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=32769
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            return_value=[32768, 32769],
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["drift_fixed"] == 1
+            mock_elbv2.register_targets.assert_not_called()
+            mock_elbv2.deregister_targets.assert_called_once_with(
+                TargetGroupArn="arn:tg/premium-12-tg",
+                Targets=[{"Id": "i-aaa", "Port": 32768}],
+            )
+
+    def test_multiple_stale_ports_all_deregistered(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=40000
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            return_value=[32768, 32769, 32770],
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            reconcile_premium_target_group_ports()
+
+            assert mock_elbv2.register_targets.call_count == 1
+            assert mock_elbv2.deregister_targets.call_count == 3
+
+    def test_skips_when_target_group_missing(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=False
+        ), patch(
+            "premium_manager.get_host_port_for_instance"
+        ) as mock_host_port:
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/gone")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["skipped_missing_tg"] == 1
+            assert summary["drift_detected"] == 0
+            mock_host_port.assert_not_called()
+            mock_elbv2.register_targets.assert_not_called()
+
+    def test_skips_when_host_port_unresolved(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance", return_value=None
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/premium-12-tg")]]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["skipped_no_host_port"] == 1
+            mock_elbv2.register_targets.assert_not_called()
+            mock_elbv2.deregister_targets.assert_not_called()
+
+    def test_iam_deny_per_row_increments_errors_and_continues(
+        self, mock_env_vars_premium
+    ):
+        """First row's describe_target_health raises; second row's
+        succeeds. Errors counted once; second row still processed."""
+
+        def host_port_side_effect(instance_id, *a, **kw):
+            return 32769
+
+        def registered_side_effect(tg, iid):
+            if iid == "i-aaa":
+                raise Exception("AccessDeniedException")
+            return [32768]
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.get_host_port_for_instance",
+            side_effect=host_port_side_effect,
+        ), patch(
+            "premium_manager.get_registered_ports_for_instance",
+            side_effect=registered_side_effect,
+        ):
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[
+                    [
+                        self._make_row(12, "i-aaa", "arn:tg/premium-12-tg"),
+                        self._make_row(13, "i-bbb", "arn:tg/premium-13-tg"),
+                    ]
+                ]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["errors"] == 1
+            assert summary["drift_fixed"] == 1
+            assert summary["assignments_scanned"] == 2
+
+    def test_db_read_failure_returns_errors_summary(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection",
+            side_effect=Exception("RDS connection refused"),
+        ):
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            assert summary["errors"] == 1
+            assert summary["drift_detected"] == 0
+            assert summary["assignments_scanned"] == 0
+
+
+class TestHandleScheduledMonitoringReconcile:
+    """handle_scheduled_monitoring must invoke the reconciler after
+    cleanup_ghost_ecs_registrations and propagate drift counts into
+    publish_premium_metrics."""
+
+    @staticmethod
+    def _lock_ctx(acquired: bool):
+        mock = MagicMock()
+        mock.return_value.__enter__.return_value = acquired
+        mock.return_value.__exit__.return_value = False
+        return mock
+
+    def _common_patches(self, mock_env_vars_premium, call_order, reconcile_summary):
+        return {
+            "env": patch.dict("os.environ", mock_env_vars_premium),
+            "lock": patch("premium_manager.distributed_lock", new=self._lock_ctx(True)),
+            "active": patch(
+                "premium_manager.count_active_premium_users", return_value=0
+            ),
+            "total": patch("premium_manager.count_total_premium_users", return_value=0),
+            "instances": patch(
+                "premium_manager.get_all_premium_instances_with_states",
+                return_value=[],
+            ),
+            "assigned": patch(
+                "premium_manager.get_assigned_users_for_instance", return_value=[]
+            ),
+            "scale": patch("premium_manager.scale_down_if_possible"),
+            "desired": patch("premium_manager.update_premium_service_desired_count"),
+            "cleanup_standby": patch(
+                "premium_manager.cleanup_failed_standby_instances"
+            ),
+            "register_orphans": patch(
+                "premium_manager.register_orphaned_stopped_instances"
+            ),
+            "terminate_aged": patch("premium_manager.terminate_aged_stopped_instances"),
+            "standby_count": patch("premium_manager.get_standby_count", return_value=0),
+            "finalize": patch(
+                "premium_manager.finalize_expired_pending_releases",
+                return_value=[],
+                side_effect=lambda: call_order.append("finalize") or [],
+            ),
+            "ghost": patch(
+                "premium_manager.cleanup_ghost_ecs_registrations",
+                side_effect=lambda: call_order.append("ghost"),
+            ),
+            "reconcile": patch(
+                "premium_manager.reconcile_premium_target_group_ports",
+                side_effect=lambda: call_order.append("reconcile") or reconcile_summary,
+            ),
+            "publish": patch(
+                "premium_manager.publish_premium_metrics",
+                side_effect=lambda **kw: call_order.append(("publish", kw)),
+            ),
+            "orphaned_ec2": patch("premium_manager.cleanup_orphaned_ec2_instances"),
+            "fix_shared": patch(
+                "premium_manager.fix_incorrect_is_shared_flags",
+                return_value={"fixed_count": 0},
+            ),
+            "shared_opt": patch(
+                "premium_manager.process_shared_instance_optimization",
+                return_value={
+                    "migrations_performed": 0,
+                    "shared_instances_found": 0,
+                },
+            ),
+        }
+
+    def _run(self, mock_env_vars_premium, call_order, reconcile_summary):
+        patches = self._common_patches(
+            mock_env_vars_premium, call_order, reconcile_summary
+        )
+        ctx_managers = [p for p in patches.values()]
+        for cm in ctx_managers:
+            cm.__enter__()
+        try:
+            from premium_manager import handle_scheduled_monitoring
+
+            return handle_scheduled_monitoring({"source": "test"}, None)
+        finally:
+            for cm in reversed(ctx_managers):
+                cm.__exit__(None, None, None)
+
+    def test_reconcile_runs_after_ghost_cleanup(self, mock_env_vars_premium):
+        call_order: list = []
+        result = self._run(
+            mock_env_vars_premium,
+            call_order,
+            {"drift_detected": 0, "drift_fixed": 0},
+        )
+
+        assert result["statusCode"] == 200
+        ghost_idx = call_order.index("ghost")
+        reconcile_idx = call_order.index("reconcile")
+        finalize_idx = call_order.index("finalize")
+        assert ghost_idx < reconcile_idx
+        assert finalize_idx < reconcile_idx
+
+    def test_publish_metrics_runs_after_reconcile_with_drift_kwargs(
+        self, mock_env_vars_premium
+    ):
+        call_order: list = []
+        self._run(
+            mock_env_vars_premium,
+            call_order,
+            {"drift_detected": 3, "drift_fixed": 2},
+        )
+
+        publish_calls = [c for c in call_order if isinstance(c, tuple)]
+        assert len(publish_calls) == 1
+        kwargs = publish_calls[0][1]
+        assert kwargs["tg_port_drift_detected"] == 3
+        assert kwargs["tg_port_drift_fixed"] == 2
+
+        reconcile_idx = call_order.index("reconcile")
+        publish_idx = call_order.index(publish_calls[0])
+        assert reconcile_idx < publish_idx
+
+    def test_reconcile_exception_does_not_break_monitor(self, mock_env_vars_premium):
+        """If the reconciler raises, the monitor still returns 200 and
+        publish_premium_metrics still runs with drift kwargs defaulting
+        to 0."""
+        call_order: list = []
+        patches = self._common_patches(
+            mock_env_vars_premium, call_order, {"drift_detected": 0, "drift_fixed": 0}
+        )
+        patches["reconcile"] = patch(
+            "premium_manager.reconcile_premium_target_group_ports",
+            side_effect=RuntimeError("kaboom"),
+        )
+        ctx_managers = [p for p in patches.values()]
+        for cm in ctx_managers:
+            cm.__enter__()
+        try:
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+        finally:
+            for cm in reversed(ctx_managers):
+                cm.__exit__(None, None, None)
+
+        assert result["statusCode"] == 200
+        publish_calls = [c for c in call_order if isinstance(c, tuple)]
+        assert len(publish_calls) == 1
+        # reconcile_summary fell back to {"errors": 1}; drift kwargs default to 0.
+        assert publish_calls[0][1]["tg_port_drift_detected"] == 0
+        assert publish_calls[0][1]["tg_port_drift_fixed"] == 0
+
+
+class TestMigrateUserToDedicatedInstanceOrder:
+    """The dedicated-to-dedicated migration branch must register the new
+    instance before deregistering the old, so the TG is never empty
+    across the swap."""
+
+    def test_dedicated_branch_registers_before_deregisters(self, mock_env_vars_premium):
+        from aws_constants import PremiumAssignment
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.pymysql.connect"
+        ) as mock_pymysql, patch(
+            "premium_manager.can_migrate_user", return_value=True, create=True
+        ), patch(
+            "premium_manager.try_reserve_instance_for_migration",
+            return_value=True,
+        ), patch(
+            "premium_manager.target_group_exists", return_value=True
+        ), patch(
+            "premium_manager.trigger_experiment_sync", return_value=True
+        ), patch(
+            "premium_user_utils.can_migrate_user", return_value=True
+        ):
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            mock_connection = setup_db_mock(
+                fetchone_values=[
+                    MockRow(
+                        {
+                            "instance_id": "i-old",
+                            "target_group_arn": "arn:tg/premium-12-tg",
+                            "alb_rule_arn": "arn:rule/r1",
+                            "active_workflow_count": 0,
+                        }
+                    ),
+                ]
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import migrate_user_to_dedicated_instance
+
+            # old_instance_id is not AUTOSCALING_POOL → dedicated branch
+            assert PremiumAssignment.AUTOSCALING_POOL != "i-old"
+            migrate_user_to_dedicated_instance(12, "i-new")
+
+            method_names = [call[0] for call in mock_elbv2.method_calls]
+            register_idx = method_names.index("register_targets")
+            deregister_idx = method_names.index("deregister_targets")
+            assert register_idx < deregister_idx, (
+                "register_targets must precede deregister_targets in "
+                "migrate.dedicated"
+            )
+
+
+class TestPublishPremiumMetricsDriftKwargs:
+    """publish_premium_metrics emits TargetGroupPortDriftDetected and
+    TargetGroupPortDriftFixed; kwargs default to 0 for back-compat."""
+
+    def test_emits_drift_metrics_with_values(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_cw = MagicMock()
+            mock_boto3.return_value = mock_cw
+
+            from premium_manager import publish_premium_metrics
+
+            publish_premium_metrics(
+                active_users=1,
+                idle_users=2,
+                running_instances=3,
+                idle_instances=4,
+                tg_port_drift_detected=5,
+                tg_port_drift_fixed=6,
+            )
+
+            args, kwargs = mock_cw.put_metric_data.call_args
+            metric_data = kwargs["MetricData"]
+            metric_by_name = {m["MetricName"]: m["Value"] for m in metric_data}
+            assert metric_by_name["TargetGroupPortDriftDetected"] == 5
+            assert metric_by_name["TargetGroupPortDriftFixed"] == 6
+
+    def test_drift_metrics_default_to_zero(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_cw = MagicMock()
+            mock_boto3.return_value = mock_cw
+
+            from premium_manager import publish_premium_metrics
+
+            publish_premium_metrics(
+                active_users=0,
+                idle_users=0,
+                running_instances=0,
+                idle_instances=0,
+            )
+
+            args, kwargs = mock_cw.put_metric_data.call_args
+            metric_by_name = {m["MetricName"]: m["Value"] for m in kwargs["MetricData"]}
+            assert metric_by_name["TargetGroupPortDriftDetected"] == 0
+            assert metric_by_name["TargetGroupPortDriftFixed"] == 0


### PR DESCRIPTION

### Content

#### Summary

Premium users get their own per-user ALB target group registered as `(instance_id, port)`. When the registered port stops matching the studio container's actual host port, ALB marks the target unhealthy, traffic falls through to the listener's default action, and the user receives free-tier responses while paying for premium. Two distinct paths produce this symptom: (a) a same-instance ECS task restart under ephemeral host ports — a latent bug class today, since prod is pinned to fixed `hostPort = 8000`, but the rollback is known temporary; (b) the dedicated→dedicated migration path, which deregisters the old target before registering the new one, leaving a measurable empty-TG window mid-swap.

This PR adds a periodic reconciler under `handle_scheduled_monitoring` that converges per-user TGs when the registered port drifts from the actual container host port. The reconciler is **idempotent and a no-op under fixed host ports** — it activates the moment ephemeral ports are re-introduced. It also swaps the order of the migrate.dedicated register/deregister pair to close the empty-TG window, consolidates the studio container port behind a single Terraform variable, and adds a runtime guard that converts silent containerPort drift into a counted error.

No CloudWatch metric is added. Drift counts and per-row errors are emitted as log lines (`reconcile_premium_target_group_ports summary: {...}` and `ReconcilerErrors: N rows failed this cycle`) so operators can opt in to alerting by adding a metric filter; the default state is silent.

#### Design Decisions

- **Reconcile-on-monitor (issue option A), not EventBridge (B).** 15-minute worst-case detection window vs seconds, but reuses the existing scheduled-monitor envelope and the `PREMIUM_SCALING_LOCK` — no new lambda, no new event source. Layering EventBridge later is an additive follow-up. Pinning `hostPort = 8000` permanently (option C) was rejected because the multi-task-per-instance motivation for ephemeral ports still stands.
- **Land the safety net before the behavior change.** The reconciler is the reader side of the ephemeral-port story: no production behavior change today, but the convergence path is already exercised when `hostPort = 0` returns. Lessons from the rollback of PRs #503 / #504 drove this split.
- **Bundle the migrate.dedicated order swap in the same PR.** It produces the same user-visible symptom (fall-through to free tier) and is the same anti-pattern the reconciler avoids. Bundled with an order-asserting unit test that prevents silent revert.
- **Plural `get_registered_ports_for_instance`.** Partial-fix scenarios can legitimately leave both stale and current ports registered simultaneously; the reconciler needs the full set to deregister all stale entries.
- **Cooling-off SQL filter `last_state_check < NOW() - INTERVAL 30 SECOND`.** Avoids racing in-flight assign/migrate writes that have updated the row but not yet completed their ELBv2 mutation. Idempotency makes this belt-and-suspenders, not load-bearing.
- **Sentinel filters in the SELECT.** Rows with `instance_id = "autoscaling-pool"` or `target_group_arn IN ("standby", "reserving")` carry placeholder strings in those columns by design. Excluded explicitly so `target_group_exists("standby")` doesn't 400 on every cycle.
- **Single Terraform variable `premium_backend_port` consolidates seven literal-8000 sites.** Premium task def's portMapping (containerPort/hostPort/name), `BACKEND_PORT` env, healthcheck command, and both premium Lambdas' `BACKEND_PORT` env all reference the variable. `terraform plan` now surfaces any partial drift at review time. The free-tier task def and security group rules are deliberately left as literal-8000 — they share an SG rule with premium today; parameterizing them is out of scope.
- **Runtime guard instead of a static module-level `assert`.** An assert against a hardcoded literal would only catch lambda-side `BACKEND_PORT` drift; the dangerous direction is task-def `containerPort` vs lambda `BACKEND_PORT`. The runtime guard in `get_host_port_for_instance` raises when `networkBindings` are present but none match the expected container port — surfaces both directions of drift via the reconciler's per-row error count.
- **Kill-switch via Terraform variable `reconcile_premium_tg_ports_enabled` (default true), not a raw env var.** `terraform apply -var reconcile_premium_tg_ports_enabled=false` disables the reconciler without redeploying lambda code, and the change is auditable in the same review surface as any other infra change.
- **No CloudWatch drift metrics.** Under fixed-port deployment they emit zero forever. The reconciler's per-cycle summary log (`reconcile_premium_target_group_ports summary: {...}`) and the dedicated `ReconcilerErrors: N rows failed this cycle` line carry the same information. Adding metrics is a small change in whatever PR re-introduces ephemeral ports.
- **Errors are log-only, no SNS/alarm wiring.** Operators who want a page can add a CloudWatch Logs metric filter on `ReconcilerErrors`; default state is silent.

### Evidence

Local pytest run on the touched test classes:

```
TestGetHostPortForInstance                  7 passed
TestGetRegisteredPortsForInstance           2 passed
TestReconcilePremiumTargetGroupPorts       14 passed
TestHandleScheduledMonitoringReconcile      2 passed
TestMigrateUserToDedicatedInstanceOrder     1 passed
```

Full file: `109 passed, 3 warnings in 2.85s`.

Telemetry-measured 232 ms empty-TG window during a dev migration (user 12, JST 06:54 on a recent dev session) was the trigger for the migrate.dedicated swap:

```
06:54:45.354  [premium-tg-mutate] site=migrate.dedicated action=deregister user=12 ...
06:54:45.586  [premium-tg-mutate] site=migrate.dedicated action=register   user=12 ...
```

Post-swap, the same trace shows `action=register` first, then `action=deregister`, with the TG non-empty across the transition.

### References

- Bug ticket: arayabrain/araya-optinist#547 (premium TG registration goes stale on same-instance ECS task restart under ephemeral host ports)
- Rollback context: PRs #503 and #504 (introduced ephemeral ports + dynamic resolution), PR #551 (rolled them back to fixed `hostPort = 8000`)
- Parent branch: `fix/long-time-migrate-users-lock` (added the migration-lock and scaling-lock plumbing this reconciler runs under)

#### Files changed

**Lambda code**

- `infrastructure/terraform/premium_manager_package/premium_manager.py` — adds `get_host_port_for_instance`, `get_registered_ports_for_instance`, `reconcile_premium_target_group_ports`; wires the reconciler into `handle_scheduled_monitoring` after `cleanup_ghost_ecs_registrations`; adds the `ReconcilerErrors` conditional log line; swaps register/deregister order in the dedicated→dedicated branch of `migrate_user_to_dedicated_instance`; adds `RECONCILE_RECENT_MUTATION_SECONDS = 30` and the `List` typing import.
- `infrastructure/aws_constants.py` — adds `class EphemeralPortConfig` with `RESOLVE_MAX_ATTEMPTS = 10` and `RESOLVE_DELAY_SECONDS = 3.0`.

**Terraform**

- `infrastructure/terraform/main.tf` — new variables `premium_backend_port` (number, default 8000) and `reconcile_premium_tg_ports_enabled` (bool, default true).
- `infrastructure/terraform/compute.tf` — premium task def's portMapping fields, `BACKEND_PORT` env, and healthcheck command all reference `var.premium_backend_port`. Autoscaling task def untouched.
- `infrastructure/terraform/premium_manager.tf` — both premium Lambdas (`premium_manager` and `premium_cleanup`) reference `var.premium_backend_port` for `BACKEND_PORT` env; `premium_manager` Lambda gains `RECONCILE_PREMIUM_TG_PORTS_ENABLED` env from the kill-switch variable; IAM policy grants `elasticloadbalancing:DescribeTargetHealth` in the read-only ELB statement.

**Tests**

- `studio/tests/infrastructure/test_premium_manager.py` — new test classes `TestGetHostPortForInstance` (7 tests), `TestGetRegisteredPortsForInstance` (2 tests), `TestReconcilePremiumTargetGroupPorts` (14 tests including 4 SELECT-predicate introspection tests), `TestHandleScheduledMonitoringReconcile` (2 tests on ordering + exception safety), `TestMigrateUserToDedicatedInstanceOrder` (1 test enforcing register-before-deregister).

### Manual Testcases

1. **No-drift baseline (works on this branch as-is).** Deploy the change. Invoke the lambda:
   ```
   aws lambda invoke --function-name <env_prefix>-premium-manager \
     --payload '{"source":"aws.events","detail-type":"Scheduled Event"}' \
     --cli-binary-format raw-in-base64-out out.json
   ```
   Expected: CloudWatch Logs show `reconcile_premium_target_group_ports summary: {..., 'drift_detected': 0, 'drift_fixed': 0, 'errors': 0, ...}`. No `ReconcilerErrors:` line. CloudTrail shows zero `RegisterTargets` / `DeregisterTargets` calls attributable to the reconciler within the cycle.

2. **Stale-TG path.** Delete a premium user's TG out of band:
   ```
   aws elbv2 delete-target-group --target-group-arn $TG
   ```
   Trigger the monitor. Expected: `skipped_missing_tg` increments in the summary log; no `RegisterTargets` against the dead ARN.

3. **Kill-switch.** Run `terraform apply -var reconcile_premium_tg_ports_enabled=false`. Trigger the monitor. Expected: `reconcile_premium_target_group_ports: disabled via kill-switch` in the lambda log; no other reconciler output that cycle. Re-apply with `=true` to restore.

4. **IAM grant present.** Before deploy: `grep -n "DescribeTargetHealth" infrastructure/terraform/premium_manager.tf` must return a hit. After deploy: confirm zero `AccessDeniedException` log lines on the `elbv2:DescribeTargetHealth` action.

5. **Migration register-then-deregister (bundled fix).** Trigger a premium user migration on dev (sign-in to an instance that requires migration). Filter CloudWatch Logs Insights for `[premium-tg-mutate] site=migrate.dedicated`. Expected: `action=register` line precedes `action=deregister` line; user's premium routing remains intact across the migration.

6. **Induced drift (requires ephemeral-port branch).** Branch from this PR onto a tree with `hostPort = 0`. Assign a premium user, confirm TG healthy. SSM into the container instance, `aws ecs stop-task` to trigger an in-place restart. Confirm `describe-target-health` shows the stale port unhealthy. Trigger the monitor. Expected: log line `reconcile: user <uid> instance <iid> drift detected — registered=[...], actual_host_port=..., tg=...` followed by `converged TG ... to port <new> (removed stale [...])`. Within ~60 s the new port reads `healthy`.

7. **Test suite:**
   ```
   cd studio && python -m pytest tests/infrastructure/test_premium_manager.py -- 109 tests pass
   ```

### Unit, Integration, Contract Test Coverage

- **Resolver behavior** (`TestGetHostPortForInstance`): first-attempt success, poll-through empty bindings, terminal None after max attempts, containerPort filter, non-RUNNING task skip, missing container-instance mapping, **containerPort mismatch raises** (regression test for the runtime guard).
- **Registered-port reader** (`TestGetRegisteredPortsForInstance`): full set returned, other instances filtered.
- **Reconciler behavior** (`TestReconcilePremiumTargetGroupPorts`): kill-switch short-circuit, converged-noop, drift-detect-and-fix, register-before-deregister order, partial-fix double-registration, multi-stale deregister, missing-TG skip, unresolved-host-port skip, per-row IAM-deny error + continue, DB-read-failure summary.
- **SELECT predicate introspection** (same class, four tests): autoscaling-pool exclusion, standby exclusion, sentinel-ARN exclusion, recently-mutated exclusion. Tests assert the SQL string and parameter tuple directly, so a refactor that loosens any predicate fails the matching test.
- **Monitor wiring** (`TestHandleScheduledMonitoringReconcile`): reconcile runs after both `finalize_expired_pending_releases` and `cleanup_ghost_ecs_registrations`; reconcile exception does not break the monitor (still returns `statusCode: 200`).
- **Migrate order** (`TestMigrateUserToDedicatedInstanceOrder`): `register_targets` call index strictly less than `deregister_targets` call index on the dedicated→dedicated branch.

### Others

#### Difficulties

The static-assert approach originally proposed for catching port drift was unworkable — it referenced an attribute that doesn't exist on `PremiumInstanceConfig`, and even synthesized would only catch lambda-side drift, not the more dangerous task-def-side drift. Replaced with a runtime guard that catches both directions and a Terraform variable that prevents the most likely drift surface at apply time.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Reconciler under fixed `hostPort = 8000` | Low | Idempotent no-op apart from read calls. Worst case observed: a few extra ECS + ELBv2 reads per monitor cycle. |
| Reconciler under ephemeral ports (future) | Medium | Sequential per-row polling can hold `PREMIUM_SCALING_LOCK` up to `RESOLVE_MAX_ATTEMPTS × RESOLVE_DELAY_SECONDS = 30 s` per unresolvable instance. Single-digit premium scale today; revisit (concurrent polling or per-cycle budget) past ~15 simultaneously-drifting rows. |
| Migrate.dedicated register-then-deregister swap | Low | Strictly safer than the previous order; ALB tolerates both targets in the TG briefly. Order-asserting test prevents silent revert. |
| New IAM grant `elasticloadbalancing:DescribeTargetHealth` | Low | Read-only ELBv2 action, no resource expansion. |
| Terraform variable `premium_backend_port` (default 8000) | Low | Default unchanged from current behavior; equivalent to today under default. Overriding the default also requires updating the shared `8000` SG rule (`aws_security_group_rule.ecs_from_alb` / `alb_to_ecs`) — flagged as a follow-up if there's ever real intent to change the port. |
| Terraform variable `reconcile_premium_tg_ports_enabled` (default true) | Low | Disable path is `terraform apply -var reconcile_premium_tg_ports_enabled=false`; no code redeploy needed. |
| Runtime guard raising on containerPort mismatch | Low | Caught by the reconciler's per-row `except`; surfaces as `errors` counter + `ReconcilerErrors: N` log line. No new alarm wiring. |
| `ReconcilerErrors` log line | Low | Log-only, no metric/alarm. Operators can opt in to alerting via a CloudWatch Logs metric filter. |

#### Rollback path

1. Disable the reconciler via the kill-switch: `terraform apply -var reconcile_premium_tg_ports_enabled=false`. Effective on the next monitor cycle, no code redeploy.
2. If deeper revert needed: revert the monitor wiring (`reconcile_premium_target_group_ports()` call inside `handle_scheduled_monitoring`). Helpers become dead code, no harm.
3. Full revert removes everything. The IAM `DescribeTargetHealth` grant is harmless to leave behind.
