### PR TITLE
resource-cap workflow execution so a heavy run can't take the site down

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -74,9 +74,16 @@ resource "aws_lb_target_group" "autoscaling" {
   target_type = "instance"
 
   health_check {
-    enabled             = true
-    healthy_threshold   = 2
-    unhealthy_threshold = 5
+    enabled           = true
+    healthy_threshold = 2
+    # Phase A (#643): with interval=60 this tolerates 8 min of failing checks
+    # before the task is evicted -- covering the worst-case window in which a
+    # bounded-swap workflow could briefly slow /health (a 4 GB swap budget on
+    # gp3 drains in a few minutes) plus an OOM-kill/restart -- so a transient
+    # spike can't evict an otherwise-healthy API. ASG health_check_type=ELB
+    # (grace 900s) + the ECS service (desired_count=1) relaunch a task that is
+    # genuinely killed.
+    unhealthy_threshold = 8
     interval            = 60
     matcher             = "200"
     path                = "/health"
@@ -593,9 +600,23 @@ resource "aws_ecs_task_definition" "autoscaling" {
       entryPoint        = ["/bin/sh", "-c"]
       command           = ["./cloud-startup.sh"]
 
+      # Phase A (#643): bound (do not eliminate) container swap. The original
+      # incident let a workflow spill into the full 32 GB swap volume and
+      # thrash the gp3 disk for ~25 min, which stalled /health and took the
+      # whole site down. Capping maxSwap gives borderline-large runs a limited
+      # cushion to finish (RAM 6656 MiB + this swap budget), while guaranteeing
+      # a runaway run is OOM-killed in isolation once it exhausts that budget --
+      # rather than thrashing indefinitely. Low swappiness keeps pages resident
+      # under normal load so /health stays fast; the workflow child is also
+      # de-prioritized (nice + idle-class ionice, see snakemake_executor.py) so
+      # its swap I/O cannot starve the API event loop.
+      # TUNING KNOB: raise maxSwap to complete larger runs (more thrash risk);
+      # lower it toward 0 to prioritise strict /health protection. Validate any
+      # change against the issue-625 suite2p load (/health must stay at 0
+      # failures for the whole run).
       linuxParameters = {
-        maxSwap    = 32768 # Max swap in MiB (matches 32GB host swap on EBS)
-        swappiness = 20    # Only swap under memory pressure (host also set to 20)
+        maxSwap    = 4096
+        swappiness = 10
       }
 
       portMappings = [
@@ -768,6 +789,16 @@ resource "aws_ecs_task_definition" "autoscaling" {
         {
           name  = "PREMIUM_MANAGER_FUNCTION_NAME"
           value = "${var.environment}-premium-manager"
+        },
+        # Phase A (#643): fewer uvicorn workers on the memory-constrained free
+        # instance. Each worker loads the full app (~hundreds of MB resident),
+        # so dropping the default 5 -> 2 frees ~0.5-1 GB of RAM for the workflow
+        # -- letting more runs complete entirely in memory (no swap) -- while
+        # still leaving ample capacity for the API's mostly-async, low-
+        # concurrency free-tier load.
+        {
+          name  = "UVICORN_WORKERS"
+          value = "2"
         },
       ]
       mountPoints = [

--- a/studio/app/common/core/snakemake/smk_status_logger.py
+++ b/studio/app/common/core/snakemake/smk_status_logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 
 from studio.app.common.core.utils.file_reader import Reader
 from studio.app.common.core.utils.filepath_creater import (
@@ -77,6 +78,31 @@ class SmkStatusLogger:
             has_error = False
 
         return WorkflowErrorInfo(has_error=has_error, error_log=error_log)
+
+    @classmethod
+    def record_external_error(
+        cls, workspace_id: str, unique_id: str, message: str
+    ) -> None:
+        """
+        Append a terminal error to the workflow error log from outside the
+        snakemake worker process.
+
+        Used when the worker is terminated before it can log its own failure
+        (e.g. OOM-killed under the container memory cap). Appends rather than
+        truncates, so any error the worker managed to write before dying is
+        preserved. Once written, get_error_content() reports has_error=True and
+        WorkflowResult.observe() surfaces the run as errored on the next poll,
+        rather than leaving it stuck in "running".
+        """
+        log_file_path = cls.__get_error_log_file_path(workspace_id, unique_id)
+        create_directory(os.path.dirname(log_file_path))
+
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            with open(log_file_path, "a") as f:
+                f.write(f"{timestamp} : ERROR - {message}\n")
+        except Exception as e:
+            print("[Exception][Logger]", e)
 
     def __init__(self, workspace_id, unique_id):
         self.workspace_id = workspace_id

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from typing import Dict, List
 
@@ -61,17 +62,33 @@ def snakemake_execute(
 
     try:
         logger.info("Starting local execution mode")
-        with ProcessPoolExecutor(max_workers=1) as executor:
-            logger.info("start snakemake running process.")
+        try:
+            with ProcessPoolExecutor(max_workers=1) as executor:
+                logger.info("start snakemake running process.")
 
-            future = executor.submit(
-                _snakemake_execute_process,
-                workspace_id,
-                unique_id,
-                params,
-                client_id=client_id,
+                future = executor.submit(
+                    _snakemake_execute_process,
+                    workspace_id,
+                    unique_id,
+                    params,
+                    client_id=client_id,
+                )
+                future_result = future.result()
+        except BrokenProcessPool as e:
+            # Phase A (#643): the worker process was terminated mid-run before
+            # it could return a result -- most commonly an OOM-kill once the
+            # workflow exhausted the container memory cap (+ bounded swap).
+            # Because the worker died, the failure-handling tail inside
+            # _snakemake_execute_process never ran, so without this the run
+            # would stay "running" until WorkflowMonitor's ~2h timeout.
+            # Surface the failure here so it appears immediately and in
+            # isolation (only this run fails; the API stays up).
+            logger.error(
+                "snakemake worker process terminated unexpectedly "
+                f"(likely out-of-memory): {e}"
             )
-            future_result = future.result()
+            _surface_terminated_workflow(workspace_id, unique_id)
+            return False
 
         # Update user storage after workflow completion
         asyncio.run(update_user_storage_after_workflow(workspace_id))
@@ -93,6 +110,70 @@ def snakemake_execute(
                 logger.error(f"Failed to decrement workflow count: {e}", exc_info=True)
 
 
+def _surface_terminated_workflow(workspace_id: str, unique_id: str) -> None:
+    """
+    Record a workflow failure from the parent process when the execution worker
+    was killed (e.g. OOM) and could not record its own failure.
+
+    Mirrors the failure-handling tail of `_snakemake_execute_process` so the run
+    transitions out of "running" immediately:
+      1. Write a terminal error to the workflow error log, so that
+         WorkflowResult.observe() reports the run as errored on the next poll.
+      2. Release the remote-sync lock so observe_overall() can read remote
+         storage (matches the failed-run branch in the worker).
+      3. Run observe_overall() now to flip the experiment/node status to error.
+      4. Force the remote sync status file into an error state.
+
+    Every step is best-effort and isolated so one failure cannot mask another.
+    """
+    error_message = (
+        "Workflow execution was terminated unexpectedly, most likely because it "
+        "exceeded the available memory (out-of-memory). Try reducing the input "
+        "data size or splitting the workflow into smaller steps."
+    )
+
+    # 1. Record the error so observe() reports has_error=True.
+    try:
+        SmkStatusLogger.record_external_error(workspace_id, unique_id, error_message)
+    except Exception as e:
+        logger.error(
+            f"Failed to record terminated-workflow error: {e}", exc_info=True
+        )
+
+    # 2. Release the sync lock (mirrors the failed-run branch in the worker).
+    if RemoteStorageController.is_available():
+        try:
+            RemoteSyncLockFileUtil.delete_sync_lock_file(workspace_id, unique_id)
+        except Exception as e:
+            logger.error(f"Failed to delete sync lock file: {e}", exc_info=True)
+
+    # 3. Update workflow/experiment status now so the run is not stuck "running".
+    try:
+        asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+    except Exception as e:
+        logger.error(
+            f"Failed to update workflow result after termination: {e}",
+            exc_info=True,
+        )
+
+    # 4. Force the remote sync status file into an error state.
+    if RemoteStorageController.is_available():
+        try:
+            remote_bucket_name = RemoteSyncStatusFileUtil.get_remote_bucket_name(
+                workspace_id, unique_id
+            )
+            RemoteSyncStatusFileUtil.create_sync_status_file_for_error(
+                remote_bucket_name,
+                workspace_id,
+                unique_id,
+                RemoteSyncAction.UPLOAD,
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to write error sync status file: {e}", exc_info=True
+            )
+
+
 @with_client_id_context  # Automatically set client_id for logging
 def _snakemake_execute_process(
     workspace_id: str,
@@ -103,6 +184,31 @@ def _snakemake_execute_process(
     # ------------------------------------------------------------
     # Snakemake execution process
     # ------------------------------------------------------------
+
+    # --- Phase A (#643): protect the API from this workflow's resource use.
+    # This child process -- and the snakemake / suite2p processes it spawns,
+    # which inherit these settings -- is made the first OOM-killer victim and
+    # de-prioritized, so a memory spike kills the workflow in isolation rather
+    # than uvicorn/the API. The idle-class IO priority is what lets the bounded
+    # container swap (see compute.tf linuxParameters) be used as a completion
+    # cushion for borderline-large runs without its swap I/O starving the API
+    # event loop and stalling /health.
+    try:
+        with open("/proc/self/oom_score_adj", "w") as _oom:
+            _oom.write("800")  # range -1000..1000; higher = killed first
+    except OSError:
+        pass
+    try:
+        os.nice(10)  # lower CPU priority -- keep the API event loop responsive
+    except OSError:
+        pass
+    try:
+        import psutil
+
+        psutil.Process().ionice(psutil.IOPRIO_CLASS_IDLE)  # lowest IO priority
+    except Exception:
+        pass
+    # --- end Phase A ---
 
     smk_logger = SmkStatusLogger(workspace_id, unique_id)
     smk_workdir = join_filepath(

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_oom.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_oom.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the OOM / worker-termination failure-surfacing path
+(Phase A, #643).
+
+These verify that when the snakemake worker process is killed mid-run (e.g.
+OOM-killed under the container memory cap) the run is surfaced as failed
+immediately, instead of being left stuck in "running" until WorkflowMonitor's
+~2h timeout.
+"""
+
+from concurrent.futures.process import BrokenProcessPool
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+MODULE = "studio.app.common.core.snakemake.snakemake_executor"
+
+WORKSPACE_ID = "test_workspace"
+UNIQUE_ID = "test_unique_id"
+
+
+class TestSnakemakeExecuteWorkerKilled:
+    """snakemake_execute() must not raise / hang when the worker is killed."""
+
+    def test_broken_process_pool_surfaces_failure(self):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            snakemake_execute,
+        )
+
+        with (
+            patch(f"{MODULE}.ProcessPoolExecutor") as mock_pool,
+            patch(f"{MODULE}._surface_terminated_workflow") as mock_surface,
+            patch(f"{MODULE}.update_user_storage_after_workflow") as mock_storage,
+        ):
+            # Context manager must not swallow the raised BrokenProcessPool.
+            mock_pool.return_value.__exit__.return_value = False
+            executor = mock_pool.return_value.__enter__.return_value
+            future = MagicMock()
+            future.result.side_effect = BrokenProcessPool("worker killed")
+            executor.submit.return_value = future
+
+            # user_id=None -> skip the workflow-count decrement branch.
+            result = snakemake_execute(WORKSPACE_ID, UNIQUE_ID, MagicMock(), None)
+
+        assert result is False
+        mock_surface.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        # Storage update should be skipped on the failure path.
+        mock_storage.assert_not_called()
+
+
+class TestSurfaceTerminatedWorkflow:
+    """_surface_terminated_workflow() mirrors the worker's failure tail."""
+
+    def test_records_error_and_observes_when_no_remote(self):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _surface_terminated_workflow,
+        )
+
+        with (
+            patch(f"{MODULE}.SmkStatusLogger") as mock_logger,
+            patch(f"{MODULE}.RemoteStorageController") as mock_remote,
+            patch(f"{MODULE}.WorkflowResult") as mock_wfr,
+        ):
+            mock_remote.is_available.return_value = False
+            mock_wfr.return_value.observe_overall = AsyncMock()
+
+            _surface_terminated_workflow(WORKSPACE_ID, UNIQUE_ID)
+
+            # An error was written so observe() reports has_error=True.
+            mock_logger.record_external_error.assert_called_once()
+            ws, uid, message = mock_logger.record_external_error.call_args[0]
+            assert ws == WORKSPACE_ID
+            assert uid == UNIQUE_ID
+            assert "memory" in message.lower()
+
+            # Status is refreshed now so the run does not stay "running".
+            mock_wfr.return_value.observe_overall.assert_awaited_once()
+
+    def test_writes_remote_error_state_when_remote_available(self):
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _surface_terminated_workflow,
+        )
+
+        with (
+            patch(f"{MODULE}.SmkStatusLogger"),
+            patch(f"{MODULE}.RemoteStorageController") as mock_remote,
+            patch(f"{MODULE}.RemoteSyncLockFileUtil") as mock_lock,
+            patch(f"{MODULE}.RemoteSyncStatusFileUtil") as mock_status,
+            patch(f"{MODULE}.WorkflowResult") as mock_wfr,
+        ):
+            mock_remote.is_available.return_value = True
+            mock_wfr.return_value.observe_overall = AsyncMock()
+            mock_status.get_remote_bucket_name.return_value = "bucket"
+
+            _surface_terminated_workflow(WORKSPACE_ID, UNIQUE_ID)
+
+            mock_lock.delete_sync_lock_file.assert_called_once_with(
+                WORKSPACE_ID, UNIQUE_ID
+            )
+            mock_status.create_sync_status_file_for_error.assert_called_once()
+
+    def test_observe_failure_is_swallowed(self):
+        """A failure inside observe_overall() must not propagate."""
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _surface_terminated_workflow,
+        )
+
+        with (
+            patch(f"{MODULE}.SmkStatusLogger"),
+            patch(f"{MODULE}.RemoteStorageController") as mock_remote,
+            patch(f"{MODULE}.WorkflowResult") as mock_wfr,
+            patch(f"{MODULE}.logger.error"),
+        ):
+            mock_remote.is_available.return_value = False
+            mock_wfr.return_value.observe_overall = AsyncMock(
+                side_effect=RuntimeError("observe failed")
+            )
+
+            # Should not raise.
+            _surface_terminated_workflow(WORKSPACE_ID, UNIQUE_ID)
+
+
+class TestRecordExternalError:
+    """SmkStatusLogger.record_external_error() makes get_error_content() error."""
+
+    def test_appends_error_and_is_detected(self, tmp_path, monkeypatch):
+        from studio.app.common.core.snakemake import smk_status_logger as smk_mod
+        from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
+
+        monkeypatch.setattr(smk_mod.DIRPATH, "OUTPUT_DIR", str(tmp_path))
+
+        # No error initially.
+        assert (
+            SmkStatusLogger.get_error_content(WORKSPACE_ID, UNIQUE_ID).has_error
+            is False
+        )
+
+        SmkStatusLogger.record_external_error(
+            WORKSPACE_ID, UNIQUE_ID, "killed by OOM"
+        )
+
+        info = SmkStatusLogger.get_error_content(WORKSPACE_ID, UNIQUE_ID)
+        assert info.has_error is True
+        assert "killed by OOM" in info.error_log
+
+    def test_appends_without_truncating_existing(self, tmp_path, monkeypatch):
+        from studio.app.common.core.snakemake import smk_status_logger as smk_mod
+        from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
+
+        monkeypatch.setattr(smk_mod.DIRPATH, "OUTPUT_DIR", str(tmp_path))
+
+        SmkStatusLogger.record_external_error(WORKSPACE_ID, UNIQUE_ID, "first")
+        SmkStatusLogger.record_external_error(WORKSPACE_ID, UNIQUE_ID, "second")
+
+        info = SmkStatusLogger.get_error_content(WORKSPACE_ID, UNIQUE_ID)
+        assert "first" in info.error_log
+        assert "second" in info.error_log
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# Phase A (#643): resource-cap workflow execution so a heavy run can't take the site down
 
## Summary
 
A single heavy workflow run (e.g. a large `suite2p` load) on the shared free/API
instance could exhaust RAM, spill into the 32 GB swap volume, thrash the gp3 disk
for ~25 min, starve `/health`, and get the API SIGKILLed by ECS — i.e. **one run
could take the whole site down** (parent #643; repro in
`issue-625-repro-findings.md`).
 
This PR keeps execution where it is (a child process on the API instance) but
**caps and de-prioritizes** its resource use, so the worst case becomes *"that one
run fails"* rather than *"the site goes down"* — while also giving borderline-large
runs enough headroom to actually complete.
 
Addresses parent **#643** (Phase A). Phase B (moving compute off the API instance)
remains out of scope.
 
## What changed
 
### Application code
 
**`studio/app/common/core/snakemake/snakemake_executor.py`**
- **De-prioritize the workflow worker** (and the snakemake / `suite2p` processes it
  spawns, which inherit these): `oom_score_adj=800` (first OOM-killer victim),
  `os.nice(10)` (low CPU priority), and idle-class `ionice` (lowest IO priority).
  This makes the workflow — not uvicorn — the OOM target, and keeps its swap IO in
  the background so the API event loop and `/health` stay responsive.
- **Failure-surfacing safety net.** Catch `BrokenProcessPool` in `snakemake_execute`
  (raised when the worker is killed — e.g. OOM — before it can return a result).
  Previously this left the run stuck `"running"` until `WorkflowMonitor`'s ~2 h
  timeout. The new `_surface_terminated_workflow()` writes a terminal error,
  releases the remote-sync lock, runs `observe_overall()`, and writes the error
  sync-status file, so the run flips to *failed* immediately and in isolation.
**`studio/app/common/core/snakemake/smk_status_logger.py`**
- Add `record_external_error()` — appends a terminal error to the run's `error.log`
  from outside the worker (append, not truncate), so `get_error_content()` /
  `WorkflowResult.observe()` surface the run as errored on the next poll.
### Infrastructure — `infrastructure/terraform/compute.tf` (free tier only)
 
- **Bound container swap:** `maxSwap` 32768 → **4096**, `swappiness` 20 → **10**.
  A runaway run is OOM-killed in isolation once it exhausts RAM (6656 MiB) + the
  4 GB swap budget, instead of thrashing the full 32 GB volume. Borderline runs get
  a limited cushion to finish. Documented inline as the primary tuning knob.
- **Free more RAM for workflows:** `UVICORN_WORKERS` 5 → **2**. Each worker holds a
  full copy of the app (~hundreds of MB resident), so this frees ~0.5–1 GB for the
  workflow — letting more runs complete entirely in RAM with no swap. The free tier's
  mostly-async, low-concurrency load is well served by 2 workers. Premium unchanged.
- **Relax health-check tolerance:** target-group `unhealthy_threshold` 5 → **8**
  (with `interval=60` → ~8 min before eviction), so a transient spike can't evict an
  otherwise-healthy API. ASG (`health_check_type=ELB`, 900 s grace) + the ECS service
  relaunch a task that is genuinely killed.
The container memory hard limit (`memory = 6656`) is unchanged — it already bounds the
container within the 8 GB host.
 
### Tests
 
- `studio/tests/app/common/core/snakemake/test_snakemake_executor_oom.py` — covers
  the `BrokenProcessPool` surfacing path, `_surface_terminated_workflow` behaviour
  (with/without remote storage, and that an `observe_overall` failure is swallowed),
  and `record_external_error` (detection + append-without-truncate).
## Note on the issue's "primary lever"
 
The issue suggests a per-process cgroup `memory.max` as the primary mechanism. That
isn't feasible inside this **non-privileged Amazon Linux 2 / cgroup-v1** container
(the cgroup filesystem is read-only and creating sub-cgroups requires delegation /
privilege). The deployable equivalent here is the **container-level hard limit + OOM
bias**, which yields the same isolation outcome. `resource.setrlimit(RLIMIT_AS)` is
intentionally avoided — it caps virtual address space per process and breaks
mmap-heavy `suite2p` — per the issue.
 
## Acceptance criteria
 
| Criterion | Status |
|---|---|
| `/health` stays at 0 failures during the previously-failing run | ⏳ Needs the validation run below |
| API is never SIGKILLed / evicted by a workflow run | ✅ By design — bounded swap + OOM bias + relaxed health checks |
| Oversized run is OOM-killed in isolation (only that run fails) | ✅ By design |
| Run failure surfaces correctly (no stuck "running") | ✅ New safety net — unit tested |
 
## Tradeoffs & required validation
 
- Re-enabling a *bounded* amount of swap reintroduces a small, time-bounded thrash
  risk (kernel reclaim threads aren't `ionice`-controlled). The de-prioritization +
  low swappiness + fewer workers mitigate this, but it must be verified.
- **Validation run (gate):** re-run the issue-625 `suite2p` load and confirm
  (a) `/health` stays at 0 failures for the entire run, and (b) the run completes.
  - If `/health` still blips → lower `maxSwap` toward `0` (stricter protection).
  - If the run still OOMs → that's the **Phase B** signal (more memory / move compute
    off the box).
## Testing notes
 
`py_compile` passes on all changed Python files, and the `record_external_error` /
`get_error_content` mechanism was exercised directly. The full pytest suite was **not**
run in CI-equivalent here (environment lacks `snakemake` / `suite2p`); please run:
 
```
pytest studio/tests/app/common/core/snakemake/test_snakemake_executor_oom.py -v
```
 
## Out of scope (Phase B)
 
Moving compute off the API instance, concurrent multi-user execution, and strict
multi-tenant isolation.