### PR TITLE
Public input-node data daily-clean EFS input cache

### DIFF
--- a/infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md
+++ b/infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md
@@ -269,6 +269,8 @@ RemoteSyncStatusFileUtil.check_sync_status_unsynced(workspace_id, unique_id)
 RemoteSyncStatusFileUtil.check_sync_status_success(workspace_id, unique_id)
 ```
 
+**Public tier note:** The public tier's raw-input cache lives on shared EFS and is wiped nightly (see `PUBLIC_INSTANCE_ARCHITECTURE.md`). Input re-fetch is therefore keyed on the input file via `RemoteStorageDownloadUtils.ensure_input_file_synced()`, independent of this output-sync status, so a wiped input is re-pulled even when the status reads `success`.
+
 ---
 
 ## Edge Case Handling
@@ -377,6 +379,7 @@ environment {
 | `GET /outputs/data/{filepath}` | On-demand sync before data access |
 | `GET /outputs/image/{filepath}` | On-demand sync before data access |
 | `POST /outputs/image/{filepath}/status` | On-demand sync for Edit ROI |
+| `GET /outputs/structured/{workspace_id}/{unique_id}/{node_id}` | On-demand input-file sync before data access |
 | `PATCH /experiments/{workspace_id}/{unique_id}/rename` | `ensure_synced_async()` before rename |
 | `DELETE /experiments/{workspace_id}/{unique_id}` | `ensure_synced_async()` before delete |
 | `POST /experiments/delete/{workspace_id}` | `ensure_synced_async()` before batch delete |

--- a/infrastructure/documentation/PUBLIC_INSTANCE_ARCHITECTURE.md
+++ b/infrastructure/documentation/PUBLIC_INSTANCE_ARCHITECTURE.md
@@ -67,6 +67,7 @@ graph TB
 | Authenticated workflow/optinist API | No - Gated out | Yes - Exclusive | No |
 | `/logs` viewer read | No | Yes - Owning tier only | No |
 | Startup published-experiment cache warm | Yes - Exclusive (leader-elected) | No | No |
+| Published input-cache cleanup (daily wipe) | Yes - via scheduled Lambda | No | No |
 | Background scheduler jobs | No - Disabled | No | Yes - Exclusive |
 
 ---
@@ -117,6 +118,38 @@ Defines the `INSTANCE_MODE` env var name and its values. `INSTANCE_MODE_PUBLIC` 
 
 ---
 
+## Published Input Cache and Daily Cleanup
+
+Published experiments are served from a cache on the shared **published-data EFS** filesystem rather than the lean root EBS, so both public tasks share one copy and it survives task replacement. Outputs and raw inputs sit under two separate EFS access points so they can be managed independently:
+
+| Cache | Access point root | Container mount | Lifecycle |
+|---|---|---|---|
+| Output | `/` | `/app/studio_data/output` | Long-lived; holds the `remote_sync_stat.json` markers |
+| Input | `/input-cache` | `/app/studio_data/input` | Wiped nightly; uid/gid 1000 so the container and the Lambda share one owner |
+
+Raw inputs are synced on demand the first time an input node is viewed, so they are pure cache -- anything deleted is re-pulled from S3 on next access. To bound EFS growth, the **public-cleanup** Lambda wipes the input cache nightly while leaving the output cache and its sync markers untouched: it mounts only the `/input-cache` access point and its IAM is scoped to that access point, so it cannot reach the output cache.
+
+```mermaid
+graph TB
+    SCHED[CloudWatch schedule<br/>cron 0 19 UTC = 04:00 JST] --> LAM[public-cleanup Lambda]
+    LAM --> WIPE[Mount /input-cache only<br/>snapshot dir, delete each entry]
+    WIPE --> Q{Any delete<br/>errors?}
+    Q -->|Yes| ALARM[Raise: Lambda Errors metric<br/>fires CloudWatch alarm]
+    Q -->|No| EMPTY[Input cache empty]
+    EMPTY --> REFETCH[Next viewer re-pulls a needed<br/>input on demand, keyed on the file]
+
+    style WIPE fill:#87CEEB
+    style ALARM fill:#FFB6C1
+    style EMPTY fill:#90EE90
+    style REFETCH fill:#90EE90
+```
+
+The re-fetch in `get_structured_data()` -- and the sibling `get_csv()` / `get_image()` input branches -- calls `RemoteStorageDownloadUtils.ensure_input_file_synced()`, which downloads the single input file regardless of the experiment's output-sync status. That independence is what makes the daily wipe safe; see Edge Case 6 and `DATA_SYNC_ARCHITECTURE.md` for the status-gate interaction.
+
+**Configuration:** `INPUT_CACHE_PATH` (default `/mnt/input`) is the Lambda's EFS mount path; the schedule is `cron(0 19 * * ? *)`; the timeout is 900s because EFS deletes are one round-trip per file.
+
+---
+
 ## Edge Case Handling
 
 ### 1. Free Tier Scaled to Zero During Login
@@ -158,6 +191,14 @@ Defines the `INSTANCE_MODE` env var name and its values. `INSTANCE_MODE_PUBLIC` 
 
 **Solution (current):** Static assets route to public via dedicated ALB rules, and the SPA shell is served by `SPARoutingMiddleware`. This works but is not optimal; the canonical pattern (future work) is S3 + CloudFront for the shell and static assets with CloudFront mapping 403/404 to `/index.html`, leaving the ALB/ECS tiers for API traffic only.
 
+### 6. Input Cache Wiped While Output Still Marked Synced
+
+**Problem:** The nightly cleanup deletes a raw input, but the experiment's `remote_sync_stat.json` -- on the un-wiped output cache -- still reads `success`. Gating the input re-fetch on that status (as the output-visualization sync path does) would short-circuit and serve a permanent 404 for input-node data.
+
+**Solution:** Input re-fetch is decoupled from output-sync status:
+- `get_structured_data()` and the `get_csv()` / `get_image()` input branches call `RemoteStorageDownloadUtils.ensure_input_file_synced()`, which downloads the input file by name regardless of sync status.
+- A genuinely-absent input still returns 404; a remote-storage error returns 503.
+
 ---
 
 ## Monitoring and Metrics
@@ -167,6 +208,7 @@ Defines the `INSTANCE_MODE` env var name and its values. `INSTANCE_MODE_PUBLIC` 
 | Public access logs | `uvicorn.access` in `/ecs/<env>-public-optinist-cloud-taskdef` | Includes SPA shell document fetches, which resemble API hits |
 | Target health | `aws_lb_target_group.public` health check on `/health` | ASG uses ELB health checks with a 900s grace period |
 | Startup sync | application logs on the elected leader task | Non-leader tasks log "Startup sync deferred to leader task" |
+| Input-cache cleanup failures | `<env>-public-cleanup-errors` alarm on the Lambda `Errors` metric | Fires on a crash/timeout or a non-zero delete-error count; daily `Sum`, `notBreaching` between runs |
 
 Verify public targets are healthy after apply:
 
@@ -215,8 +257,12 @@ Stripe variables are intentionally omitted because the subscriptions router is g
 | Target group | `aws_lb_target_group.public` | `/health` check, 600s deregistration delay |
 | Launch template | `aws_launch_template.public` | `var.public_instance_type`, 30 GB gp3 root |
 | Auto Scaling Group | `aws_autoscaling_group.public` | ELB health check, 900s grace, `OldestInstance` policy |
-| Task definition | `aws_ecs_task_definition.public` | EC2/bridge, EFS published-data mount |
+| Task definition | `aws_ecs_task_definition.public` | EC2/bridge, EFS published-data mounts (output + input cache) |
 | ECS service | `aws_ecs_service.public` | EC2 launch type, `tier == public` placement constraint |
 | Log group | `aws_cloudwatch_log_group.public_optinist` | `/ecs/<env>-public-optinist-cloud-taskdef`, 30-day retention |
+| Input-cache access point | `aws_efs_access_point.published_data_input` | `/input-cache` subtree, uid/gid 1000; mounted at `/app/studio_data/input` |
+| Cleanup Lambda | `aws_lambda_function.public_cleanup` | Daily input-cache wipe; VPC + EFS-mounted, 900s timeout |
+| Cleanup schedule | `aws_cloudwatch_event_rule.public_cleanup_schedule` | `cron(0 19 * * ? *)` (04:00 JST) |
+| Cleanup errors alarm | `aws_cloudwatch_metric_alarm.public_cleanup_errors` | Lambda `Errors` > 0; wired to `local.critical_alerts_actions` |
 
 Public-bound ALB listener rules live in `infrastructure/terraform/public_alb_rules.tf`; see `ALB_ROUTING_ARCHITECTURE.md` for the full priority band.

--- a/infrastructure/terraform/infrastructure.tf
+++ b/infrastructure/terraform/infrastructure.tf
@@ -540,6 +540,32 @@ resource "aws_efs_access_point" "published_data" {
   }
 }
 
+# Separate subtree for the on-demand-synced raw input cache, kept off the lean
+# root EBS and isolated from the output cache so it can be swept independently.
+resource "aws_efs_access_point" "published_data_input" {
+  file_system_id = aws_efs_file_system.published_data.id
+
+  # Pin all access through this point to uid/gid 1000 so the container's writes
+  # and the cleanup Lambda's deletes share one owner.
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+
+  root_directory {
+    path = "/input-cache"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  tags = {
+    Name = "${local.env_prefix}-public-published-data-input-ap"
+  }
+}
+
 # =========
 # Databases
 # =========

--- a/infrastructure/terraform/public_cleanup.py
+++ b/infrastructure/terraform/public_cleanup.py
@@ -1,0 +1,39 @@
+"""Scheduled cleanup tasks for the public tier.
+
+Currently wipes the on-demand raw-input cache on shared EFS — those inputs are
+kept off the lean root EBS and are pure cache (re-synced on access), so clearing
+them daily bounds EFS growth. Add further public-tier cleanup tasks here as
+needed; `handler` aggregates each task's result.
+"""
+
+import os
+import shutil
+
+INPUT_CACHE_PATH = os.environ.get("INPUT_CACHE_PATH", "/mnt/input")
+
+
+def _clear_dir_contents(path):
+    """Remove everything under `path`, leaving the directory itself in place."""
+    if not os.path.isdir(path):
+        print(f"[public-cleanup] {path} not present; nothing to do")
+        return {"deleted": 0, "errors": 0}
+
+    deleted = 0
+    errors = 0
+    for entry in os.scandir(path):
+        try:
+            if entry.is_dir(follow_symlinks=False):
+                shutil.rmtree(entry.path)
+            else:
+                os.remove(entry.path)
+            deleted += 1
+        except OSError as e:
+            errors += 1
+            print(f"[public-cleanup] failed to delete {entry.path}: {e}")
+    return {"deleted": deleted, "errors": errors}
+
+
+def handler(event, context):
+    results = {"input_cache": _clear_dir_contents(INPUT_CACHE_PATH)}
+    print(f"[public-cleanup] done: {results}")
+    return results

--- a/infrastructure/terraform/public_cleanup.py
+++ b/infrastructure/terraform/public_cleanup.py
@@ -18,15 +18,23 @@ def _clear_dir_contents(path):
         print(f"[public-cleanup] {path} not present; nothing to do")
         return {"deleted": 0, "errors": 0}
 
+    # Snapshot before deleting: mutating a directory mid-scandir has undefined
+    # ordering on NFS/EFS and could skip entries.
+    with os.scandir(path) as it:
+        entries = list(it)
+
     deleted = 0
     errors = 0
-    for entry in os.scandir(path):
+    for entry in entries:
         try:
             if entry.is_dir(follow_symlinks=False):
                 shutil.rmtree(entry.path)
             else:
                 os.remove(entry.path)
             deleted += 1
+        except FileNotFoundError:
+            # Raced with a concurrent writer that removed it first; not an error.
+            pass
         except OSError as e:
             errors += 1
             print(f"[public-cleanup] failed to delete {entry.path}: {e}")
@@ -36,4 +44,9 @@ def _clear_dir_contents(path):
 def handler(event, context):
     results = {"input_cache": _clear_dir_contents(INPUT_CACHE_PATH)}
     print(f"[public-cleanup] done: {results}")
+
+    total_errors = sum(r["errors"] for r in results.values())
+    if total_errors:
+        # Fail the invocation so the errors surface on the Lambda Errors metric.
+        raise RuntimeError(f"public-cleanup hit {total_errors} delete error(s)")
     return results

--- a/infrastructure/terraform/public_cleanup.tf
+++ b/infrastructure/terraform/public_cleanup.tf
@@ -17,8 +17,11 @@ resource "aws_lambda_function" "public_cleanup" {
   role             = aws_iam_role.public_cleanup_lambda.arn
   handler          = "public_cleanup.handler"
   runtime          = "python3.11"
-  timeout          = 300
   source_code_hash = data.archive_file.public_cleanup_zip.output_base64sha256
+
+  # Deletes are one EFS round-trip per file, so a large day's cache can outrun a
+  # short timeout; use the Lambda max for headroom.
+  timeout = 900
 
   environment {
     variables = {
@@ -112,6 +115,33 @@ resource "aws_cloudwatch_log_group" "public_cleanup_logs" {
   tags = {
     Name = "Public Cleanup Logs"
     Type = "Public-CloudWatch"
+  }
+}
+
+# Fires on a failed run: Lambda crash/timeout, or the handler raising on a
+# non-zero delete-error count. notBreaching covers the gaps between daily runs.
+resource "aws_cloudwatch_metric_alarm" "public_cleanup_errors" {
+  alarm_name          = "${var.environment}-public-cleanup-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "86400"
+  statistic           = "Sum"
+  threshold           = "0"
+  alarm_description   = "Public cleanup Lambda reported errors on its last run"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.critical_alerts_actions
+  ok_actions          = local.critical_alerts_actions
+
+  dimensions = {
+    FunctionName = aws_lambda_function.public_cleanup.function_name
+  }
+
+  tags = {
+    Name    = "Public Cleanup Errors Alarm"
+    Type    = "Public-CloudWatch"
+    Service = "public"
   }
 }
 

--- a/infrastructure/terraform/public_cleanup.tf
+++ b/infrastructure/terraform/public_cleanup.tf
@@ -1,0 +1,146 @@
+# =============================================================================
+# Public cleanup Lambda
+# Scheduled cleanup tasks for the public tier. Currently wipes the on-demand
+# raw-input cache on EFS (pure cache, re-synced on access) to bound EFS growth
+# without touching the output cache (mounts only the /input-cache access point).
+# =============================================================================
+
+data "archive_file" "public_cleanup_zip" {
+  type        = "zip"
+  source_file = "${path.module}/public_cleanup.py"
+  output_path = "${path.module}/public_cleanup.py.zip"
+}
+
+resource "aws_lambda_function" "public_cleanup" {
+  filename         = data.archive_file.public_cleanup_zip.output_path
+  function_name    = "${var.environment}-public-cleanup"
+  role             = aws_iam_role.public_cleanup_lambda.arn
+  handler          = "public_cleanup.handler"
+  runtime          = "python3.11"
+  timeout          = 300
+  source_code_hash = data.archive_file.public_cleanup_zip.output_base64sha256
+
+  environment {
+    variables = {
+      INPUT_CACHE_PATH = "/mnt/input"
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = [aws_subnet.private1.id, aws_subnet.private2.id]
+    security_group_ids = [aws_security_group.ecs.id]
+  }
+
+  file_system_config {
+    arn              = aws_efs_access_point.published_data_input.arn
+    local_mount_path = "/mnt/input"
+  }
+
+  tags = {
+    Name    = "Public Cleanup Lambda"
+    Type    = "Public-Lambda"
+    Service = "public"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.public_cleanup_vpc,
+    aws_iam_role_policy.public_cleanup_efs,
+    aws_cloudwatch_log_group.public_cleanup_logs,
+    aws_efs_mount_target.published_data_private1,
+    aws_efs_mount_target.published_data_private2,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# IAM
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "public_cleanup_lambda" {
+  name = "${var.environment}-public-cleanup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "Public Cleanup Lambda Role"
+    Type = "Public-IAM"
+  }
+}
+
+# VPC ENI management + CloudWatch Logs.
+resource "aws_iam_role_policy_attachment" "public_cleanup_vpc" {
+  role       = aws_iam_role.public_cleanup_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# EFS access, scoped to the input access point only.
+resource "aws_iam_role_policy" "public_cleanup_efs" {
+  name = "${var.environment}-public-cleanup-efs"
+  role = aws_iam_role.public_cleanup_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:ClientMount",
+          "elasticfilesystem:ClientWrite",
+        ]
+        Resource = aws_efs_file_system.published_data.arn
+        Condition = {
+          StringEquals = {
+            "elasticfilesystem:AccessPointArn" = aws_efs_access_point.published_data_input.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "public_cleanup_logs" {
+  name              = "/aws/lambda/${var.environment}-public-cleanup"
+  retention_in_days = 30
+
+  tags = {
+    Name = "Public Cleanup Logs"
+    Type = "Public-CloudWatch"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Schedule: 19:00 UTC = 04:00 JST, daily.
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "public_cleanup_schedule" {
+  name                = "${var.environment}-public-cleanup-schedule"
+  description         = "Daily 04:00 JST public-tier cleanup (input cache wipe)"
+  schedule_expression = "cron(0 19 * * ? *)"
+  state               = "ENABLED"
+
+  tags = {
+    Name    = "Public Cleanup Schedule"
+    Type    = "Public-CloudWatch"
+    Service = "public"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "public_cleanup_target" {
+  rule      = aws_cloudwatch_event_rule.public_cleanup_schedule.name
+  target_id = "PublicCleanupTarget"
+  arn       = aws_lambda_function.public_cleanup.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_public_cleanup" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.public_cleanup.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.public_cleanup_schedule.arn
+}

--- a/infrastructure/terraform/public_service.tf
+++ b/infrastructure/terraform/public_service.tf
@@ -235,6 +235,13 @@ resource "aws_ecs_task_definition" "public" {
           sourceVolume  = "${local.env_prefix}-public-published-data-volume"
           containerPath = "/app/studio_data/output"
           readOnly      = false
+        },
+        {
+          # Raw inputs are synced on demand; keep them on shared EFS (not the
+          # lean root EBS) so both instances share one copy and it can be swept.
+          sourceVolume  = "${local.env_prefix}-public-input-cache-volume"
+          containerPath = "/app/studio_data/input"
+          readOnly      = false
         }
       ]
 
@@ -273,6 +280,19 @@ resource "aws_ecs_task_definition" "public" {
       transit_encryption = "ENABLED"
       authorization_config {
         access_point_id = aws_efs_access_point.published_data.id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "${local.env_prefix}-public-input-cache-volume"
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.published_data.id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = aws_efs_access_point.published_data_input.id
         iam             = "DISABLED"
       }
     }

--- a/studio/app/common/core/storage/mock_storage_controller.py
+++ b/studio/app/common/core/storage/mock_storage_controller.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     BaseRemoteStorageController,
+    InputFileLock,
     RemoteExperimentSyncMode,
     StorageDirectoryType,
 )
@@ -90,25 +91,28 @@ class MockStorageController(BaseRemoteStorageController):
             workspace_id, filename
         )
 
-        if os.path.isfile(input_data_local_path):
-            logger.debug(f"skip download input data: {input_data_remote_path}")
-            return False
+        async with InputFileLock.acquire(workspace_id, filename):
+            if os.path.isfile(input_data_local_path):
+                logger.debug(f"skip download input data: {input_data_remote_path}")
+                return False
 
-        if not os.path.isfile(input_data_remote_path):
-            logger.warning("remote path is not exists. [%s]", input_data_remote_path)
-            return False
+            if not os.path.isfile(input_data_remote_path):
+                logger.warning(
+                    "remote path is not exists. [%s]", input_data_remote_path
+                )
+                return False
 
-        logger.debug(
-            "download input data from remote storage (mock). [%s -> %s]",
-            input_data_remote_path,
-            input_data_local_path,
-        )
+            logger.debug(
+                "download input data from remote storage (mock). [%s -> %s]",
+                input_data_remote_path,
+                input_data_local_path,
+            )
 
-        # ----------------------------------------
-        # exec downloading
-        # ----------------------------------------
+            # ----------------------------------------
+            # exec downloading
+            # ----------------------------------------
 
-        shutil.copy(input_data_remote_path, input_data_local_path)
+            shutil.copy(input_data_remote_path, input_data_local_path)
 
         return True
 

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -1,8 +1,11 @@
+import asyncio
+import fcntl
 import json
 import os
 import shutil
 import time
 from abc import ABCMeta, abstractmethod
+from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from enum import Enum
@@ -403,6 +406,58 @@ class RemoteSyncLockFileUtil:
             f"after {elapsed:.1f}s, proceeding anyway"
         )
         return False
+
+
+class InputFileLock:
+    """Per-(workspace, file) flock so concurrent processes sharing INPUT_DIR
+    over EFS don't redundantly download the same input. On timeout we fall
+    through unlocked — tmp+rename in the download keeps partial reads
+    impossible regardless."""
+
+    LOCKS_DIRNAME = ".locks"
+    LOCK_WAIT_MAX_SECONDS = 300
+    LOCK_WAIT_POLL_INTERVAL = 1.0
+
+    @classmethod
+    def _lock_path(cls, workspace_id: str, filename: str) -> str:
+        return join_filepath(
+            [DIRPATH.INPUT_DIR, workspace_id, cls.LOCKS_DIRNAME, f"{filename}.lock"]
+        )
+
+    @classmethod
+    @asynccontextmanager
+    async def acquire(cls, workspace_id: str, filename: str):
+        lock_path = cls._lock_path(workspace_id, filename)
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+
+        fd = await asyncio.to_thread(os.open, lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+
+            def _try_lock() -> bool:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return True
+                except BlockingIOError:
+                    return False
+
+            start = time.monotonic()
+            while True:
+                if await asyncio.to_thread(_try_lock):
+                    break
+                elapsed = time.monotonic() - start
+                if elapsed >= cls.LOCK_WAIT_MAX_SECONDS:
+                    logger.warning(
+                        f"InputFileLock acquire timeout after {elapsed:.1f}s "
+                        f"for {workspace_id}/{filename}; proceeding without "
+                        "exclusive lock"
+                    )
+                    break
+                await asyncio.sleep(cls.LOCK_WAIT_POLL_INTERVAL)
+
+            yield
+        finally:
+            # close releases the flock; off-loop in case it blocks on NFS.
+            await asyncio.to_thread(os.close, fd)
 
 
 class BaseRemoteStorageController(metaclass=ABCMeta):
@@ -1154,11 +1209,12 @@ class RemoteStorageDownloadUtils:
 
         logger.info(f"On-demand sync for input file: {workspace_id}/{filename}")
 
+        # Lock is held inside download_input_data, covering all entry points.
         controller = RemoteStorageController(remote_bucket_name)
         downloaded = await controller.download_input_data(workspace_id, filename)
         if not downloaded:
             logger.warning(
-                f"Input file not found in remote storage: {workspace_id}/{filename}"
+                f"Input file not found in remote storage: " f"{workspace_id}/{filename}"
             )
             return False
         return os.path.exists(input_path)

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -416,7 +416,7 @@ class InputFileLock:
 
     LOCKS_DIRNAME = ".locks"
     LOCK_WAIT_MAX_SECONDS = 300
-    LOCK_WAIT_POLL_INTERVAL = 1.0
+    LOCK_WAIT_POLL_INTERVAL = 0.1
 
     @classmethod
     def _lock_path(cls, workspace_id: str, filename: str) -> str:

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -218,6 +218,14 @@ class S3StorageController(BaseRemoteStorageController):
         Returns:
             True if file was downloaded, False if skipped
         """
+        # NFS keeps a negative-dentry cache that stat() doesn't bypass — a peer
+        # that just released the InputFileLock may have a fresh file on the
+        # server we still see as missing. READDIR via listdir invalidates it.
+        try:
+            os.listdir(os.path.dirname(local_file_path))
+        except OSError:
+            pass
+
         if os.path.isfile(local_file_path):
             local_size = os.path.getsize(local_file_path)
             if local_size == file_size:

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import re
 import time
+import uuid
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING, Dict, List
 
@@ -22,6 +23,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.file_filter import FileSyncFilter
 from studio.app.common.core.storage.remote_storage_controller import (
     BaseRemoteStorageController,
+    InputFileLock,
     RemoteExperimentNotFoundError,
     RemoteExperimentSyncMode,
     RemoteStorageBucketNotFoundError,
@@ -233,7 +235,20 @@ class S3StorageController(BaseRemoteStorageController):
 
         os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
 
-        await s3_client.download_file(self.bucket_name, s3_file_path, local_file_path)
+        # Download to a sibling tmp path then atomic-rename, so a concurrent
+        # reader on shared storage (e.g. EFS) never sees a partial file at
+        # local_file_path. rename(2) is atomic within a single filesystem.
+        tmp_path = f"{local_file_path}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+        try:
+            await s3_client.download_file(self.bucket_name, s3_file_path, tmp_path)
+            os.replace(tmp_path, local_file_path)
+        except BaseException:
+            if os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
 
         logger.debug(
             f"Finish download data from S3 [{self.bucket_name}] " f"{s3_file_path}"
@@ -314,42 +329,44 @@ class S3StorageController(BaseRemoteStorageController):
 
         MAX_DOWNLOAD_FILES = 1000
 
-        async with self.__get_s3_client() as __s3_client:
-            all_s3_objects = await self._list_s3_objects_paginated(
-                __s3_client, input_data_remote_path, max_files=MAX_DOWNLOAD_FILES
-            )
-
-            if not all_s3_objects:
-                logger.warning(
-                    "Remote data does not exist. [%s] [%s]",
-                    self.bucket_name,
-                    input_data_remote_path,
+        # Serialize same-(workspace, file) downloads across EFS-shared processes.
+        async with InputFileLock.acquire(workspace_id, filename):
+            async with self.__get_s3_client() as __s3_client:
+                all_s3_objects = await self._list_s3_objects_paginated(
+                    __s3_client, input_data_remote_path, max_files=MAX_DOWNLOAD_FILES
                 )
-                return False
 
-            # Sort by directory depth (shallower files first)
-            all_s3_objects.sort(key=lambda obj: obj["Key"].count("/"))
+                if not all_s3_objects:
+                    logger.warning(
+                        "Remote data does not exist. [%s] [%s]",
+                        self.bucket_name,
+                        input_data_remote_path,
+                    )
+                    return False
 
-            target_files_count = len(all_s3_objects)
-            s3_prefix = __class__.make_s3_input_prefix()
+                # Sort by directory depth (shallower files first)
+                all_s3_objects.sort(key=lambda obj: obj["Key"].count("/"))
 
-            for index, s3_object in enumerate(all_s3_objects):
-                s3_file_path = s3_object["Key"]
-                file_size = s3_object["Size"]
+                target_files_count = len(all_s3_objects)
+                s3_prefix = __class__.make_s3_input_prefix()
 
-                # Compute local path from S3 path
-                # s3_file_path: app/studio_data/input/{workspace_id}/{relative_path}
-                # local path:   {INPUT_DIR}/{workspace_id}/{relative_path}
-                relative_path = s3_file_path.replace(s3_prefix, "")
-                local_file_path = os.path.join(DIRPATH.INPUT_DIR, relative_path)
+                for index, s3_object in enumerate(all_s3_objects):
+                    s3_file_path = s3_object["Key"]
+                    file_size = s3_object["Size"]
 
-                await self._download_s3_with_update_check(
-                    __s3_client,
-                    s3_file_path,
-                    local_file_path,
-                    file_size,
-                    progress_info=f"({index+1}/{target_files_count})",
-                )
+                    # Compute local path from S3 path
+                    # s3_file_path: app/studio_data/input/{workspace_id}/{relative_path}
+                    # local path:   {INPUT_DIR}/{workspace_id}/{relative_path}
+                    relative_path = s3_file_path.replace(s3_prefix, "")
+                    local_file_path = os.path.join(DIRPATH.INPUT_DIR, relative_path)
+
+                    await self._download_s3_with_update_check(
+                        __s3_client,
+                        s3_file_path,
+                        local_file_path,
+                        file_size,
+                        progress_info=f"({index+1}/{target_files_count})",
+                    )
 
         return True
 

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -908,6 +908,7 @@ async def get_structured_data(
     node_id: str,
     start_index: Optional[int] = 0,
     end_index: Optional[int] = 10,
+    remote_bucket_name: str = Depends(get_outputs_remote_bucket_name),
 ):
     try:
         config = WorkflowConfigReader.read(workspace_id, unique_id)
@@ -925,6 +926,13 @@ async def get_structured_data(
         raise HTTPException(status_code=400, detail="Node has no file path")
 
     full_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, file_path])
+    if not os.path.exists(full_path):
+        # Input data is synced lazily to keep the cache lean; fetch it on demand
+        # before giving up, as the other outputs endpoints do.
+        await _ensure_visualization_synced(
+            join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
+            remote_bucket_name,
+        )
     if not os.path.exists(full_path):
         raise HTTPException(status_code=404, detail=f"File not found: {file_path}")
 

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -927,12 +927,18 @@ async def get_structured_data(
 
     full_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, file_path])
     if not os.path.exists(full_path):
-        # Input data is synced lazily to keep the cache lean; fetch it on demand
-        # before giving up, as the other outputs endpoints do.
-        await _ensure_visualization_synced(
-            join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
-            remote_bucket_name,
-        )
+        # Inputs are cleared independently of outputs, so re-fetch keyed on the
+        # file itself, not the experiment's output-sync status.
+        try:
+            await RemoteStorageDownloadUtils.ensure_input_file_synced(
+                workspace_id, file_path, remote_bucket_name
+            )
+        except Exception as e:
+            logger.error(f"Failed to sync input data: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Failed to sync input file from cloud storage",
+            )
     if not os.path.exists(full_path):
         raise HTTPException(status_code=404, detail=f"File not found: {file_path}")
 

--- a/studio/tests/app/common/core/storage/test_input_file_lock.py
+++ b/studio/tests/app/common/core/storage/test_input_file_lock.py
@@ -1,0 +1,255 @@
+"""
+Unit tests for InputFileLock.
+
+Tests advisory locking around on-demand input-file sync: lock path layout,
+serialization of concurrent acquires on the same file, independence across
+different files, fd cleanup on flock failure, and timeout fallback.
+"""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from studio.app.common.core.storage.remote_storage_controller import (
+    InputFileLock,
+    RemoteStorageDownloadUtils,
+)
+
+
+@pytest.fixture
+def input_dir(tmp_path, monkeypatch):
+    """Point DIRPATH.INPUT_DIR at a sandbox for the duration of the test."""
+    monkeypatch.setattr(
+        "studio.app.common.core.storage.remote_storage_controller.DIRPATH.INPUT_DIR",
+        str(tmp_path),
+    )
+    return str(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def fast_lock_poll(monkeypatch):
+    """Tighten the LOCK_NB poll interval so concurrent-acquire tests don't wait
+    a full second between retries."""
+    monkeypatch.setattr(InputFileLock, "LOCK_WAIT_POLL_INTERVAL", 0.01)
+
+
+class TestLockPath:
+    def test_lock_path_layout(self, input_dir):
+        path = InputFileLock._lock_path("ws1", "data.tif")
+        assert path == os.path.join(input_dir, "ws1", ".locks", "data.tif.lock")
+
+    def test_lock_path_nested_filename(self, input_dir):
+        path = InputFileLock._lock_path("ws1", "sub/dir/data.tif")
+        assert path == os.path.join(
+            input_dir, "ws1", ".locks", "sub", "dir", "data.tif.lock"
+        )
+
+
+class TestAcquireRelease:
+    @pytest.mark.asyncio
+    async def test_creates_lock_file_under_locks_dir(self, input_dir):
+        async with InputFileLock.acquire("ws1", "data.tif"):
+            assert os.path.isfile(
+                os.path.join(input_dir, "ws1", ".locks", "data.tif.lock")
+            )
+
+    @pytest.mark.asyncio
+    async def test_lock_file_persists_after_release(self, input_dir):
+        """Lock file is intentionally not deleted — it's reused by the next caller."""
+        async with InputFileLock.acquire("ws1", "data.tif"):
+            pass
+        assert os.path.isfile(os.path.join(input_dir, "ws1", ".locks", "data.tif.lock"))
+
+    @pytest.mark.asyncio
+    async def test_serializes_same_file(self, input_dir):
+        """Two acquires on the same file run strictly one-at-a-time."""
+        events = []
+
+        async def hold(label, hold_for):
+            async with InputFileLock.acquire("ws1", "data.tif"):
+                events.append(f"{label}-enter")
+                await asyncio.sleep(hold_for)
+                events.append(f"{label}-exit")
+
+        await asyncio.gather(hold("a", 0.1), hold("b", 0.05))
+
+        # Whichever ran first must fully exit before the other enters.
+        first = events[0].split("-")[0]
+        second = "b" if first == "a" else "a"
+        assert events == [
+            f"{first}-enter",
+            f"{first}-exit",
+            f"{second}-enter",
+            f"{second}-exit",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_independent_files_do_not_block(self, input_dir):
+        """Locks on different files are independent."""
+        b_started = asyncio.Event()
+        a_can_finish = asyncio.Event()
+
+        async def hold_a():
+            async with InputFileLock.acquire("ws1", "a.tif"):
+                # Wait until b has clearly entered its own critical section.
+                await asyncio.wait_for(b_started.wait(), timeout=1.0)
+                a_can_finish.set()
+
+        async def hold_b():
+            async with InputFileLock.acquire("ws1", "b.tif"):
+                b_started.set()
+                await asyncio.wait_for(a_can_finish.wait(), timeout=1.0)
+
+        # If the locks were shared, this would deadlock and the timeouts fire.
+        await asyncio.gather(hold_a(), hold_b())
+
+    @pytest.mark.asyncio
+    async def test_workspace_isolation(self, input_dir):
+        """Same filename in different workspaces does not contend."""
+        ws2_started = asyncio.Event()
+        ws1_can_finish = asyncio.Event()
+
+        async def hold_ws1():
+            async with InputFileLock.acquire("ws1", "data.tif"):
+                await asyncio.wait_for(ws2_started.wait(), timeout=1.0)
+                ws1_can_finish.set()
+
+        async def hold_ws2():
+            async with InputFileLock.acquire("ws2", "data.tif"):
+                ws2_started.set()
+                await asyncio.wait_for(ws1_can_finish.wait(), timeout=1.0)
+
+        await asyncio.gather(hold_ws1(), hold_ws2())
+
+
+class TestFailureCleanup:
+    @pytest.mark.asyncio
+    async def test_flock_failure_closes_fd(self, input_dir):
+        """If fcntl.flock raises, the just-opened fd must be closed (no leak)."""
+        opened_fds = []
+        real_open = os.open
+        real_close = os.close
+
+        def tracking_open(*args, **kwargs):
+            fd = real_open(*args, **kwargs)
+            opened_fds.append(fd)
+            return fd
+
+        closed = []
+
+        def tracking_close(fd):
+            closed.append(fd)
+            real_close(fd)
+
+        with patch(
+            "studio.app.common.core.storage.remote_storage_controller.os.open",
+            side_effect=tracking_open,
+        ), patch(
+            "studio.app.common.core.storage.remote_storage_controller.os.close",
+            side_effect=tracking_close,
+        ), patch(
+            "studio.app.common.core.storage.remote_storage_controller.fcntl.flock",
+            side_effect=OSError("simulated flock failure"),
+        ):
+            with pytest.raises(OSError, match="simulated flock failure"):
+                async with InputFileLock.acquire("ws1", "data.tif"):
+                    pass
+
+        assert opened_fds, "expected os.open to be called"
+        assert closed == opened_fds, f"fd leak: opened {opened_fds}, closed {closed}"
+
+
+class TestTimeout:
+    @pytest.mark.asyncio
+    async def test_acquire_times_out_and_proceeds_without_lock(
+        self, input_dir, monkeypatch, caplog
+    ):
+        """A blocked acquire should give up after LOCK_WAIT_MAX_SECONDS, log a
+        warning, and let the body run anyway — atomic rename in the actual
+        download still prevents partial reads."""
+        import logging
+
+        monkeypatch.setattr(InputFileLock, "LOCK_WAIT_MAX_SECONDS", 0.1)
+
+        body_entered = asyncio.Event()
+        holder_can_release = asyncio.Event()
+
+        async def hold_forever():
+            async with InputFileLock.acquire("ws1", "data.tif"):
+                await holder_can_release.wait()
+
+        holder = asyncio.create_task(hold_forever())
+        # Wait for the holder to actually own the lock.
+        await asyncio.sleep(0.05)
+
+        with caplog.at_level(logging.WARNING):
+
+            async def attempt():
+                async with InputFileLock.acquire("ws1", "data.tif"):
+                    body_entered.set()
+
+            await asyncio.wait_for(attempt(), timeout=2.0)
+
+        assert (
+            body_entered.is_set()
+        ), "acquire should fall through and run the body on timeout"
+        assert any(
+            "InputFileLock acquire timeout" in r.message for r in caplog.records
+        ), "expected a timeout warning to be logged"
+
+        holder_can_release.set()
+        await holder
+
+
+class TestEnsureInputFileSynced:
+    """ensure_input_file_synced no longer locks directly — it delegates to
+    download_input_data, which acquires InputFileLock at the implementation
+    layer (S3 / Mock). These tests cover the orchestrator's own behavior:
+    fast-path, exception propagation."""
+
+    @pytest.mark.asyncio
+    async def test_already_local_short_circuits_without_lock(self, input_dir):
+        """If the file already exists locally, no controller is constructed."""
+        ws, fn = "ws1", "data.tif"
+        local = os.path.join(input_dir, ws, fn)
+        os.makedirs(os.path.dirname(local), exist_ok=True)
+        open(local, "wb").close()
+
+        with patch(
+            "studio.app.common.core.storage.remote_storage_controller."
+            "RemoteStorageController"
+        ) as mock_ctrl:
+            result = await RemoteStorageDownloadUtils.ensure_input_file_synced(
+                ws, fn, "bucket-x"
+            )
+
+        assert result is True
+        mock_ctrl.assert_not_called()
+        # No lock file should have been created either.
+        assert not os.path.exists(os.path.join(input_dir, ws, ".locks", f"{fn}.lock"))
+
+    @pytest.mark.asyncio
+    async def test_download_exception_propagates(self, input_dir):
+        """Exceptions from download_input_data are surfaced to the caller."""
+        from unittest.mock import AsyncMock
+
+        ws, fn = "ws1", "data.tif"
+
+        mock_controller = AsyncMock()
+        mock_controller.download_input_data.side_effect = RuntimeError("boom")
+
+        with patch(
+            "studio.app.common.core.storage.remote_storage_controller."
+            "RemoteStorageController",
+            return_value=mock_controller,
+        ), patch(
+            "studio.app.common.core.storage.remote_storage_controller."
+            "RemoteStorageController.is_available",
+            return_value=True,
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await RemoteStorageDownloadUtils.ensure_input_file_synced(
+                    ws, fn, "bucket-x"
+                )

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -4,6 +4,8 @@ Unit tests for S3StorageController class.
 Tests S3 operations including download_experiment with sync_mode filtering.
 """
 
+import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -124,6 +126,8 @@ class TestS3StorageControllerDownloadExperiment:
         ), patch(
             "os.makedirs"
         ), patch(
+            "os.replace"
+        ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
@@ -167,6 +171,8 @@ class TestS3StorageControllerDownloadExperiment:
             "os.path.isdir", return_value=False
         ), patch(
             "os.makedirs"
+        ), patch(
+            "os.replace"
         ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
@@ -223,6 +229,8 @@ class TestS3StorageControllerDownloadExperiment:
         ), patch(
             "os.makedirs"
         ), patch(
+            "os.replace"
+        ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
@@ -270,6 +278,8 @@ class TestS3StorageControllerDownloadExperiment:
             "os.path.isdir", return_value=False
         ), patch(
             "os.makedirs"
+        ), patch(
+            "os.replace"
         ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
@@ -329,6 +339,8 @@ class TestS3StorageControllerDownloadExperiment:
         ), patch(
             "os.makedirs"
         ), patch(
+            "os.replace"
+        ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
@@ -381,6 +393,8 @@ class TestS3StorageControllerDownloadExperiment:
         ), patch(
             "os.makedirs"
         ), patch(
+            "os.replace"
+        ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
             mock_dirpath.OUTPUT_DIR = "/app/studio_data/output"
@@ -423,6 +437,8 @@ class TestS3StorageControllerDownloadExperiment:
             "os.path.isdir", return_value=False
         ), patch(
             "os.makedirs"
+        ), patch(
+            "os.replace"
         ), patch(
             "studio.app.common.core.storage.s3_storage_controller.DIRPATH"
         ) as mock_dirpath:
@@ -875,3 +891,195 @@ class TestValidateExperimentInS3:
         assert result["valid"] is False
         # Both 0-byte -> found_files empty -> "No objects found"
         assert result["error"] is not None
+
+
+class TestDownloadS3AtomicRename:
+    """_download_s3_with_update_check writes to a tmp path then atomic-renames."""
+
+    def setup_method(self):
+        self.controller = S3StorageController("test-bucket")
+
+    @pytest.mark.asyncio
+    async def test_writes_via_tmp_then_replaces(self, tmp_path):
+        """Successful download lands at the final path; no tmp left behind."""
+        final_path = str(tmp_path / "sub" / "data.bin")
+        payload = b"hello-s3"
+
+        async def fake_download(bucket, key, dest):
+            # Simulate s3transfer writing the object body to the given dest.
+            with open(dest, "wb") as f:
+                f.write(payload)
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock(side_effect=fake_download)
+
+        result = await self.controller._download_s3_with_update_check(
+            mock_client, "s3/key/data.bin", final_path, file_size=len(payload)
+        )
+
+        assert result is True
+        # The call to download_file received a tmp path, not the final path.
+        called_dest = mock_client.download_file.call_args.args[2]
+        assert called_dest != final_path
+        assert called_dest.startswith(final_path + ".tmp.")
+        # Final file is in place with the full payload.
+        assert open(final_path, "rb").read() == payload
+        # Tmp file was renamed away, not left behind.
+        assert not os.path.exists(called_dest)
+
+    @pytest.mark.asyncio
+    async def test_download_failure_cleans_up_tmp_and_no_final(self, tmp_path):
+        """If S3 raises mid-download, tmp is removed and final path stays absent."""
+        final_path = str(tmp_path / "data.bin")
+        observed_tmp = {}
+
+        async def failing_download(bucket, key, dest):
+            # Simulate partial write before the transfer raises.
+            with open(dest, "wb") as f:
+                f.write(b"partial")
+            observed_tmp["path"] = dest
+            raise RuntimeError("s3 boom")
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock(side_effect=failing_download)
+
+        with pytest.raises(RuntimeError, match="s3 boom"):
+            await self.controller._download_s3_with_update_check(
+                mock_client, "s3/key/data.bin", final_path, file_size=7
+            )
+
+        assert not os.path.exists(final_path), "no partial file at the final path"
+        assert not os.path.exists(observed_tmp["path"]), "tmp must be cleaned up"
+
+    @pytest.mark.asyncio
+    async def test_skip_when_local_size_matches(self, tmp_path):
+        """Existing local file with matching size short-circuits — no S3 call."""
+        final_path = str(tmp_path / "data.bin")
+        with open(final_path, "wb") as f:
+            f.write(b"xxxxx")
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock()
+
+        result = await self.controller._download_s3_with_update_check(
+            mock_client, "s3/key/data.bin", final_path, file_size=5
+        )
+
+        assert result is False
+        mock_client.download_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_overwrites_when_local_size_mismatches(self, tmp_path):
+        """Existing file with wrong size is overwritten via tmp+rename."""
+        final_path = str(tmp_path / "data.bin")
+        with open(final_path, "wb") as f:
+            f.write(b"stale")
+
+        new_payload = b"fresh-content"
+
+        async def fake_download(bucket, key, dest):
+            with open(dest, "wb") as f:
+                f.write(new_payload)
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock(side_effect=fake_download)
+
+        result = await self.controller._download_s3_with_update_check(
+            mock_client, "s3/key/data.bin", final_path, file_size=len(new_payload)
+        )
+
+        assert result is True
+        assert open(final_path, "rb").read() == new_payload
+
+
+class TestS3DownloadInputDataLocking:
+    """download_input_data takes the per-(workspace, file) InputFileLock so
+    concurrent callers across paths (ensure_input_file_synced,
+    download_experiment, download_thumbnail_source) are serialized."""
+
+    @pytest.fixture(autouse=True)
+    def fast_lock_poll(self, monkeypatch):
+        from studio.app.common.core.storage.remote_storage_controller import (
+            InputFileLock,
+        )
+
+        monkeypatch.setattr(InputFileLock, "LOCK_WAIT_POLL_INTERVAL", 0.01)
+
+    @pytest.fixture
+    def input_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "studio.app.common.core.storage."
+            "remote_storage_controller.DIRPATH.INPUT_DIR",
+            str(tmp_path),
+        )
+        return str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_blocks_while_lock_held(self, input_dir):
+        """If another caller holds the lock for (ws, fn), download_input_data
+        cannot make progress until it is released."""
+        from studio.app.common.core.storage.remote_storage_controller import (
+            InputFileLock,
+        )
+
+        controller = S3StorageController("test-bucket")
+
+        # Patch __get_s3_client to a sentinel that would raise if reached —
+        # the lock should block before we ever touch S3.
+        unreachable_client = MagicMock(
+            side_effect=AssertionError("S3 client must not be reached")
+        )
+        with patch.object(
+            controller,
+            "_S3StorageController__get_s3_client",
+            new=unreachable_client,
+        ):
+            async with InputFileLock.acquire("ws1", "data.tif"):
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        controller.download_input_data("ws1", "data.tif"),
+                        timeout=0.3,
+                    )
+
+        # After releasing, the lock file should exist (acquire creates it,
+        # release does not delete it).
+        assert os.path.exists(os.path.join(input_dir, "ws1", ".locks", "data.tif.lock"))
+
+    @pytest.mark.asyncio
+    async def test_releases_lock_on_error(self, input_dir):
+        """If the body raises, the lock must be released so the next caller
+        is not parked."""
+        from studio.app.common.core.storage.remote_storage_controller import (
+            InputFileLock,
+        )
+
+        controller = S3StorageController("test-bucket")
+
+        class BoomClient:
+            def __call__(self):
+                return self
+
+            async def __aenter__(self):
+                raise RuntimeError("s3 boom")
+
+            async def __aexit__(self, *exc):
+                return False
+
+        with patch.object(
+            controller,
+            "_S3StorageController__get_s3_client",
+            new=BoomClient(),
+        ):
+            with pytest.raises(RuntimeError, match="s3 boom"):
+                await controller.download_input_data("ws1", "data.tif")
+
+        # A fresh acquire should not hang.
+        await asyncio.wait_for(
+            _acquire_then_release(InputFileLock, "ws1", "data.tif"),
+            timeout=1.0,
+        )
+
+
+async def _acquire_then_release(lock_cls, ws: str, fn: str) -> None:
+    async with lock_cls.acquire(ws, fn):
+        pass

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -1083,3 +1083,74 @@ class TestS3DownloadInputDataLocking:
 async def _acquire_then_release(lock_cls, ws: str, fn: str) -> None:
     async with lock_cls.acquire(ws, fn):
         pass
+
+
+class TestDownloadS3RefreshesParentDir:
+    """_download_s3_with_update_check forces an NFS dentry refresh on the
+    parent dir before checking for the file, so a peer process's writes on
+    EFS are visible after we acquire the cross-instance lock."""
+
+    def setup_method(self):
+        self.controller = S3StorageController("test-bucket")
+
+    @pytest.mark.asyncio
+    async def test_listdir_called_before_existence_check(self, tmp_path):
+        """os.listdir on the parent runs before os.path.isfile."""
+        final_path = str(tmp_path / "data.bin")
+        order = []
+
+        real_listdir = os.listdir
+        real_isfile = os.path.isfile
+
+        def tracking_listdir(p):
+            order.append(("listdir", p))
+            return real_listdir(p)
+
+        def tracking_isfile(p):
+            order.append(("isfile", p))
+            return real_isfile(p)
+
+        async def fake_download(bucket, key, dest):
+            with open(dest, "wb") as f:
+                f.write(b"x")
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock(side_effect=fake_download)
+
+        with patch(
+            "studio.app.common.core.storage.s3_storage_controller.os.listdir",
+            side_effect=tracking_listdir,
+        ), patch(
+            "studio.app.common.core.storage.s3_storage_controller.os.path.isfile",
+            side_effect=tracking_isfile,
+        ):
+            await self.controller._download_s3_with_update_check(
+                mock_client, "s3/key/data.bin", final_path, file_size=1
+            )
+
+        # listdir must be the first FS observation, before any isfile check.
+        first_listdir = next(i for i, (op, _) in enumerate(order) if op == "listdir")
+        first_isfile = next(
+            (i for i, (op, _) in enumerate(order) if op == "isfile"), None
+        )
+        assert first_isfile is None or first_listdir < first_isfile
+
+    @pytest.mark.asyncio
+    async def test_missing_parent_dir_is_tolerated(self, tmp_path):
+        """If the parent dir doesn't exist yet, the refresh swallows OSError."""
+        final_path = str(tmp_path / "nonexistent-dir" / "data.bin")
+
+        async def fake_download(bucket, key, dest):
+            with open(dest, "wb") as f:
+                f.write(b"x")
+
+        mock_client = MagicMock()
+        mock_client.download_file = AsyncMock(side_effect=fake_download)
+
+        # Must not raise even though parent dir doesn't exist at entry.
+        result = await self.controller._download_s3_with_update_check(
+            mock_client, "s3/key/data.bin", final_path, file_size=1
+        )
+
+        assert result is True
+        assert os.path.isfile(final_path)

--- a/studio/tests/app/common/routers/test_structured_outputs.py
+++ b/studio/tests/app/common/routers/test_structured_outputs.py
@@ -329,3 +329,43 @@ def test_structured_3d_default_pagination(client):
     assert data["data_type"] == "images"
     assert len(data["data"]) == 10
     assert data["total_frames"] == 10
+
+
+@pytest.mark.asyncio
+async def test_structured_missing_input_triggers_on_demand_sync():
+    """A missing input must trigger an on-demand sync before 404, so public
+    viewers get the lazily-synced input data (mirrors the other endpoints)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from studio.app.common.routers.outputs import get_structured_data
+
+    node = MagicMock()
+    node.data.path = "lazy_input.h5"
+    node.data.hdf5Path = "x"
+    node.data.matPath = None
+    config = MagicMock()
+    config.nodeDict.get.return_value = node
+
+    with patch(
+        "studio.app.common.routers.outputs.WorkflowConfigReader.read",
+        return_value=config,
+    ), patch(
+        "studio.app.common.routers.outputs.os.path.exists", return_value=False
+    ), patch(
+        "studio.app.common.routers.outputs._ensure_visualization_synced",
+        new_callable=AsyncMock,
+    ) as mock_sync:
+        with pytest.raises(HTTPException) as exc:
+            await get_structured_data(
+                workspace_id="6",
+                unique_id="abc123",
+                node_id="n",
+                remote_bucket_name="bucket-x",
+            )
+
+    # The fix: sync is attempted (with the experiment's output dir) before 404.
+    mock_sync.assert_awaited_once()
+    assert mock_sync.await_args.args[1] == "bucket-x"
+    assert exc.value.status_code == 404

--- a/studio/tests/app/common/routers/test_structured_outputs.py
+++ b/studio/tests/app/common/routers/test_structured_outputs.py
@@ -333,8 +333,9 @@ def test_structured_3d_default_pagination(client):
 
 @pytest.mark.asyncio
 async def test_structured_missing_input_triggers_on_demand_sync():
-    """A missing input must trigger an on-demand sync before 404, so public
-    viewers get the lazily-synced input data (mirrors the other endpoints)."""
+    """A missing input must trigger an on-demand input-file sync before 404, so
+    public viewers get the lazily-synced input data (mirrors the csv/image
+    endpoints)."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from fastapi import HTTPException
@@ -354,7 +355,8 @@ async def test_structured_missing_input_triggers_on_demand_sync():
     ), patch(
         "studio.app.common.routers.outputs.os.path.exists", return_value=False
     ), patch(
-        "studio.app.common.routers.outputs._ensure_visualization_synced",
+        "studio.app.common.routers.outputs.RemoteStorageDownloadUtils."
+        "ensure_input_file_synced",
         new_callable=AsyncMock,
     ) as mock_sync:
         with pytest.raises(HTTPException) as exc:
@@ -365,7 +367,59 @@ async def test_structured_missing_input_triggers_on_demand_sync():
                 remote_bucket_name="bucket-x",
             )
 
-    # The fix: sync is attempted (with the experiment's output dir) before 404.
-    mock_sync.assert_awaited_once()
-    assert mock_sync.await_args.args[1] == "bucket-x"
+    # Sync is keyed on the input file + bucket, then 404 if still missing.
+    mock_sync.assert_awaited_once_with("6", "lazy_input.h5", "bucket-x")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_structured_missing_input_resyncs_via_download_layer():
+    """Regression: a missing input is re-fetched by downloading the input file
+    itself, independent of the experiment's output-sync status. Routing the
+    re-fetch through the output-sync path left inputs permanently 404 once the
+    input cache was wiped while the output stayed marked synced."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from studio.app.common.routers.outputs import get_structured_data
+
+    node = MagicMock()
+    node.data.path = "wiped_input.h5"
+    node.data.hdf5Path = "x"
+    node.data.matPath = None
+    config = MagicMock()
+    config.nodeDict.get.return_value = node
+
+    rsc = "studio.app.common.core.storage.remote_storage_controller"
+    with patch(
+        "studio.app.common.routers.outputs.WorkflowConfigReader.read",
+        return_value=config,
+    ), patch(
+        "studio.app.common.routers.outputs.os.path.exists", return_value=False
+    ), patch(
+        # Output marked fully synced: must NOT gate the input re-fetch.
+        "studio.app.common.routers.outputs.RemoteSyncStatusFileUtil."
+        "check_sync_status_unsynced",
+        return_value=False,
+    ), patch(
+        f"{rsc}.os.path.exists", return_value=False
+    ), patch(
+        f"{rsc}.RemoteStorageController"
+    ) as mock_controller_cls:
+        mock_controller_cls.is_available.return_value = True
+        mock_controller_cls.return_value.download_input_data = AsyncMock(
+            return_value=True
+        )
+        with pytest.raises(HTTPException) as exc:
+            await get_structured_data(
+                workspace_id="6",
+                unique_id="abc123",
+                node_id="n",
+                remote_bucket_name="bucket-x",
+            )
+
+    mock_controller_cls.return_value.download_input_data.assert_awaited_once_with(
+        "6", "wiped_input.h5"
+    )
     assert exc.value.status_code == 404


### PR DESCRIPTION
### Content

#### Summary
- Fixes HDF5/MAT input nodes failing with "Error loading data: Rejected" on the public page even though the files are in S3 (see Problem below): `get_structured_data` now fetches a missing input from S3 on access, like the image/CSV endpoints already did.
- Moves the raw-input cache off each task's lean root EBS onto the shared published-data EFS, under its own `/input-cache` access point, so both public tasks share one copy and it survives task replacement.
- Adds a daily Lambda that wipes the input cache (04:00 JST) to bound EFS growth, scoped so it can only touch the input subtree, never the output cache or its sync markers.
- Public-tier only; the output cache, the authenticated tiers, and the request path for already-cached inputs are unchanged.

#### Problem and root cause
On the public page, HDF5/MAT input nodes failed with "Error loading data: Rejected" while TIFF and CSV inputs on the same experiments loaded -- although every file is present in S3 (example: workflow `81a4af6b`'s `sample_hdf5.h5`). The deciding factor is the input *type*, because each type is served by a different endpoint and only some fetched-on-miss:

| Input type | Endpoint | Fetched from S3 on a local cache miss? |
|---|---|---|
| TIFF (image) | `get_image` | Yes -- via `ensure_input_file_synced()` |
| CSV | `get_csv` | Yes -- via `ensure_input_file_synced()` |
| HDF5 / MAT | `get_structured_data` | No (before this branch) -- reads the local cache, 404s on a miss |

The public tier's local input cache is per-instance and is populated only by the visualization/full-sync loops, which are skipped once an experiment is marked `success` and never run on the startup warm. So whenever an instance's cache was cold for an experiment, image/CSV inputs self-healed (fetched on demand) but HDF5/MAT inputs 404'd -- which is why some input data loads and some does not despite all of it being in S3. The 404 surfaces in `StructuredFilePlot` as "Error loading data: Rejected" (the rejected request's error message). This branch gives `get_structured_data` the same self-healing fetch the image/CSV endpoints already had.

#### Design Decisions
- **Input re-fetch is keyed on the file, not the output-sync status.** The visualization sync path (`_ensure_visualization_synced`) short-circuits once `remote_sync_stat.json` reads `success`. That marker lives on the output cache, which the cleanup never wipes, so routing input re-fetch through it would suppress the re-download after a nightly wipe and 404 input-node data permanently. `get_structured_data` instead calls `RemoteStorageDownloadUtils.ensure_input_file_synced()` -- the same helper `get_csv()` / `get_image()` already use -- which downloads the single input by name regardless of sync status. This independence is what makes the daily wipe safe.
- **Two EFS access points on one filesystem.** Output stays rooted at `/`; input gets a separate access point rooted at `/input-cache`. The cleanup Lambda mounts only the input access point and its IAM is conditioned on that access-point ARN, so it physically cannot reach the output cache or the sync markers. The access point's `posix_user` pins all access to uid/gid 1000, so the container's writes and the Lambda's deletes share one owner and no EFS root access is needed.
- **External scheduled Lambda, not the in-process scheduler.** The public tier runs `DISABLE_BACKGROUND_SCHEDULER=1`: that scheduler bundles destructive free/premium user-lifecycle jobs (cleanup, expiration deletion, reconciliation) and has no cross-task leader election, while the public tier runs multiple replicas. A dedicated, singleton, scheduled Lambda is the correct pattern for public-tier periodic work.
- **Unconditional daily wipe, not age-based eviction.** Inputs are pure cache (re-pulled on access), so a blunt nightly wipe bounds EFS growth with no bookkeeping; the only cost is the first viewer after 04:00 JST paying a re-download. Growth is bounded by one day.
- **Cleanup robustness.** The handler snapshots the directory before deleting (deleting during an open `os.scandir` is undefined on NFS/EFS and can skip entries), treats `FileNotFoundError` as a benign race rather than an error, and raises on any real delete error so failures surface on the Lambda `Errors` metric. Timeout is 900s because EFS deletes are one round-trip per file.

### Evidence
- Public CloudWatch logs (`/ecs/development-public-optinist-cloud-taskdef`) show the symptom and the type asymmetry. HDF5 input nodes 404 repeatedly across tasks, while image/CSV inputs are fetched on demand and succeed:
  ```
  GET /outputs/structured/6/81a4af6b/input_cpmiuzyroh ... 404
  GET /outputs/structured/6/81a4af6b/input_6m0vw0sv6s ... 404
  download_input_data() ... app/studio_data/input/2/sample_mouse2p_image.tiff -> /app/studio_data/input/...
  download_input_data() ... app/studio_data/input/2/sample_mouse2p_behavior.csv -> /app/studio_data/input/...
  GET /outputs/image/6/81a4af6b/.../refImg.json ... 200
  ```
  A search for `sample_hdf5` returns no `download_input_data` line -- the HDF5 input is never pulled to local disk, so the no-fetch endpoint 404s permanently.
- `pytest studio/tests/app/common/routers/test_structured_outputs.py -k missing_input` -- 2 passed. The status-independence regression also fails against the pre-fix code (verified by temporarily reverting), confirming it is a real guard.
- `terraform validate` -- "Success! The configuration is valid." `terraform fmt -check` clean on the changed files.
- Cleanup handler exercised locally against a temp tree: nested files/dirs removed (parent preserved), missing path is a no-op, handler raises on a non-zero error count and returns results when clean.

### References
- Depends on the public instance tier; see `infrastructure/documentation/PUBLIC_INSTANCE_ARCHITECTURE.md`.
- Cache lifecycle and the sync-status interaction: `infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md`.

#### Files changed
Backend
- `studio/app/common/routers/outputs.py` -- `get_structured_data` (`GET /api/visualizations/structured/{workspace_id}/{unique_id}/{node_id}`) re-fetches a missing input via `ensure_input_file_synced()` (file-keyed, status-independent); 503 on a remote-storage error, 404 if the input is genuinely absent.
- `studio/tests/app/common/routers/test_structured_outputs.py` -- two async tests: the helper is awaited with `(workspace_id, file_path, bucket)`, and the regression that the input download is still attempted when the output is marked `success`.

Infrastructure
- `infrastructure/terraform/infrastructure.tf` -- `aws_efs_access_point.published_data_input` (`/input-cache`, uid/gid 1000) on the existing published-data EFS.
- `infrastructure/terraform/public_service.tf` -- input-cache volume + mount at `/app/studio_data/input` on the public task definition.
- `infrastructure/terraform/public_cleanup.py` -- cleanup Lambda handler: snapshot-then-delete, race-tolerant, raises on real errors.
- `infrastructure/terraform/public_cleanup.tf` -- Lambda, IAM scoped to the input access point, daily `cron(0 19 * * ? *)` schedule, and the `public-cleanup-errors` alarm wired to `local.critical_alerts_actions`.

Documentation
- `infrastructure/documentation/PUBLIC_INSTANCE_ARCHITECTURE.md` -- "Published Input Cache and Daily Cleanup" section, Edge Case 6, responsibility/monitoring/AWS-resource rows.
- `infrastructure/documentation/DATA_SYNC_ARCHITECTURE.md` -- cross-reference note by the sync-status gate.

### Manual Testcases

Each step is "what to do" → "expected result"; run against a public-tier dev deploy.
- [x] 1. **Input node serves on demand.**
   - As a visitor, open a published experiment on the public tier and view an input node's structured data → data renders; the input file is synced from S3 on first access.
- [x] 2. **Input re-fetched after a cache wipe (core regression).**
   - With that experiment fully synced (output marker `success`), invoke the cleanup Lambda (or wait for 04:00 JST) so the input cache is emptied, then re-view the same input node → data renders again (input re-fetched), not a 404. Pre-fix this returned 404.
- [x] 3. **Cleanup isolation.**
   - Before a wipe, `touch /app/studio_data/output/.probe` on a public task and confirm a cached input exists under `/app/studio_data/input/`. After the cleanup runs → the input cache is empty but `.probe` on the output mount is still present (the Lambda mounts only `/input-cache`).
- [x] 4. **Error mapping.**
   - View an input node whose file is absent from S3 → 404 (not 500); a transient S3 error → 503.
- [x] 5. **Terraform resources created.**
   - `terraform plan` in a non-prod workspace → `aws_efs_access_point.published_data_input`, `aws_lambda_function.public_cleanup`, `aws_cloudwatch_event_rule.public_cleanup_schedule`, and `aws_cloudwatch_metric_alarm.public_cleanup_errors` are created; the public task definition gains the `/app/studio_data/input` mount.
- [x] 6. **Cleanup errors alarm wired.**
   - `aws cloudwatch describe-alarms --alarm-name-prefix <env>-public-cleanup` → `<env>-public-cleanup-errors` exists (state `OK`/`INSUFFICIENT_DATA`). A run with a non-zero delete-error count raises, registers on the Lambda `Errors` metric, and drives the alarm to `ALARM` (notifies only where the critical-alerts SNS topic exists).

Automated regression test:

```
pytest studio/tests/app/common/routers/test_structured_outputs.py -k missing_input -- 2 tests pass
```

### Unit, Integration, Contract Test Coverage
- `test_structured_missing_input_triggers_on_demand_sync` -- asserts `get_structured_data` re-fetches via `ensure_input_file_synced(workspace_id, file_path, bucket)` before 404.
- `test_structured_missing_input_resyncs_via_download_layer` -- drives the real helper with the output marked `success` and asserts the per-file download is still attempted (the daily-wipe regression).
- The remaining tests in the file use the FastAPI TestClient fixture and require the container test environment; the two added tests run standalone.
- Terraform validated via `terraform validate` / `terraform plan`; the cleanup handler has no automated suite but was exercised locally as noted under Evidence.

### Others

#### Difficulties (if any)
- The failure mode is subtle: it only appears after a wipe on an experiment whose output is already marked `success`, so plots keep working while input-node data 404s. The fix had to decouple input presence from the output-sync marker, which now live on independently-managed EFS subtrees.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Input serving (`get_structured_data`) | Low | Single endpoint; file-keyed re-fetch mirrors `get_csv`/`get_image`; covered by two tests including the regression. Error mapping: 404 absent, 503 transient. |
| EFS input cache (new access point + mount) | Medium | New shared mount applied on the next public deploy. Inputs are pure cache (re-synced on access), so no data-loss risk; the output cache is a separate access point and is untouched. |
| Daily cleanup Lambda | Medium | Deletes on shared EFS nightly; access-point root-jail + scoped IAM keep it off the output cache. The raising handler triggers up to two async retries, which are idempotent (already-gone entries are skipped). The errors alarm notifies only in production (SNS topic exists there). |
| Terraform apply | Low | Adds Lambda/access point/schedule/alarm; `terraform validate` passes; no state migration or rollback concern. |
