### PR TITLE
add asg_health_check_type

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -218,7 +218,7 @@ resource "aws_autoscaling_group" "main" {
   name                      = "${local.env_prefix}-asg"
   vpc_zone_identifier       = [aws_subnet.private1.id, aws_subnet.private2.id]
   target_group_arns         = [aws_lb_target_group.autoscaling.arn]
-  health_check_type         = "ELB"
+  health_check_type         = var.asg_health_check_type
   health_check_grace_period = 900
   default_cooldown          = 300
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -220,6 +220,16 @@ variable "asg_desired_capacity" {
   default     = 1
 }
 
+variable "asg_health_check_type" {
+  description = "ASG health check type. Override to 'EC2' for diagnostic runs (e.g. issue #625 repro) that should not self-evict when the ALB declares the target unhealthy. Production stays on the 'ELB' default."
+  type        = string
+  default     = "ELB"
+  validation {
+    condition     = contains(["ELB", "EC2"], var.asg_health_check_type)
+    error_message = "asg_health_check_type must be either ELB or EC2."
+  }
+}
+
 # Instance type configuration
 variable "free_instance_type" {
   description = "Instance type for free tier instances"


### PR DESCRIPTION
### Content
 
#### Summary
 
Make the Auto Scaling Group health check type configurable instead of hard-coding `"ELB"`. A new `asg_health_check_type` Terraform variable now feeds `aws_autoscaling_group.main.health_check_type`, defaulting to `"ELB"` so production behaviour is unchanged.
 
The motivation is the issue #625 diagnostic work. During that incident the ASG terminated the only EC2 instance because the ALB `/health` probe — which runs through the same FastAPI/uvicorn process as the data path — timed out under a heavy `suite2p` EBS write burst. To reproduce the failure safely on dev we need the ASG to *not* self-evict the instance when the ALB declares the target unhealthy, which means temporarily switching the health check type to `"EC2"`. That toggle was previously applied out-of-band via the AWS CLI; this change codifies it in Terraform so the override is managed in code and does not show up as state drift.
 
#### Design Decisions
 
- **Default stays `"ELB"`.** The variable defaults to the current production value, so no environment changes behaviour unless it explicitly sets the override. This keeps the change a no-op for production plans.
- **Input validation.** A `validation` block restricts the value to `"ELB"` or `"EC2"`, failing fast on typos before an invalid value can reach AWS.
- **Variable placement.** The variable is added to `main.tf` alongside the other ASG variables (`asg_desired_capacity`, etc.); this repo keeps variables in `main.tf` and has no `variables.tf`.
- **Single resource wired.** Only `aws_autoscaling_group.main` reads the variable; `health_check_grace_period` and other ASG settings are untouched.
### Evidence
 
```
infrastructure/terraform/compute.tf |  2 +-
infrastructure/terraform/main.tf    | 10 ++++++++++
2 files changed, 11 insertions(+), 1 deletion(-)
```
 
`compute.tf`
 
```hcl
resource "aws_autoscaling_group" "main" {
  name                      = "${local.env_prefix}-asg"
  ...
-  health_check_type         = "ELB"
+  health_check_type         = var.asg_health_check_type
  health_check_grace_period = 900
```
 
`main.tf`
 
```hcl
variable "asg_health_check_type" {
  description = "ASG health check type. Override to 'EC2' for diagnostic runs (e.g. issue #625 repro) that should not self-evict when the ALB declares the target unhealthy. Production stays on the 'ELB' default."
  type        = string
  default     = "ELB"
  validation {
    condition     = contains(["ELB", "EC2"], var.asg_health_check_type)
    error_message = "asg_health_check_type must be either ELB or EC2."
  }
}
```
 
With no override, `terraform plan` reports no change to `health_check_type` (it resolves to `"ELB"`). With `-var asg_health_check_type=EC2`, the only changed attribute on `aws_autoscaling_group.main` is `health_check_type`.
 
### References
 
- Issue #625 — Site outage: ASG failed health check during heavy snakemake I/O (root cause confirmed: ALB `/health` probe on the shared request path timed out under EBS write saturation; `min = desired = 1` made it a full outage).
- Related: #349 (public-site container isolation — the structural fix) and #574 (premium↔free fleet coupling).
- Base branch: `develop-main` (this branch is 1 commit ahead).
### Files changed
 
- `infrastructure/terraform/compute.tf` — `aws_autoscaling_group.main.health_check_type` now reads `var.asg_health_check_type` instead of the literal `"ELB"`.
- `infrastructure/terraform/main.tf` — adds the `asg_health_check_type` variable (default `"ELB"`, validated against `["ELB", "EC2"]`).
### Manual Testcases
 
1. `terraform fmt -check && terraform validate` — passes.
2. `terraform plan` with no override (production path) — `health_check_type` resolves to `"ELB"`; no change to the ASG.
3. `terraform plan -var asg_health_check_type=EC2` — the only changed attribute on the ASG is `health_check_type: "ELB" -> "EC2"`.
4. `terraform plan -var asg_health_check_type=FOO` — fails with `asg_health_check_type must be either ELB or EC2.`
5. After applying with `EC2` on dev, confirm live:
   `aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names development-optinist-asg --query 'AutoScalingGroups[0].HealthCheckType'` returns `"EC2"`.
### Unit, Integration, Contract Test Coverage
 
Not applicable — this is infrastructure configuration. There is no Terraform unit-test harness in the repo, so validation relies on `terraform validate` plus a reviewed `terraform plan` showing only the intended attribute change. The new `validation` block provides built-in guard-rails against invalid values.
 
### Others
 
#### Difficulties (if any)
 
The ECS service health still keys off the ALB target group, so even with the ASG on `"EC2"` the *container* may be recycled during a repro while the *instance* survives. That is acceptable for the diagnostic run because host-level instrumentation persists across a container restart, but it means this variable only controls instance self-eviction, not container recycling.
 
#### Risk Assessment
 
| Area | Risk | Notes |
|------|------|-------|
| Production behaviour | Low | Default is `"ELB"`, identical to the previous hard-coded value; production plans are unaffected unless explicitly overridden. |
| Invalid input | Low | The `validation` block rejects anything other than `"ELB"` / `"EC2"` at plan time. |
| Reduced fault detection when set to `"EC2"` | Medium | Under `"EC2"` the ASG no longer replaces an instance that is failing only at the ALB layer. This is intentional for diagnostics; the override must be reverted to `"ELB"` (and a default `"ELB"` plan re-applied) once the #625 repro is finished. |
| State drift | Low (reduced) | Codifying the toggle removes the prior need to set it via the AWS CLI, so it no longer appears as out-of-band drift. |