### PR TITLE
fix(subscription): handle Stripe subscription webhooks, release premium on expiry, and fix active-user email lookup

### DIFF
--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -25,6 +25,7 @@ from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.core.subscription.constants import (
     ExpirationDeletion,
+    PremiumExpirationSweep,
     StorageReconciliation,
     SyncStatusConstants,
 )
@@ -34,6 +35,9 @@ if not MODE.IS_STANDALONE:
     from studio.app.common.core.background.cleanup_job import DataCleanupJob
     from studio.app.common.core.background.expiration_lifecycle_job import (
         ExpirationLifecycleJob,
+    )
+    from studio.app.common.core.background.premium_expiration_sweep_job import (
+        PremiumExpirationSweepJob,
     )
     from studio.app.common.core.background.scheduler import BackgroundScheduler
     from studio.app.common.core.background.storage_reconciliation_job import (
@@ -164,6 +168,15 @@ async def lifespan(app: FastAPI):
             func=ExpirationLifecycleJob.run,
             interval_minutes=ExpirationDeletion.JOB_INTERVAL_MINUTES,
             job_id=ExpirationDeletion.JOB_ID,
+        )
+
+        # Backstop: release dangling premium assignments after expiration
+        # (covers missed customer.subscription.deleted events / direct DB
+        # expirations). Event-driven release still happens in WebhookService.
+        BackgroundScheduler.add_job(
+            func=PremiumExpirationSweepJob.run,
+            interval_minutes=PremiumExpirationSweep.JOB_INTERVAL_MINUTES,
+            job_id=PremiumExpirationSweep.JOB_ID,
         )
 
         # Start scheduler

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -142,6 +142,9 @@ class PremiumExpirationSweepJob:
                     UserSubscription.expiration <= grace_cutoff,
                     ~has_active_sub,
                 )
+                # Oldest expirations first so the per-run cap is deterministic
+                # and never starves long-expired assignments.
+                .order_by(UserSubscription.expiration.asc())
                 .limit(PremiumExpirationSweep.MAX_RELEASES_PER_RUN)
                 .all()
             )

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -73,7 +73,12 @@ class PremiumExpirationSweepJob:
                     hard=True,
                     timeout=PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS,
                 )
-                if result.get("success"):
+                release_confirmed = (
+                    result.get("success")
+                    and result.get("lambda_success", True)
+                    and not result.get("timed_out")
+                )
+                if release_confirmed:
                     processed += 1
                     logger.info(
                         f"Premium expiration sweep: released user {user_id} "

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -68,7 +68,10 @@ class PremiumExpirationSweepJob:
         for user_id, user_uid in candidates:
             try:
                 result = await premium_assignment_service.release_premium_user(
-                    user_id=user_id, user_uid=user_uid, hard=True
+                    user_id=user_id,
+                    user_uid=user_uid,
+                    hard=True,
+                    timeout=PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS,
                 )
                 if result.get("success"):
                     processed += 1

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -1,0 +1,148 @@
+"""
+Backstop sweep: release dangling premium assignments after expiration.
+
+Runs periodically as a safety net for the event-driven path. Normally a
+premium compute assignment is released when Stripe sends
+``customer.subscription.deleted`` (handled in ``WebhookService``). If that
+event is missed or never sent (e.g. a lost webhook, or a local expiration
+applied by a direct DB update), the per-user EC2/ALB assignment can dangle,
+still attached to a user who is now effectively free.
+
+This job finds users whose PREMIUM subscription expired more than
+``GRACE_PERIOD_DAYS`` ago, who have no currently-active subscription, and who
+still hold an ``active`` (non-standby) premium assignment, and hard-releases
+them. It complements (and is more precise than) the activity-based stale
+sweep performed by the Premium Cleanup Lambda.
+"""
+
+from datetime import timedelta
+from typing import List, Tuple
+
+from sqlalchemy import and_, exists
+from sqlalchemy.orm import aliased
+
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.premium.premium_assignment_service import (
+    premium_assignment_service,
+)
+from studio.app.common.core.subscription.constants import (
+    PremiumExpirationSweep,
+    SubscriptionPeriods,
+    SubscriptionPlanIds,
+)
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
+from studio.app.common.db.database import session_scope
+from studio.app.common.models.premium_user import PremiumUserAssignment
+from studio.app.common.models.subscription import UserSubscription
+from studio.app.common.models.user import User
+
+logger = AppLogger.get_logger()
+
+
+class PremiumExpirationSweepJob:
+    @classmethod
+    async def run(cls):
+        """Periodic backstop: release premium assignments for expired users."""
+        logger.info("Starting premium expiration sweep job")
+
+        try:
+            candidates = cls._find_dangling_assignments()
+        except Exception as e:
+            logger.error(
+                f"Premium expiration sweep: failed to query candidates: {e}",
+                exc_info=True,
+            )
+            return
+
+        if not candidates:
+            logger.debug("Premium expiration sweep: no dangling assignments found")
+            return
+
+        logger.info(
+            f"Premium expiration sweep: {len(candidates)} dangling "
+            f"assignment(s) to release"
+        )
+
+        processed = 0
+        errors = 0
+        for user_id, user_uid in candidates:
+            try:
+                result = await premium_assignment_service.release_premium_user(
+                    user_id=user_id, user_uid=user_uid, hard=True
+                )
+                if result.get("success"):
+                    processed += 1
+                    logger.info(
+                        f"Premium expiration sweep: released user {user_id} "
+                        f"({result.get('message')})"
+                    )
+                else:
+                    errors += 1
+                    logger.warning(
+                        "Premium expiration sweep: release returned failure for "
+                        f"user {user_id}: {result.get('message')}"
+                    )
+            except Exception as e:
+                errors += 1
+                logger.error(
+                    f"Premium expiration sweep: error releasing user {user_id}: {e}",
+                    exc_info=True,
+                )
+
+        logger.info(
+            f"Premium expiration sweep completed: {processed} released, "
+            f"{errors} errors"
+        )
+
+    @staticmethod
+    def _find_dangling_assignments() -> List[Tuple[int, str]]:
+        """
+        Return ``[(user_id, user_uid), ...]`` for users who:
+        - hold an ``active`` non-standby premium assignment,
+        - have a PREMIUM subscription expired more than GRACE_PERIOD_DAYS ago, and
+        - have no currently-active subscription (i.e. have not re-subscribed).
+
+        Primitives are extracted inside the session so it can close before the
+        async release calls (which talk to AWS Lambda) run.
+        """
+        current_time = get_current_datetime()
+        grace_cutoff = current_time - timedelta(
+            days=SubscriptionPeriods.GRACE_PERIOD_DAYS
+        )
+
+        # Exclude users who have any currently-active subscription row.
+        active_sub = aliased(UserSubscription)
+        has_active_sub = exists().where(
+            and_(
+                active_sub.user_id == UserSubscription.user_id,
+                active_sub.expiration > current_time,
+            )
+        )
+
+        with session_scope() as db:
+            rows = (
+                db.query(PremiumUserAssignment.user_id, User.uid)
+                .join(User, User.id == PremiumUserAssignment.user_id)
+                .join(
+                    UserSubscription,
+                    UserSubscription.user_id == PremiumUserAssignment.user_id,
+                )
+                .filter(
+                    PremiumUserAssignment.status == "active",
+                    PremiumUserAssignment.is_standby == False,  # noqa: E712
+                    UserSubscription.plan_id == SubscriptionPlanIds.PREMIUM,
+                    UserSubscription.expiration <= grace_cutoff,
+                    ~has_active_sub,
+                )
+                .limit(PremiumExpirationSweep.MAX_RELEASES_PER_RUN)
+                .all()
+            )
+
+            seen = set()
+            candidates: List[Tuple[int, str]] = []
+            for user_id, user_uid in rows:
+                if user_id in seen:
+                    continue
+                seen.add(user_id)
+                candidates.append((user_id, user_uid))
+            return candidates

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -35,6 +35,10 @@ class PremiumStatusCheckError(Exception):
 LAMBDA_TIMEOUT_SECONDS = 60
 LAMBDA_MAX_RETRIES = 2
 LAMBDA_RETRY_BASE_DELAY_SECONDS = 2
+# Short bound for latency-sensitive callers (e.g. the Stripe webhook path),
+# which must respond quickly. Cleanup that exceeds this is handled by the
+# periodic premium-expiration sweep, so failing open here is safe.
+WEBHOOK_RELEASE_TIMEOUT_SECONDS = 10
 
 
 class PremiumAssignmentService:
@@ -297,7 +301,12 @@ class PremiumAssignmentService:
             }
 
     async def release_premium_user(
-        self, user_id: int, user_uid: str, *, hard: bool = False
+        self,
+        user_id: int,
+        user_uid: str,
+        *,
+        hard: bool = False,
+        timeout: float = LAMBDA_TIMEOUT_SECONDS,
     ) -> Dict[str, any]:
         """
         Release a premium user from their assigned instance and clear rate limiting.
@@ -308,12 +317,16 @@ class PremiumAssignmentService:
             hard: If True, immediately delete assignment + ALB resources.
                   If False (default), soft-release with grace period so a
                   page refresh can restore the assignment instantly.
+            timeout: Max seconds to wait for the release Lambda before failing
+                  open. Latency-sensitive callers (e.g. the Stripe webhook)
+                  should pass a short value; defaults to LAMBDA_TIMEOUT_SECONDS.
 
         Returns:
             Dict containing release result:
             - success: bool
             - message: str
             - released_instance: str (if successful)
+            - timed_out: bool (present and True if the Lambda call timed out)
         """
         try:
             release_type = "hard" if hard else "soft"
@@ -352,9 +365,32 @@ class PremiumAssignmentService:
                 )
                 return response
 
-            # Run in thread pool to avoid blocking
+            # Run in thread pool with a bounded timeout so a slow/hung Lambda
+            # cannot stall the caller indefinitely (e.g. the Stripe webhook
+            # path, where this previously risked webhook timeouts/retries).
+            # Fail open on timeout: the assignment may not be torn down yet,
+            # but the periodic premium-expiration sweep is the backstop that
+            # will release it.
             loop = asyncio.get_event_loop()
-            response = await loop.run_in_executor(None, invoke_lambda)
+            try:
+                response = await asyncio.wait_for(
+                    loop.run_in_executor(None, invoke_lambda),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Release Lambda timed out after {timeout}s for user "
+                    f"{user_id}; deferring to background cleanup"
+                )
+                return {
+                    "success": False,
+                    "timed_out": True,
+                    "message": (
+                        f"Release timed out after {timeout}s; "
+                        "will be retried by the background sweep"
+                    ),
+                    "warnings": [f"Release Lambda timed out after {timeout}s"],
+                }
 
             # Parse the response
             response_payload = json.loads(response["Payload"].read())

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -5,6 +5,7 @@ import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from studio.app.common.core.logger import AppLogger
@@ -337,26 +338,59 @@ class CheckoutService:
         )
 
         if existing_subscription:
-            # Update existing subscription
-            existing_subscription.plan_id = plan_id
-            existing_subscription.sync_status = SyncStatus.SYNCED
-            existing_subscription.expiration = expiration_date
-            existing_subscription.scheduled_downgrade = False
-            existing_subscription.updated_at = (
-                SubscriptionService.get_current_datetime()
+            return CheckoutService._apply_subscription_update(
+                existing_subscription, plan_id, expiration_date
             )
-            return existing_subscription.id
-        else:
-            # Create new subscription
-            new_subscription = UserSubscription(
-                plan_id=plan_id,
-                user_id=user_id,
-                expiration=expiration_date,
-                sync_status=SyncStatus.SYNCED,
-            )
-            db.add(new_subscription)
-            db.flush()  # Get ID without committing
+
+        # Create new subscription. `subscription_users.user_id` is unique, and
+        # SELECT ... FOR UPDATE does not lock a row that doesn't exist yet, so
+        # concurrent webhook deliveries (e.g. checkout.session.completed racing
+        # customer.subscription.created) can both reach this branch and one will
+        # hit an IntegrityError. Guard the insert with a SAVEPOINT and, on
+        # conflict, fall back to selecting + updating the row that the other
+        # delivery just created. This makes the upsert idempotent and avoids a
+        # spurious 500 -> Stripe retry.
+        try:
+            with db.begin_nested():
+                new_subscription = UserSubscription(
+                    plan_id=plan_id,
+                    user_id=user_id,
+                    expiration=expiration_date,
+                    sync_status=SyncStatus.SYNCED,
+                )
+                db.add(new_subscription)
+                db.flush()  # Get ID without committing
             return new_subscription.id
+        except IntegrityError:
+            logger.warning(
+                "Concurrent insert detected for subscription_users "
+                f"user_id={user_id}; falling back to update"
+            )
+            existing_subscription = (
+                db.query(UserSubscription)
+                .filter(UserSubscription.user_id == user_id)
+                .with_for_update()
+                .first()
+            )
+            if existing_subscription is None:
+                # The conflict implies a row exists; if we still can't find it,
+                # surface the original error rather than silently swallowing it.
+                raise
+            return CheckoutService._apply_subscription_update(
+                existing_subscription, plan_id, expiration_date
+            )
+
+    @staticmethod
+    def _apply_subscription_update(
+        subscription, plan_id: int, expiration_date: datetime
+    ) -> int:
+        """Apply the standard field updates to an existing subscription row."""
+        subscription.plan_id = plan_id
+        subscription.sync_status = SyncStatus.SYNCED
+        subscription.expiration = expiration_date
+        subscription.scheduled_downgrade = False
+        subscription.updated_at = SubscriptionService.get_current_datetime()
+        return subscription.id
 
     @staticmethod
     def get_subscription_account(

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -463,6 +463,19 @@ class ExpirationDeletion:
     METRIC_ERRORS = "ExpirationDeletionErrors"
 
 
+class PremiumExpirationSweep:
+    """Constants for the premium expiration -> release backstop sweep job.
+
+    Safety net for the event-driven path: releases dangling premium
+    assignments for users whose subscription expired past the grace period
+    when no Stripe ``customer.subscription.deleted`` event released them.
+    """
+
+    JOB_ID = "premium_expiration_sweep"
+    JOB_INTERVAL_MINUTES = 60  # Hourly backstop
+    MAX_RELEASES_PER_RUN = 50  # Bound work per run
+
+
 class S3Pagination:
     """Constants for S3 pagination and streaming"""
 

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -118,11 +118,14 @@ class StripeWebhookEvent(StrEnum):
 
     CHECKOUT_SESSION_COMPLETED = "checkout.session.completed"
     INVOICE_PAYMENT_FAILED = "invoice.payment_failed"
+    CUSTOMER_SUBSCRIPTION_CREATED = "customer.subscription.created"
+    CUSTOMER_SUBSCRIPTION_UPDATED = "customer.subscription.updated"
     CUSTOMER_SUBSCRIPTION_DELETED = "customer.subscription.deleted"
     SUBSCRIPTION_SCHEDULE_RELEASED = "subscription_schedule.released"
     INVOICE_PAYMENT_SUCCEEDED = "invoice.payment_succeeded"
     INVOICE_CREATED = "invoice.created"
     INVOICE_FINALIZED = "invoice.finalized"
+    BILLING_PORTAL_SESSION_CREATED = "billing_portal.session.created"
 
 
 # ============================================================================

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -474,6 +474,11 @@ class PremiumExpirationSweep:
     JOB_ID = "premium_expiration_sweep"
     JOB_INTERVAL_MINUTES = 60  # Hourly backstop
     MAX_RELEASES_PER_RUN = 50  # Bound work per run
+    # Short per-release timeout so one slow/hung Lambda can't stall the whole
+    # sweep. This is a backstop: a skipped release is retried next run.
+    # Worst case per run ~= MAX_RELEASES_PER_RUN * RELEASE_TIMEOUT_SECONDS,
+    # which stays well under JOB_INTERVAL_MINUTES.
+    RELEASE_TIMEOUT_SECONDS = 15
 
 
 class S3Pagination:

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1404,7 +1404,220 @@ class WebhookService:
         return webhook_secret
 
     @staticmethod
-    def dispatch_webhook_event(
+    def _sync_subscription_from_event(
+        db: Session, subscription_data: Dict[str, Any], event_label: str
+    ) -> Dict[str, Any]:
+        """
+        Mirror a Stripe ``customer.subscription.*`` event into local state.
+
+        Shared by the ``created`` and ``updated`` handlers. Upserts the
+        ``subscription_users`` row (plan + expiration), mirrors
+        ``cancel_at_period_end`` onto ``scheduled_downgrade``, syncs the
+        storage quota to the plan, and invalidates the tier cache so the
+        next ``/users/me`` request reflects the change.
+
+        Returns a result dict. If the customer cannot be mapped to a local
+        account (e.g. test webhooks, incomplete checkout) the event is
+        acknowledged without a DB change to avoid Stripe retries.
+        """
+        customer_id = subscription_data.get("customer")
+        stripe_subscription_id = subscription_data.get("id")
+        logger.info(
+            f"Webhook: Handling customer.subscription.{event_label} for "
+            f"customer {customer_id} (subscription {stripe_subscription_id})"
+        )
+
+        # 1. Map Stripe customer -> local user account
+        user_account = (
+            db.query(SubscriptionUserAccount)
+            .filter(SubscriptionUserAccount.provider_customer_id == customer_id)
+            .first()
+        )
+        if not user_account:
+            logger.warning(
+                f"Webhook: No user account for customer_id {customer_id}; "
+                f"acknowledging subscription.{event_label} without DB change"
+            )
+            return {
+                "success": True,
+                "skipped": True,
+                "reason": "missing_user_account",
+                "message": f"No user account for customer: {customer_id}",
+            }
+        user_id = user_account.user_id
+
+        # 2. Derive expiration from the event payload (trial overrides period)
+        trial_end = subscription_data.get("trial_end")
+        current_period_end = subscription_data.get("current_period_end")
+        if trial_end:
+            expiration_date = datetime_from_timestamp(trial_end)
+        elif current_period_end:
+            expiration_date = datetime_from_timestamp(current_period_end)
+        else:
+            logger.warning(
+                f"Webhook: No period end in subscription {stripe_subscription_id}; "
+                f"acknowledging subscription.{event_label} without DB change"
+            )
+            return {
+                "success": True,
+                "skipped": True,
+                "reason": "missing_expiration",
+                "message": (
+                    f"No period end in subscription: {stripe_subscription_id}"
+                ),
+            }
+
+        # 3. Derive plan from subscription metadata, default to premium
+        metadata = subscription_data.get("metadata") or {}
+        plan_id_raw = metadata.get("plan_id")
+        try:
+            plan_id = (
+                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
+            )
+        except (TypeError, ValueError):
+            plan_id = SubscriptionPlanIds.PREMIUM
+
+        # 4. Upsert subscription_users (lock-safe helper)
+        CheckoutService.create_or_update_subscription(
+            db, user_id, plan_id, expiration_date
+        )
+
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade
+        cancel_at_period_end = bool(
+            subscription_data.get("cancel_at_period_end")
+        )
+        subscription = (
+            db.query(UserSubscription)
+            .filter(UserSubscription.user_id == user_id)
+            .order_by(UserSubscription.expiration.desc())
+            .first()
+        )
+        if subscription:
+            subscription.scheduled_downgrade = cancel_at_period_end
+            subscription.updated_at = SubscriptionService.get_current_datetime()
+
+        # 6. Sync storage quota to match the plan
+        storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
+        rows_updated = db.execute(
+            update(UserStorageUsage)
+            .where(UserStorageUsage.user_id == user_id)
+            .values(storage_quota_bytes=storage_quota_bytes)
+        ).rowcount
+        if not rows_updated:
+            db.add(
+                UserStorageUsage(
+                    user_id=user_id,
+                    storage_usage_bytes=0,
+                    storage_quota_bytes=storage_quota_bytes,
+                )
+            )
+
+        db.commit()
+
+        # 7. Invalidate tier cache so the GUI reflects the change promptly
+        user = db.query(User).filter(User.id == user_id).first()
+        if user:
+            invalidate_user_tier_cache(user.uid)
+
+        logger.info(
+            f"Webhook: Synced subscription.{event_label} for user {user_id} "
+            f"(plan_id={plan_id}, expiration={expiration_date}, "
+            f"scheduled_downgrade={cancel_at_period_end})"
+        )
+        return {
+            "success": True,
+            "user_id": user_id,
+            "plan_id": plan_id,
+            "expiration": expiration_date,
+            "scheduled_downgrade": cancel_at_period_end,
+            "message": f"Subscription {event_label} synced",
+        }
+
+    @staticmethod
+    def handle_subscription_created(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Handle customer.subscription.created webhook.
+
+        Activates the subscription locally so the user is no longer stuck on
+        "Activation Pending" if checkout.session.completed did not complete
+        the activation (issue #629, consequence 1).
+        """
+        return WebhookService._sync_subscription_from_event(
+            db, subscription_data, event_label="created"
+        )
+
+    @staticmethod
+    def handle_subscription_updated(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Handle customer.subscription.updated webhook.
+
+        Mirrors Stripe-side changes (renewal period, plan, scheduled
+        cancellation) into local state (issue #629, consequence 2).
+        """
+        return WebhookService._sync_subscription_from_event(
+            db, subscription_data, event_label="updated"
+        )
+
+    @staticmethod
+    async def _release_premium_assignment(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> None:
+        """
+        Release a dangling premium compute assignment when a subscription
+        ends (issue #629, consequence 3).
+
+        ``handle_subscription_cancelled`` only expires the DB row; without
+        this the per-user EC2/ALB resources stay attached to a now-free user
+        until logout / tab-close / stale-sweep. Best-effort: logs but does
+        not raise, so a release failure never blocks webhook acknowledgement.
+        """
+        # Local import avoids any import cycle with the subscription package.
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        customer_id = subscription_data.get("customer")
+        user_account = (
+            db.query(SubscriptionUserAccount)
+            .filter(SubscriptionUserAccount.provider_customer_id == customer_id)
+            .first()
+        )
+        if not user_account:
+            logger.info(
+                f"Webhook: No user account for customer {customer_id}; "
+                "no premium assignment to release"
+            )
+            return
+
+        user = db.query(User).filter(User.id == user_account.user_id).first()
+        if not user:
+            logger.warning(
+                f"Webhook: User {user_account.user_id} not found; "
+                "cannot release premium assignment"
+            )
+            return
+
+        try:
+            result = await premium_assignment_service.release_premium_user(
+                user_id=user.id, user_uid=user.uid, hard=True
+            )
+            logger.info(
+                f"Webhook: Released premium assignment for user {user.id} on "
+                f"subscription delete: {result.get('message')}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Webhook: Failed to release premium assignment for user "
+                f"{user_account.user_id}: {e}",
+                exc_info=True,
+            )
+
+    @staticmethod
+    async def dispatch_webhook_event(
         db: Session, event_type: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
@@ -1432,9 +1645,20 @@ class WebhookService:
                         "message": "Payment failed event processed",
                     }
 
+                case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_CREATED:
+                    logger.info("Handling customer.subscription.created")
+                    return WebhookService.handle_subscription_created(db, data)
+
+                case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_UPDATED:
+                    logger.info("Handling customer.subscription.updated")
+                    return WebhookService.handle_subscription_updated(db, data)
+
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED:
                     logger.info("Handling customer.subscription.deleted")
                     WebhookService.handle_subscription_cancelled(db, data)
+                    # Release the dangling premium compute assignment so a
+                    # now-free user does not keep a dedicated instance.
+                    await WebhookService._release_premium_assignment(db, data)
                     return {
                         "success": True,
                         "message": "Subscription cancellation processed",
@@ -1461,6 +1685,16 @@ class WebhookService:
                 case StripeWebhookEvent.INVOICE_FINALIZED:
                     logger.info("Handling invoice.finalized")
                     return WebhookService.handle_invoice_finalized(data)
+
+                case StripeWebhookEvent.BILLING_PORTAL_SESSION_CREATED:
+                    # Informational only; nothing to mirror locally.
+                    logger.info(
+                        "Acknowledged billing_portal.session.created (no-op)"
+                    )
+                    return {
+                        "success": True,
+                        "message": "Billing portal session acknowledged",
+                    }
 
                 case _:
                     logger.info(f"Unhandled webhook event type: {event_type}")

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1482,10 +1482,18 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Mirror cancel_at_period_end -> scheduled_downgrade
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade and mark SYNCED.
+        # sync_status tracks whether the local DB reflects Stripe's current
+        # state (sync success), NOT billing health: a subscription we
+        # successfully mirrored is SYNCED even when Stripe reports
+        # past_due / unpaid / incomplete. Tier/billing state is derived from
+        # `expiration` at read time, so a delinquent-but-synced row is still
+        # shown correctly to the user. (We log stripe_status for visibility.)
         cancel_at_period_end = bool(
             subscription_data.get("cancel_at_period_end")
         )
+        stripe_status = subscription_data.get("status")
+        sync_status = SyncStatus.SYNCED
         subscription = (
             db.query(UserSubscription)
             .filter(UserSubscription.user_id == user_id)
@@ -1494,6 +1502,7 @@ class WebhookService:
         )
         if subscription:
             subscription.scheduled_downgrade = cancel_at_period_end
+            subscription.sync_status = sync_status
             subscription.updated_at = SubscriptionService.get_current_datetime()
 
         # 6. Sync storage quota to match the plan
@@ -1524,6 +1533,7 @@ class WebhookService:
         logger.info(
             f"Webhook: Synced subscription.{event_label} for user {user_id} "
             f"(plan_id={plan_id}, expiration={expiration_date}, "
+            f"stripe_status={stripe_status}, sync_status={sync_status}, "
             f"scheduled_downgrade={cancel_at_period_end})"
         )
         return {
@@ -1532,6 +1542,7 @@ class WebhookService:
             "plan_id": plan_id,
             "expiration": expiration_date,
             "scheduled_downgrade": cancel_at_period_end,
+            "sync_status": sync_status,
             "message": f"Subscription {event_label} synced",
         }
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1620,17 +1620,29 @@ class WebhookService:
                 hard=True,
                 timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             )
-            if result.get("success"):
+            # `success` is True for any non-timeout response because the service
+            # never blocks logout; the real Lambda outcome lives in
+            # `lambda_success`. Only treat the release as confirmed when both
+            # are true and no warnings were reported.
+            confirmed = (
+                result.get("success")
+                and result.get("lambda_success", True)
+                and not result.get("timed_out")
+            )
+            if confirmed:
                 logger.info(
                     f"Webhook: Released premium assignment for user {user.id} "
                     f"on subscription delete: {result.get('message')}"
                 )
             else:
-                # Not released in-band (e.g. timed out). The background sweep
-                # will release it; acknowledge the webhook regardless.
+                # Not released in-band (timeout, Lambda-reported failure, or
+                # warnings). The background sweep will release it; acknowledge
+                # the webhook regardless.
                 logger.warning(
                     f"Webhook: Premium release not confirmed for user "
                     f"{user.id}: {result.get('message')}; "
+                    f"warnings={result.get('warnings')}, "
+                    f"timed_out={result.get('timed_out', False)}; "
                     "deferring to background sweep"
                 )
         except Exception as e:

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1462,18 +1462,14 @@ class WebhookService:
                 "success": True,
                 "skipped": True,
                 "reason": "missing_expiration",
-                "message": (
-                    f"No period end in subscription: {stripe_subscription_id}"
-                ),
+                "message": (f"No period end in subscription: {stripe_subscription_id}"),
             }
 
         # 3. Derive plan from subscription metadata, default to premium
         metadata = subscription_data.get("metadata") or {}
         plan_id_raw = metadata.get("plan_id")
         try:
-            plan_id = (
-                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
-            )
+            plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
             plan_id = SubscriptionPlanIds.PREMIUM
 
@@ -1489,9 +1485,7 @@ class WebhookService:
         # past_due / unpaid / incomplete. Tier/billing state is derived from
         # `expiration` at read time, so a delinquent-but-synced row is still
         # shown correctly to the user. (We log stripe_status for visibility.)
-        cancel_at_period_end = bool(
-            subscription_data.get("cancel_at_period_end")
-        )
+        cancel_at_period_end = bool(subscription_data.get("cancel_at_period_end"))
         stripe_status = subscription_data.get("status")
         sync_status = SyncStatus.SYNCED
         subscription = (
@@ -1701,9 +1695,7 @@ class WebhookService:
 
                 case StripeWebhookEvent.BILLING_PORTAL_SESSION_CREATED:
                     # Informational only; nothing to mirror locally.
-                    logger.info(
-                        "Acknowledged billing_portal.session.created (no-op)"
-                    )
+                    logger.info("Acknowledged billing_portal.session.created (no-op)")
                     return {
                         "success": True,
                         "message": "Billing portal session acknowledged",

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1581,9 +1581,14 @@ class WebhookService:
         this the per-user EC2/ALB resources stay attached to a now-free user
         until logout / tab-close / stale-sweep. Best-effort: logs but does
         not raise, so a release failure never blocks webhook acknowledgement.
+
+        Uses a short timeout so a slow/hung release Lambda cannot stall the
+        webhook response (and trigger Stripe retries). If it times out, the
+        periodic premium-expiration sweep releases the assignment later.
         """
         # Local import avoids any import cycle with the subscription package.
         from studio.app.common.core.premium.premium_assignment_service import (
+            WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             premium_assignment_service,
         )
 
@@ -1610,12 +1615,24 @@ class WebhookService:
 
         try:
             result = await premium_assignment_service.release_premium_user(
-                user_id=user.id, user_uid=user.uid, hard=True
+                user_id=user.id,
+                user_uid=user.uid,
+                hard=True,
+                timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             )
-            logger.info(
-                f"Webhook: Released premium assignment for user {user.id} on "
-                f"subscription delete: {result.get('message')}"
-            )
+            if result.get("success"):
+                logger.info(
+                    f"Webhook: Released premium assignment for user {user.id} "
+                    f"on subscription delete: {result.get('message')}"
+                )
+            else:
+                # Not released in-band (e.g. timed out). The background sweep
+                # will release it; acknowledge the webhook regardless.
+                logger.warning(
+                    f"Webhook: Premium release not confirmed for user "
+                    f"{user.id}: {result.get('message')}; "
+                    "deferring to background sweep"
+                )
         except Exception as e:
             logger.error(
                 f"Webhook: Failed to release premium assignment for user "

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1498,12 +1498,14 @@ class WebhookService:
 
         # 6. Sync storage quota to match the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
-        rows_updated = db.execute(
-            update(UserStorageUsage)
-            .where(UserStorageUsage.user_id == user_id)
-            .values(storage_quota_bytes=storage_quota_bytes)
-        ).rowcount
-        if not rows_updated:
+        user_storage_usage = (
+            db.query(UserStorageUsage)
+            .filter(UserStorageUsage.user_id == user_id)
+            .first()
+        )
+        if user_storage_usage:
+            user_storage_usage.storage_quota_bytes = storage_quota_bytes
+        else:
             db.add(
                 UserStorageUsage(
                     user_id=user_id,

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -612,14 +612,20 @@ class WebhookService:
                     status_code=400, detail=f"No email found for customer {customer_id}"
                 )
 
-            # Find user by email
+            # Find user by email (filter active users to avoid matching
+            # soft-deleted accounts re-registered with the same email)
             from studio.app.common.models.user import User  # Adjust import as needed
 
-            user = db.query(User).filter(User.email == customer_email).first()
+            user = (
+                db.query(User)
+                .filter(User.email == customer_email, User.active.is_(True))
+                .first()
+            )
 
             if not user:
                 raise HTTPException(
-                    status_code=404, detail=f"No user found with email {customer_email}"
+                    status_code=404,
+                    detail=f"No active user found with email {customer_email}",
                 )
 
             # Find the plan by matching the price or metadata

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -506,10 +506,15 @@ async def validate_checkout_session(
                 message="An internal error occurred. Please contact support.",
             )
 
-        # Find user by email
-        user = db.query(UserModel).filter(UserModel.email == customer_email).first()
+        # Find user by email (filter active users to avoid matching
+        # soft-deleted accounts that were re-registered with the same email)
+        user = (
+            db.query(UserModel)
+            .filter(UserModel.email == customer_email, UserModel.active.is_(True))
+            .first()
+        )
         if not user:
-            logger.error(f"No user found with email {customer_email}")
+            logger.error(f"No active user found with email {customer_email}")
             return CheckoutValidationResponse(
                 status=CheckoutValidationStatus.WEBHOOK_FAILED,
                 message="An internal error occurred. Please contact support.",

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -743,7 +743,7 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
 
         logger.info(f"Processing event type: {event_type}")
 
-        WebhookService.dispatch_webhook_event(db, event_type, data)
+        await WebhookService.dispatch_webhook_event(db, event_type, data)
 
         logger.info(f"Successfully processed {event_type}")
         return {"received": True, "processed": event_type}

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -17,6 +17,7 @@ def _self_returning_query(rows):
     q = MagicMock()
     q.join.return_value = q
     q.filter.return_value = q
+    q.order_by.return_value = q
     q.limit.return_value = q
     q.all.return_value = rows
     return q

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -7,6 +7,7 @@ import pytest
 from studio.app.common.core.background.premium_expiration_sweep_job import (
     PremiumExpirationSweepJob,
 )
+from studio.app.common.core.subscription.constants import PremiumExpirationSweep
 
 MODULE = "studio.app.common.core.background.premium_expiration_sweep_job"
 
@@ -52,8 +53,13 @@ class TestRun:
             await PremiumExpirationSweepJob.run()
 
         assert mock_release.await_count == 2
-        mock_release.assert_any_await(user_id=1, user_uid="uid_a", hard=True)
-        mock_release.assert_any_await(user_id=2, user_uid="uid_b", hard=True)
+        timeout = PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS
+        mock_release.assert_any_await(
+            user_id=1, user_uid="uid_a", hard=True, timeout=timeout
+        )
+        mock_release.assert_any_await(
+            user_id=2, user_uid="uid_b", hard=True, timeout=timeout
+        )
 
     @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
     @pytest.mark.asyncio

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -1,0 +1,109 @@
+"""Tests for the premium expiration -> release backstop sweep job (issue #629)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from studio.app.common.core.background.premium_expiration_sweep_job import (
+    PremiumExpirationSweepJob,
+)
+
+MODULE = "studio.app.common.core.background.premium_expiration_sweep_job"
+
+
+def _self_returning_query(rows):
+    """A query mock where join/filter/limit chain back to itself and all()->rows."""
+    q = MagicMock()
+    q.join.return_value = q
+    q.filter.return_value = q
+    q.limit.return_value = q
+    q.all.return_value = rows
+    return q
+
+
+def _mock_session_scope(mock_db):
+    """Patch target for session_scope() used as a context manager."""
+    scope = MagicMock()
+    scope.return_value.__enter__ = MagicMock(return_value=mock_db)
+    scope.return_value.__exit__ = MagicMock(return_value=False)
+    return scope
+
+
+class TestRun:
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_no_candidates_no_release(self, mock_find):
+        mock_find.return_value = []
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(),
+        ) as mock_release:
+            await PremiumExpirationSweepJob.run()
+        mock_release.assert_not_awaited()
+
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_releases_each_candidate_hard(self, mock_find):
+        mock_find.return_value = [(1, "uid_a"), (2, "uid_b")]
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(return_value={"success": True, "message": "released"}),
+        ) as mock_release:
+            await PremiumExpirationSweepJob.run()
+
+        assert mock_release.await_count == 2
+        mock_release.assert_any_await(user_id=1, user_uid="uid_a", hard=True)
+        mock_release.assert_any_await(user_id=2, user_uid="uid_b", hard=True)
+
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_continues_after_release_error(self, mock_find):
+        """One failing release must not stop the rest of the batch."""
+        mock_find.return_value = [(1, "uid_a"), (2, "uid_b")]
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(
+                side_effect=[Exception("boom"), {"success": True, "message": "ok"}]
+            ),
+        ) as mock_release:
+            # Should not raise.
+            await PremiumExpirationSweepJob.run()
+
+        assert mock_release.await_count == 2
+
+
+class TestFindDanglingAssignments:
+    @patch(f"{MODULE}.get_current_datetime")
+    @patch(f"{MODULE}.session_scope")
+    def test_returns_deduped_candidates(self, mock_scope, mock_now):
+        from datetime import datetime
+
+        mock_now.return_value = datetime(2026, 5, 22)
+        mock_db = MagicMock()
+        # Duplicate user_id should be collapsed to a single candidate.
+        mock_db.query.return_value = _self_returning_query(
+            [(1, "uid_a"), (1, "uid_a"), (2, "uid_b")]
+        )
+        mock_scope.return_value = _mock_session_scope(mock_db).return_value
+
+        result = PremiumExpirationSweepJob._find_dangling_assignments()
+
+        assert result == [(1, "uid_a"), (2, "uid_b")]
+
+    @patch(f"{MODULE}.get_current_datetime")
+    @patch(f"{MODULE}.session_scope")
+    def test_returns_empty_when_no_rows(self, mock_scope, mock_now):
+        from datetime import datetime
+
+        mock_now.return_value = datetime(2026, 5, 22)
+        mock_db = MagicMock()
+        mock_db.query.return_value = _self_returning_query([])
+        mock_scope.return_value = _mock_session_scope(mock_db).return_value
+
+        result = PremiumExpirationSweepJob._find_dangling_assignments()
+
+        assert result == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/core/premium/test_release_timeout.py
+++ b/studio/tests/app/common/core/premium/test_release_timeout.py
@@ -1,0 +1,58 @@
+"""
+Tests for the bounded timeout on PremiumAssignmentService.release_premium_user.
+
+Regression coverage for the review on issue #629: the release Lambda call must
+not stall the caller (e.g. the Stripe webhook path) indefinitely. On timeout it
+fails open (returns a dict, does not raise) so the caller can proceed; the
+periodic premium-expiration sweep is the cleanup backstop.
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from studio.app.common.core.premium.premium_assignment_service import (
+    PremiumAssignmentService,
+)
+
+_OK_PAYLOAD = {"Payload": AsyncMock(read=lambda: b'{"statusCode": 200, "body": "{}"}')}
+
+
+class TestReleaseTimeout:
+    @pytest.mark.asyncio
+    async def test_release_times_out_fails_open(self):
+        """A slow Lambda triggers the timeout and returns a fail-open result."""
+        service = PremiumAssignmentService()
+
+        def slow_invoke(*args, **kwargs):
+            time.sleep(0.3)  # exceeds the 0.05s timeout below
+            return _OK_PAYLOAD
+
+        with patch.object(service, "_get_lambda_client") as mock_client:
+            mock_client.return_value.invoke.side_effect = slow_invoke
+            result = await service.release_premium_user(
+                user_id=1, user_uid="uid", hard=True, timeout=0.05
+            )
+
+        assert result["success"] is False
+        assert result["timed_out"] is True
+        assert "timed out" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_release_succeeds_within_timeout(self):
+        """The new timeout parameter does not break the happy path."""
+        service = PremiumAssignmentService()
+
+        with patch.object(service, "_get_lambda_client") as mock_client:
+            mock_client.return_value.invoke.return_value = _OK_PAYLOAD
+            result = await service.release_premium_user(
+                user_id=1, user_uid="uid", hard=True, timeout=5
+            )
+
+        assert result["success"] is True
+        assert result.get("timed_out") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -4,9 +4,11 @@ import os
 # Set environment variables before other imports
 os.environ["STRIPE_SECRET_KEY"] = "sk_test_fake_key_for_testing"
 
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 
@@ -127,6 +129,74 @@ class TestCheckoutIntegration:
 
         # Should fail signature verification
         assert response.status_code == 400
+
+
+class TestCreateOrUpdateSubscriptionConcurrency:
+    """create_or_update_subscription idempotency under concurrent inserts."""
+
+    @staticmethod
+    def _mock_db(existing_first, existing_after_conflict):
+        """db whose SELECT...FOR UPDATE returns existing_first, then
+        existing_after_conflict on the post-conflict re-select."""
+        from unittest.mock import MagicMock
+
+        db = Mock()
+        first = Mock(side_effect=[existing_first, existing_after_conflict])
+        db.query.return_value.filter.return_value.with_for_update.return_value.first = (
+            first
+        )
+        # begin_nested() as a context manager that does NOT suppress exceptions.
+        cm = MagicMock()
+        cm.__enter__.return_value = cm
+        cm.__exit__.return_value = False
+        db.begin_nested.return_value = cm
+        db.add = Mock()
+        return db
+
+    def test_concurrent_insert_falls_back_to_update(self):
+        """A unique-constraint conflict on insert re-selects and updates."""
+        from studio.app.common.core.subscription.checkout_service import (
+            CheckoutService,
+        )
+
+        existing_row = Mock()
+        existing_row.id = 555
+        db = self._mock_db(existing_first=None, existing_after_conflict=existing_row)
+        # The insert flush raises a unique-violation IntegrityError.
+        db.flush = Mock(
+            side_effect=IntegrityError("INSERT", {}, Exception("duplicate user_id"))
+        )
+
+        expiration = datetime.now() + timedelta(days=30)
+        with patch.object(
+            SubscriptionService, "get_current_datetime", return_value=datetime.now()
+        ):
+            result_id = CheckoutService.create_or_update_subscription(
+                db, user_id=42, plan_id=2, expiration_date=expiration
+            )
+
+        # Fell back to updating the row the racing delivery created.
+        assert result_id == 555
+        assert existing_row.plan_id == 2
+        assert existing_row.expiration == expiration
+        assert existing_row.scheduled_downgrade is False
+
+    def test_other_integrity_error_is_not_swallowed(self):
+        """If no row exists even after the conflict, the error is re-raised."""
+        from studio.app.common.core.subscription.checkout_service import (
+            CheckoutService,
+        )
+
+        db = self._mock_db(existing_first=None, existing_after_conflict=None)
+        db.flush = Mock(
+            side_effect=IntegrityError("INSERT", {}, Exception("some other constraint"))
+        )
+
+        expiration = datetime.now() + timedelta(days=30)
+        with pytest.raises(IntegrityError):
+            CheckoutService.create_or_update_subscription(
+                db, user_id=42, plan_id=2, expiration_date=expiration
+            )
 
 
 if __name__ == "__main__":

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -155,9 +155,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_concurrent_insert_falls_back_to_update(self):
         """A unique-constraint conflict on insert re-selects and updates."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         existing_row = Mock()
         existing_row.id = 555
@@ -183,9 +181,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_other_integrity_error_is_not_swallowed(self):
         """If no row exists even after the conflict, the error is re-raised."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         db = self._mock_db(existing_first=None, existing_after_conflict=None)
         db.flush = Mock(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -945,6 +945,9 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["user_id"] == 42
         assert result["plan_id"] == 2
         assert result["scheduled_downgrade"] is False
+        # status="active" -> SYNCED
+        assert result["sync_status"] == SyncStatus.SYNCED
+        assert mock_subscription.sync_status == SyncStatus.SYNCED
         mock_upsert.assert_called_once()
         upsert_args = mock_upsert.call_args[0]
         assert upsert_args[1] == 42  # user_id
@@ -977,6 +980,37 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["success"] is True
         assert result["scheduled_downgrade"] is True
         assert mock_subscription.scheduled_downgrade is True
+
+    def test_updated_past_due_still_marked_synced(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A successfully-mirrored delinquent subscription is SYNCED.
+
+        sync_status reflects DB<->Stripe sync success, not billing health, so
+        a past_due/unpaid/incomplete status that we wrote to the DB is still
+        SYNCED. Billing state is derived from `expiration` at read time.
+        """
+        subscription_event["status"] = "past_due"
+        mock_subscription = Mock()
+        mock_subscription.scheduled_downgrade = False
+        mock_subscription.sync_status = None
+        mock_subscription.updated_at = None
+        self._setup_query_chain(
+            mock_db, mock_user_account, mock_subscription, mock_user
+        )
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ), patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["sync_status"] == SyncStatus.SYNCED
+        assert mock_subscription.sync_status == SyncStatus.SYNCED
 
     def test_subscription_event_acknowledged_when_no_account(
         self, mock_db, subscription_event

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from sqlmodel import Session
@@ -855,6 +855,262 @@ class TestCheckoutStorageQuotaUpdate:
 
         expected_quota = StorageQuota.bytes_for_plan(SubscriptionPlanIds.PREMIUM)
         assert added_obj.storage_quota_bytes == expected_quota
+
+
+class TestSubscriptionLifecycleWebhooks:
+    """Tests for customer.subscription.* handling (issue #629).
+
+    Covers the previously-unhandled created/updated events and the
+    premium-assignment release on subscription delete.
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        db = Mock(spec=Session)
+        db.query = Mock()
+        db.add = Mock()
+        db.flush = Mock()
+        db.commit = Mock()
+        db.rollback = Mock()
+        db.execute = Mock()
+        return db
+
+    @pytest.fixture
+    def mock_user_account(self):
+        account = Mock()
+        account.user_id = 42
+        account.provider_customer_id = "cus_test123"
+        return account
+
+    @pytest.fixture
+    def mock_user(self):
+        user = Mock()
+        user.id = 42
+        user.uid = "user_uid_42"
+        return user
+
+    @pytest.fixture
+    def subscription_event(self):
+        """A customer.subscription.* event payload (event['data']['object'])."""
+        return {
+            "id": "sub_stripe123",
+            "customer": "cus_test123",
+            "status": "active",
+            "current_period_end": 2000000000,  # far-future unix timestamp
+            "cancel_at_period_end": False,
+            "metadata": {"plan_id": "2"},
+        }
+
+    def _setup_query_chain(self, mock_db, account, subscription, user):
+        """Sequential query results: account, subscription, user."""
+        mock_db.query.side_effect = [
+            # 1. SubscriptionUserAccount by customer_id
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=account)))),
+            # 2. UserSubscription by user_id (order_by -> first)
+            Mock(
+                filter=Mock(
+                    return_value=Mock(
+                        order_by=Mock(
+                            return_value=Mock(first=Mock(return_value=subscription))
+                        )
+                    )
+                )
+            ),
+            # 3. User for cache invalidation
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=user)))),
+        ]
+
+    def test_subscription_created_activates_subscription(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """created upserts subscription_users and invalidates the tier cache."""
+        mock_subscription = Mock()
+        mock_subscription.scheduled_downgrade = None
+        mock_subscription.updated_at = None
+        self._setup_query_chain(
+            mock_db, mock_user_account, mock_subscription, mock_user
+        )
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ) as mock_invalidate:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["user_id"] == 42
+        assert result["plan_id"] == 2
+        assert result["scheduled_downgrade"] is False
+        mock_upsert.assert_called_once()
+        upsert_args = mock_upsert.call_args[0]
+        assert upsert_args[1] == 42  # user_id
+        assert upsert_args[2] == 2  # plan_id from metadata
+        mock_db.commit.assert_called_once()
+        mock_invalidate.assert_called_once_with("user_uid_42")
+
+    def test_subscription_updated_mirrors_scheduled_downgrade(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """updated mirrors cancel_at_period_end onto scheduled_downgrade."""
+        subscription_event["cancel_at_period_end"] = True
+        mock_subscription = Mock()
+        mock_subscription.scheduled_downgrade = False
+        mock_subscription.updated_at = None
+        self._setup_query_chain(
+            mock_db, mock_user_account, mock_subscription, mock_user
+        )
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ), patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["scheduled_downgrade"] is True
+        assert mock_subscription.scheduled_downgrade is True
+
+    def test_subscription_event_acknowledged_when_no_account(
+        self, mock_db, subscription_event
+    ):
+        """Unknown customer is acknowledged without a DB write (no Stripe retries)."""
+        mock_db.query.side_effect = [
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
+        ]
+        with patch.object(
+            CheckoutService, "create_or_update_subscription"
+        ) as mock_upsert:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "missing_user_account"
+        mock_upsert.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+    def test_subscription_event_acknowledged_when_no_period_end(
+        self, mock_db, mock_user_account, subscription_event
+    ):
+        """Missing expiration is acknowledged without a DB write."""
+        subscription_event.pop("current_period_end")
+        subscription_event.pop("trial_end", None)
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+        ]
+        with patch.object(
+            CheckoutService, "create_or_update_subscription"
+        ) as mock_upsert:
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "missing_expiration"
+        mock_upsert.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_on_delete(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """The delete path hard-releases the user's premium assignment."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            # account by customer_id
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            # User by id
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+        with patch.object(
+            premium_assignment_service,
+            "release_premium_user",
+            new=AsyncMock(return_value={"success": True, "message": "released"}),
+        ) as mock_release:
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+        mock_release.assert_awaited_once_with(
+            user_id=42, user_uid="user_uid_42", hard=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_no_account_is_noop(
+        self, mock_db, subscription_event
+    ):
+        """No local account -> nothing to release, no error."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
+        ]
+        with patch.object(
+            premium_assignment_service, "release_premium_user", new=AsyncMock()
+        ) as mock_release:
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+        mock_release.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_delete_mirrors_and_releases(
+        self, mock_db, subscription_event
+    ):
+        """dispatch routes delete to the cancel handler AND the release helper."""
+        with patch.object(
+            WebhookService, "handle_subscription_cancelled"
+        ) as mock_cancel, patch.object(
+            WebhookService, "_release_premium_assignment", new=AsyncMock()
+        ) as mock_release:
+            result = await WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.deleted", subscription_event
+            )
+
+        assert result["success"] is True
+        mock_cancel.assert_called_once_with(mock_db, subscription_event)
+        mock_release.assert_awaited_once_with(mock_db, subscription_event)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_created_routes_to_handler(
+        self, mock_db, subscription_event
+    ):
+        """dispatch routes created to handle_subscription_created."""
+        with patch.object(
+            WebhookService,
+            "handle_subscription_created",
+            return_value={"success": True},
+        ) as mock_created:
+            result = await WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.created", subscription_event
+            )
+
+        assert result["success"] is True
+        mock_created.assert_called_once_with(mock_db, subscription_event)
 
 
 if __name__ == "__main__":

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -902,7 +902,7 @@ class TestSubscriptionLifecycleWebhooks:
         }
 
     def _setup_query_chain(self, mock_db, account, subscription, user):
-        """Sequential query results: account, subscription, user."""
+        """Sequential query results: account, subscription, storage, user."""
         mock_db.query.side_effect = [
             # 1. SubscriptionUserAccount by customer_id
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=account)))),
@@ -916,7 +916,9 @@ class TestSubscriptionLifecycleWebhooks:
                     )
                 )
             ),
-            # 3. User for cache invalidation
+            # 3. UserStorageUsage for quota sync
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
+            # 4. User for cache invalidation
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=user)))),
         ]
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1064,8 +1064,9 @@ class TestSubscriptionLifecycleWebhooks:
     async def test_release_premium_assignment_on_delete(
         self, mock_db, mock_user_account, mock_user, subscription_event
     ):
-        """The delete path hard-releases the user's premium assignment."""
+        """The delete path hard-releases with the short webhook timeout."""
         from studio.app.common.core.premium.premium_assignment_service import (
+            WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             premium_assignment_service,
         )
 
@@ -1089,8 +1090,45 @@ class TestSubscriptionLifecycleWebhooks:
             )
 
         mock_release.assert_awaited_once_with(
-            user_id=42, user_uid="user_uid_42", hard=True
+            user_id=42,
+            user_uid="user_uid_42",
+            hard=True,
+            timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS,
         )
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_continues_on_timeout(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A fail-open (timed-out) release must not raise; webhook still acks."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+        timed_out = {
+            "success": False,
+            "timed_out": True,
+            "message": "Release timed out",
+        }
+        with patch.object(
+            premium_assignment_service,
+            "release_premium_user",
+            new=AsyncMock(return_value=timed_out),
+        ) as mock_release:
+            # Must not raise even though release reports failure.
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+        mock_release.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_release_premium_assignment_no_account_is_noop(


### PR DESCRIPTION
# fix(subscription): handle Stripe subscription webhooks, release premium on expiry, and fix active-user email lookup
 
Closes #629
 
> **Alignment with #629.** The issue documented three consequences during the 2026‑05‑19 system test round; they map directly to **Problems 1–3** below (P1 = Scenario 1 / test **600‑17a**; P2 = consequence 2; P3 = Scenario 2 / test **600‑17b**). **Problems 4–5** were found while implementing and validating the fix — P4 in code review, P5 during a dev‑environment investigation of a lingering "Activation Pending."
 
## Reported problems
 
| # | Problem (issue ref) | Occurrence rate | Cause & why it wasn't caught earlier | Risk — to users | Risk — to the system |
|---|---------------------|-----------------|--------------------------------------|-----------------|----------------------|
| 1 | New paid subscription not activated locally; UI stuck on "Activation Pending" (Scenario 1 / **600‑17a**) | Conditional — whenever activation must fall back to `customer.subscription.created` (i.e. `checkout.session.completed` is delayed, fails partway, or isn't delivered). In 600‑17a it hit every new Upgrade | No `case` for `customer.subscription.created` → silent "Unhandled" default (200 OK, no DB write). **Not caught before** because activation already worked through the primary `checkout.session.completed` path, and existing tests bypassed activation with a manual `subscription_users` INSERT — so the `created` handler was never exercised until 600‑17a hit the path that depends on it | Pays but is stuck on "Activation Pending" indefinitely, no self‑service recovery — looks like they paid for nothing | Manual DB INSERT required per affected user (ops burden); support load; erodes trust in billing |
| 2 | Stripe‑initiated subscription changes not mirrored locally (consequence 2 / `customer.subscription.updated`) | Every Stripe‑initiated change (proration, payment‑method‑failure auto‑cancel, plan change). Rare in manual testing, real in production | No `case` for `customer.subscription.updated` → silent default. **Not caught before** because the cancel test passed via an inline DB write in `handle_cancel_user_subscription` (`scheduled_downgrade=1`), masking the ignored webhook; no test exercised a Stripe‑originated change | Local plan / expiration / scheduled‑downgrade silently wrong vs Stripe; may be limited or billed incorrectly; Stripe‑side cancellations/downgrades not reflected | Local DB drifts from Stripe (source of truth); silent inconsistency with no error signal; hard to audit |
| 3 | Premium compute not released when a subscription ends (Scenario 2 / **600‑17b**) | ~Every expiration/cancellation — released only on logout / tab‑close or the activity stale‑sweep (up to ~3h) | `handle_subscription_cancelled` expired the row but never called `release_premium_user`; no expiration→release path existed. **Not caught before** because the UI tier flips to free correctly (derived per request from `subscription_users.expiration` in `_enrich_user_with_subscription_status`), so the screen looked right; the dangling `premium_user_assignments` row is only visible in DB/infra, and cleanup eventually fired via unrelated paths | Low direct impact (UI correctly downgrades), but a free‑tier account retaining dedicated compute is a fairness / isolation concern | Orphaned dedicated EC2/ALB attached to a now‑free user for up to ~3h per expiry → **direct cost leak** + wasted capacity; scales with churn |
| 4 | Inline release on `deleted` could stall the webhook (found in review) | When the release Lambda is slow or hung | `release_premium_user` awaited an unbounded `run_in_executor` (no `asyncio.wait_for`; ~60s botocore default), unlike `assign_premium_user`. **Newly relevant** only because this PR added an inline release on the webhook path; previously release ran from logout/beacon where latency mattered less | Cancel/expire flow hangs; possible duplicate side effects from retried deliveries | Webhook blocked → Stripe marks delivery failed and **retries** → duplicate `deleted` deliveries; executor‑thread pressure |
| 5 | "Activation Pending" after soft‑delete + re‑register with the same email (found in dev investigation) | Every time a user soft‑deletes their account and re‑registers with the same email, then subscribes | `validate_checkout_session` and `handle_subscription_schedule_released` looked up users by email **without** `active=True`; `.first()` could return the old soft‑deleted row. The webhook wrote the subscription to the new active user (via `metadata.user_id`), but validation resolved the email to the inactive user, and `get_user_subscription` (which filters `active=True`) then found nothing. **Not caught before** because deletion is a soft‑delete and this only manifests on the re‑register‑same‑email path — outside the normal flow and not covered by prior tests; confirmed on dev (webhook wrote to user 102, validation resolved the email to inactive user 75) | Pays, webhook succeeds, but is permanently stuck on "Activation Pending"; hits returning users specifically | Identity‑resolution correctness bug → support escalations; subscription recorded on a different user row than validation resolves |
 
**Why none of this was caught before this implementation.** Subscription registration/activation *was* working prior to this change — but each gap was independently masked: P1 by the primary `checkout.session.completed` path plus a manual‑INSERT test bypass, P2 by an inline DB write in the cancel path, and P3 by the per‑request tier derivation that made the UI look correct. Because the happy path worked, the missing webhook handlers were invisible until the 2026‑05‑19 system test round (600‑17a / 600‑17b) and the later dev investigation (P5) exercised the paths that actually depend on them. P4 is a latent risk introduced by the fix itself (doing the release inline on the webhook).
 
## Fix direction (from the issue) → what this PR does
 
- *"Wire `dispatch_webhook_event` to handle `created` / `updated` / `deleted` (mirror + `release_premium_user`)"* → implemented via `_sync_subscription_from_event` + `handle_subscription_created/updated` and an `await`ed `_release_premium_assignment` in the `deleted` case (P1, P2, P3).
- *"Add a periodic sweep for local‑expiration‑past‑grace without a Stripe `deleted` event"* → new `PremiumExpirationSweepJob`, hourly (P3, and the 600‑17b direct‑`UPDATE` trigger).
- *"600‑17b: implement the expiration→release hook (option a)"* → done (event‑driven release + backstop sweep).
## Summary
 
The Stripe webhook dispatcher silently ignored `customer.subscription.created`, `customer.subscription.updated`, and `billing_portal.session.created` — they fell through to the `Unhandled webhook event type` default and returned `200 OK` without touching the database. On subscription end, `customer.subscription.deleted` expired the DB row but never released the user's dedicated premium compute. Separately, `validate_checkout_session` and `handle_subscription_schedule_released` looked up users by email without filtering `active=True`, so a soft‑deleted + re‑registered user could resolve to the wrong (inactive) record and appear permanently "Activation Pending."
 
This PR wires up those events, releases the premium assignment on delete (with a bounded, fail‑open timeout), adds a periodic backstop sweep that releases dangling assignments when the `deleted` event is missed or expiration is applied directly in the DB, makes the activation upsert idempotent under concurrent webhook deliveries, and fixes the email‑lookup queries to only match active users.
 
## Root cause
 
`WebhookService.dispatch_webhook_event` had no `case` for the `created`/`updated` events, and `handle_subscription_cancelled` (the `deleted` handler) only expired the subscription row — it never called `premium_assignment_service.release_premium_user`, which until now was only triggered by the logout and tab‑close beacon paths in `users_me.py`. Separately, `validate_checkout_session` (in `subscriptions.py`) and `handle_subscription_schedule_released` (in `webhook_service.py`) used an unfiltered email lookup (`.filter(User.email == email).first()`); since account deletion is a soft‑delete (`active=False`), re‑registering with the same email creates a second row and `.first()` could return the old inactive one, while `get_user_subscription` filters `active=True` and finds nothing.
 
## Behavior: before → after
 
| Scenario | Before | After |
| --- | --- | --- |
| `customer.subscription.created` | Ignored (logged "Unhandled", 200 OK) | Upserts `subscription_users`; activation no longer relies solely on `checkout.session.completed` |
| `customer.subscription.updated` | Ignored | Mirrors plan, expiration, and `cancel_at_period_end` into local state |
| `customer.subscription.deleted` | Expired DB row only; premium compute left dangling | Expires DB row **and** hard‑releases the premium assignment (bounded, fail‑open) |
| `billing_portal.session.created` | Logged as "Unhandled" noise | Explicitly acknowledged as a no‑op |
| Expiration with no `deleted` event (lost webhook / direct DB update) | Dangles until the activity stale‑sweep (~hours) | Hourly backstop releases it once expired past the grace period |
| Concurrent `checkout.session.completed` + `created` | One delivery could `IntegrityError` → 500 → Stripe retry | Idempotent upsert: conflict falls back to an update |
| Soft‑delete → re‑register same email → subscribe | `validate_checkout_session` could match the old inactive user → "Activation Pending" though the webhook succeeded | Email lookups filter `active=True`; validation finds the correct active user |
 
## Test plan
 
CI result: **74 unit tests pass; 3 integration tests skipped (require live Stripe).** Categories below map each test to the problem it covers (P1–P5).
 
### Automated unit tests
 
| Test | Category | Verifies |
|------|----------|----------|
| `test_subscription_created_activates_subscription` | P1 Activation | `created` upserts `subscription_users` (plan+expiration), `sync_status=synced`, tier cache invalidated |
| `test_dispatch_created_routes_to_handler` | P1 Activation | dispatch routes `created` → `handle_subscription_created` |
| `test_subscription_event_acknowledged_when_no_account` | P1/P2 Guard | unknown customer → 200 ack, no DB write, no Stripe retry |
| `test_subscription_event_acknowledged_when_no_period_end` | P1/P2 Guard | event with no period end → ack, no DB write |
| `test_subscription_updated_mirrors_scheduled_downgrade` | P2 State sync | `updated` mirrors `cancel_at_period_end` → `scheduled_downgrade` |
| `test_updated_past_due_still_marked_synced` | P2 State sync | `sync_status` stays `synced` for `past_due` (sync success ≠ billing health) |
| `test_concurrent_insert_falls_back_to_update` | P1/P2 Concurrency | racing insert → `IntegrityError` → re‑select+update (idempotent) |
| `test_other_integrity_error_is_not_swallowed` | P1/P2 Concurrency | non‑conflict `IntegrityError` is re‑raised |
| `test_release_premium_assignment_on_delete` | P3 Release (+P4) | `deleted` path hard‑releases with the short timeout |
| `test_dispatch_delete_mirrors_and_releases` | P3 Release | dispatch `deleted` → cancellation mirror + release |
| `test_release_premium_assignment_no_account_is_noop` | P3 Release | no account → no release, no error |
| `test_no_candidates_no_release` | P3 Backstop | empty candidate set → no release calls |
| `test_releases_each_candidate_hard` | P3 Backstop | hard‑release each candidate with bounded timeout |
| `test_continues_after_release_error` | P3 Backstop | one failing release doesn't stop the batch |
| `test_returns_deduped_candidates` | P3 Backstop | dedup; exercises the ordered query path |
| `test_returns_empty_when_no_rows` | P3 Backstop | empty result handled |
| `test_release_times_out_fails_open` | P4 Resilience | `release_premium_user` returns fail‑open dict on timeout |
| `test_release_succeeds_within_timeout` | P4 Resilience | timeout param doesn't break the happy path |
| `test_release_premium_assignment_continues_on_timeout` | P4 Resilience | timed‑out release doesn't raise; webhook still acks |
 
> **Gap:** Problem 5 (active‑user email lookup) has no dedicated unit test yet — it is covered by the manual/system case TC‑S7 below. Recommend adding a unit test that asserts both `validate_checkout_session` and `handle_subscription_schedule_released` resolve the **active** user when two rows share an email.
 
### Manual / system test cases
 
> Common environment:
> - Stripe **test mode** with the dev webhook endpoint subscribed to `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`, `invoice.payment_succeeded`.
> - Test card `4242 4242 4242 4242`, exp `12/34`, CVC `123`, ZIP `12345`.
> - SQL client connected to the dev RDS (`subscr-…` or `development-…`).
> - AWS CLI configured for region `ap-northeast-1`.
> - CloudWatch Logs Insights opened on `/ecs/development-optinist-cloud-taskdef`.
> - Stripe Dashboard tab open at *Developers → Webhooks → endpoint → Recent deliveries*.
 
---
 
#### TC‑S1 — P1 Activation (system test 600‑17a)
 
**Objective.** Confirm `customer.subscription.created` activates a new paid subscription end‑to‑end **without** the manual `subscription_users` INSERT bypass.
 
**Preconditions.**
1. PR is deployed to dev. Confirm by checking the ECS image tag or by running a one‑off webhook (TC‑S8) and seeing `Handling customer.subscription.created` (not `Unhandled webhook event type: customer.subscription.created`) in CloudWatch.
2. A dev test user with **no premium subscription** exists. Pre‑check:
   ```sql
   SELECT id, email, active FROM users WHERE email = '<TEST_EMAIL>';
   -- Expected: 1 row, active = 1. Record <UID>.
   SELECT id, plan_id, expiration FROM subscription_users WHERE user_id = <UID>;
   -- Expected: 0 rows (or only a FREE row with no future expiration).
   ```
 
**Steps.**
1. Note start time `T0` (UTC): `date -u +%FT%TZ`.
2. Log in to the dev frontend as `<TEST_EMAIL>`.
3. Navigate to **Subscription → Upgrade** and click the premium plan's Upgrade button.
4. On Stripe Checkout, enter test card `4242 4242 4242 4242`, exp `12/34`, CVC `123`, ZIP `12345`, then click **Pay**. The browser redirects to `/subscription/thanks`.
5. In Stripe Dashboard → Webhooks → Recent deliveries, find the `customer.subscription.created` delivery for this customer; confirm status **200**, note its timestamp.
6. Wait on `/subscription/thanks`. The page calls `POST /api/subsc/checkout/validate-checkout-session` and retries once on `WEBHOOK_FAILED`. It should resolve to the **"Thank you!"** screen within ~5 s.
7. Navigate to the Dashboard. The premium tier indicator/feature gates must be visible.
**Verification.**
- CloudWatch (window: `T0 − 1 min` … now):
  ```
  fields @timestamp, @message
  | filter @message like /Handling customer.subscription.created|Webhook: Synced subscription.created for user|Validating checkout session ID|valid and database is updated/
  | sort @timestamp asc
  ```
  Expected: both `Handling customer.subscription.created` and `Webhook: Synced subscription.created for user <UID>` appear; then `Checkout session … is valid and database is updated … for user <UID>`.
- Negative assertion in the same window:
  ```
  filter @message like /Unhandled webhook event type: customer.subscription.created|Activation Pending/
  ```
  Expected: **0** results.
- DB:
  ```sql
  SELECT user_id, plan_id, expiration, scheduled_downgrade, sync_status
  FROM subscription_users WHERE user_id = <UID>;
  -- Expected: 1 row, plan_id = 2 (PREMIUM), expiration in the future, sync_status = 'synced'.
 
  SELECT provider_customer_id FROM subscription_user_accounts WHERE user_id = <UID>;
  -- Expected: 1 row with the Stripe customer id (cus_…) for this checkout.
  ```
 
**Pass criteria.** All three of: positive CW lines present, negative CW filter empty, DB rows match — and the UI never displays "Activation Pending."
 
**Cleanup.** Cancel the subscription in Stripe Dashboard (immediately) and/or soft‑delete the test user.
 
---
 
#### TC‑S2 — P3 Backstop sweep (system test 600‑17b)
 
**Objective.** Confirm that a subscription expired past the 30‑day grace **without** a Stripe `deleted` event still releases the dangling `premium_user_assignments` row via the hourly backstop sweep.
 
**Preconditions.**
1. PR deployed. The `premium_expiration_sweep` job is registered. Verify in CloudWatch (search any time after deploy):
   ```
   filter @message like /Added background job: premium_expiration_sweep/
   ```
2. A premium test user with an `active` assignment. Capture state:
   ```sql
   SELECT u.id AS user_id, u.uid, su.id AS sub_id, su.plan_id, su.expiration,
          pua.id AS asg_id, pua.instance_id, pua.status, pua.is_standby
   FROM users u
   JOIN subscription_users su ON su.user_id = u.id
   LEFT JOIN premium_user_assignments pua ON pua.user_id = u.id
   WHERE u.email = '<TEST_EMAIL>';
   -- Expected: plan_id = 2, expiration > NOW(), pua.status = 'active', pua.is_standby = 0.
   ```
   Record `<UID>`, `<SID>`, `<ASGID>`, `<INSTID>`.
**Steps.**
1. Note `T0` (UTC).
2. Force the subscription 35 days past expiry (no Stripe event):
   ```sql
   UPDATE subscription_users
      SET expiration = DATE_SUB(NOW(), INTERVAL 35 DAY)
    WHERE user_id = <UID> AND id = <SID>;
   ```
   Verify: `SELECT expiration FROM subscription_users WHERE id = <SID>;` shows a date >30 days in the past.
3. Trigger the sweep — pick **A** or **B**:
   - **A. Wait.** Default interval `JOB_INTERVAL_MINUTES = 60`. In CloudWatch, find the last `Starting premium expiration sweep job` to compute the next firing time (`last + 60 min`). Wait until after that.
   - **B. Invoke manually.** Exec into the background ECS task (`development‑background‑optinist‑cloud‑taskdef`) and run:
     ```
     python -c "import asyncio; from studio.app.common.core.background.premium_expiration_sweep_job import PremiumExpirationSweepJob; asyncio.run(PremiumExpirationSweepJob.run())"
     ```
4. Re‑query the assignment and ALB resources (see Verification).
**Verification.**
- CloudWatch (window: `T0` … `T0 + 65 min`):
  ```
  fields @timestamp, @message
  | filter @message like /Starting premium expiration sweep job|Premium expiration sweep: .*dangling assignment|Premium expiration sweep: released user <UID>|Premium expiration sweep completed/
  | sort @timestamp asc
  ```
  Expected order: `Starting premium expiration sweep job` → `Premium expiration sweep: N dangling assignment(s) to release` (N ≥ 1) → `Premium expiration sweep: released user <UID>` → `Premium expiration sweep completed: N released, 0 errors`.
- DB:
  ```sql
  SELECT id, instance_id, status FROM premium_user_assignments WHERE id = <ASGID>;
  -- Expected: row deleted (hard release), OR status = 'terminating' if the
  -- Premium Cleanup Lambda hasn't finalized yet.
  ```
- AWS (per‑user ALB rule + target group torn down):
  ```
  aws elbv2 describe-rules --region ap-northeast-1 --listener-arn <DEV_ALB_LISTENER_ARN> \
    --query "Rules[?Conditions[?Field=='path-pattern' && contains(Values[0], '/user/<UID>/')]]"
  # Expected: []
  aws elbv2 describe-target-groups --region ap-northeast-1 \
    --query "TargetGroups[?TargetGroupName=='premium-user-<UID>']"
  # Expected: []
  ```
- Negative: no errors in the sweep window:
  ```
  filter @message like /Premium expiration sweep: error releasing user <UID>/
  ```
  Expected: 0.
**Pass criteria.** Sweep release log present for `<UID>`; assignment row gone or `terminating`; ALB rule + per‑user target group removed.
 
**Cleanup.** Restore the test user's `expiration` (or terminate the test user) before re‑running.
 
---
 
#### TC‑S3 — P3 Release (event‑driven)
 
**Objective.** Confirm `customer.subscription.deleted` mirrors the expiration **and** hard‑releases the premium assignment immediately (no need to wait for the sweep).
 
**Preconditions.** Premium test user with an `active` `premium_user_assignments` row and a linked Stripe customer (`subscription_user_accounts.provider_customer_id` populated). Capture `<UID>`, `<ASGID>`, `<SUB_ID>` (Stripe subscription id from Stripe Dashboard).
 
**Steps.**
1. Note `T0` (UTC).
2. Cancel the subscription **immediately** in Stripe:
   - Stripe Dashboard → Customers → the test customer → Subscriptions → click subscription → **Cancel subscription → Immediately** (not "at period end").
   - Or CLI: `stripe subscriptions cancel <SUB_ID>` (test mode key).
3. In Stripe Dashboard → Webhooks → Recent deliveries, confirm `customer.subscription.deleted` was delivered with **200**. Note the latency (should be < 1 s under normal conditions, ≤ `WEBHOOK_RELEASE_TIMEOUT_SECONDS` under slow release).
**Verification.**
- CloudWatch (window: `T0 − 1 min` … `T0 + 5 min`):
  ```
  fields @timestamp, @message
  | filter @message like /Handling customer.subscription.deleted|Webhook: Subscription cancelled for customer|Webhook: Released premium assignment for user <UID>/
  | sort @timestamp asc
  ```
  Expected: all three lines present.
- DB:
  ```sql
  SELECT plan_id, expiration, sync_status FROM subscription_users WHERE user_id = <UID>;
  -- Expected: expiration ≈ NOW() (mirror cancelled), sync_status = 'synced'.
 
  SELECT id, status FROM premium_user_assignments WHERE id = <ASGID>;
  -- Expected: 0 rows (hard release deleted it).
  ```
- AWS verification of ALB rule + target group as in TC‑S2.
**Pass criteria.** Webhook delivered 200; release log present; assignment row gone; ALB resources removed; subscription marked expired in DB.
 
**Cleanup.** None required (the subscription is already cancelled).
 
---
 
#### TC‑S4 — P2 State sync via `customer.subscription.updated` (600‑17a downgrade spec)
 
**Objective.** Confirm `cancel_at_period_end → scheduled_downgrade=1` is mirrored from Stripe, and the user remains premium until period end.
 
**Preconditions.** Active premium test user; capture `<UID>` and `<SUB_ID>` (Stripe subscription id).
 
**Steps.**
1. Cancel **at end of period** (NOT immediately):
   - Stripe Dashboard → subscription → **Cancel → At end of billing period**.
   - Or CLI: `stripe subscriptions update <SUB_ID> -d cancel_at_period_end=true`.
2. Stripe fires `customer.subscription.updated` with `cancel_at_period_end=true`.
3. Refresh the dashboard.
**Verification.**
- CloudWatch:
  ```
  filter @message like /Handling customer.subscription.updated|Webhook: Synced subscription.updated for user <UID>/
  ```
  Expected: handler line; the `Synced …` line includes `scheduled_downgrade=True`.
- DB:
  ```sql
  SELECT plan_id, expiration, scheduled_downgrade, sync_status
  FROM subscription_users WHERE user_id = <UID>;
  -- Expected: plan_id = 2, expiration unchanged (still future), scheduled_downgrade = 1, sync_status = 'synced'.
  ```
- UI: user is still premium (Dashboard shows premium tier; features remain available).
- **Reverse test** (optional): `stripe subscriptions update <SUB_ID> -d cancel_at_period_end=false` → expect `scheduled_downgrade=0` and another `Synced …` log line.
**Pass criteria.** `scheduled_downgrade` flips with the event; UI keeps the user premium.
 
**Cleanup.** Reverse the cancellation, or let the test user roll off naturally.
 
---
 
#### TC‑S5 — P2 State sync, delinquent (`past_due`)
 
**Objective.** Confirm a `customer.subscription.updated` event with `status=past_due` is mirrored into local state and `sync_status` stays `synced` (it reflects sync success, not billing health).
 
**Preconditions.** Active premium test user.
 
**Steps (canonical, using a Stripe test clock).**
1. In Stripe Dashboard, replace the default payment method with one that **succeeds on attach but fails on renewal**: card `4000 0000 0000 0341`.
2. Stripe Dashboard → **Test clocks** → create a clock attached to this customer → advance the clock to **1 s after** the current period end.
3. Stripe attempts the renewal charge → it fails → Stripe transitions the subscription to `past_due` and fires `customer.subscription.updated`.
**Alternative quicker setup.** From Stripe Dashboard → Developers → Events → find any past `customer.subscription.updated` event with `status=past_due` for any test customer → click **Resend** (point at our dev webhook). (Sign verification is fine because the event is signed by Stripe.)
 
**Verification.**
- CloudWatch:
  ```
  filter @message like /Webhook: Synced subscription.updated for user <UID>/
  ```
  Expected: the line contains `stripe_status=past_due` and `sync_status=synced`.
- DB:
  ```sql
  SELECT plan_id, expiration, sync_status FROM subscription_users WHERE user_id = <UID>;
  -- Expected: sync_status = 'synced' (NOT 'failed'); expiration mirrored from the event payload.
  ```
- Tier behavior: derived from `expiration` at read time. If the new `expiration` is past, the user is on free tier and `invoice.payment_failed` handling drives any payment‑failure warning — `sync_status` is **not** repurposed for that.
**Pass criteria.** `sync_status` stays `synced` despite `past_due`; row is mirrored.
 
**Cleanup.** Delete the Stripe test clock; restore the original payment method.
 
---
 
#### TC‑S6 — P4 Webhook resilience under a slow release Lambda
 
**Objective.** Confirm that a slow/hung release Lambda does not stall the webhook response, that the timeout log fires, and that the sweep cleans up the assignment afterwards.
 
**Setup (dev only — revert when done).**
1. In `studio/app/common/core/premium/premium_assignment_service.py`, temporarily set `WEBHOOK_RELEASE_TIMEOUT_SECONDS = 1`. Deploy to dev.
2. Add a temporary `time.sleep(5)` at the top of the `release` handler in `infrastructure/terraform/.build/premium_manager/premium_manager.py` (so the Lambda exceeds the new timeout). Deploy that Lambda.
3. Set up a premium test user with an `active` assignment (as in TC‑S3). Capture `<UID>`, `<ASGID>`, `<SUB_ID>`.
**Steps.**
1. Trigger an immediate cancel (TC‑S3 step 2).
2. In Stripe Dashboard → Recent deliveries, measure the response time for the `customer.subscription.deleted` delivery.
3. Watch CloudWatch and the DB.
**Verification.**
- Stripe Dashboard: delivery response time **≤ ~1.5 s** (the webhook returned 200 instead of waiting the full 5 s). No retries appear.
- CloudWatch (window: T0 … T0+2 min):
  ```
  filter @message like /Release Lambda timed out after .* for user <UID>|deferring to background cleanup|Webhook: Premium release not confirmed for user <UID>/
  ```
  Expected: timeout warning lines present; no Webhook 500 / Stripe retry lines.
- DB immediately after: the assignment is **still present** (release didn't confirm in time).
- After the next sweep run (or via manual invoke per TC‑S2 step 3B): the assignment is released.
**Pass criteria.** Webhook responded within the bounded timeout; timeout log present; no Stripe retries; sweep eventually cleans up.
 
**Cleanup (mandatory).** Revert `WEBHOOK_RELEASE_TIMEOUT_SECONDS` to its original value and remove the `time.sleep` from the Lambda. Redeploy both.
 
---
 
#### TC‑S7 — P5 Active‑user email lookup (soft‑delete → re‑register same email)
 
**Objective.** Confirm that when two `users` rows share the same email (an old soft‑deleted row + a new active row), `validate_checkout_session` resolves to the **active** user and the new subscription is found — no "Activation Pending."
 
**Preconditions.** Two test emails are available; you'll reuse one after deletion.
 
**Steps.**
1. **Create user A.** Sign up at the dev frontend with email `t1@example.com`. Complete email verification (or use admin verification in dev). Log in. Pre‑check:
   ```sql
   SELECT id, email, active FROM users WHERE email = 't1@example.com';
   -- Expected: 1 row, active = 1. Record <A_UID>.
   ```
2. **As user A, subscribe.** Run TC‑S1 steps 2–4. Confirm:
   ```sql
   SELECT user_id, plan_id FROM subscription_users WHERE user_id = <A_UID>; -- premium row
   SELECT provider_customer_id FROM subscription_user_accounts WHERE user_id = <A_UID>; -- cus_…
   ```
3. **Soft‑delete account A.** Pick one:
   - **A (canonical via API).** Authenticated as A, call `DELETE /api/users/me` (handler at `studio/app/common/routers/users_me.py:463`). The flow deletes the Firebase user and ends with `users.active = False` (`crud_users.py:785`).
   - **B (faster, manual).** Delete the Firebase user via the Firebase Admin SDK / console for the project, then:
     ```sql
     UPDATE users SET active = 0 WHERE id = <A_UID>;
     ```
   Verify:
   ```sql
   SELECT id, email, active FROM users WHERE id = <A_UID>;
   -- Expected: active = 0.
   ```
4. **Re‑register with the same email.** At the dev frontend, sign up again with `t1@example.com` (different password). Firebase accepts (the prior Firebase user was deleted in step 3). A new local `users` row is created.
   ```sql
   SELECT id, email, active FROM users WHERE email = 't1@example.com';
   -- Expected: 2 rows — <A_UID> active = 0, and a new row active = 1. Record <B_UID>.
   ```
5. **As user B, subscribe.** Log in as B and run TC‑S1 steps 2–4. The browser redirects to `/subscription/thanks`.
6. Observe the thanks page resolve to "Thank you!" within ~5 s (must NOT show "Activation Pending").
**Verification.**
- CloudWatch (window covering both webhook + validation):
  ```
  fields @timestamp, @message
  | filter @message like /Webhook: Synced subscription.created for user|Validating checkout session ID|valid and database is updated.*for user/
  | sort @timestamp asc
  ```
  Expected: `Webhook: Synced subscription.created for user <B_UID>` AND `Checkout session … is valid and database is updated … for user <B_UID>`.
- Negative assertion — validation must NOT resolve to A:
  ```
  filter @message like /for user <A_UID>|No premium subscription found .* user <A_UID>|Successfully recovered subscription for user <A_UID>/
  ```
  Expected: 0 results.
- DB:
  ```sql
  SELECT user_id, plan_id, expiration, sync_status
  FROM subscription_users WHERE user_id IN (<A_UID>, <B_UID>);
  -- Expected: premium row for <B_UID>; <A_UID> has no row (deletion cleanup) or only a stale free row.
  ```
 
**Pre‑fix evidence (for reference).** On dev, the webhook wrote the subscription to user 102 (active) but `validate_checkout_session` resolved the email to inactive user 75 → `get_user_subscription(75)` returned nothing → `WEBHOOK_FAILED` → "Activation Pending" permanently.
 
**Pass criteria.** Validation resolves to the active user `<B_UID>`; UI flips to premium with no "Activation Pending"; CW shows no lookup of `<A_UID>`.
 
**Cleanup.** Cancel user B's subscription in Stripe (immediately) and soft‑delete user B if desired.
 