### PR TITLE
Fix: instance_usage_log not recorded for free user re-login sessions

### DIFF
--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -462,11 +462,13 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
                 from sqlalchemy import select
 
                 open_session = session.execute(
-                    select(InstanceUsageLog.id).where(
+                    select(InstanceUsageLog.id)
+                    .where(
                         InstanceUsageLog.user_id == user_id,
                         InstanceUsageLog.tier == TIER_FREE,
                         InstanceUsageLog.ended_at.is_(None),
-                    ).limit(1)
+                    )
+                    .limit(1)
                 ).scalar()
 
                 if open_session is None:

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -454,6 +454,29 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
                     started_at=now,
                 )
                 session.add(usage_entry)
+            else:
+                # Existing assignment updated — ensure an open usage
+                # session exists.  After a logout/re-login cycle the
+                # previous InstanceUsageLog has ended_at set, so we
+                # need to start a new one for the current session.
+                from sqlalchemy import select
+
+                open_session = session.execute(
+                    select(InstanceUsageLog.id).where(
+                        InstanceUsageLog.user_id == user_id,
+                        InstanceUsageLog.tier == TIER_FREE,
+                        InstanceUsageLog.ended_at.is_(None),
+                    ).limit(1)
+                ).scalar()
+
+                if open_session is None:
+                    usage_entry = InstanceUsageLog(
+                        user_id=user_id,
+                        instance_id=instance_id,
+                        tier=TIER_FREE,
+                        started_at=now,
+                    )
+                    session.add(usage_entry)
 
             session.commit()
             return True


### PR DESCRIPTION
### Summary
- Fix a bug where a new `instance_usage_log` session row was not created when a free user re-logged in, causing `ended_at` to not be updated on subsequent logout
- Detected by System Testcases `01 Authentication & Registration > 122.Logout` 

### Background
`InstanceUsageLog` rows were only created in `_update_free_user_activity_sync()` when a new `FreeUserAssignment` was inserted (first-ever login). On re-login, the `FreeUserAssignment` row already existed, so the UPDATE path was taken and no new usage log was created.

As a result, the logout endpoint (`POST /users/me/free/logout`) executed `UPDATE instance_usage_log SET ended_at = NOW() WHERE ended_at IS NULL`, which matched 0 rows because the previous session's log had already been closed.

### Changes
- In `_update_free_user_activity_sync()`, when the UPDATE path is taken (existing `FreeUserAssignment`), check whether an open `InstanceUsageLog` row (`ended_at IS NULL`) exists for the user. If not, create a new one for the current session.

### Impact
- Severity: **Middle** (affects cost tracking and usage analytics; no direct impact on user operations)
- Performance: the additional SELECT uses the `idx_usage_log_active` index and is throttled to at most once per minute per user

### Safety: multiple rows per user_id
`instance_usage_log` is a history/log table with no UNIQUE constraint on `user_id`. Multiple rows per user are by design (one row per session).

All three places that reference this table use the same bulk-UPDATE pattern:
`UPDATE instance_usage_log SET ended_at = NOW() WHERE user_id = ? AND tier = 'free' AND ended_at IS NULL`.
If multiple open rows (`ended_at IS NULL`) exist, they are all closed at once — no data inconsistency occurs.

Additionally, the fix uses `SELECT ... LIMIT 1` to check for an existing open session before inserting, which prevents duplicate open rows from being created.

### Test plan
- [x] All 49 existing unit tests passed
- [x] First login -> logout: `free_user_assignments.logged_out_at` and `instance_usage_log.ended_at` are updated
- [x] Re-login -> logout: a new `instance_usage_log` row is created and `ended_at` is updated on logout
