### PR TITLE
Fix(ecs): remove Secrets Manager credential injection, use Task Role …

### DIFF
--- a/cloud-startup.sh
+++ b/cloud-startup.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e  # Exit immediately if a command exits with a non-zero status
 
+# === AWS CREDENTIAL DIAGNOSTIC (remove after investigation of #612) ===
+echo "=== AWS CREDENTIAL DIAGNOSTIC ==="
+echo "AWS_ACCESS_KEY_ID set: $([ -n "$AWS_ACCESS_KEY_ID" ] && echo "YES (${AWS_ACCESS_KEY_ID:0:4}...)" || echo "NO")"
+echo "AWS_SECRET_ACCESS_KEY set: $([ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "YES" || echo "NO")"
+echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: ${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-NOT SET}"
+echo "Calling sts get-caller-identity..."
+aws sts get-caller-identity --region "${AWS_DEFAULT_REGION:-ap-northeast-1}" 2>&1 || echo "STS CALL FAILED"
+echo "=== END DIAGNOSTIC ==="
+# === END DIAGNOSTIC ===
+
 # Map infrastructure environment variables (DB_*) to application expected variables (MYSQL_*)
 # This allows the application's config.py to find the correct environment variables
 # while maintaining infrastructure naming conventions

--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -282,17 +282,6 @@ resource "aws_ecs_task_definition" "background" {
           value = "${var.environment}-premium-manager"
         },
       ]
-      secrets = [
-        {
-          name      = "AWS_ACCESS_KEY_ID"
-          valueFrom = "${aws_secretsmanager_secret.aws_credentials.arn}:AWS_ACCESS_KEY_ID::"
-        },
-        {
-          name      = "AWS_SECRET_ACCESS_KEY"
-          valueFrom = "${aws_secretsmanager_secret.aws_credentials.arn}:AWS_SECRET_ACCESS_KEY::"
-        },
-      ]
-
       mountPoints = [
         {
           sourceVolume  = "${var.environment}-background-optinist-cloud-snmk-volume"

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -770,17 +770,6 @@ resource "aws_ecs_task_definition" "autoscaling" {
           value = "${var.environment}-premium-manager"
         },
       ]
-      secrets = [
-        {
-          name      = "AWS_ACCESS_KEY_ID"
-          valueFrom = "${aws_secretsmanager_secret.aws_credentials.arn}:AWS_ACCESS_KEY_ID::"
-        },
-        {
-          name      = "AWS_SECRET_ACCESS_KEY"
-          valueFrom = "${aws_secretsmanager_secret.aws_credentials.arn}:AWS_SECRET_ACCESS_KEY::"
-        },
-      ]
-
       mountPoints = [
         {
           sourceVolume  = "${local.env_prefix}-cloud-snmk-volume"


### PR DESCRIPTION
## Overview

**Related Issues:** #591, #592 (prior partial fix)
**Status:** Root cause unidentifiable from code/config analysis. Permanent fix applied (secrets block removal).

| Item | Details |
|------|---------|
| **Confirmed** | Container authenticates as `Account-X`; reproducible 2/2 for deployer A (4/30, 5/15) |
| **Secrets Manager verified** | Contains `Account-P` — correct value was present during both incidents |
| **Code audit result** | No code path found where default profile leaks in deploy commands |
| **Architectural issue** | IAM User creds (Secrets Manager) overrode ECS Task Role which already has correct permissions |
| **Root cause** | **Unidentifiable** from code/config analysis; all hypotheses eliminated |
| **Credential persistence risk** | Very low — no mechanism found for `Account-X` to be stored in `Account-P` environment |
| **Fix applied** | Removed `secrets` block from task definitions; added runtime diagnostic to `cloud-startup.sh` |
| **Fix risk** | Very low — all required Task Role permissions verified |

> **Account aliases used in this document** (per #591 convention):
>
> - `Account-X` = unrelated account that appeared in error logs (developer's local credentials)
> - `Account-P` = production/infrastructure account used for `terraform apply` and all AWS resources

---

## Incident Details

After deploying via `ecr_build_push.sh`, the running ECS container accessed AWS resources using account `Account-X` (deployer's local default profile) instead of the intended account `Account-P`.

### Error Evidence

```
Failed to upload ... to development-optinist-user-12-16c1c3b780/...: AccessDenied (PutObject)

Function not found: arn:aws:lambda:ap-northeast-1:Account-X:function:development-premium-manager:$LATEST
```

The Lambda ARN reveals that boto3 authenticated as an identity in account `Account-X`.

### Key Observations

- ECR push succeeded (correct profile was active in the deployer's shell)
- Container restart itself was successful
- S3 and Lambda calls failed post-restart with wrong-account errors
- Account `Account-X` is the deployer's **local default profile**
- The deployer confirmed `AWS_PROFILE` was set correctly during deployment commands
- **Reproducible:** 2/2 occurrences (2026/4/30, 2026/5/15) for the same deployer
- **Deployer-specific:** Another deployer (who only has `Account-P` profile) succeeded with the same procedure
- ECS redeployment was triggered via AWS Console "Force new deployment" in `Account-P` account

---

## Architecture: How Container Credentials Worked (Before Fix)

```
┌─────────────────────────────────────────────────────────────────────┐
│ terraform apply                                                      │
│   → Creates IAM User (subscr_optinist_cloud_user) in target account │
│   → Creates Access Key for that user                                │
│   → Stores credentials in Secrets Manager                           │
│     (secret: ${env_prefix}-cloud-credentials)                       │
└──────────────────────────────┬──────────────────────────────────────┘
                               │
┌──────────────────────────────▼──────────────────────────────────────┐
│ ECS Task Launch                                                      │
│   → ECS Agent (using execution role) fetches secret from SM         │
│   → Injects AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY as env vars   │
│   → These env vars OVERRIDE the ECS Task Role in boto3's chain      │
└──────────────────────────────┬──────────────────────────────────────┘
                               │
┌──────────────────────────────▼──────────────────────────────────────┐
│ Application (boto3)                                                  │
│   → boto3.client("s3")    → uses env var credentials                │
│   → boto3.client("lambda") → uses env var credentials               │
│   (Task Role credentials are NEVER reached because env vars exist)  │
└─────────────────────────────────────────────────────────────────────┘
```

**Critical architectural issue:** The ECS Task Role (`security.tf:590-639`) ALREADY has S3 and Lambda permissions. The IAM User credentials injected from Secrets Manager were **redundant** and created a fragile override that masked the functioning Task Role.

Relevant source locations:

- ECS Task Role S3 policy: `infrastructure/terraform/security.tf:590-619`
- ECS Task Role Lambda policy: `infrastructure/terraform/security.tf:622-639`
- ECS Task Role Secrets Manager access: `infrastructure/terraform/security.tf:712-731`
- ECS Task Role ECS metadata access: `infrastructure/terraform/security.tf:692-709`
- Secrets Manager credential storage: `infrastructure/terraform/security.tf:958-968`
- boto3 Lambda client (no explicit creds): `studio/app/common/core/premium/premium_assignment_service.py:53`
- boto3 S3 client (no explicit creds): `studio/app/common/core/storage/s3_storage_controller.py:1103`

---

## Root Cause Analysis

### Code Path Audit: No Default Profile Leak Found in Deploy Commands

All AWS/Terraform commands in `ecr_build_push.sh` were audited:

| Command in ecr_build_push.sh | Auth mechanism | Status |
|------------------------------|----------------|--------|
| `terraform -chdir=../terraform output -raw ...` (×5) | Inherits `AWS_PROFILE` | ✅ Correct |
| `aws ecr get-login-password --region $REGION` | Inherits `AWS_PROFILE` | ✅ Correct |
| `aws ecr describe-repositories ...` | Inherits `AWS_PROFILE` | ✅ Correct |
| `aws secretsmanager get-secret-value ...` (Firebase) | Inherits `AWS_PROFILE` | ✅ Correct |
| `docker build -f ... .` | Isolated (no host env vars) | ✅ Correct |
| `docker push` | Uses ECR token from `docker login` | ✅ Correct |

Additional checks performed:

- **Dockerfile:** No `ENV` directives for AWS credentials, no `COPY ~/.aws/`, no `RUN aws configure`
- **cloud-startup.sh:** Does not reference `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`
- **aws_constants.py** (copied into image): No hardcoded account IDs
- **Root `.dockerignore`:** Does not exist, but Dockerfile only `COPY`s specific directories (no credential leak risk)
- **Application code:** `boto3.client(...)` calls use no explicit credentials (rely on credential chain)
- **`ecr_build_push.sh`:** Does NOT register task definitions, does NOT update ECS services, does NOT trigger redeployment. Only pushes Docker image to ECR.

**Conclusion: No code path exists in the deployment commands where the default AWS profile could override `AWS_PROFILE`.**

### Secrets Manager Runtime Verification (2026-05-16)

Direct inspection of the Secrets Manager secret revealed:

```
Secret: development-optinist-cloud-credentials
ARN: arn:aws:secretsmanager:ap-northeast-1:Account-P:secret:development-optinist-cloud-credentials-6MCHut

Versions:
  AWSCURRENT  : terraform-20260317112622954600000003 (created 2026-03-17, last accessed 2026-05-15)
  AWSPREVIOUS : terraform-20260310113919215000000017 (created 2026-03-10)
```

| Version | sts get-caller-identity result | Match deployer A's key? |
|---------|-------------------------------|------------------------|
| AWSCURRENT (2026-03-17) | `Account-P` ✅ | N/A (correct account) |
| AWSPREVIOUS (2026-03-10) | `InvalidClientTokenId` (key deleted from IAM) | ❌ Does NOT match deployer A's default profile key |

**Critical finding:** Both incidents (4/30, 5/15) occurred AFTER 2026-03-17. At that time, `AWSCURRENT` was the `Account-P` key. **Secrets Manager contained the correct value during both incidents.**

### Why ECR Push Succeeds But the Container Uses Wrong Credentials

These are **two completely independent authentication paths**:

| Operation | Auth Source | Profile Used |
|-----------|-------------|--------------|
| `ecr_build_push.sh` (ECR push) | Shell's `AWS_PROFILE` env var | Correct (`Account-P`) |
| Container's S3/Lambda calls | Unknown source (NOT Secrets Manager) | Wrong (`Account-X`) |

### Hypothesis Assessment

#### ~~Hypothesis A — Previous `terraform apply` ran with wrong profile~~

**Ruled out.** Terraform state backend (S3) resides in account `Account-P`. Running `terraform apply` with `Account-X` credentials would fail at state read/lock (`AccessDenied`). Terraform cannot proceed without state access.

#### ~~Hypothesis B — Secrets Manager value was manually overwritten~~

**Ruled out by reporter.** Not a one-time event; reproducible 2/2 times for the same deployer. Manual modification would not be deployer-specific.

#### ~~Hypothesis C — ECS Secrets Manager injection is failing, fallback to EC2 instance profile~~

**Does not explain `Account-X`.** If injection fails, boto3 falls through to EC2 Instance Metadata, which provides the instance profile for account `Account-P`. Account `Account-X` cannot appear via this path.

#### ~~Hypothesis D — IAM Access Key deactivated/deleted~~

**Ruled out.** Another deployer's deployment works correctly using the same infrastructure. Also, deactivated keys produce `InvalidClientTokenId`, not `ResourceNotFoundException`.

#### ~~Hypothesis E — Secrets Manager contained wrong credentials~~

**Ruled out by direct verification.** Both `AWSCURRENT` and `AWSPREVIOUS` are not deployer A's credentials. `AWSCURRENT` (active during both incidents) confirmed as `Account-P`. Architecturally, `terraform apply` creates the IAM user IN the target account — it cannot produce `Account-X` credentials.

#### ~~Hypothesis F — ecr_build_push.sh modifies ECS or Secrets Manager~~

**Ruled out by code review.** The script only reads Terraform outputs and pushes Docker images to ECR. It does not register task definitions, update ECS services, or write to Secrets Manager.

### Conclusion: Root Cause Unidentifiable

**All verifiable hypotheses have been eliminated.** The contradiction is:

- Secrets Manager contained `Account-P` credentials during both incidents ✅
- `terraform apply` cannot produce `Account-X` credentials (architecture prevents it) ✅
- `ecr_build_push.sh` does not modify runtime credentials ✅
- No code path leaks the default profile ✅
- Yet the container authenticated as `Account-X` ❌

The source of `Account-X` credentials in the container environment remains unexplained through code/configuration analysis. A runtime diagnostic is required to observe the actual credential state at container startup.

---

## Deployment Procedure Clarification

### Is `terraform apply` required before `ecr_build_push.sh`?

**No.** Per `DEPLOYMENT_PROCEDURE.md` (lines 116-124):

| What changed | Actions needed |
|-------------|---------------|
| Frontend/Studio code only | `ecr_build_push.sh` → Force ECS redeployment |
| Lambda code / `.tf` files | `terraform apply` |
| Both | `terraform apply` → `ecr_build_push.sh` → Force ECS redeployment |

`ecr_build_push.sh` requires only that `terraform init` has been run (to read outputs from state). It does NOT require `terraform apply`.

### What `ecr_build_push.sh` does

```bash
# 1. Reads Terraform outputs (read-only)
ENVIRONMENT=$(terraform -chdir=../terraform output -raw environment)
ECR_URI=$(terraform -chdir=../terraform output -raw ecr_repository_url)
AUTOSCALING_HOST=$(terraform -chdir=../terraform output -raw domain_name)
AUTOSCALING_PORT=$(terraform -chdir=../terraform output -raw domain_port)
AUTOSCALING_PROTO=$(terraform -chdir=../terraform output -raw domain_protocol)

# 2. Gets Firebase config from Secrets Manager (read-only)
# 3. Builds frontend
# 4. Builds Docker image
# 5. Pushes to ECR
# DOES NOT: update ECS service, register task definitions, or trigger redeployment
```

### Implication for This Incident

The reported deployment steps (`terraform init` → `terraform plan` → `ecr_build_push.sh` → Console "Force new deployment") are **correct procedure for application-code-only deployments**.

This procedure **never modifies** Secrets Manager contents, ECS task definitions, or IAM credentials.

---

## Credential Persistence Risk Assessment

### Could `Account-X` credentials be persisted in the `Account-P` AWS environment?

| Location | Risk | Reason |
|----------|------|--------|
| Secrets Manager (current) | ❌ None | Confirmed `Account-P` |
| Secrets Manager (history) | ❌ None | Only AWSCURRENT/AWSPREVIOUS retained; neither matches deployer A's key |
| ECS Task Definition revisions | ⚠️ Low (verify) | If any past revision had hardcoded credentials in `environment` block |
| Terraform State (S3) | ❌ None | Terraform can only produce `Account-P` keys |
| ECR image layers | ❌ None | Dockerfile does not COPY/ENV credentials |
| CloudTrail | ℹ️ Logs exist | API calls made AS `Account-X` are logged (but secret key itself is not recorded) |
| CloudWatch Logs | ❌ Low | Application does not log credentials |

**Overall risk: Very low.** No mechanism was found by which `Account-X` secret keys could be persisted in the `Account-P` environment.

**Recommended verification:** Check past ECS task definition revisions for hardcoded credentials:
```bash
aws ecs list-task-definitions \
    --family-prefix development-optinist \
    --region ap-northeast-1

# For each revision, check for hardcoded AWS credentials:
aws ecs describe-task-definition \
    --task-definition <revision-arn> \
    --query "taskDefinition.containerDefinitions[0].environment[?name=='AWS_ACCESS_KEY_ID']"
```

**Note:** PR #592 has already addressed operational aspects of this issue.

---

## Applied Fix: Remove Secrets Manager Credential Injection

### Rationale

Since the root cause is unidentifiable but the architectural weakness is clear, the fix eliminates the entire class of problems by removing the unnecessary credential injection mechanism.

### Changes Applied (2026-05-16)

| File | Change |
|------|--------|
| `infrastructure/terraform/compute.tf` | Removed `secrets` block (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY from Secrets Manager) |
| `infrastructure/terraform/background_service.tf` | Removed `secrets` block (same) |
| `cloud-startup.sh` | Added runtime credential diagnostic at container startup |

### How credentials work after the fix

```
┌─────────────────────────────────────────────────────────────────────┐
│ ECS Task Launch (after fix)                                          │
│   → NO secrets injection (AWS_ACCESS_KEY_ID not set as env var)     │
│   → ECS Agent provides Task Role credentials via                    │
│     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI                          │
└──────────────────────────────┬─────────────────────────���────────────┘
                               │
┌──────────────────────────────▼──────────────────────────────────────┐
│ Application (boto3)                                                  │
│   → boto3.client("s3")    → uses Task Role (via container creds)   │
│   → boto3.client("lambda") → uses Task Role (via container creds)  │
│   → aws cli (cloud-startup.sh) → uses Task Role                    │
│   Task Role is ALWAYS in Account-P (managed by Terraform)          │
└─────────────────────────────────────────────────────────────────────┘
```

### ECS Task Role permissions verified

All permissions required by the container are already defined on the Task Role:

| Permission | Policy resource | Location |
|------------|----------------|----------|
| `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`, etc. | `ecs_task_s3_access` | security.tf:591-619 |
| `lambda:InvokeFunction` | `ecs_task_lambda_invoke` | security.tf:622-639 |
| `secretsmanager:GetSecretValue` (Firebase config) | `ecs_task_secrets_access` | security.tf:712-731 |
| `ecs:DescribeTasks`, `ecs:DescribeContainerInstances` | `ecs_task_metadata` | security.tf:692-709 |

### Risk assessment of the fix

| Risk | Severity | Mitigation |
|------|----------|------------|
| Task Role missing permissions | **None** | All required permissions verified (see above) |
| `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` unavailable | **Very low** | Standard for ECS agent v1.16.0+ (current on ECS-optimized AMIs) |
| Detection delay if new issue occurs | **Low** | Runtime diagnostic logs credential state at startup |
| Data corruption | **None** | Permission failures produce clean `AccessDenied` errors, no partial writes |

### Runtime diagnostic added to `cloud-startup.sh`

```bash
# === AWS CREDENTIAL DIAGNOSTIC (remove after investigation of #612) ===
echo "=== AWS CREDENTIAL DIAGNOSTIC ==="
echo "AWS_ACCESS_KEY_ID set: $([ -n "$AWS_ACCESS_KEY_ID" ] && echo "YES (${AWS_ACCESS_KEY_ID:0:4}...)" || echo "NO")"
echo "AWS_SECRET_ACCESS_KEY set: $([ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "YES" || echo "NO")"
echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: ${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-NOT SET}"
echo "Calling sts get-caller-identity..."
aws sts get-caller-identity --region "${AWS_DEFAULT_REGION:-ap-northeast-1}" 2>&1 || echo "STS CALL FAILED"
echo "=== END DIAGNOSTIC ==="
# === END DIAGNOSTIC ===
```

Expected output after fix:
```
=== AWS CREDENTIAL DIAGNOSTIC ===
AWS_ACCESS_KEY_ID set: NO
AWS_SECRET_ACCESS_KEY set: NO
AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /v2/credentials/<uuid>
Calling sts get-caller-identity...
{
    "UserId": "AROA...:...",
    "Account": "Account-P",
    "Arn": "arn:aws:sts::Account-P:assumed-role/development-ecs-task-role/..."
}
=== END DIAGNOSTIC ===
```

### Deployment requirements

This fix requires `terraform apply` to take effect (task definition change). Deployment steps:

1. `terraform apply` — registers new task definition revision (without `secrets` block)
2. ECS "Force new deployment" — launches new task using updated definition
3. Verify CloudWatch Logs — confirm diagnostic output shows correct account

### Test Cases

After `terraform apply` + ECS "Force new deployment":

**1. Credential diagnostic (CloudWatch Logs)**

Verify the startup diagnostic in CloudWatch for each task type:

| Task type | Check | Expected |
|---|---|---|
| Regular (autoscaling) | `AWS_ACCESS_KEY_ID set:` | `NO` |
| Regular (autoscaling) | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:` | `/v2/credentials/<uuid>` (not `NOT SET`) |
| Regular (autoscaling) | `sts get-caller-identity` Account | `Account-P` |
| Background service | Same three checks as above | Same expected values |

If `AWS_ACCESS_KEY_ID set: YES` appears, the `secrets` block was not removed from the active task definition revision.

**2. Core application operations (Regular/Free task)**

| # | Operation | How to verify | What confirms success |
|---|---|---|---|
| 2a | S3 upload | Run a workflow → check output files saved | No `AccessDenied` on `PutObject` in CloudWatch |
| 2b | S3 download | Open experiment list in browser | Experiment list loads without error |
| 2c | Lambda invoke | Trigger premium-manager action (e.g. assign) | No `ResourceNotFoundException` with `Account-X` ARN |

These are the exact operations that failed during the incidents.

**3. Background service**

| # | Operation | How to verify | What confirms success |
|---|---|---|---|
| 3a | Background S3 access | Confirm background tasks (cleanup, sync) run | No `AccessDenied` in background service CloudWatch logs |

**4. Premium task (regression check — no change expected)**

| # | Operation | How to verify | What confirms success |
|---|---|---|---|
| 4a | Premium S3 access | Premium user opens experiment list | Loads without error (same behavior as before) |

Premium tasks were not modified. This confirms no unintended side effects.

### Additional preventive measures (recommended)

| Fix | Effort | Impact |
|-----|--------|--------|
| Add `allowed_account_ids` to Terraform provider | Low | Prevents wrong-account `terraform apply` |
| Add `aws sts get-caller-identity` check to `ecr_build_push.sh` | Low | Catches profile mistakes at deploy time |
| Convert runtime diagnostic to permanent health check | Low | Ongoing visibility into credential issues |

---

## Relationship to Past Issues

This is the same fundamental problem as #591/#592. The prior fix addressed documentation and deployment procedures but did not resolve the underlying architectural weakness: **IAM User access keys in Secrets Manager creating a fragile override of the correctly-configured ECS Task Role.**

Removing the credential injection is both the simplest and most robust fix. It eliminates the problem regardless of root cause.

---

## Credential Architecture Unification (PR #598 / #600 Context)

### Background: Credential Asymmetry Between Premium and Regular (Free) Tasks

PR #598 and PR #600 explicitly documented an architectural inconsistency in how Premium and Regular (Free) ECS tasks obtained AWS credentials.

**PR #598 (Note: Architectural inconsistency — out of scope)**:
> The free and premium task definitions use different AWS credential strategies:
> - **Free**: Injects static IAM User credentials via Secrets Manager `secrets` block
> - **Premium**: Uses ECS Task Role (AWS recommended approach)
>
> Both task definitions specify the same `task_role_arn`, so the free task's `secrets` block is **redundant** and could be removed to unify on the Task Role approach. This is a separate cleanup effort and not addressed in this PR.

**PR #600 (Section 3: Architecture Context)**:

| Aspect | Regular Task (pre-fix) | Premium Task |
|---|---|---|
| AWS Credentials | IAM User (via `secrets` env vars) | ECS Task Role (no env vars) |
| `AWS_ACCESS_KEY_ID` | Set (from Secrets Manager) | **Not set** |
| `AWS_SECRET_ACCESS_KEY` | Set (from Secrets Manager) | **Not set** |
| `AWS_DEFAULT_REGION` | Not set (added by PR #600) | Not set (added by PR #600) |
| Credential chain | env vars → config → container | Container credentials only |
| Task Role | `subscr-optinist-cloud-task-role` | `subscr-optinist-cloud-task-role` |

### Unification Achieved by This Fix

This PR (#612) implements the cleanup that PR #598 explicitly recommended as "a separate cleanup effort". After the `secrets` block removal, all task types use a unified credential strategy.

**Post-fix architecture (all task types unified)**:

| Aspect | Regular / Background / Premium (all tasks) |
|---|---|
| AWS Credentials | ECS Task Role |
| `AWS_ACCESS_KEY_ID` | Not set (no env var injection) |
| `AWS_SECRET_ACCESS_KEY` | Not set (no env var injection) |
| `AWS_DEFAULT_REGION` | Set (added by PR #600) |
| Credential chain | Container credentials (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`) |
| Task Role | Same `task_role_arn` (managed centrally by Terraform) |

### Consistency Verification

| Concern | Verdict | Rationale |
|---|---|---|
| Consistency with PR #598 | ✅ Consistent | PR #598 explicitly stated the `secrets` block is "redundant" and "could be removed". This fix executes that cleanup |
| Consistency with PR #600 | ✅ Consistent | Premium tasks already operated on Task Role alone with proven success. Regular tasks now use the same approach |
| Impact on PR #600's user 71 issue | ✅ No risk | Root cause was missing region (fixed by PR #600's `AWS_DEFAULT_REGION` addition), not the credential type |
| Impact on Premium tasks | ✅ None | Premium task definitions never had a `secrets` block. No change to Premium tasks |
| Impact on Background Service | ✅ Consistent | Same `task_role_arn`. Now unified with Premium's credential strategy |

### Contradictions or Oversights

**None identified.** This fix implements a cleanup that was explicitly recommended (but deferred) in PR #598, and is fully consistent with the architectural analysis documented in PR #600. The credential unification eliminates the asymmetry that was a known latent risk.
