### PR TITLE
Handle ChunkLoadError after deploy

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -4,6 +4,8 @@ import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import Typography from "@mui/material/Typography"
 
+import { isChunkLoadError, triggerChunkReload } from "utils/chunkLoadReload"
+
 interface ErrorBoundaryProps {
   children: ReactNode
   fallback?: ReactNode
@@ -13,19 +15,31 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean
   error: Error | null
+  isReloading: boolean
 }
 
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props)
-    this.state = { hasError: false, error: null }
+    this.state = { hasError: false, error: null, isReloading: false }
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { hasError: true, error }
+    if (isChunkLoadError(error)) {
+      return { hasError: false, error: null, isReloading: true }
+    }
+    return { hasError: true, error, isReloading: false }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    if (isChunkLoadError(error)) {
+      // Skip console.error/onError so the patched reporter doesn't ship deploy-time noise.
+      if (!triggerChunkReload()) {
+        // Guard suppressed the reload — show error UI so the user isn't stranded blank.
+        this.setState({ hasError: true, error, isReloading: false })
+      }
+      return
+    }
     // eslint-disable-next-line no-console
     console.error("ErrorBoundary caught an error:", error, errorInfo)
     this.props.onError?.(error, errorInfo)
@@ -36,10 +50,13 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   handleRetry = (): void => {
-    this.setState({ hasError: false, error: null })
+    this.setState({ hasError: false, error: null, isReloading: false })
   }
 
   render(): ReactNode {
+    if (this.state.isReloading) {
+      return null
+    }
     if (this.state.hasError) {
       if (this.props.fallback) {
         return this.props.fallback

--- a/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
@@ -20,14 +20,21 @@ const ControllableThrowError = () => {
 
 describe("ErrorBoundary", () => {
   const originalConsoleError = console.error
+  let originalLocation: Location
 
   beforeEach(() => {
     console.error = jest.fn()
+    originalLocation = window.location
   })
 
   afterEach(() => {
     console.error = originalConsoleError
     shouldThrowExternal = false
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
   })
 
   it("should render children when no error occurs", () => {
@@ -115,6 +122,7 @@ describe("ErrorBoundary", () => {
     Object.defineProperty(window, "location", {
       value: { reload: reloadMock },
       writable: true,
+      configurable: true,
     })
 
     render(
@@ -139,5 +147,87 @@ describe("ErrorBoundary", () => {
     )
 
     expect(screen.getByText("An unexpected error occurred")).toBeInTheDocument()
+  })
+
+  it("should reload the page when a ChunkLoadError is thrown", () => {
+    const reloadMock = jest.fn()
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    })
+    sessionStorage.removeItem("chunk-reload-attempted")
+
+    const ThrowChunkError = () => {
+      const error = new Error("Loading chunk 17 failed.")
+      error.name = "ChunkLoadError"
+      throw error
+    }
+
+    render(
+      <ErrorBoundary>
+        <ThrowChunkError />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+    sessionStorage.removeItem("chunk-reload-attempted")
+  })
+
+  it("should not log or call onError for a ChunkLoadError", () => {
+    const reloadMock = jest.fn()
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    })
+    sessionStorage.removeItem("chunk-reload-attempted")
+    const onError = jest.fn()
+
+    const ThrowChunkError = () => {
+      const error = new Error("Loading chunk 17 failed.")
+      error.name = "ChunkLoadError"
+      throw error
+    }
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowChunkError />
+      </ErrorBoundary>,
+    )
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalledWith(
+      "ErrorBoundary caught an error:",
+      expect.anything(),
+      expect.anything(),
+    )
+    sessionStorage.removeItem("chunk-reload-attempted")
+  })
+
+  it("should show the error UI when the reload guard suppresses the reload", () => {
+    const reloadMock = jest.fn()
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    })
+    sessionStorage.setItem("chunk-reload-attempted", "1")
+
+    const ThrowChunkError = () => {
+      const error = new Error("Loading chunk 17 failed.")
+      error.name = "ChunkLoadError"
+      throw error
+    }
+
+    render(
+      <ErrorBoundary>
+        <ThrowChunkError />
+      </ErrorBoundary>,
+    )
+
+    expect(reloadMock).not.toHaveBeenCalled()
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument()
+    sessionStorage.removeItem("chunk-reload-attempted")
   })
 })

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,8 +10,10 @@ import App from "App"
 import reportWebVitals from "reportWebVitals"
 import { store } from "store/store"
 import { theme } from "Theme"
+import { initChunkReloadHandler } from "utils/chunkLoadReload"
 import { initErrorReporter } from "utils/errorReporter"
 
+initChunkReloadHandler()
 initErrorReporter()
 
 const root = createRoot(document.getElementById("root")!)

--- a/frontend/src/utils/__tests__/chunkLoadReload.test.ts
+++ b/frontend/src/utils/__tests__/chunkLoadReload.test.ts
@@ -1,0 +1,198 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals"
+
+import {
+  initChunkReloadHandler,
+  isChunkLoadError,
+  triggerChunkReload,
+  _resetForTesting,
+} from "utils/chunkLoadReload"
+
+describe("isChunkLoadError", () => {
+  it("matches a webpack-style ChunkLoadError instance", () => {
+    const error = new Error("Loading chunk 42 failed.")
+    error.name = "ChunkLoadError"
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it("matches by message even when name is generic", () => {
+    expect(isChunkLoadError(new Error("Loading chunk abc.def failed."))).toBe(
+      true,
+    )
+  })
+
+  it("matches CSS chunk load failures", () => {
+    expect(isChunkLoadError(new Error("Loading CSS chunk 12 failed."))).toBe(
+      true,
+    )
+  })
+
+  it("matches a raw string message", () => {
+    expect(isChunkLoadError("Loading chunk main failed.")).toBe(true)
+    expect(isChunkLoadError("ChunkLoadError: oops")).toBe(true)
+  })
+
+  it("does not match unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Network Error"))).toBe(false)
+    expect(isChunkLoadError("Something else")).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+    expect(isChunkLoadError(42)).toBe(false)
+    expect(isChunkLoadError({})).toBe(false)
+  })
+})
+
+describe("triggerChunkReload", () => {
+  let reloadMock: ReturnType<typeof jest.fn>
+
+  let originalLocation: Location
+
+  beforeEach(() => {
+    _resetForTesting()
+    sessionStorage.clear()
+    originalLocation = window.location
+    reloadMock = jest.fn()
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    sessionStorage.clear()
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it("reloads once and sets the loop-guard flag", () => {
+    const result = triggerChunkReload()
+    expect(result).toBe(true)
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem("chunk-reload-attempted")).toBe("1")
+  })
+
+  it("does not reload again while the loop-guard flag is set", () => {
+    triggerChunkReload()
+    reloadMock.mockClear()
+
+    const result = triggerChunkReload()
+    expect(result).toBe(false)
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+
+  it("reloads again after the flag is cleared", () => {
+    triggerChunkReload()
+    sessionStorage.removeItem("chunk-reload-attempted")
+    reloadMock.mockClear()
+
+    expect(triggerChunkReload()).toBe(true)
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("initChunkReloadHandler", () => {
+  let reloadMock: ReturnType<typeof jest.fn>
+
+  let originalLocation: Location
+
+  beforeEach(() => {
+    _resetForTesting()
+    sessionStorage.clear()
+    originalLocation = window.location
+    reloadMock = jest.fn()
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    sessionStorage.clear()
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it("reloads on a window 'error' event whose error matches", () => {
+    initChunkReloadHandler()
+    const error = new Error("Loading chunk 7 failed.")
+    error.name = "ChunkLoadError"
+    window.dispatchEvent(new ErrorEvent("error", { error, message: "" }))
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("reloads when only the event message matches (no error object)", () => {
+    initChunkReloadHandler()
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "ChunkLoadError: boom" }),
+    )
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores unrelated window 'error' events", () => {
+    initChunkReloadHandler()
+    window.dispatchEvent(
+      new ErrorEvent("error", { error: new Error("Network Error") }),
+    )
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+
+  it("reloads on an unhandledrejection whose reason matches", () => {
+    initChunkReloadHandler()
+    const error = new Error("Loading chunk 9 failed.")
+    error.name = "ChunkLoadError"
+    const event = new Event("unhandledrejection") as PromiseRejectionEvent
+    Object.defineProperty(event, "reason", { value: error })
+    window.dispatchEvent(event)
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("is idempotent across repeated init calls", () => {
+    initChunkReloadHandler()
+    initChunkReloadHandler()
+    const error = new Error("Loading chunk 1 failed.")
+    error.name = "ChunkLoadError"
+    window.dispatchEvent(new ErrorEvent("error", { error }))
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not clear the loop-guard flag immediately on 'load'", () => {
+    jest.useFakeTimers()
+    try {
+      initChunkReloadHandler()
+      sessionStorage.setItem("chunk-reload-attempted", "1")
+      window.dispatchEvent(new Event("load"))
+      expect(sessionStorage.getItem("chunk-reload-attempted")).toBe("1")
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("clears the loop-guard flag after the post-load delay elapses", () => {
+    jest.useFakeTimers()
+    try {
+      initChunkReloadHandler()
+      sessionStorage.setItem("chunk-reload-attempted", "1")
+      window.dispatchEvent(new Event("load"))
+      jest.advanceTimersByTime(30_000)
+      expect(sessionStorage.getItem("chunk-reload-attempted")).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/utils/__tests__/chunkLoadReload.test.ts
+++ b/frontend/src/utils/__tests__/chunkLoadReload.test.ts
@@ -195,4 +195,37 @@ describe("initChunkReloadHandler", () => {
       jest.useRealTimers()
     }
   })
+
+  it("stops propagation on matched chunk-load rejections", () => {
+    initChunkReloadHandler()
+    const downstream = jest.fn()
+    window.addEventListener("unhandledrejection", downstream)
+    try {
+      const error = new Error("Loading chunk 5 failed.")
+      error.name = "ChunkLoadError"
+      const event = new Event("unhandledrejection") as PromiseRejectionEvent
+      Object.defineProperty(event, "reason", { value: error })
+      window.dispatchEvent(event)
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      expect(downstream).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener("unhandledrejection", downstream)
+    }
+  })
+
+  it("removes its window listeners on _resetForTesting", () => {
+    initChunkReloadHandler()
+    _resetForTesting()
+    // Sink absorbs the event so jsdom doesn't surface it as uncaught.
+    const sink = jest.fn()
+    window.addEventListener("error", sink)
+    try {
+      const error = new Error("Loading chunk 8 failed.")
+      error.name = "ChunkLoadError"
+      window.dispatchEvent(new ErrorEvent("error", { error }))
+      expect(reloadMock).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener("error", sink)
+    }
+  })
 })

--- a/frontend/src/utils/chunkLoadReload.ts
+++ b/frontend/src/utils/chunkLoadReload.ts
@@ -1,0 +1,93 @@
+const RELOAD_FLAG_KEY = "chunk-reload-attempted"
+const CHUNK_ERROR_PATTERN =
+  /Loading (?:CSS )?chunk [^\s]+ failed|ChunkLoadError/
+const GUARD_CLEAR_DELAY_MS = 30_000
+
+// Captured before errorReporter patches console.warn — keeps reload noise off the log queue.
+const _originalWarn = console.warn.bind(console)
+
+let _initialized = false
+let _guardClearTimer: ReturnType<typeof setTimeout> | null = null
+
+export function isChunkLoadError(value: unknown): boolean {
+  if (!value) return false
+
+  if (typeof value === "string") {
+    return CHUNK_ERROR_PATTERN.test(value)
+  }
+
+  if (typeof value === "object") {
+    const candidate = value as { name?: unknown; message?: unknown }
+    if (candidate.name === "ChunkLoadError") return true
+    if (typeof candidate.message === "string") {
+      return CHUNK_ERROR_PATTERN.test(candidate.message)
+    }
+  }
+
+  return false
+}
+
+export function triggerChunkReload(): boolean {
+  _originalWarn(
+    "[chunkLoadReload] Chunk load error detected; attempting reload",
+  )
+
+  let alreadyAttempted = false
+  try {
+    alreadyAttempted = sessionStorage.getItem(RELOAD_FLAG_KEY) === "1"
+  } catch {
+    // sessionStorage may be unavailable (e.g. privacy mode); fall through.
+  }
+
+  if (alreadyAttempted) return false
+
+  try {
+    sessionStorage.setItem(RELOAD_FLAG_KEY, "1")
+  } catch {
+    // Best effort — proceed with reload even if we can't persist the flag.
+  }
+
+  window.location.reload()
+  return true
+}
+
+export function initChunkReloadHandler() {
+  if (_initialized) return
+  _initialized = true
+
+  window.addEventListener("error", (event) => {
+    if (isChunkLoadError(event.error) || isChunkLoadError(event.message)) {
+      triggerChunkReload()
+    }
+  })
+
+  window.addEventListener("unhandledrejection", (event) => {
+    if (isChunkLoadError(event.reason)) {
+      triggerChunkReload()
+    }
+  })
+
+  // Delay the clear so a chunk failure firing just after `load` can't bypass the guard.
+  window.addEventListener("load", () => {
+    _guardClearTimer = setTimeout(() => {
+      try {
+        sessionStorage.removeItem(RELOAD_FLAG_KEY)
+      } catch {
+        // No-op.
+      }
+    }, GUARD_CLEAR_DELAY_MS)
+  })
+}
+
+export function _resetForTesting() {
+  _initialized = false
+  if (_guardClearTimer) {
+    clearTimeout(_guardClearTimer)
+    _guardClearTimer = null
+  }
+  try {
+    sessionStorage.removeItem(RELOAD_FLAG_KEY)
+  } catch {
+    // No-op.
+  }
+}

--- a/frontend/src/utils/chunkLoadReload.ts
+++ b/frontend/src/utils/chunkLoadReload.ts
@@ -8,6 +8,9 @@ const _originalWarn = console.warn.bind(console)
 
 let _initialized = false
 let _guardClearTimer: ReturnType<typeof setTimeout> | null = null
+let _errorListener: ((event: ErrorEvent) => void) | null = null
+let _rejectionListener: ((event: PromiseRejectionEvent) => void) | null = null
+let _loadListener: (() => void) | null = null
 
 export function isChunkLoadError(value: unknown): boolean {
   if (!value) return false
@@ -55,20 +58,24 @@ export function initChunkReloadHandler() {
   if (_initialized) return
   _initialized = true
 
-  window.addEventListener("error", (event) => {
+  _errorListener = (event) => {
     if (isChunkLoadError(event.error) || isChunkLoadError(event.message)) {
       triggerChunkReload()
     }
-  })
+  }
+  window.addEventListener("error", _errorListener)
 
-  window.addEventListener("unhandledrejection", (event) => {
+  _rejectionListener = (event) => {
     if (isChunkLoadError(event.reason)) {
+      // Block errorReporter's later listener from shipping deploy-time noise.
+      event.stopImmediatePropagation()
       triggerChunkReload()
     }
-  })
+  }
+  window.addEventListener("unhandledrejection", _rejectionListener)
 
   // Delay the clear so a chunk failure firing just after `load` can't bypass the guard.
-  window.addEventListener("load", () => {
+  _loadListener = () => {
     _guardClearTimer = setTimeout(() => {
       try {
         sessionStorage.removeItem(RELOAD_FLAG_KEY)
@@ -76,7 +83,8 @@ export function initChunkReloadHandler() {
         // No-op.
       }
     }, GUARD_CLEAR_DELAY_MS)
-  })
+  }
+  window.addEventListener("load", _loadListener)
 }
 
 export function _resetForTesting() {
@@ -84,6 +92,18 @@ export function _resetForTesting() {
   if (_guardClearTimer) {
     clearTimeout(_guardClearTimer)
     _guardClearTimer = null
+  }
+  if (_errorListener) {
+    window.removeEventListener("error", _errorListener)
+    _errorListener = null
+  }
+  if (_rejectionListener) {
+    window.removeEventListener("unhandledrejection", _rejectionListener)
+    _rejectionListener = null
+  }
+  if (_loadListener) {
+    window.removeEventListener("load", _loadListener)
+    _loadListener = null
   }
   try {
     sessionStorage.removeItem(RELOAD_FLAG_KEY)

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -26,6 +26,9 @@ from studio.app.common.core.middleware import (
     SPARoutingMiddleware,
     UserActivityMiddleware,
 )
+from studio.app.common.core.middleware.spa_routing_middleware import (
+    INDEX_HTML_CACHE_HEADERS,
+)
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.core.subscription.constants import (
@@ -316,10 +319,14 @@ build_templates = Jinja2Templates(directory=DIRPATH.FRONTEND_DIRS.BUILD)
 @app.get("/")
 async def root(request: Request):
     if os.path.exists(f"{DIRPATH.FRONTEND_DIRS.BUILD}/index.html"):
-        return build_templates.TemplateResponse("index.html", {"request": request})
+        return build_templates.TemplateResponse(
+            "index.html", {"request": request}, headers=INDEX_HTML_CACHE_HEADERS
+        )
     else:
         return public_templates.TemplateResponse(
-            "no-built-pages.html", {"request": request}
+            "no-built-pages.html",
+            {"request": request},
+            headers=INDEX_HTML_CACHE_HEADERS,
         )
 
 

--- a/studio/app/common/core/middleware/spa_routing_middleware.py
+++ b/studio/app/common/core/middleware/spa_routing_middleware.py
@@ -26,6 +26,11 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from studio.app.dir_path import DIRPATH
 
+INDEX_HTML_CACHE_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Pragma": "no-cache",
+}
+
 
 class SPARoutingMiddleware:
     """
@@ -94,11 +99,15 @@ class SPARoutingMiddleware:
         # Check if build exists, otherwise serve no-build page
         if os.path.exists(f"{DIRPATH.FRONTEND_DIRS.BUILD}/index.html"):
             return self.build_templates.TemplateResponse(
-                "index.html", {"request": request}
+                "index.html",
+                {"request": request},
+                headers=INDEX_HTML_CACHE_HEADERS,
             )
         else:
             return self.public_templates.TemplateResponse(
-                "no-built-pages.html", {"request": request}
+                "no-built-pages.html",
+                {"request": request},
+                headers=INDEX_HTML_CACHE_HEADERS,
             )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:


### PR DESCRIPTION
# Pull Request: Handle ChunkLoadError after deploy

**Current Branch:** feature/ChunkLoadError
**Target Branch:** feature/public-instance

----------
### Content

#### Summary
- After a frontend deploy, users with an open tab hold a cached `index.html` that references hashed chunk filenames (e.g. `main.abc123.js`) which no longer exist on the server. The next dynamic `import()` then throws `ChunkLoadError`, leaving the user stranded.
- This PR makes the SPA recover automatically: detect the error in the React `ErrorBoundary` and via global `error` / `unhandledrejection` listeners, then `window.location.reload()` once to pick up the new shell.
- It also stops the backend from sending `index.html` with cacheable headers, so the recovery reload actually fetches a fresh shell instead of replaying the same stale HTML from disk cache.
- A `sessionStorage` loop-guard (cleared 30 s after `load`) keeps the page from reload-looping if the new shell still 404s.

#### Design Decisions
- **Three detection sites, one shared utility.** Chunk errors surface in three places: React render (caught by `ErrorBoundary.componentDidCatch`), uncaught script-execution errors (`window.addEventListener("error")`), and rejected dynamic-import promises (`unhandledrejection`). All three call into the same `triggerChunkReload()` so the loop guard is centralised.
- **Loop guard via `sessionStorage`, cleared after a delay.** A naive on-`load` clear is defeated by the common case: `load` fires before lazy chunks have a chance to fail, so the guard would clear immediately and a second failure would loop. Delaying the clear by 30 s preserves recovery for *later* chunk failures in the same session while still preventing reload loops when the shell itself is broken.
- **Bypass the patched `console.warn` in the reload path.** `utils/errorReporter.ts` monkey-patches `console.error`/`console.warn` and ships them to `/log-report/frontend-errors` via `beforeunload`. Without a bypass, every chunk-recovery cycle would ship 1–2 log entries per session per deploy. We capture `console.warn` at module init (before `errorReporter` patches it) and route the recovery notice through that original reference.
- **Short-circuit `componentDidCatch` for chunk errors.** Skips `console.error("ErrorBoundary caught …")` and the `onError` prop callback so the reporter doesn't pick them up either. If the guard suppresses the reload, the boundary falls through to its normal error UI rather than rendering `null` forever.
- **`isReloading` state instead of the standard error UI flash.** When a chunk error is caught, `getDerivedStateFromError` sets `isReloading: true` and `render()` returns `null`, so the user doesn't see the generic "Something went wrong" box flash for a frame before the reload kicks in.
- **No-cache on the SPA shell only.** `Cache-Control: no-cache, no-store, must-revalidate` is applied only to `index.html` / `no-built-pages.html` — not to the hashed static assets under `/static` and `/images`, which are content-addressed and safely cacheable. Headers are centralised in `INDEX_HTML_CACHE_HEADERS` and imported by both `SPARoutingMiddleware._serve_index_html` and the `/` route handlers, since each handles a different `Accept` path (browser via middleware; curl/`*/*` via route handler).
- **Alternatives rejected.** (a) Reload-counter with N-attempt backoff: more code, no benefit for the dominant single-reload case. (b) Service worker for cache invalidation: out of scope and adds substantial complexity. (c) `Pragma: no-cache` is included alongside `Cache-Control` for the very small set of intermediaries that still honour it; both are cheap.

### Evidence
- Affected test runs are green locally: 13 chunk-reload tests + 11 ErrorBoundary tests + 17 errorReporter tests pass.
- Manual reproduction in dev is captured under Manual Testcases below.

### References
- Branch: `feature/ChunkLoadError`
- Sole commit: `1dbe072e3 feature: handle ChunkLoadError after deploy`

#### Files changed

Frontend
- `frontend/src/utils/chunkLoadReload.ts` — new utility: `isChunkLoadError`, `triggerChunkReload`, `initChunkReloadHandler`. Implements the loop guard, the deferred-clear behaviour after `load`, and the bypass of `errorReporter`'s patched `console.warn`.
- `frontend/src/components/common/ErrorBoundary.tsx` — adds `isReloading` state, hooks `getDerivedStateFromError` and `componentDidCatch` into `chunkLoadReload`, short-circuits logging and `onError` for chunk errors, and recovers to the normal error UI when the loop guard blocks a reload.
- `frontend/src/index.tsx` — calls `initChunkReloadHandler()` *before* `initErrorReporter()` so the global error path can short-circuit to reload before the reporter starts capturing.
- `frontend/src/utils/__tests__/chunkLoadReload.test.ts` — new tests covering the matcher, the loop guard, the deferred clear (using fake timers), and the global event listeners.
- `frontend/src/components/common/__tests__/ErrorBoundary.test.tsx` — adds tests for chunk-error reload, the no-log/no-`onError` short-circuit, and the fallback-to-error-UI recovery when the guard suppresses the reload. Updates the existing test setup to use `configurable: true` when stubbing `window.location`.

Backend
- `studio/app/common/core/middleware/spa_routing_middleware.py` — defines `INDEX_HTML_CACHE_HEADERS` and passes them on both index template responses inside `_serve_index_html`.
- `studio/__main_unit__.py` — imports `INDEX_HTML_CACHE_HEADERS` and applies them to the `/` route's `index.html` / `no-built-pages.html` responses (covers the `Accept: */*` path the middleware doesn't intercept).

### Manual Testcases

Setup: a running stack with the new code deployed.

1. **Happy path (no-op for fresh sessions).**
   - As any user, open the SPA in a fresh tab.
   - Navigate around the app.
   - Expected: no reloads, no console warnings from `[chunkLoadReload]`.

2. **Stale shell after deploy → auto-recovery.**
   - As any user, open the SPA.
   - In DevTools → Application → Service Workers / Storage, leave session storage as-is. In DevTools → Network, enable "Disable cache".
   - In a separate terminal, rebuild the frontend so chunk hashes change. Redeploy / restart the backend.
   - Back in the open tab, trigger any action that runs an `await import()` (e.g. logout — `utils/auth/AuthUtils.ts` dynamically imports `utils/axios` and `api/users/UsersMe`).
   - Expected: page reloads exactly once; after reload, the action succeeds; `sessionStorage["chunk-reload-attempted"]` is removed 30 s after `load`.

3. **Loop guard active (degraded path).**
   - In DevTools → Application → Session Storage, set `chunk-reload-attempted` to `1`.
   - Trigger a `ChunkLoadError` by visiting a route whose lazy chunk you've blocked in DevTools → Network.
   - Expected: no reload; the standard "Something went wrong" error UI renders with the chunk error message and a Reload Page button.

4. **Cache headers on the shell.**
   - As any user, run: `curl -i https://<host>/ -H "Accept: text/html"` and `curl -i https://<host>/workspaces -H "Accept: text/html"`.
   - Expected: both responses include `Cache-Control: no-cache, no-store, must-revalidate` and `Pragma: no-cache`.
   - Run: `curl -i https://<host>/static/js/<some-hashed>.js`.
   - Expected: cache headers are **not** overridden — static assets still benefit from normal caching.

5. **Error reporter is not poisoned by chunk errors.**
   - With DevTools open, force a chunk error (e.g. block the chunk URL).
   - Check `Network` for a `POST /log-report/frontend-errors` flush before unload.
   - Expected: the flush does **not** contain the `[chunkLoadReload]` warn or the `ErrorBoundary caught an error: …ChunkLoadError…` line.

6. **Automated tests.**
   - `cd frontend && CI=true yarn test --watchAll=false --testPathPattern="(chunkLoadReload|ErrorBoundary|errorReporter)"` — all 41 tests pass.

### Unit, Integration, Contract Test Coverage
- **Unit (frontend):** `chunkLoadReload.test.ts` covers the matcher, the reload + loop-guard, the deferred-clear via fake timers, and the global `error` / `unhandledrejection` paths. `ErrorBoundary.test.tsx` covers normal error rendering, fallback prop, retry/reload buttons, chunk-error reload, no-log/no-`onError` short-circuit, and guard-blocked fallback to error UI.
- **Integration:** none added; the reload path is exercised indirectly via the ErrorBoundary tests and the global handler tests.
- **Backend:** no new tests — the cache-header change is a one-line annotation on existing TemplateResponses; behaviour is observable via the curl checks in step 4.

### Others

#### Difficulties (if any)
- Timing of `load` vs dynamic-import failure required care: dynamic imports do not block `load`, so the naive on-`load` clear of the loop guard left a window where a second chunk failure would loop. Resolved by deferring the clear by 30 s.
- `errorReporter` patches `console.warn` globally, which would have made every chunk-recovery cycle ship two log entries to the backend. Resolved by capturing the original `console.warn` reference at module init in `chunkLoadReload`.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Frontend reload behaviour | Low | New code is opt-in (only triggers on matched chunk errors); loop guard bounds worst-case reload count. |
| Existing `ErrorBoundary` consumers | Low | Non-chunk error paths are unchanged; only chunk errors short-circuit. App.tsx is the sole consumer and passes no `onError`. |
| `errorReporter` interaction | Low | Bypass relies on module-init ordering (`chunkLoadReload` imported before `errorReporter` patches `console.warn`); enforced by `index.tsx` import order. If a future refactor re-orders these, chunk warnings would once again be queued — covered by Test 5 above. |
| Backend cache headers | Low | Scoped to the SPA shell. Static assets (`/static`, `/images`) are untouched and remain cacheable. |
| First deploy of this change | Medium | Users with a *pre-existing* cached `index.html` from before this commit do not have the new no-store header on that cached copy; their first reload after the deploy may still serve the stale shell from disk cache. Self-heals on the subsequent reload (one user-visible blip at worst, bounded by the loop guard). |
| Bundler assumption | Low | Regex is webpack-specific (`Loading chunk … failed` / `ChunkLoadError`). Repo uses `react-scripts` (webpack); a future Vite migration would need the regex updated. |
