### PR TITLE
Fix: Premium User Not Assigned to Dedicated Instance After Login

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -781,6 +781,19 @@ export const PremiumAssignmentProvider: React.FC<{
           routingService.setPremiumAssigned(true)
           setPollInterval(INITIAL_POLL_INTERVAL_MS)
           setPollAttempts(0)
+
+          // Acquire beacon token (matches autoAssignOnLogin behavior).
+          // Also serves as a routing probe — if the dedicated instance is
+          // unreachable, the 502/503 handler will flip premiumAssigned off
+          // and emit unreachable, causing polling to resume automatically.
+          try {
+            const tokenRes = await getBeaconTokenApi()
+            beaconTokenRef.current = tokenRes.data.token
+          } catch {
+            // Non-critical; beacon will fail gracefully.
+            // If this was a 502/503, the axios interceptor already
+            // handled recovery (setPremiumAssigned(false) + retry).
+          }
         } else {
           if (assignment) {
             setState((prev) => {

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -228,7 +228,7 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
     expect(routingService.isPremiumAssigned()).toBe(true)
   })
 
-  test("polling success on shared→dedicated calls fetchBeaconToken (PR #623 fix)", async () => {
+  test("polling success on shared→dedicated calls getBeaconTokenApi", async () => {
     // Before the fix, the polling success path set assignmentResult and
     // restored routing but did NOT call getBeaconTokenApi(). This left
     // beaconTokenRef stale and skipped the routing probe that would
@@ -245,7 +245,7 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
       expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
     })
 
-    // autoAssignOnLogin path calls fetchBeaconToken once for the shared assignment.
+    // autoAssignOnLogin path calls getBeaconTokenApi once for the shared assignment.
     const callsAfterMount = mockGetBeaconTokenApi.mock.calls.length
     expect(callsAfterMount).toBeGreaterThanOrEqual(1)
 
@@ -259,9 +259,9 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
       expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
     })
 
-    // The fix: fetchBeaconToken must be called again after polling detects
+    // The fix: getBeaconTokenApi must be called again after polling detects
     // the dedicated instance — this is the beacon-token acquisition +
-    // routing probe that was missing before PR #623.
+    // routing probe that was missing before this fix.
     expect(mockGetBeaconTokenApi.mock.calls.length).toBeGreaterThan(
       callsAfterMount,
     )

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -228,6 +228,79 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
     expect(routingService.isPremiumAssigned()).toBe(true)
   })
 
+  test("polling success on shared→dedicated calls fetchBeaconToken (PR #623 fix)", async () => {
+    // Before the fix, the polling success path set assignmentResult and
+    // restored routing but did NOT call getBeaconTokenApi(). This left
+    // beaconTokenRef stale and skipped the routing probe that would
+    // trigger auto-recovery on 502/503.
+    mockGetPremiumStatus
+      .mockResolvedValueOnce(sharedStatus)
+      .mockResolvedValue(dedicatedStatus)
+
+    mockGetBeaconTokenApi.mockClear()
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    // autoAssignOnLogin path calls fetchBeaconToken once for the shared assignment.
+    const callsAfterMount = mockGetBeaconTokenApi.mock.calls.length
+    expect(callsAfterMount).toBeGreaterThanOrEqual(1)
+
+    // Advance timer to trigger polling; next /status returns dedicated.
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+
+    // The fix: fetchBeaconToken must be called again after polling detects
+    // the dedicated instance — this is the beacon-token acquisition +
+    // routing probe that was missing before PR #623.
+    expect(mockGetBeaconTokenApi.mock.calls.length).toBeGreaterThan(
+      callsAfterMount,
+    )
+  })
+
+  test("polling success on shared→dedicated acquires beacon token even when fetch fails", async () => {
+    // When getBeaconTokenApi rejects (e.g. 502/503 from the dedicated
+    // instance), the polling success path must NOT throw — the catch
+    // block absorbs the error and the assignment flow continues.
+    mockGetPremiumStatus
+      .mockResolvedValueOnce(sharedStatus)
+      .mockResolvedValue(dedicatedStatus)
+
+    // Let mount-time beacon call succeed, then fail on the polling path.
+    mockGetBeaconTokenApi
+      .mockResolvedValueOnce({ data: { token: "mount-token" } })
+      .mockRejectedValueOnce(new Error("Service Unavailable"))
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    // Advance timer to trigger polling; beacon fetch will reject.
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    // Despite the beacon failure, assignment must still transition to dedicated.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+    expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    // No error should be surfaced to the user.
+    expect(ctxRef.current?.error).toBeNull()
+  })
+
   test("polling uses /status — converges to dedicated even if /assign would still return shared", async () => {
     // Models ISSUE_2 candidate (3): the canonical row is dedicated, but a hypothetical
     // /assign call would still return shared. /status reads the canonical row, so


### PR DESCRIPTION
## Summary

- Fix premium user not being assigned to dedicated instance after login
- Add missing `fetchBeaconToken()` call in the polling success path of `PremiumAssignmentContext.tsx`
- This matches the existing behavior in `autoAssignOnLogin()` and also serves as a routing probe for auto-recovery

## Root Cause

The polling success path in `PremiumAssignmentContext.tsx` was missing a `fetchBeaconToken()` call when it detected a dedicated instance.

**Trigger condition**: Only occurs when the user is initially assigned to the autoscaling-pool (Tier 5) and then polling detects the dedicated instance after migration completes. Direct assignment to a dedicated instance (Tier 1-3) is unaffected because `autoAssignOnLogin()` executes the complete flow including beacon-token fetch.

**Impact**:
- `beaconTokenRef` not refreshed — sendBeacon on page close fails silently
- No routing probe to the dedicated instance — cannot verify ALB routing health
- UI remains in "not assigned" state until browser reload

## Changes

**File**: `frontend/src/contexts/PremiumAssignmentContext.tsx`

Added `fetchBeaconToken()` after `setPollAttempts(0)` in the polling success path:

```typescript
// Acquire beacon token (matches autoAssignOnLogin behavior).
// Also serves as a routing probe — if the dedicated instance is
// unreachable, the 502/503 handler will flip premiumAssigned off
// and emit unreachable, causing polling to resume automatically.
try {
  const tokenRes = await getBeaconTokenApi()
  beaconTokenRef.current = tokenRes.data.token
} catch {
  // Non-critical; beacon will fail gracefully.
  // If this was a 502/503, the axios interceptor already
  // handled recovery (setPremiumAssigned(false) + retry).
}
```

### Design Properties

1. **Feature parity** with `autoAssignOnLogin()` — beacon-token is now acquired in both code paths
2. **Routing probe** — if the dedicated instance is not yet reachable via ALB, the 502/503 handler automatically triggers recovery (`setPremiumAssigned(false)` → `emitPremiumUnreachable()` → polling resumes)
3. **Non-blocking** — failure is caught and does not break the assignment flow
4. **TypeScript compilation verified** — no errors

---

## Investigation Details

### Bug Report

A premium user signed in via the frontend Login page but never appeared to be assigned to their premium instance. A browser reload resolved the issue.

| Time     | Event                                                         |
| -------- | ------------------------------------------------------------- |
| 09:31    | Premium user signs in                                         |
| ~09:31   | EC2 instance `i-02604332ec60dfcd1` begins starting            |
| 09:38    | ECS task starts on the instance                               |
| ~09:58   | User still perceives "not assigned"; no `beacon-token` calls  |
| (reload) | Browser reload resolves the issue — beacon-token GET 200 OK   |

**Reproduction condition**: Intermittent — only occurs when Tier 5 (autoscaling-pool) assignment is used and polling detects the dedicated instance. Direct assignment (Tier 1-3) is unaffected.

### Architecture Overview

```
Frontend Login
  → autoAssignOnLogin()
    → getPremiumStatus()        // check existing assignment
    → assignPremiumInstance()   // POST /users/me/premium/assign
      → Backend (FastAPI)
        → Lambda (synchronous RequestResponse invocation)
          → 5-tier priority cascade:
              Tier 1: Dedicated Running
              Tier 2: Dedicated Starting
              Tier 3: Dedicated Stopped → Start
              Tier 4: Available from Pool
              Tier 5: Scale New (autoscaling-pool temporary assignment)
```

| Component | Description |
|-----------|-------------|
| **Default listener action** | Forward to `autoscaling` target group (shared/free-tier) |
| **Per-user rules** | Created dynamically, matching `X-User-Tier: premium` AND `X-Routing-ID: <user-routing-id>` |
| **Per-user TG naming** | `premium-{user_id}-tg` (e.g., `premium-12-tg`) |
| **Rule lifecycle** | Created at assignment, modified at migration, deleted at release |

### Incident Flow Reconstruction

**Assignment (09:31:41 – 09:31:54)**

ALB Access Log: `POST /users/me/premium/assign` → HTTP 200, 12.883s

Lambda Log:
```
09:31:44 === PREMIUM USER ASSIGNMENT START ===
  - Running instances: 0, Standby available: 0
  - "User 12 will login via autoscaling pool"

09:31:44 === ASSIGNMENT SUCCESS ===
  - Instance ID: autoscaling-pool
  - Assignment source: autoscaling_temp
  - Is shared: True

09:31:45 ALB Rule Created:
  - Priority 100, Rule ARN: .../399e0e579eb41dc2
  - Target: development-optinist-tg/6d7eaba17c01f722 (default TG)

09:31:50 EC2 instance i-02604332ec60dfcd1 created
09:31:51 Triggered async migration via Lambda
09:31:54 Request complete (Duration: 12,831 ms)
```

Frontend `autoAssignOnLogin()` executed:
1. `setAssignmentResult({ assigned: true, is_shared: true })`
2. `routingService.setPremiumAssigned(true)` → routing headers enabled
3. `fetchBeaconToken()` → beacon-token acquired
4. `shouldPoll()` → `true` (is_shared=true) → polling started

**Polling Phase (09:32:25 – 09:39:16)**

| Poll # | Time     | Result |
|--------|----------|--------|
| 1      | 09:32:25 | autoscaling-pool, is_shared=1 → 404 |
| 2      | 09:33:11 | autoscaling-pool, is_shared=1 → 404 |
| 3–7    | 09:34–09:38 | autoscaling-pool, is_shared=1 → 404 |
| 8      | 09:39:16 | **i-02604332ec60dfcd1, is_shared=0 → 200** |

Poll 8 confirms migration completed — ALB rule `399e0e579eb41dc2` modified from default TG to `premium-12-tg`.

**After Poll #8 — The Bug**

Frontend polling success path executed:
1. `setAssignmentResult({ assigned: true, is_shared: false })` ✓
2. `routingService.setPremiumAssigned(true)` ✓ (idempotent)
3. `setPollAttempts(0)` ✓
4. **`fetchBeaconToken()` — NOT CALLED** ← the bug

Polling stopped, but `beaconTokenRef.current` was stale (from 09:31:54, shared instance). No routing probe to dedicated instance occurred. The axios 502/503 auto-recovery could not trigger because no request exercised the new ALB routing path.

### The Code Difference

**`autoAssignOnLogin` success path**:
```typescript
setAssignmentResult(result)
routingService.setPremiumAssigned(true)
fetchBeaconToken()   // ← CALLED
```

**Polling success path** (before fix):
```typescript
setAssignmentResult(statusToAssignmentResult(assignment))
routingService.setPremiumAssigned(true)
setPollAttempts(0)
// ← fetchBeaconToken() NOT CALLED
```

### Backend Verification

All backend components confirmed working:

| Component | Status | Evidence |
|-----------|--------|----------|
| Backend assignment (Lambda) | Working | user 12 assigned at 09:31:44 |
| EC2 instance launch | Working | i-02604332ec60dfcd1 created at 09:31:50 |
| Migration execution | Working | DB state changed: autoscaling-pool → dedicated by 09:39 |
| ALB rule creation | Working | Rule 399e0e579eb41dc2 created at 09:31:45 |
| ALB rule modification | Working | Same rule modified to point to premium-12-tg |
| Frontend routing headers | Working | Sent on all requests after 09:31:54 |
| **fetchBeaconToken on poll success** | **BUG (fixed)** | **Not called at 09:39:16** |

### Disproven Hypotheses

| Hypothesis | Evidence Disproving |
|------------|-------------------|
| ALB idle timeout killed /assign request | Request completed in 12.883s (HTTP 200) |
| ALB rule not updated during migration | Lambda logs show rule modified from default TG to premium-12-tg |
| Dev environment doesn't use per-user ALB rules | Codebase confirms identical logic to production |
| Frontend routing headers not sent | RoutingService state had both conditions met |
| 502/503 cleared premiumAssigned | No 502/503 in ALB logs between 09:31–09:48 |

---

## Test Plan

### Automated Tests

Two tests added to `frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx`:

| # | Test Name | Verification |
|---|-----------|--------------|
| 1 | `polling success on shared→dedicated calls getBeaconTokenApi` | `getBeaconTokenApi()` is called again after polling detects the dedicated instance |
| 2 | `polling success on shared→dedicated acquires beacon token even when fetch fails` | `getBeaconTokenApi()` rejection does not break the assignment flow |

```
yarn test --testPathPattern=PremiumPollingRoutingRestore
→ 8 passed (6 existing + 2 new)
```

### Manual Test Prerequisites

- A premium-subscribed test user account
- Access to AWS Console (EC2, ECS, ALB, CloudWatch Logs) and MySQL (RDS) via the RDS Proxy endpoint (`RDS_HOST` environment variable)
- Browser DevTools open (Network tab, Console tab)
- Network tab "Preserve log" enabled

### Test 1: Beacon-token acquisition after Tier 5 polling success (primary test case)

**Objective**: Verify that when a premium user logs in via Tier 5 (autoscaling-pool) and polling detects the dedicated instance, `fetchBeaconToken()` is called in the polling success path.

#### Step 1: Create Tier 5 entry conditions

Force the Lambda 5-tier cascade to skip Tiers 1–4 and reach Tier 5 (Scale New). This requires eliminating **all** premium instances in the environment, not just those belonging to the target user.

**Why all instances must be removed**: The 5-tier cascade evaluates **all** premium instances globally, not per-user. If any other user's instance exists, it will be assigned before reaching Tier 5:
- Running instance with 0 users → Tier 1 (Dedicated)
- Running instance with users → Tier 2 (Shared)
- Stopped instance → adopted into Tier 3 by `register_orphaned_stopped_instances()` before the cascade runs

**Sign-in state**: Ensure **all** premium users are signed out before starting. Performing backend state cleanup (instance termination, assignment record deletion) while any frontend holds an active premium session can cause inconsistent state.

1. **Ensure all premium users are signed out.**
   - Coordinate with other testers or verify via the application that no other premium user sessions are active.

2. **MySQL (RDS)**: List all assignment records.
   - **Connection**: Use the RDS Proxy endpoint specified by the `RDS_HOST` environment variable.
   ```sql
   SELECT id, user_id, instance_id, status, is_shared, is_standby, instance_state
     FROM premium_user_assignments;
   ```
   - Note all `instance_id` values (both user assignments and standby entries).

3. **AWS EC2 Console**: Identify all premium instances.
   - Go to Instances and apply the following filters:
     - Tag `Type` = `Premium-Instance`
     - Tag `Service` = `premium-tier`
   - Note all instance IDs, regardless of state (Running, Stopped, etc.).

4. **Terminate all premium instances.**
   - Select all instances found in step 3 and terminate them.
   - **Important**: Use Terminate, not Stop. A stopped instance will be adopted into the standby pool (Tier 3) by `register_orphaned_stopped_instances()` before the cascade runs.

5. **MySQL (RDS)**: Delete all assignment and standby records.
   ```sql
   DELETE FROM premium_user_assignments;
   ```
   - This removes user assignments (`is_standby = 0`) and standby entries (`is_standby = 1`) alike.
   - Alternatively, to delete only specific records:
     ```sql
     -- Delete target user's assignment
     DELETE FROM premium_user_assignments WHERE user_id = <target_user_id>;
     -- Delete all standby entries
     DELETE FROM premium_user_assignments WHERE is_standby = 1;
     -- Delete other users' assignments (only if those users are signed out)
     DELETE FROM premium_user_assignments WHERE user_id IS NOT NULL;
     ```

6. **Verify no premium instances remain.**
   1. **MySQL (RDS)**:
      ```sql
      SELECT COUNT(*) FROM premium_user_assignments;
      ```
      - Must return 0.
   2. **AWS EC2 Console**: Re-apply the filters from step 3.
      - Tag `Type` = `Premium-Instance`, Tag `Service` = `premium-tier`
      - Instance state: exclude `Terminated`
      - Must show 0 instances.

7. **Note on automatic replenishment**: The standby pool is automatically replenished (controlled by the `PREMIUM_STANDBY_POOL_SIZE` environment variable, default `1`). The 15-minute scheduled monitor (`handle_scheduled_monitoring()`) may create new standby instances after cleanup. Ensure the test login is performed before the next monitor cycle runs, or temporarily disable the EventBridge rule `{env_prefix}-premium-manager-schedule` during the test.

**Checkpoint**: All of the following must be true:
- All premium users are signed out.
- No records exist in `premium_user_assignments` (0 rows).
- No non-terminated premium EC2 instances exist (filtered by `Type = Premium-Instance`).
- The 15-minute scheduled monitor has not run since cleanup (or is temporarily disabled).

#### Step 2: Log in and confirm Tier 5 assignment

1. Open browser DevTools Network tab.
2. Set the filter to `premium`.
3. Log in as the premium user.

#### Step 3: Verify the assign response

1. Select `POST /users/me/premium/assign` in the Network tab.
2. Inspect the response body:
   ```json
   {
     "assigned": true,
     "instance_id": "autoscaling-pool",
     "is_shared": true,
     "assignment_source": "autoscaling_temp"
   }
   ```
3. **Verify**: `instance_id` is `"autoscaling-pool"` (confirms Tier 5 was reached).
4. **Verify**: `GET /users/me/premium/beacon-token` is called immediately after and returns `200 OK` (this is the `autoAssignOnLogin` path beacon-token fetch).

#### Step 4: Monitor the polling phase

1. Confirm `GET /users/me/premium/status` is polled periodically in the Network tab.
2. While migration is in progress, each poll response returns `"assignment": null`. This is expected — the Lambda GET handler intentionally returns 404 for autoscaling-pool assignments so the frontend continues polling until the dedicated instance is ready.
3. Wait for EC2 instance launch → ECS task start → ALB health check pass (typically 5–10 minutes).

#### Step 5: Verify beacon-token fetch after migration completes (This PR fix target)

1. Confirm the poll response transitions from `"assignment": null` to a real assignment:
   ```json
   {
     "assignment": {
       "instance_id": "i-xxxxxxxxxxxx",
       "is_shared": false,
       "instance_id_hash": "abcdef1234567890"
     }
   }
   ```
2. **Verify (This PR fix)**: `GET /users/me/premium/beacon-token` is called **again** immediately after this transition.
   - Before the fix, this second beacon-token call was missing.
3. **Verify**: The beacon-token response is `200 OK`.
4. **Verify**: The UI transitions to the dedicated-instance-assigned state without a browser reload.

#### Step 6: End-to-end routing and beacon verification

After Step 5 confirms the UI transition, verify that requests are actually routed to the dedicated instance and that the beacon token is functional.

1. **Without reloading the browser**, navigate to a workflow page or perform any action that triggers API requests.
2. Select any API request in the Network tab (e.g., `GET /optinist/...`) and inspect the **response headers**:
   - **Verify**: `x-served-by-instance` header is present and its value matches the `instance_id_hash` from Step 5.
   - **Verify**: `x-routing-id` header is present.
3. **Verify**: The snackbar "Your dedicated premium instance is temporarily unreachable. Retrying…" does NOT appear.
4. Close the browser tab (or the browser entirely).
5. **Verify**: In the Network tab (with "Preserve log" enabled), a `POST /users/me/premium/release-beacon` request appears (type "ping"). This confirms the beacon token acquired in Step 5 was valid and `sendBeacon` fired successfully on page close.

#### Step 7: Lambda log verification (optional)

Check CloudWatch Logs (`/aws/lambda/{env}-premium-manager`):
```
=== PREMIUM USER ASSIGNMENT START ===
Running instances: 0, Standby available: 0
"User XX will login via autoscaling pool"
=== ASSIGNMENT SUCCESS ===
Instance ID: autoscaling-pool
Assignment source: autoscaling_temp
```

### Test 2: Direct assignment regression check (Tier 1 representative)

**Objective**: Verify that the fix does not affect existing behavior for direct-assignment paths (no polling).

**Scope & Rationale**:

This test exercises **Tier 1 (Dedicated Running)** as a representative case for all non-polling tiers:

| Tier | `is_shared` | Polling starts? | PR fix code executed? | Covered by |
|------|-------------|-----------------|----------------------|------------|
| Tier 1 (Dedicated Running) | `false` | No | No — polling never starts | **This test** |
| Tier 2 (Shared Instance) | `true` | Yes | Yes — same polling success path as Tier 3.5/5 | Test 1 |
| Tier 3 (Standby Stopped) | `false` | No | No — polling never starts | Implicitly by this test (frontend behavior identical to Tier 1) |

- **Tier 3** returns `is_shared: false` after starting the standby instance, so from the frontend perspective the code path is identical to Tier 1 (only backend latency differs by 5-15s).
- **Tier 2** triggers polling and migration — the same code path already verified by Test 1. Additionally, manual setup of Tier 2 conditions (another user's instance must exist, no dedicated instance for the test user, no standby available) is impractical.
- The PR fix is **exclusively** in the polling success path. For any tier where `is_shared: false`, the fix code is unreachable.

**Precondition**: The premium user's dedicated instance is already in **running** state (i.e., the user has been assigned previously and the instance was not terminated). If Test 1 was executed immediately before, the instance launched during Test 1 satisfies this condition.

1. If the premium user is currently signed in, sign out first.
2. Open browser DevTools Network tab. Set the filter to `premium`.
3. Log in as the premium user.
4. **Verify**: `POST /users/me/premium/assign` response has `is_shared: false` and `instance_id` is a real EC2 instance ID (`i-xxxx` format) — confirming Tier 1 (Dedicated Running) was used.
5. **Verify**: `GET /users/me/premium/beacon-token` is called immediately via the `autoAssignOnLogin` path and returns `200 OK`.
6. **Verify**: `GET /users/me/premium/status` polling does NOT start (`is_shared: false` → `shouldPoll()` returns `false`).

### Checklist

- [x] **Test 1**: Beacon-token is acquired after polling success on Tier 5 path, routing headers confirmed, sendBeacon functional
- [x] **Test 2**: No regression on direct-assignment path (Tier 1 representative; Tier 3 implicitly covered, Tier 2 covered by Test 1)

---

## Appendix

### Key Files

| File | Role |
| ---- | ---- |
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | Core: autoAssignOnLogin, polling, beacon handling |
| `frontend/src/contexts/premium/unreachableMachine.ts` | Unreachable state machine, shouldPoll logic |
| `frontend/src/api/premium/PremiumAssignmentApi.ts` | API calls: assign, status, beacon-token, heartbeat |
| `frontend/src/utils/axios.ts` | Axios interceptors: auth, routing headers, 502/503 fallback |
| `frontend/src/utils/routing/RoutingService.ts` | Premium routing header management |
| `studio/app/common/core/middleware/secure_routing_middleware.py` | Backend: X-Routing-ID header injection |
| `infrastructure/terraform/premium_manager_package/premium_manager.py` | Lambda: assignment, migration, ALB rule management |

### Investigation Phases

| Phase | Focus | Outcome |
|-------|-------|---------|
| 1 | ALB idle timeout hypothesis | Disproven — request completed in 12.883s |
| 2 | Actual flow reconstruction from ALB logs | Polling worked correctly; no beacon-token after poll #8 |
| 3 | Root cause narrowing | Identified missing `fetchBeaconToken()` in polling success path |
| 4 | Deep code review (RoutingService, axios, SecureRoutingMiddleware) | Confirmed frontend routing state was correct |
| 5 | Lambda log analysis & ALB routing verification | Backend confirmed working; root cause is frontend-only |

### Log Sources

| Source | Path/Location |
|--------|------|
| ALB Access Logs | AWS ALB access logs (development environment) |
| Backend ECS Logs | CloudWatch Logs for ECS tasks |
| Lambda Logs | `/aws/lambda/development-premium-manager` (30-day retention) |
| Lambda Log Extract | `#Review/619_lambda-development-premium-manager.log` |
