### PR TITLE
Uncomment out swap parameters from premium

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -857,11 +857,10 @@ resource "aws_ecs_task_definition" "premium" {
       entryPoint        = ["/bin/sh", "-c"]
       command           = ["./cloud-startup.sh"]
 
-      # linuxParameters = {
-      #   maxSwap    = 32768  # Max swap in MiB (matches 32GB host swap on EBS)
-      #   swappiness = 20     # Only swap under memory pressure (host also set to 20)
-      # }
-      # NOTE: Uncomment after Stage 2 (swap enabled on instances)
+      linuxParameters = {
+        maxSwap    = 32768 # Max swap in MiB (matches 32GB host swap on EBS)
+        swappiness = 20    # Only swap under memory pressure (host also set to 20)
+      }
 
       portMappings = [
         {


### PR DESCRIPTION
### Content

Uncomment out swap parameters which stopped premium instances being able to use swap correctly

### Evidence

### References

See https://github.com/arayabrain/araya-optinist/issues/624 for details

### Files changed

compute.tf

### Manual Testcases

Check swap is accessible from inside instance with 

```
# cgroup v1 (このフリート)
cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes
cat /sys/fs/cgroup/memory/memory.limit_in_bytes

# cgroup v2 (後で移行された場合)
cat /sys/fs/cgroup/memory.swap.max
cat /sys/fs/cgroup/memory.max
```


### Unit, Integration, Contract Test Coverage

### Others

#### Difficulties (if any)

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Terraform  | Low | Working correctly in asg instances already |
