### PR TITLE
Fix: re-fire the auto-assign effect when activity restarts

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -171,6 +171,9 @@ export const PremiumAssignmentProvider: React.FC<{
   // StrictMode double-invocations without triggering extra renders.
   const hasAttemptedRef = useRef(ssRead(SS_HAS_ATTEMPTED) === "true")
 
+  // Bumped to re-fire the auto-assign effect when its deps wouldn't change.
+  const [autoAssignGeneration, setAutoAssignGeneration] = useState(0)
+
   // Polling state with backoff
   const [pollInterval, setPollInterval] = useState(INITIAL_POLL_INTERVAL_MS)
   const [pollAttempts, setPollAttempts] = useState(() => {
@@ -304,6 +307,12 @@ export const PremiumAssignmentProvider: React.FC<{
    */
   const recordActivity = useCallback(async (): Promise<void> => {
     if (!isPremiumUser) return
+
+    // No assignment — trigger re-assign; a heartbeat without an instance fails.
+    if (!hasAttemptedRef.current) {
+      setAutoAssignGeneration((g) => g + 1)
+      return
+    }
 
     for (let attempt = 0; attempt < HEARTBEAT_MAX_RETRIES; attempt++) {
       try {
@@ -560,9 +569,9 @@ export const PremiumAssignmentProvider: React.FC<{
       // On network error (catch below), leave unpersisted so refresh retries.
       ssWrite(SS_HAS_ATTEMPTED, "true") // duplicated in already-assigned path above — both exits must persist
     } catch (error) {
-      // hasAttemptedRef stays true to prevent rapid-fire retries on this mount.
-      // sessionStorage is NOT written, so a page refresh will retry.
-      // Set error state so the error notification fires
+      // Reset so a subsequent user gesture (or page refresh) can retry.
+      // sessionStorage is NOT written on failure, so refresh-triggered retries also work.
+      hasAttemptedRef.current = false
       const errorMessage =
         error instanceof Error ? error.message : "Assignment failed"
       // eslint-disable-next-line no-console
@@ -634,6 +643,9 @@ export const PremiumAssignmentProvider: React.FC<{
         )
         setState((prev) => ({ ...prev, showInactivityWarning: false }))
         autoReleaseOnLogout()
+        tabSync.broadcastPremiumReleased()
+        hasAttemptedRef.current = false
+        ssRemove(SS_HAS_ATTEMPTED)
       } else if (
         timeSinceLastActivity >= oneHourMs &&
         !showInactivityWarningRef.current
@@ -689,9 +701,27 @@ export const PremiumAssignmentProvider: React.FC<{
         assignmentResult: null,
         statusResult: null,
       }))
+      hasAttemptedRef.current = false
+      ssRemove(SS_HAS_ATTEMPTED)
     })
     return unsubscribe
   }, [])
+
+  // Re-fire auto-assign after inactivity auto-release when user resumes activity.
+  useEffect(() => {
+    if (!isPremiumUser) return
+    const onActivity = () => {
+      if (!hasAttemptedRef.current) {
+        setAutoAssignGeneration((g) => g + 1)
+      }
+    }
+    window.addEventListener("pointerdown", onActivity)
+    window.addEventListener("keydown", onActivity)
+    return () => {
+      window.removeEventListener("pointerdown", onActivity)
+      window.removeEventListener("keydown", onActivity)
+    }
+  }, [isPremiumUser])
 
   // Auto-assign when premium user is detected
   useEffect(() => {
@@ -704,7 +734,7 @@ export const PremiumAssignmentProvider: React.FC<{
         hasCurrentUser: !!currentUser,
       })
     }
-  }, [isPremiumUser, currentUser, autoAssignOnLogin])
+  }, [isPremiumUser, currentUser, autoAssignOnLogin, autoAssignGeneration])
 
   // Reset polling state when user changes or gets a dedicated instance
   useEffect(() => {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -308,7 +308,8 @@ export const PremiumAssignmentProvider: React.FC<{
   const recordActivity = useCallback(async (): Promise<void> => {
     if (!isPremiumUser) return
 
-    // No assignment — trigger re-assign; a heartbeat without an instance fails.
+    // No instance yet (initial mount or post-release reset) — bump to re-assign
+    // instead of heartbeating. DOM listener bumps too; hasAttemptedRef dedups.
     if (!hasAttemptedRef.current) {
       setAutoAssignGeneration((g) => g + 1)
       return

--- a/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
@@ -1,0 +1,315 @@
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: () => {},
+    broadcastPremiumReleased: () => {},
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type))
+        mockTabSyncHandlers.set(type, new Set())
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => 0,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+const { routingService } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const renderProvider = () => {
+  const ctxRef: { current: Ctx | null } = { current: null }
+  render(
+    <SnackbarProvider maxSnack={3}>
+      <PremiumAssignmentProvider>
+        <Harness ctxRef={ctxRef} />
+      </PremiumAssignmentProvider>
+    </SnackbarProvider>,
+  )
+  return ctxRef
+}
+
+const dedicatedAssignment: PremiumAssignmentResult = {
+  message: "dedicated",
+  instance_id: "inst-A",
+  assigned: true,
+  is_shared: false,
+  assignment_source: "fresh",
+}
+
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2026-05-12T00:00:00Z",
+    status: "active",
+  },
+}
+
+const noAssignmentStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: null,
+}
+
+describe("PremiumAssignmentProvider — inactivity re-assignment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockTabSyncHandlers.clear()
+    localStorage.clear()
+    sessionStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: jest.fn(() => true),
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("clicks after 2h inactivity auto-release re-fire assignPremiumInstance", async () => {
+    mockGetPremiumStatus.mockResolvedValueOnce(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBe("true")
+
+    mockGetPremiumStatus.mockResolvedValue(noAssignmentStatus)
+    mockAssignPremiumInstance.mockClear()
+
+    await act(async () => {
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000 + 60 * 1000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBeNull()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test("a failed reassign does not strand the user — next click retries", async () => {
+    mockGetPremiumStatus.mockResolvedValueOnce(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    mockGetPremiumStatus.mockResolvedValue(noAssignmentStatus)
+    mockAssignPremiumInstance.mockReset()
+    mockAssignPremiumInstance
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue(dedicatedAssignment)
+
+    await act(async () => {
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000 + 60 * 1000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  test("cross-tab PREMIUM_RELEASED primes the receiving tab to reassign on click", async () => {
+    mockGetPremiumStatus.mockResolvedValueOnce(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBe("true")
+
+    mockGetPremiumStatus.mockResolvedValue(noAssignmentStatus)
+    mockAssignPremiumInstance.mockClear()
+
+    await act(async () => {
+      const handlers = mockTabSyncHandlers.get("PREMIUM_RELEASED")
+      handlers?.forEach((h) =>
+        h({ type: "PREMIUM_RELEASED" } as TabSyncMessage),
+      )
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test("clicks while assignment is active do not trigger redundant re-assignment", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    mockAssignPremiumInstance.mockClear()
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"))
+      window.dispatchEvent(new Event("keydown"))
+      await Promise.resolve()
+    })
+
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION

### Content

#### Summary

After a premium user's instance is auto-released following 2h of inactivity,
resuming activity on the same tab did not re-trigger assignment. The user
stayed signed in without premium compute and had to logout/login or close the
tab to recover. This PR makes the next pointerdown/keydown after release
re-fire `autoAssignOnLogin`, broadcasts the release cross-tab so sibling tabs
also re-prime, and resets the `hasAttemptedRef` guard on assignment failure so
a transient network error no longer strands the user.

#### Design Decisions

- **Trigger mechanism: `autoAssignGeneration` bump + DOM listeners over a
  one-shot listener.** Issue #594 listed both options. A state counter feeds
  into the existing `useEffect` that calls `autoAssignOnLogin`, so the
  re-assign path is the same code path as initial login — no duplicate
  fork. The DOM listeners (`pointerdown`, `keydown`) are scoped to
  `isPremiumUser` and no-op when `hasAttemptedRef.current` is true, so they
  cost effectively zero during normal sessions.
- **Reset the ref in the `autoAssignOnLogin` catch block.** The previous
  comment ("stays true to prevent rapid-fire retries on this mount") was
  guarding against an effect-rerun loop that the dep array already prevents.
  Without the reset, a failed reassign locks the user out until refresh; with
  it, the next user gesture retries. Worst case is N network attempts on
  rage-clicks — backend rate limiting is the right place for that guard, not
  this component.
- **Broadcast `PREMIUM_RELEASED` from the 2h branch.** `autoReleaseOnLogout`
  itself does not broadcast because it is also called from the explicit
  logout flow (where `release()` already broadcasts). Broadcasting only from
  the inactivity caller keeps the two release paths cleanly separated.
- **Receive-side `hasAttemptedRef` reset.** Without it, Tab B's local state
  clears via the existing handler but its ref stays true, so the new gesture
  listener silently no-ops. Redundant on the explicit-logout path (the
  `currentUser` change effect handles it there) but harmless.
- **Rejected: client-side mitigation for the `getPremiumStatus` beacon race.**
  `sendBeacon` is fire-and-forget, so a click immediately after the 2h timer
  may see the soon-to-be-released assignment in `/status`. A client-side
  `assigned_at`-vs-release-timestamp comparison was considered and rejected:
  it introduces clock-skew fragility and the proper fix is server-side
  (idempotent release + status excluding queued-release rows). Tracked
  separately; not blocking.

### Evidence

See parent issue [#594](https://github.com/arayabrain/araya-optinist/issues/594)
for full root-cause analysis, repro steps, log excerpts, and the
flag-lifecycle comparison table that motivated this fix.

Test output (local):

```
PASS src/contexts/__tests__/PremiumInactivityReassign.test.tsx
  PremiumAssignmentProvider — inactivity re-assignment
    ✓ clicks after 2h inactivity auto-release re-fire assignPremiumInstance
    ✓ a failed reassign does not strand the user — next click retries
    ✓ cross-tab PREMIUM_RELEASED primes the receiving tab to reassign on click
    ✓ clicks while assignment is active do not trigger redundant re-assignment

Tests: 4 passed, 4 total
```

Full premium-context suite: 129/129 passing.

### References

- Issue: [#594 — Unable to resume premium instance assignment after inactivity](https://github.com/arayabrain/araya-optinist/issues/594)
- Related prior PRs (same area):
  - #601 — log-not-reflected
  - #595 — fix/premium-logout
  - #592 — fix/custom-ami-credential-cleaning

#### Files changed

- `frontend/src/contexts/PremiumAssignmentContext.tsx` — add
  `autoAssignGeneration` counter, pointerdown/keydown listener that bumps it
  when `hasAttemptedRef.current` is false, broadcast `PREMIUM_RELEASED` from
  the 2h inactivity branch, reset `hasAttemptedRef`/sessionStorage on
  `PREMIUM_RELEASED` receive, reset `hasAttemptedRef` in
  `autoAssignOnLogin`'s catch so failures are recoverable.
- `frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx` — new
  test file covering: post-2h-release reassign on click; failed reassign
  recovers on next click; cross-tab `PREMIUM_RELEASED` primes the receiving
  tab; clicks during active assignment do not trigger redundant reassigns.

### Manual Testcases

**Note on inactivity timing.** The 1h/2h thresholds are local `const`s
inside `checkInactivity` (`PremiumAssignmentContext.tsx` ~L631-632) — they
are baked into the JS bundle at build time, so there is no AWS CLI / dev
console knob that flips them at runtime. Two options for testing quickly:

#### Option A — Fast-forward the timer in DevTools (no rebuild)

Works on local dev *or* the deployed dev environment. The inactivity check
reads `Math.max(lastActivityTimeRef.current, localStorage["premium_last_activity"])`,
so making both stale fires the 2h branch on the next 30s interval tick.

1. Sign in as a premium user; confirm assignment.
2. Open DevTools → Console:
   ```js
   const TWO_HOURS_AGO = Date.now() - 2 * 60 * 60 * 1000 - 5000
   localStorage.setItem("premium_last_activity", String(TWO_HOURS_AGO))
   ```
3. Open React DevTools → find `PremiumAssignmentProvider` → set
   `state.lastActivityTime` to `TWO_HOURS_AGO`.
4. Wait ≤30s for the next interval tick → release fires; verify in Network
   that the release-beacon `POST` goes out and `sessionStorage`
   `premium_hasAttempted` is cleared.
5. Click anywhere → verify `POST /users/me/premium/assign` fires.

To fast-forward only to the 1h warning, subtract `60 * 60 * 1000 + 5000`
instead.

#### Option B — Shortened-bundle build (for stakeholder verification)

Edit the two constants in `PremiumAssignmentContext.tsx` (e.g. `30 * 1000`
and `60 * 1000`), then from `infrastructure/scripts/` with the development
Terraform backend initialised:

```bash
./ecr_build_push.sh --yes
```

The script reads `environment` and `ecr_repository_url` from Terraform
outputs, builds the frontend, bakes the Docker image, and pushes `:latest`
+ a timestamped tag to ECR. ECS picks up `:latest` on next task launch (or
force a new deployment via the AWS console / `aws ecs update-service
--force-new-deployment`).

**After testing**, revert the constants and re-run `ecr_build_push.sh
--yes` from a clean checkout. Do not leave a shortened-timer bundle in dev.

#### Test cases (use Option A above to skip the 2h wait)

1. **Same-tab reassign after auto-release.**
   - Sign in as a premium user → confirm a dedicated instance is assigned.
   - Fast-forward to ~1h via Option A → confirm the inactivity warning modal
     appears.
   - Fast-forward to ~2h → confirm `assignmentResult` clears in DevTools
     React state, `sessionStorage` `premium_hasAttempted` is removed, and a
     beacon `POST` to `/users/me/premium/release-beacon` fires in the
     Network tab.
   - Click anywhere on the page (or press any key) → expect a new
     `POST /users/me/premium/assign` and `assignmentResult` to be re-populated
     with a dedicated instance.

2. **Recovery from a failed reassign.**
   - Reach the post-release state as in #1.
   - In DevTools → Network, set `/users/me/premium/assign` to "Block request URL".
   - Click → expect one failed `assign` call and the error toast.
   - Un-block the URL.
   - Click again → expect a fresh `assign` call that succeeds and a populated
     `assignmentResult`. Previously the user would have been stuck until
     refresh.

3. **Cross-tab reassign.**
   - Open the app in two tabs (A and B) as the same premium user, confirm
     both show the assigned instance.
   - In Tab A, wait for the 2h release.
   - In Tab B (without bringing it to foreground first, so its
     `setInterval` is throttled), observe that `assignmentResult` and
     `sessionStorage` `premium_hasAttempted` both clear via the
     `PREMIUM_RELEASED` tab-sync message.
   - Click in Tab B → expect a new `assign` call and re-assignment in Tab B.

4. **No redundant reassign during an active session.**
   - Sign in as a premium user.
   - Click and type repeatedly for ~30s.
   - In Network tab, expect zero additional `POST /users/me/premium/assign`
     calls beyond the initial login assignment.

5. **Logout-then-login still works (regression check).**
   - Sign in, sign out, sign in again as the same premium user.
   - Expect one `POST /users/me/premium/assign` per login, no extras.

`CI=true yarn test --testPathPattern="PremiumInactivityReassign" -- all 4 tests pass`

### Unit, Integration, Contract Test Coverage

- Unit tests: 4 new in
  `frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx`
  covering the four flows above (post-2h reassign, failure recovery,
  cross-tab broadcast, no-double-fire during active session).
- Integration: existing 129 premium-context tests continue to pass with no
  modification.
- Contract: no API surface change; uses existing `assignPremiumInstance`,
  `getPremiumStatus`, `tabSync.broadcastPremiumReleased`.

### Others

#### Difficulties

- The pre-existing `import type` syntax in
  `PremiumInactivityReassign.test.tsx` (and sibling test files) parses
  cleanly under `tsc --noEmit` but fails the project's `react-app-rewired
  test` babel config. Converted the new file's imports to value imports so
  the suite runs; the sibling test files
  (`PremiumPollingRoutingRestore.test.tsx`,
  `PremiumUnreachableIntegration.test.tsx`) have the same issue and should
  be cleaned up in a follow-up.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Premium assignment lifecycle | Low | Same-mount flow unchanged; new path is gated by `autoAssignGeneration` and the same `hasAttemptedRef` guard used today. |
| Cross-tab coordination | Low | New broadcast reuses the existing `tabSync.broadcastPremiumReleased` channel; receive handler is additive. |
| Rate of `/assign` calls | Low-Medium | Rage-clicks after a failure can produce N attempts where today the user is stuck at 0. Backend rate limiting (existing) should clamp; revisit if `/assign` traffic spikes after rollout. |
| Beacon race on click-immediately-after-release | Medium | Pre-existing on the explicit-logout path; the new feature makes it reachable from inactivity-release too. Not fixed here; tracked separately. Server-side fix is the right shape. |
