### PR TITLE
Cloudwatch logging accuracy and frequency

### DIFF
--- a/infrastructure/documentation/LOGGING_ARCHITECTURE.md
+++ b/infrastructure/documentation/LOGGING_ARCHITECTURE.md
@@ -435,12 +435,17 @@ Logs to stdout (captured by ECS awslogs driver). Covers:
 
 Configured in `ecs-user-data.sh`, publishes to `CWAgent` namespace:
 
-| Metric                | Type       | Collection Interval |
-|-----------------------|------------|---------------------|
-| `mem_used_percent`    | Memory     | Default (60s)       |
-| `cpu_usage_idle`      | CPU        | Default (60s)       |
-| `cpu_usage_iowait`    | CPU        | Default (60s)       |
-| `procstat` (all)      | Per-process| 60s                 |
+| Metric                     | Type   | Collection Interval |
+|----------------------------|--------|---------------------|
+| `mem_used_percent`         | Memory | Default (60s)       |
+| `cpu_usage_idle`           | CPU    | Default (60s)       |
+| `cpu_usage_iowait`         | CPU    | Default (60s)       |
+| `diskio_iops_in_progress`  | Disk   | Default (60s)       |
+| `diskio_io_time`           | Disk   | Default (60s)       |
+
+Every metric carries an `AutoScalingGroupName` dimension (`append_dimensions`)
+and is rolled up to the ASG level (`aggregation_dimensions`). Without this,
+the host-only dimension would never match the ASG-scoped alarms below.
 
 Also collects `/proc/loadavg` to log group `/aws/ec2/loadavg`.
 
@@ -677,19 +682,26 @@ The free manager also triggers on ASG lifecycle events (instance launch/terminat
 | `subscr-optinist-memory-low`       | MemoryUtilization         | < 10%        | AWS/ECS                |
 | `subscr-optinist-load-average-high`| CPUUtilization            | > 80%        | AWS/EC2                |
 | `subscr-optinist-high-iowait`      | cpu_usage_iowait          | > 30%        | CWAgent                |
+| `subscr-optinist-ebs-queue-length-high` | diskio_iops_in_progress | > 8 (2/3 min) | CWAgent              |
 | `subscr-optinist-rds-cpu-high`     | CPUUtilization            | > 80%        | AWS/RDS                |
 | `subscr-optinist-rds-connections-high` | DatabaseConnections   | > 80         | AWS/RDS                |
 | `subscr-optinist-rds-storage-low`  | FreeStorageSpace          | < 10 GB      | AWS/RDS                |
 | `subscr-optinist-efs-burst-credits-low` | BurstCreditBalance   | < 1 TB       | AWS/EFS                |
 | `subscr-optinist-efs-throughput-high` | PercentIOLimit         | > 80%        | AWS/EFS                |
-| `subscr-optinist-alb-5xx-errors`   | HTTPCode_Target_5XX_Count | > 10/min     | AWS/ApplicationELB     |
-| `subscr-optinist-alb-response-time-high` | TargetResponseTime  | > 5s         | AWS/ApplicationELB     |
+| `subscr-optinist-alb-5xx-errors`   | HTTPCode_Target_5XX_Count | >= 20 / 5 min | AWS/ApplicationELB    |
+| `subscr-optinist-free-tg-response-time-high` | TargetResponseTime | p95 > 10s (25/30 min) | AWS/ApplicationELB |
+| `subscr-optinist-public-tg-response-time-high` | TargetResponseTime | p95 > 5s (25/30 min) | AWS/ApplicationELB |
+| `subscr-optinist-free-tg-unhealthy-hosts`   | UnHealthyHostCount  | > 0          | AWS/ApplicationELB     |
+| `subscr-optinist-public-tg-unhealthy-hosts` | UnHealthyHostCount  | > 0          | AWS/ApplicationELB     |
+| `subscr-premium-<user_id>-tg-unhealthy-hosts` | UnHealthyHostCount | > 0 (created per-user by the premium-manager Lambda) | AWS/ApplicationELB |
 | `subscr-background-task-stopped`   | RunningTaskCount          | < 1          | ECS/ContainerInsights  |
 | `subscr-background-cpu-high`       | CpuUtilized               | > 400 units  | ECS/ContainerInsights  |
 | `subscr-background-memory-high`    | MemoryUtilized            | > 600 MB     | ECS/ContainerInsights  |
 | `subscr-monthly-cost-high` | TotalMonthlyCost          | > $500/day   | OptiNiSt/Cost          |
 | `subscr-premium-cpu-high`          | CPUUtilization            | > 80%        | AWS/ECS                |
 | `subscr-premium-memory-high`       | MemoryUtilization         | > 85%        | AWS/ECS                |
+
+**Alarm name prefixes differ by who creates them.** Terraform-managed alarms use the `subscr-optinist-` prefix (Terraform `local.env_prefix` = `<environment>-optinist`). Premium alarms created by the premium-manager/cleanup Lambdas use the bare `subscr-` prefix (the Lambdas' `ENV_PREFIX` = `<environment>`, matching their instance and target-group naming). When listing alarms, filter on `subscr-` to catch both; `subscr-optinist-` alone will miss every per-user premium alarm.
 
 ### CloudWatch Dashboard
 

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -423,6 +423,7 @@ When an alarm fires, follow the procedure for that alarm category.
 |---|---|---|
 | `subscr-optinist-load-average-high` | EC2 CPU > 80% (2 periods) | Check if user workloads are unusually heavy. May need larger instances. |
 | `subscr-optinist-high-iowait` | I/O wait > 30% (2 periods) | Check EFS throughput, disk-heavy operations. Consider EFS provisioned throughput. |
+| `subscr-optinist-ebs-queue-length-high` | EBS I/O queue > 8 (2 of 3 min) | Disk saturation — check for heavy Snakemake I/O. Sustained saturation can fail health checks and evict the instance. |
 
 ### RDS Alarms
 
@@ -443,8 +444,11 @@ When an alarm fires, follow the procedure for that alarm category.
 
 | Alarm | Threshold | Action |
 |---|---|---|
-| `subscr-optinist-alb-5xx-errors` | > 10 5XX errors (2 periods of 60s) | **HIGH PRIORITY.** Check ECS task health, recent deployments, application logs. |
-| `subscr-optinist-alb-response-time-high` | Avg > 5s (2 periods) | Check RDS performance, ECS resource utilization, heavy user workloads. |
+| `subscr-optinist-alb-5xx-errors` | >= 20 5XX errors in 5 min | **HIGH PRIORITY.** A sustained error storm. Check ECS task health, recent deployments, application logs. |
+| `subscr-optinist-free-tg-response-time-high` | p95 > 10s for 25 of 30 min | Persistent (not transient) latency. Check RDS, ECS utilization, heavy workloads. |
+| `subscr-optinist-public-tg-response-time-high` | p95 > 5s for 25 of 30 min | Sustained SPA/public-dataview latency. Check public instance health and cold-cache reads. |
+| `subscr-optinist-free-tg-unhealthy-hosts` | UnHealthyHostCount > 0 | Free workflow instance failing health checks. Check ECS task and EBS I/O. |
+| `subscr-optinist-public-tg-unhealthy-hosts` | UnHealthyHostCount > 0 | SPA delivery / public-dataview at risk. Check public ASG instances. |
 
 ### Background Service Alarms
 
@@ -466,12 +470,13 @@ When an alarm fires, follow the procedure for that alarm category.
 |---|---|---|
 | `subscr-premium-cpu-high` | CPU > 80% (2 periods) | Check premium user workload. May need larger instance type. |
 | `subscr-premium-memory-high` | Memory > 85% (3 periods) | Check for memory-intensive workflows. Review premium task definition limits. |
+| `subscr-premium-<user_id>-tg-unhealthy-hosts` | UnHealthyHostCount > 0 | Created/deleted per-user by the premium-manager Lambda. That user's dedicated instance is failing health checks. |
 
 ---
 
 ## Reference: Critical Alert Configuration
 
-Critical CloudWatch alarms send email notifications to `optinist-support@araya.org` via an SNS topic (`subscr-optinist-critical-alerts`, defined in `monitoring.tf`). Both `alarm_actions` and `ok_actions` are wired so the team is notified when an alarm fires and when it recovers.
+Critical CloudWatch alarms send email notifications to `optinist-support@araya.org` via an SNS topic (`subscr-optinist-critical-alerts`, defined in `monitoring.tf`). Most alarms wire both `alarm_actions` and `ok_actions`, so the team is notified when an alarm fires and when it recovers. The ALB 5XX and response-time alarms wire only `alarm_actions` (no recovery email) and treat missing data as not-breaching, to suppress the OK/INSUFFICIENT_DATA flapping that sparse traffic would otherwise generate.
 
 **Note:** After the initial `terraform apply`, AWS sends a confirmation email to the subscription endpoint. The subscription must be confirmed before alerts are delivered.
 
@@ -485,8 +490,12 @@ Critical CloudWatch alarms send email notifications to `optinist-support@araya.o
 | `subscr-optinist-rds-storage-low` | `monitoring.tf` | Database could become read-only if storage is exhausted |
 | `subscr-optinist-rds-cpu-high` | `monitoring.tf` | Database overloaded, queries slow or timing out |
 | `subscr-optinist-rds-connections-high` | `monitoring.tf` | Connection exhaustion → application errors |
-| `subscr-optinist-alb-5xx-errors` | `monitoring.tf` | Users are seeing server errors |
-| `subscr-optinist-alb-response-time-high` | `monitoring.tf` | Users experiencing >5s response times |
+| `subscr-optinist-alb-5xx-errors` | `monitoring.tf` | Sustained 5XX storm — users seeing server errors |
+| `subscr-optinist-free-tg-response-time-high` | `monitoring.tf` | Persistent high latency on the free tier |
+| `subscr-optinist-public-tg-response-time-high` | `monitoring.tf` | Persistent high latency on the public tier |
+| `subscr-optinist-free-tg-unhealthy-hosts` | `monitoring.tf` | Free workflow instance down |
+| `subscr-optinist-public-tg-unhealthy-hosts` | `monitoring.tf` | SPA delivery / public-dataview at risk |
+| `subscr-optinist-ebs-queue-length-high` | `monitoring.tf` | Disk saturation can fail health checks and evict the instance |
 | `subscr-optinist-load-average-high` | `monitoring.tf` | EC2 hosts saturated, all services degrade |
 | `subscr-monthly-cost-high` | `monitoring.tf` | Unexpected cost spike |
 

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -130,6 +130,12 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << 'CW_C
 {
     "metrics": {
         "namespace": "CWAgent",
+        "append_dimensions": {
+            "AutoScalingGroupName": "$${aws:AutoScalingGroupName}"
+        },
+        "aggregation_dimensions": [
+            ["AutoScalingGroupName"]
+        ],
         "metrics_collected": {
             "mem": {
                 "measurement": [
@@ -142,6 +148,12 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << 'CW_C
                     "cpu_usage_iowait"
                 ],
                 "totalcpu": true
+            },
+            "diskio": {
+                "measurement": [
+                    "iops_in_progress",
+                    "io_time"
+                ]
             }
         }
     },

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -166,6 +166,32 @@ resource "aws_cloudwatch_metric_alarm" "high_iowait" {
 }
 
 # ==================================================
+# EBS I/O Saturation Monitoring
+# ==================================================
+# AWS/EBS VolumeQueueLength is keyed on VolumeId, which the ASG assigns
+# dynamically per instance, so it can't be alarmed statically. The agent's
+# per-device queue gauge aggregated to the ASG dimension is the workaround.
+resource "aws_cloudwatch_metric_alarm" "ebs_queue_length_high" {
+  alarm_name          = "${local.env_prefix}-ebs-queue-length-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  datapoints_to_alarm = "2"
+  metric_name         = "diskio_iops_in_progress"
+  namespace           = "CWAgent"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "8"
+  alarm_description   = "EBS I/O queue depth high — sustained disk saturation can fail health checks and evict the instance."
+  alarm_actions       = local.critical_alerts_actions
+  ok_actions          = local.critical_alerts_actions
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.main.name
+  }
+}
+
+# ==================================================
 # RDS Monitoring Alarms
 # ==================================================
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
@@ -266,16 +292,18 @@ resource "aws_cloudwatch_metric_alarm" "efs_throughput_high" {
 # ==================================================
 resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
   alarm_name          = "${local.env_prefix}-alb-5xx-errors"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
   metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = "300"
   statistic           = "Sum"
-  threshold           = "10"
-  alarm_description   = "ALB target 5XX errors exceeded threshold"
+  threshold           = "20"
+  alarm_description   = "At least 20 target 5XX responses in a 5-min window (a sustained error storm, not a transient blip)."
   alarm_actions       = local.critical_alerts_actions
-  ok_actions          = local.critical_alerts_actions
+  # The metric only publishes when 5XX occur; without this the alarm flaps
+  # OK<->INSUFFICIENT_DATA on quiet traffic and emails on every gap.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     LoadBalancer = aws_lb.autoscaling.arn_suffix
@@ -283,22 +311,37 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_response_time_high" {
-  alarm_name          = "${local.env_prefix}-alb-response-time-high"
+  for_each = {
+    free = {
+      tg_arn_suffix = aws_lb_target_group.autoscaling.arn_suffix
+      threshold     = "10"
+      description   = "Free TG p95 response time exceeded 10s for 25 of 30 min — persistent latency degradation, not a self-healing cold-cache spike."
+    }
+    public = {
+      tg_arn_suffix = aws_lb_target_group.public.arn_suffix
+      threshold     = "5"
+      description   = "Public TG p95 response time exceeded 5s for 25 of 30 min — sustained SPA shell or public-dataview latency degradation."
+    }
+  }
+
+  alarm_name          = "${local.env_prefix}-${each.key}-tg-response-time-high"
   comparison_operator = "GreaterThanThreshold"
-  # p95 over 3×5-min: Average is tripped by one slow request on sparse traffic.
-  evaluation_periods  = "3"
-  datapoints_to_alarm = "3"
+  # p95 sustained over 25 of 30 min: only persistent degradation pages; brief
+  # spikes (cold-cache S3 reads) self-heal and are ignored.
+  evaluation_periods  = "6"
+  datapoints_to_alarm = "5"
   metric_name         = "TargetResponseTime"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
   extended_statistic  = "p95"
-  threshold           = "5"
-  alarm_description   = "ALB p95 response time exceeded 5s across 3×5-min windows."
+  threshold           = each.value.threshold
+  alarm_description   = each.value.description
   alarm_actions       = local.critical_alerts_actions
-  ok_actions          = local.critical_alerts_actions
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     LoadBalancer = aws_lb.autoscaling.arn_suffix
+    TargetGroup  = each.value.tg_arn_suffix
   }
 }
 
@@ -332,8 +375,9 @@ resource "aws_cloudwatch_metric_alarm" "tg_unhealthy_hosts" {
   }
 }
 
-# Premium TG alarms are emitted by the premium-manager Lambda per-user;
-# static alarms here would not match the dynamic TG ARNs.
+# Premium UnHealthyHostCount alarms are created/deleted by the premium-manager
+# Lambda alongside each per-user target group; static alarms here would not
+# match the dynamic per-user TG ARNs.
 
 # CloudWatch Dashboard for monitoring both Free and Premium tiers
 resource "aws_cloudwatch_dashboard" "main" {
@@ -739,7 +783,9 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 4
         properties = {
           title = "Alarm Status Overview"
-          alarms = [
+          # cpu_low excluded: it only drives scale-down (no SNS), so it sits in
+          # ALARM whenever the ASG is idle by design — a permanent false red here.
+          alarms = concat([
             # Background Service Alarms
             aws_cloudwatch_metric_alarm.background_task_stopped.arn,
             aws_cloudwatch_metric_alarm.background_cpu_high.arn,
@@ -751,10 +797,10 @@ resource "aws_cloudwatch_dashboard" "main" {
             # Autoscaling Alarms
             aws_cloudwatch_metric_alarm.cpu_high.arn,
             aws_cloudwatch_metric_alarm.memory_high.arn,
-            aws_cloudwatch_metric_alarm.cpu_low.arn,
             aws_cloudwatch_metric_alarm.memory_low.arn,
             aws_cloudwatch_metric_alarm.load_average_high.arn,
             aws_cloudwatch_metric_alarm.high_iowait.arn,
+            aws_cloudwatch_metric_alarm.ebs_queue_length_high.arn,
             # RDS Alarms
             aws_cloudwatch_metric_alarm.rds_cpu_high.arn,
             aws_cloudwatch_metric_alarm.rds_connections_high.arn,
@@ -764,8 +810,11 @@ resource "aws_cloudwatch_dashboard" "main" {
             aws_cloudwatch_metric_alarm.efs_throughput_high.arn,
             # ALB Alarms
             aws_cloudwatch_metric_alarm.alb_5xx_errors.arn,
-            aws_cloudwatch_metric_alarm.alb_response_time_high.arn
-          ]
+            ],
+            # Per-TG alarms (for_each maps) flattened into the overview.
+            [for a in aws_cloudwatch_metric_alarm.alb_response_time_high : a.arn],
+            [for a in aws_cloudwatch_metric_alarm.tg_unhealthy_hosts : a.arn],
+          )
         }
       }
     ]

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -42,9 +42,39 @@ from aws_constants import (
 DEFAULT_STALE_ASSIGNMENT_TIMEOUT_HOURS = 2
 
 if TYPE_CHECKING:
+    from mypy_boto3_cloudwatch import CloudWatchClient
     from mypy_boto3_ec2 import EC2Client
     from mypy_boto3_ecs import ECSClient
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
+
+
+def _premium_tg_alarm_name(tg_arn: str) -> str | None:
+    """Derive the per-TG alarm name from a TG ARN.
+
+    Must match the name used at alarm creation so deletion targets it.
+    """
+    idx = tg_arn.find(":targetgroup/")
+    suffix = tg_arn[idx + 1 :] if idx != -1 else tg_arn
+    parts = suffix.split("/")
+    if len(parts) < 2:
+        return None
+    return f"{PremiumInstanceConfig.get_env_prefix()}-{parts[1]}-unhealthy-hosts"
+
+
+def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
+    """Best-effort delete of a per-TG UnHealthyHostCount alarm.
+
+    Idempotent: delete_alarms ignores names that do not exist, so this is safe
+    for any TG ARN (the shared autoscaling TG simply has no matching alarm).
+    """
+    alarm_name = _premium_tg_alarm_name(tg_arn)
+    if not alarm_name:
+        return
+    try:
+        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+    except Exception as e:
+        print(f"Warning: Failed to delete unhealthy-host alarm {alarm_name}: {e}")
 
 
 def _cleanup_assignment_alb_resources(
@@ -74,6 +104,7 @@ def _cleanup_assignment_alb_resources(
         and target_group_arn != autoscaling_tg_arn
     ):
         try:
+            _delete_premium_tg_unhealthy_alarm(target_group_arn)
             elbv2.delete_target_group(TargetGroupArn=target_group_arn)
             print(f"Deleted target group for user {user_id}: {target_group_arn}")
         except Exception as e:
@@ -445,6 +476,7 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
                 autoscaling_tg_arn = os.environ.get("AUTOSCALING_TARGET_GROUP_ARN")
                 if target_group_arn and target_group_arn != autoscaling_tg_arn:
                     try:
+                        _delete_premium_tg_unhealthy_alarm(target_group_arn)
                         elbv2.delete_target_group(TargetGroupArn=target_group_arn)
                         target_groups_deleted += 1
                         print(f"Deleted target group: {target_group_arn}")
@@ -577,6 +609,7 @@ def cleanup_duplicate_alb_rules() -> Dict[str, Any]:
                             tg_arn = action.get("TargetGroupArn")
                             if tg_arn:
                                 try:
+                                    _delete_premium_tg_unhealthy_alarm(tg_arn)
                                     elbv2.delete_target_group(TargetGroupArn=tg_arn)
                                     target_groups_deleted += 1
                                     print(f"Deleted target group {tg_arn}")

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -30,6 +30,7 @@ import pymysql
 from aws_constants import (
     DatabaseConfig,
     ECSTaskStatus,
+    EnvironmentConfig,
     InstanceState,
     PremiumAssignment,
     PremiumInstanceConfig,
@@ -48,6 +49,18 @@ if TYPE_CHECKING:
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
 
 
+_cloudwatch_client: "CloudWatchClient | None" = None
+
+
+def _get_cloudwatch_client() -> "CloudWatchClient":
+    """Reuse one CloudWatch client across calls within a warm Lambda container."""
+    global _cloudwatch_client
+    if _cloudwatch_client is None:
+        _cloudwatch_client = boto3.client("cloudwatch")
+    return _cloudwatch_client
+
+
+# Mirrored in premium_manager.py — keep both in sync if the alarm naming changes.
 def _premium_tg_alarm_name(tg_arn: str) -> str | None:
     """Derive the per-TG alarm name from a TG ARN.
 
@@ -58,7 +71,7 @@ def _premium_tg_alarm_name(tg_arn: str) -> str | None:
     parts = suffix.split("/")
     if len(parts) < 2:
         return None
-    return f"{PremiumInstanceConfig.get_env_prefix()}-{parts[1]}-unhealthy-hosts"
+    return f"{EnvironmentConfig.get_env_prefix()}-{parts[1]}-unhealthy-hosts"
 
 
 def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
@@ -71,7 +84,7 @@ def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
     if not alarm_name:
         return
     try:
-        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch = _get_cloudwatch_client()
         cloudwatch.delete_alarms(AlarmNames=[alarm_name])
     except Exception as e:
         print(f"Warning: Failed to delete unhealthy-host alarm {alarm_name}: {e}")

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -545,7 +545,7 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
           "cloudwatch:DeleteAlarms",
           "cloudwatch:DescribeAlarms"
         ]
-        Resource = "*"
+        Resource = "arn:aws:cloudwatch:${var.aws_region}:${data.aws_caller_identity.current.account_id}:alarm:${var.environment}-premium-*-unhealthy-hosts"
       },
       # ASG Describe (read-only)
       {

--- a/infrastructure/terraform/premium_manager.tf
+++ b/infrastructure/terraform/premium_manager.tf
@@ -22,16 +22,19 @@ resource "aws_lambda_function" "premium_manager" {
       ALB_ARN                      = aws_lb.autoscaling.arn
       ALB_LISTENER_ARN             = aws_lb_listener.autoscaling_https.arn
       AUTOSCALING_TARGET_GROUP_ARN = aws_lb_target_group.autoscaling.arn
-      PREMIUM_INSTANCE_IDS         = join(",", aws_instance.premium[*].id)
-      PREMIUM_LAUNCH_TEMPLATE_ID   = aws_launch_template.premium.id
-      PREMIUM_INSTANCE_TYPE        = var.premium_instance_type
-      CLUSTER_NAME                 = aws_ecs_cluster.main.name
-      PREMIUM_SERVICE_NAME         = aws_ecs_service.premium.name
-      RDS_HOST                     = aws_db_proxy.main.endpoint
-      RDS_USER                     = var.mysql_user
-      RDS_PASSWORD                 = var.mysql_password
-      RDS_DATABASE                 = var.mysql_database
-      ROUTING_SECRET_KEY           = var.routing_secret_key
+      # SNS topic wired into the per-user TG UnHealthyHostCount alarms the
+      # Lambda creates. Empty outside production (no critical-alerts topic).
+      CRITICAL_ALERTS_TOPIC_ARN  = try(local.critical_alerts_actions[0], "")
+      PREMIUM_INSTANCE_IDS       = join(",", aws_instance.premium[*].id)
+      PREMIUM_LAUNCH_TEMPLATE_ID = aws_launch_template.premium.id
+      PREMIUM_INSTANCE_TYPE      = var.premium_instance_type
+      CLUSTER_NAME               = aws_ecs_cluster.main.name
+      PREMIUM_SERVICE_NAME       = aws_ecs_service.premium.name
+      RDS_HOST                   = aws_db_proxy.main.endpoint
+      RDS_USER                   = var.mysql_user
+      RDS_PASSWORD               = var.mysql_password
+      RDS_DATABASE               = var.mysql_database
+      ROUTING_SECRET_KEY         = var.routing_secret_key
       # Dynamic capacity settings (use existing ABSOLUTE_MAX + minimal new ones)
       PREMIUM_EXTRA_CAPACITY        = "1" # Extra instances for quick response
       PREMIUM_STANDBY_POOL_SIZE     = "1" # Number of stopped instances to maintain
@@ -531,6 +534,16 @@ resource "aws_iam_role_policy" "premium_manager_permissions" {
         Action = [
           "cloudwatch:PutMetricData",
           "cloudwatch:GetMetricData"
+        ]
+        Resource = "*"
+      },
+      # CloudWatch alarms for per-user premium target groups
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DeleteAlarms",
+          "cloudwatch:DescribeAlarms"
         ]
         Resource = "*"
       },

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2484,6 +2484,7 @@ def cleanup_duplicate_rules_for_routing_id(listener_arn: str, routing_id: str) -
                                     )
                                     if tg_arn and tg_arn != autoscaling_tg:
                                         try:
+                                            _delete_premium_tg_unhealthy_alarm(tg_arn)
                                             elbv2.delete_target_group(
                                                 TargetGroupArn=tg_arn
                                             )
@@ -2562,6 +2563,82 @@ def _enable_sticky_sessions(
         print(f"WARNING: Failed to enable sticky sessions on {target_group_arn}: {e}")
 
 
+def _alb_arn_suffix(alb_arn: str) -> str:
+    """ALB ARN -> CloudWatch LoadBalancer dimension value (app/name/hash)."""
+    marker = ":loadbalancer/"
+    idx = alb_arn.find(marker)
+    return alb_arn[idx + len(marker) :] if idx != -1 else alb_arn
+
+
+def _tg_arn_suffix(tg_arn: str) -> str:
+    """Target group ARN -> CloudWatch TargetGroup dimension value."""
+    idx = tg_arn.find(":targetgroup/")
+    return tg_arn[idx + 1 :] if idx != -1 else tg_arn
+
+
+def _premium_tg_alarm_name(tg_arn: str) -> Optional[str]:
+    """Derive the per-TG alarm name (e.g. subscr-premium-123-tg-unhealthy-hosts)."""
+    parts = _tg_arn_suffix(tg_arn).split("/")
+    if len(parts) < 2:
+        return None
+    return f"{EnvironmentConfig.get_env_prefix()}-{parts[1]}-unhealthy-hosts"
+
+
+def _ensure_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
+    """Create/update an UnHealthyHostCount alarm for a premium user's TG.
+
+    Best-effort: a failure here must not block provisioning.
+    """
+    alb_arn = os.environ.get("ALB_ARN")
+    alarm_name = _premium_tg_alarm_name(tg_arn)
+    if not alb_arn or not alarm_name:
+        return
+    topic_arn = os.environ.get("CRITICAL_ALERTS_TOPIC_ARN", "")
+    actions = [topic_arn] if topic_arn else []
+    try:
+        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch.put_metric_alarm(
+            AlarmName=alarm_name,
+            ComparisonOperator="GreaterThanThreshold",
+            EvaluationPeriods=2,
+            MetricName="UnHealthyHostCount",
+            Namespace="AWS/ApplicationELB",
+            Period=60,
+            Statistic="Maximum",
+            Threshold=0,
+            AlarmDescription=(
+                "Premium TG has unhealthy targets — the user's dedicated "
+                "instance may be failing health checks."
+            ),
+            AlarmActions=actions,
+            OKActions=actions,
+            TreatMissingData="missing",
+            Dimensions=[
+                {"Name": "LoadBalancer", "Value": _alb_arn_suffix(alb_arn)},
+                {"Name": "TargetGroup", "Value": _tg_arn_suffix(tg_arn)},
+            ],
+        )
+    except Exception as e:
+        print(f"WARNING: Failed to create unhealthy-host alarm {alarm_name}: {e}")
+
+
+def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
+    """Best-effort delete of a per-TG UnHealthyHostCount alarm.
+
+    Idempotent: delete_alarms ignores names that do not exist, so this is safe
+    to call for any TG ARN (including the shared autoscaling TG, whose derived
+    name will simply not match an existing alarm).
+    """
+    alarm_name = _premium_tg_alarm_name(tg_arn)
+    if not alarm_name:
+        return
+    try:
+        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+    except Exception as e:
+        print(f"WARNING: Failed to delete unhealthy-host alarm {alarm_name}: {e}")
+
+
 def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
     """
     Create a new target group for a premium user, or return existing one if
@@ -2599,6 +2676,7 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
         )
         tg_arn = response["TargetGroups"][0]["TargetGroupArn"]
         _enable_sticky_sessions(elbv2, tg_arn)
+        _ensure_premium_tg_unhealthy_alarm(tg_arn)
         return tg_arn
 
     except Exception as e:
@@ -2611,6 +2689,7 @@ def create_or_get_target_group(user_id: int, vpc_id: str) -> str:
                 response = elbv2.describe_target_groups(Names=[target_group_name])
                 existing_arn = response["TargetGroups"][0]["TargetGroupArn"]
                 _enable_sticky_sessions(elbv2, existing_arn)
+                _ensure_premium_tg_unhealthy_alarm(existing_arn)
                 print(f"Found existing target group: {existing_arn}")
                 return existing_arn
             except Exception as describe_error:
@@ -3437,6 +3516,7 @@ def assign_premium_user(
                         f"({old_arn}) before creating new one"
                     )
                     try:
+                        _delete_premium_tg_unhealthy_alarm(old_arn)
                         elbv2.delete_target_group(TargetGroupArn=old_arn)
                     except Exception as del_err:
                         print(f"Warning: could not delete orphaned TG: {del_err}")
@@ -3469,6 +3549,7 @@ def assign_premium_user(
                 "TargetGroupArn"
             ]
             _enable_sticky_sessions(elbv2, target_group_arn)
+            _ensure_premium_tg_unhealthy_alarm(target_group_arn)
 
             # 8. Register instance to target group
             print(
@@ -3602,6 +3683,7 @@ def assign_premium_user(
         try:
             # Clean up target group if created (skip placeholder markers)
             if target_group_arn and target_group_arn != PremiumAssignment.RESERVING:
+                _delete_premium_tg_unhealthy_alarm(target_group_arn)
                 elbv2.delete_target_group(TargetGroupArn=target_group_arn)
                 print(f"Cleaned up target group after error: {target_group_arn}")
         except Exception as cleanup_error:
@@ -4491,6 +4573,7 @@ def _teardown_alb_resources(user_id, rule_arn, target_group_arn):
         and target_group_arn != autoscaling_tg_arn
     ):
         try:
+            _delete_premium_tg_unhealthy_alarm(target_group_arn)
             elbv2.delete_target_group(TargetGroupArn=target_group_arn)
             print(f"Deleted target group: {target_group_arn}")
         except Exception as tg_error:

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2576,7 +2576,19 @@ def _tg_arn_suffix(tg_arn: str) -> str:
     return tg_arn[idx + 1 :] if idx != -1 else tg_arn
 
 
-def _premium_tg_alarm_name(tg_arn: str) -> Optional[str]:
+_cloudwatch_client: Optional["CloudWatchClient"] = None
+
+
+def _get_cloudwatch_client() -> "CloudWatchClient":
+    """Reuse one CloudWatch client across calls within a warm Lambda container."""
+    global _cloudwatch_client
+    if _cloudwatch_client is None:
+        _cloudwatch_client = boto3.client("cloudwatch")
+    return _cloudwatch_client
+
+
+# Mirrored in premium_cleanup.py — keep both in sync if the alarm naming changes.
+def _premium_tg_alarm_name(tg_arn: str) -> str | None:
     """Derive the per-TG alarm name (e.g. subscr-premium-123-tg-unhealthy-hosts)."""
     parts = _tg_arn_suffix(tg_arn).split("/")
     if len(parts) < 2:
@@ -2596,7 +2608,7 @@ def _ensure_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
     topic_arn = os.environ.get("CRITICAL_ALERTS_TOPIC_ARN", "")
     actions = [topic_arn] if topic_arn else []
     try:
-        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch = _get_cloudwatch_client()
         cloudwatch.put_metric_alarm(
             AlarmName=alarm_name,
             ComparisonOperator="GreaterThanThreshold",
@@ -2633,7 +2645,7 @@ def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
     if not alarm_name:
         return
     try:
-        cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
+        cloudwatch = _get_cloudwatch_client()
         cloudwatch.delete_alarms(AlarmNames=[alarm_name])
     except Exception as e:
         print(f"WARNING: Failed to delete unhealthy-host alarm {alarm_name}: {e}")

--- a/studio/tests/app/common/routers/test_instance_mode_routers.py
+++ b/studio/tests/app/common/routers/test_instance_mode_routers.py
@@ -30,7 +30,7 @@ class TestInstanceModePublic:
     def test_outputs_router_is_registered(self):
         # Public carve-out lives in the auth dependency, not in registration.
         paths = _registered_paths("public")
-        assert any(p.startswith("/outputs") for p in paths)
+        assert any(p.startswith("/api/visualizations") for p in paths)
 
     def test_internal_router_is_registered(self):
         paths = _registered_paths("public")
@@ -99,15 +99,15 @@ class TestInstanceModePublic:
             ), f"{prefix} should not be registered in INSTANCE_MODE=public"
 
     def test_roi_edit_endpoints_are_not_registered(self):
-        # roi.router shares prefix "/outputs"; assert each endpoint explicitly.
+        # roi.router shares prefix "/api/visualizations"; assert each explicitly.
         paths = _registered_paths("public")
         roi_endpoints = (
-            "/outputs/image/{filepath:path}/status",
-            "/outputs/image/{filepath:path}/add_roi",
-            "/outputs/image/{filepath:path}/merge_roi",
-            "/outputs/image/{filepath:path}/delete_roi",
-            "/outputs/image/{filepath:path}/commit_edit",
-            "/outputs/image/{filepath:path}/cancel_edit",
+            "/api/visualizations/image/{filepath:path}/status",
+            "/api/visualizations/image/{filepath:path}/add_roi",
+            "/api/visualizations/image/{filepath:path}/merge_roi",
+            "/api/visualizations/image/{filepath:path}/delete_roi",
+            "/api/visualizations/image/{filepath:path}/commit_edit",
+            "/api/visualizations/image/{filepath:path}/cancel_edit",
         )
         for endpoint in roi_endpoints:
             assert endpoint not in paths, (


### PR DESCRIPTION
### Content

#### Summary
- Retunes the CloudWatch monitoring stack for the public-instance ALB topology so alarms reflect *sustained* degradation instead of transient blips, and so per-tier/per-instance health is actually observable.
- Teaches the CloudWatch agent to roll host metrics up to the AutoScaling Group dimension and to collect EBS I/O depth, which repairs the previously-dead `high_iowait` alarm and enables a new disk-saturation alarm.
- Adds per-target-group `UnHealthyHostCount` alarms: static ones for the free/public tiers, and per-user alarms that the premium-manager Lambda creates and tears down alongside each premium target group.
- Monitoring/observability only — no application request path or data changes.

#### Design Decisions
- **ASG-dimension aggregation for host metrics.** `AWS/EBS VolumeQueueLength` keys on `VolumeId`, which the ASG assigns dynamically per instance, so it can't be alarmed statically. The agent now appends `AutoScalingGroupName` and aggregates to that dimension (`append_dimensions` + `aggregation_dimensions`), letting `ebs_queue_length_high` (on `diskio_iops_in_progress`) alarm at the ASG level. Side benefit: `high_iowait` already keyed on `AutoScalingGroupName` but the agent never emitted that dimension, so it was effectively stuck in `INSUFFICIENT_DATA` — this change makes it fire for real. `aggregation_dimensions` is kept to the single `["AutoScalingGroupName"]` rollup; the dimensionless rollup was dropped as no alarm or dashboard widget reads it.
- **Lambda-managed premium alarms.** Per-user premium target-group ARNs are created at runtime, so static Terraform alarms can't reference them. `premium_manager.py` creates/updates an `UnHealthyHostCount` alarm in `create_or_get_target_group`, and `_delete_premium_tg_unhealthy_alarm` is wired into every target-group teardown path in both `premium_manager.py` and `premium_cleanup.py` so alarms don't orphan. Both create and delete are idempotent.
- **Flapping suppression on sparse ALB metrics.** `HTTPCode_Target_5XX_Count` and `TargetResponseTime` only publish when traffic occurs, so they previously flapped `OK <-> INSUFFICIENT_DATA` on quiet periods and emailed on every gap. Both now set `treat_missing_data = notBreaching`; the 5XX and response-time alarms drop `ok_actions` (no recovery email). 5XX is retuned to "≥20 in one 5-min window" (a storm, not a blip), and response-time becomes a `for_each` over the free (p95 > 10s) and public (p95 > 5s) target groups, requiring 25 of 30 min.
- **Naming convention is intentional, not a bug.** Terraform-managed alarms use the `subscr-optinist-` prefix (`local.env_prefix`); Lambda-managed premium alarms use the bare `subscr-` prefix, matching the premium subsystem's existing instance/TG naming (Lambda `ENV_PREFIX = var.environment`). Forcing them to align would break `get_environment_label()` and the `subscr-premium-*` discovery filters, so it's documented instead. Operators should filter alarms on `subscr-` to catch both.
- **`CRITICAL_ALERTS_TOPIC_ARN = try(local.critical_alerts_actions[0], "")`** rather than `join("")`, so a future second SNS action can't silently concatenate two ARNs into one invalid string. Empty outside production, where no critical-alerts topic exists.

### References
- Builds on PR #639 (constants/for_each/locals refactor) on the same branch.

#### Files changed
- `infrastructure/scripts/ecs-user-data.sh` — CloudWatch agent: append `AutoScalingGroupName`, aggregate to the ASG dimension, collect `diskio` `iops_in_progress`/`io_time`.
- `infrastructure/terraform/monitoring.tf` — new `ebs_queue_length_high` alarm; retuned `alb_5xx_errors`; `alb_response_time_high` and `tg_unhealthy_hosts` migrated to per-TG `for_each` (free/public); dashboard overview drops `cpu_low` and flattens the per-TG alarm maps via `concat`.
- `infrastructure/terraform/premium_manager.tf` — new `CRITICAL_ALERTS_TOPIC_ARN` Lambda env var; IAM grant for `cloudwatch:PutMetricAlarm`/`DeleteAlarms`/`DescribeAlarms`.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — `_ensure_premium_tg_unhealthy_alarm` / `_delete_premium_tg_unhealthy_alarm` plus ARN-suffix helpers; create on TG provisioning, delete on every teardown path.
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` — matching `_delete_premium_tg_unhealthy_alarm` wired into the orphan/duplicate cleanup sweeps.
- `infrastructure/documentation/LOGGING_ARCHITECTURE.md` — metric table updated (diskio added, stale `procstat` row removed), new alarms documented, prefix-convention note added.
- `infrastructure/documentation/MAINTENANCE_PROCEDURES.md` — runbook rows for the new EBS/response-time/unhealthy-host alarms and the alarm-action behavior.

### Manual Testcases
- Operator: in a non-prod apply, `terraform plan` and confirm `ebs_queue_length_high`, `alb_5xx_errors`, `alb_response_time_high["free"]`, `alb_response_time_high["public"]`, and both `tg_unhealthy_hosts` alarms are created, and the singular `*-alb-response-time-high` alarm is destroyed.
- Operator: assign a premium user; confirm a `subscr-premium-<user_id>-tg-unhealthy-hosts` alarm appears in CloudWatch. Unassign that user; confirm the alarm is deleted.
- Operator: on a running instance, `aws cloudwatch list-metrics --namespace CWAgent` and confirm `diskio_iops_in_progress` and `cpu_usage_iowait` publish with an `AutoScalingGroupName` dimension.
- Operator: confirm the monitoring dashboard alarm overview renders without `cpu_low` and includes the per-TG alarms.

### Unit, Integration, Contract Test Coverage
- No automated tests cover this infrastructure; validated via `terraform validate` / `terraform plan` and post-apply CloudWatch inspection.

### Others

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `alb_response_time_high` for_each migration | Low | Old singular alarm is destroyed and replaced by free/public alarms on apply; brief gap, alarm-only. |
| Premium-manager IAM + alarm lifecycle | Medium | New `cloudwatch:*Alarm` grant; alarm create/delete are best-effort and must not block provisioning (wrapped, logged). Out-of-band TG deletion could orphan an alarm; covered by the cleanup sweeps. |
| CloudWatch agent config change | Low | Global `append_dimensions` only adds a dimension; the sole CWAgent-metric alarm (`high_iowait`) already expected it. ECS/EC2/RDS alarms are unaffected. |
| Alarm retuning (5XX, response time) | Low/Medium | Less sensitive to single-request spikes by design; sustained storms still page. `notBreaching` means quiet periods read as healthy. |
