### PR TITLE
# fix(subscription): handle `customer.subscription.created` webhook (closes #629 — Problem 1)

### DIFF
--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -5,6 +5,7 @@ import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from studio.app.common.core.logger import AppLogger
@@ -337,26 +338,60 @@ class CheckoutService:
         )
 
         if existing_subscription:
-            # Update existing subscription
-            existing_subscription.plan_id = plan_id
-            existing_subscription.sync_status = SyncStatus.SYNCED
-            existing_subscription.expiration = expiration_date
-            existing_subscription.scheduled_downgrade = False
-            existing_subscription.updated_at = (
-                SubscriptionService.get_current_datetime()
+            return CheckoutService._apply_subscription_update(
+                existing_subscription, plan_id, expiration_date
             )
-            return existing_subscription.id
-        else:
-            # Create new subscription
-            new_subscription = UserSubscription(
-                plan_id=plan_id,
-                user_id=user_id,
-                expiration=expiration_date,
-                sync_status=SyncStatus.SYNCED,
-            )
-            db.add(new_subscription)
-            db.flush()  # Get ID without committing
+
+        # Create new subscription. ``subscription_users.user_id`` is unique,
+        # and SELECT ... FOR UPDATE does not lock a row that doesn't exist
+        # yet — so concurrent webhook deliveries (e.g. ``checkout.session.
+        # completed`` racing ``customer.subscription.created``) can both
+        # reach this branch and one will hit IntegrityError. Guard the
+        # insert with a SAVEPOINT and, on conflict, fall back to selecting
+        # + updating the row that the other delivery just created. This
+        # makes the upsert idempotent and avoids a spurious 500 -> Stripe
+        # retry.
+        try:
+            with db.begin_nested():
+                new_subscription = UserSubscription(
+                    plan_id=plan_id,
+                    user_id=user_id,
+                    expiration=expiration_date,
+                    sync_status=SyncStatus.SYNCED,
+                )
+                db.add(new_subscription)
+                db.flush()  # Get ID without committing
             return new_subscription.id
+        except IntegrityError:
+            logger.warning(
+                "Concurrent insert detected for subscription_users "
+                f"user_id={user_id}; falling back to update"
+            )
+            existing_subscription = (
+                db.query(UserSubscription)
+                .filter(UserSubscription.user_id == user_id)
+                .with_for_update()
+                .first()
+            )
+            if existing_subscription is None:
+                # The conflict implies a row exists; if we still can't find
+                # it, surface the original error rather than swallow it.
+                raise
+            return CheckoutService._apply_subscription_update(
+                existing_subscription, plan_id, expiration_date
+            )
+
+    @staticmethod
+    def _apply_subscription_update(
+        subscription, plan_id: int, expiration_date: datetime
+    ) -> int:
+        """Apply the standard field updates to an existing subscription row."""
+        subscription.plan_id = plan_id
+        subscription.sync_status = SyncStatus.SYNCED
+        subscription.expiration = expiration_date
+        subscription.scheduled_downgrade = False
+        subscription.updated_at = SubscriptionService.get_current_datetime()
+        return subscription.id
 
     @staticmethod
     def get_subscription_account(

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -383,7 +383,7 @@ class CheckoutService:
 
     @staticmethod
     def _apply_subscription_update(
-        subscription, plan_id: int, expiration_date: datetime
+        subscription: UserSubscription, plan_id: int, expiration_date: datetime
     ) -> int:
         """Apply the standard field updates to an existing subscription row."""
         subscription.plan_id = plan_id

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -119,6 +119,7 @@ class StripeWebhookEvent(StrEnum):
     CHECKOUT_SESSION_COMPLETED = "checkout.session.completed"
     INVOICE_PAYMENT_FAILED = "invoice.payment_failed"
     CUSTOMER_SUBSCRIPTION_CREATED = "customer.subscription.created"
+    CUSTOMER_SUBSCRIPTION_UPDATED = "customer.subscription.updated"
     CUSTOMER_SUBSCRIPTION_DELETED = "customer.subscription.deleted"
     SUBSCRIPTION_SCHEDULE_RELEASED = "subscription_schedule.released"
     INVOICE_PAYMENT_SUCCEEDED = "invoice.payment_succeeded"

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -118,6 +118,7 @@ class StripeWebhookEvent(StrEnum):
 
     CHECKOUT_SESSION_COMPLETED = "checkout.session.completed"
     INVOICE_PAYMENT_FAILED = "invoice.payment_failed"
+    CUSTOMER_SUBSCRIPTION_CREATED = "customer.subscription.created"
     CUSTOMER_SUBSCRIPTION_DELETED = "customer.subscription.deleted"
     SUBSCRIPTION_SCHEDULE_RELEASED = "subscription_schedule.released"
     INVOICE_PAYMENT_SUCCEEDED = "invoice.payment_succeeded"

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1429,6 +1429,17 @@ class WebhookService:
         """
         customer_id = subscription_data.get("customer")
         stripe_subscription_id = subscription_data.get("id")
+        if not customer_id:
+            logger.warning(
+                f"Webhook: No customer ID in subscription.{event_label} event "
+                f"(subscription {stripe_subscription_id}); acknowledging"
+            )
+            return {
+                "success": True,
+                "skipped": True,
+                "reason": "missing_customer_id",
+                "message": "No customer ID in subscription event",
+            }
         logger.info(
             f"Webhook: Handling customer.subscription.{event_label} for "
             f"customer {customer_id} (subscription {stripe_subscription_id})"
@@ -1479,6 +1490,11 @@ class WebhookService:
             plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
             plan_id = SubscriptionPlanIds.PREMIUM
+        if not plan_id_raw:
+            logger.warning(
+                f"Webhook: No plan_id in subscription metadata for "
+                f"{stripe_subscription_id}; defaulting to PREMIUM"
+            )
 
         # 4. Upsert subscription_users (lock-safe, idempotent helper)
         CheckoutService.create_or_update_subscription(
@@ -1532,9 +1548,21 @@ class WebhookService:
         ``checkout.session.completed`` alone (delayed, partial failure, or
         not delivered).
         """
-        return WebhookService._sync_subscription_from_event(
-            db, subscription_data, event_label="created"
-        )
+        try:
+            return WebhookService._sync_subscription_from_event(
+                db, subscription_data, event_label="created"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Webhook: Error handling subscription.created: {e}",
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error processing subscription.created: {e}",
+            )
 
     @staticmethod
     async def _release_premium_assignment(
@@ -1677,7 +1705,7 @@ class WebhookService:
                     return WebhookService.handle_invoice_finalized(data)
 
                 case _:
-                    logger.info(f"Unhandled webhook event type: {event_type}")
+                    logger.warning(f"Unhandled webhook event type: {event_type}")
                     return {
                         "success": True,
                         "message": f"Unhandled event type: {event_type}",

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1459,18 +1459,14 @@ class WebhookService:
                 "success": True,
                 "skipped": True,
                 "reason": "missing_expiration",
-                "message": (
-                    f"No period end in subscription: {stripe_subscription_id}"
-                ),
+                "message": (f"No period end in subscription: {stripe_subscription_id}"),
             }
 
         # 3. Derive plan from subscription metadata, default to premium
         metadata = subscription_data.get("metadata") or {}
         plan_id_raw = metadata.get("plan_id")
         try:
-            plan_id = (
-                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
-            )
+            plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
             plan_id = SubscriptionPlanIds.PREMIUM
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1511,22 +1511,23 @@ class WebhookService:
         ).rowcount
         if not rows_updated:
             try:
-                db.add(
-                    UserStorageUsage(
-                        user_id=user_id,
-                        storage_usage_bytes=0,
-                        storage_quota_bytes=storage_quota_bytes,
+                with db.begin_nested():
+                    db.add(
+                        UserStorageUsage(
+                            user_id=user_id,
+                            storage_usage_bytes=0,
+                            storage_quota_bytes=storage_quota_bytes,
+                        )
                     )
-                )
-                db.flush()
+                    db.flush()
             except IntegrityError:
                 # checkout.session.completed already inserted the row;
-                # rollback the failed INSERT and UPDATE instead.
+                # SAVEPOINT rolled back the INSERT only, outer transaction
+                # (including Step 4 subscription upsert) is preserved.
                 logger.warning(
                     f"Webhook: Concurrent storage insert for user {user_id}; "
                     f"falling back to update"
                 )
-                db.rollback()
                 db.execute(
                     update(UserStorageUsage)
                     .where(UserStorageUsage.user_id == user_id)

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1479,7 +1479,28 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Sync storage quota to the plan
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade. The upsert
+        # set scheduled_downgrade=False unconditionally; only override when
+        # the event carries cancel_at_period_end=True, so the common (no-
+        # cancel) case avoids an extra query. This is the P2 addition that
+        # captures Stripe-initiated downgrades (proration, payment-method-
+        # failure auto-cancel, plan change at period end).
+        cancel_at_period_end = bool(
+            subscription_data.get("cancel_at_period_end")
+        )
+        if cancel_at_period_end:
+            subscription = (
+                db.query(UserSubscription)
+                .filter(UserSubscription.user_id == user_id)
+                .first()
+            )
+            if subscription is not None:
+                subscription.scheduled_downgrade = True
+                subscription.updated_at = (
+                    SubscriptionService.get_current_datetime()
+                )
+
+        # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
         rows_updated = db.execute(
             update(UserStorageUsage)
@@ -1497,20 +1518,22 @@ class WebhookService:
 
         db.commit()
 
-        # 6. Invalidate tier cache so the GUI reflects the change promptly
+        # 7. Invalidate tier cache so the GUI reflects the change promptly
         user = db.query(User).filter(User.id == user_id).first()
         if user:
             invalidate_user_tier_cache(user.uid)
 
         logger.info(
             f"Webhook: Synced subscription.{event_label} for user {user_id} "
-            f"(plan_id={plan_id}, expiration={expiration_date})"
+            f"(plan_id={plan_id}, expiration={expiration_date}, "
+            f"scheduled_downgrade={cancel_at_period_end})"
         )
         return {
             "success": True,
             "user_id": user_id,
             "plan_id": plan_id,
             "expiration": expiration_date,
+            "scheduled_downgrade": cancel_at_period_end,
             "message": f"Subscription {event_label} synced",
         }
 
@@ -1528,6 +1551,24 @@ class WebhookService:
         """
         return WebhookService._sync_subscription_from_event(
             db, subscription_data, event_label="created"
+        )
+
+    @staticmethod
+    def handle_subscription_updated(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Handle customer.subscription.updated webhook (issue #629, Problem 2).
+
+        Mirrors Stripe-initiated subscription changes into local state:
+        - plan + expiration (via the shared upsert), and
+        - cancel_at_period_end -> scheduled_downgrade (when scheduling a
+          downgrade), so a Stripe-initiated change (proration, plan change,
+          payment-method-failure auto-cancel, etc.) does not silently drift
+          from Stripe.
+        """
+        return WebhookService._sync_subscription_from_event(
+            db, subscription_data, event_label="updated"
         )
 
     @staticmethod
@@ -1562,6 +1603,10 @@ class WebhookService:
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_CREATED:
                     logger.info("Handling customer.subscription.created")
                     return WebhookService.handle_subscription_created(db, data)
+
+                case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_UPDATED:
+                    logger.info("Handling customer.subscription.updated")
+                    return WebhookService.handle_subscription_updated(db, data)
 
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED:
                     logger.info("Handling customer.subscription.deleted")

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1404,6 +1404,133 @@ class WebhookService:
         return webhook_secret
 
     @staticmethod
+    def _sync_subscription_from_event(
+        db: Session, subscription_data: Dict[str, Any], event_label: str
+    ) -> Dict[str, Any]:
+        """
+        Mirror a Stripe ``customer.subscription.*`` event into local state
+        (issue #629, Problem 1 — activation fallback).
+
+        Upserts ``subscription_users`` (plan + expiration), syncs the storage
+        quota, and invalidates the tier cache so the next ``/users/me`` call
+        reflects the change. Acknowledges without a DB write when the
+        customer cannot be mapped or the event has no period end, so Stripe
+        does not retry.
+        """
+        customer_id = subscription_data.get("customer")
+        stripe_subscription_id = subscription_data.get("id")
+        logger.info(
+            f"Webhook: Handling customer.subscription.{event_label} for "
+            f"customer {customer_id} (subscription {stripe_subscription_id})"
+        )
+
+        # 1. Map Stripe customer -> local user account
+        user_account = (
+            db.query(SubscriptionUserAccount)
+            .filter(SubscriptionUserAccount.provider_customer_id == customer_id)
+            .first()
+        )
+        if not user_account:
+            logger.warning(
+                f"Webhook: No user account for customer_id {customer_id}; "
+                f"acknowledging subscription.{event_label} without DB change"
+            )
+            return {
+                "success": True,
+                "skipped": True,
+                "reason": "missing_user_account",
+                "message": f"No user account for customer: {customer_id}",
+            }
+        user_id = user_account.user_id
+
+        # 2. Derive expiration from the event payload (trial overrides period)
+        trial_end = subscription_data.get("trial_end")
+        current_period_end = subscription_data.get("current_period_end")
+        if trial_end:
+            expiration_date = datetime_from_timestamp(trial_end)
+        elif current_period_end:
+            expiration_date = datetime_from_timestamp(current_period_end)
+        else:
+            logger.warning(
+                f"Webhook: No period end in subscription {stripe_subscription_id}; "
+                f"acknowledging subscription.{event_label} without DB change"
+            )
+            return {
+                "success": True,
+                "skipped": True,
+                "reason": "missing_expiration",
+                "message": (
+                    f"No period end in subscription: {stripe_subscription_id}"
+                ),
+            }
+
+        # 3. Derive plan from subscription metadata, default to premium
+        metadata = subscription_data.get("metadata") or {}
+        plan_id_raw = metadata.get("plan_id")
+        try:
+            plan_id = (
+                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
+            )
+        except (TypeError, ValueError):
+            plan_id = SubscriptionPlanIds.PREMIUM
+
+        # 4. Upsert subscription_users (lock-safe, idempotent helper)
+        CheckoutService.create_or_update_subscription(
+            db, user_id, plan_id, expiration_date
+        )
+
+        # 5. Sync storage quota to the plan
+        storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
+        rows_updated = db.execute(
+            update(UserStorageUsage)
+            .where(UserStorageUsage.user_id == user_id)
+            .values(storage_quota_bytes=storage_quota_bytes)
+        ).rowcount
+        if not rows_updated:
+            db.add(
+                UserStorageUsage(
+                    user_id=user_id,
+                    storage_usage_bytes=0,
+                    storage_quota_bytes=storage_quota_bytes,
+                )
+            )
+
+        db.commit()
+
+        # 6. Invalidate tier cache so the GUI reflects the change promptly
+        user = db.query(User).filter(User.id == user_id).first()
+        if user:
+            invalidate_user_tier_cache(user.uid)
+
+        logger.info(
+            f"Webhook: Synced subscription.{event_label} for user {user_id} "
+            f"(plan_id={plan_id}, expiration={expiration_date})"
+        )
+        return {
+            "success": True,
+            "user_id": user_id,
+            "plan_id": plan_id,
+            "expiration": expiration_date,
+            "message": f"Subscription {event_label} synced",
+        }
+
+    @staticmethod
+    def handle_subscription_created(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Handle customer.subscription.created webhook (issue #629, Problem 1).
+
+        Activates the subscription locally so the user is no longer stuck on
+        "Activation Pending" when activation cannot complete through
+        ``checkout.session.completed`` alone (delayed, partial failure, or
+        not delivered).
+        """
+        return WebhookService._sync_subscription_from_event(
+            db, subscription_data, event_label="created"
+        )
+
+    @staticmethod
     def dispatch_webhook_event(
         db: Session, event_type: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -1431,6 +1558,10 @@ class WebhookService:
                         "success": True,
                         "message": "Payment failed event processed",
                     }
+
+                case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_CREATED:
+                    logger.info("Handling customer.subscription.created")
+                    return WebhookService.handle_subscription_created(db, data)
 
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED:
                     logger.info("Handling customer.subscription.deleted")

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1475,12 +1475,11 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Mirror cancel_at_period_end -> scheduled_downgrade. The upsert
-        # set scheduled_downgrade=False unconditionally; only override when
-        # the event carries cancel_at_period_end=True, so the common (no-
-        # cancel) case avoids an extra query. This is the P2 addition that
-        # captures Stripe-initiated downgrades (proration, payment-method-
-        # failure auto-cancel, plan change at period end).
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade.
+        # Step 4's upsert (_apply_subscription_update) always resets
+        # scheduled_downgrade=False, so the False case is already handled.
+        # We only need a second query when cancel_at_period_end=True to
+        # flip it back on.
         cancel_at_period_end = bool(subscription_data.get("cancel_at_period_end"))
         if cancel_at_period_end:
             subscription = (
@@ -1494,12 +1493,14 @@ class WebhookService:
 
         # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
-        rows_updated = db.execute(
-            update(UserStorageUsage)
-            .where(UserStorageUsage.user_id == user_id)
-            .values(storage_quota_bytes=storage_quota_bytes)
-        ).rowcount
-        if not rows_updated:
+        existing_usage = (
+            db.query(UserStorageUsage)
+            .filter(UserStorageUsage.user_id == user_id)
+            .first()
+        )
+        if existing_usage:
+            existing_usage.storage_quota_bytes = storage_quota_bytes
+        else:
             db.add(
                 UserStorageUsage(
                     user_id=user_id,
@@ -1631,7 +1632,7 @@ class WebhookService:
                     return WebhookService.handle_invoice_finalized(data)
 
                 case _:
-                    logger.info(f"Unhandled webhook event type: {event_type}")
+                    logger.warning(f"Unhandled webhook event type: {event_type}")
                     return {
                         "success": True,
                         "message": f"Unhandled event type: {event_type}",

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1490,6 +1490,10 @@ class WebhookService:
         try:
             plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
+            logger.warning(
+                f"Webhook: Invalid plan_id '{plan_id_raw}' in subscription metadata for"
+                f" {stripe_subscription_id}; defaulting to PREMIUM"
+            )
             plan_id = SubscriptionPlanIds.PREMIUM
         if not plan_id_raw:
             logger.warning(

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1459,18 +1459,14 @@ class WebhookService:
                 "success": True,
                 "skipped": True,
                 "reason": "missing_expiration",
-                "message": (
-                    f"No period end in subscription: {stripe_subscription_id}"
-                ),
+                "message": (f"No period end in subscription: {stripe_subscription_id}"),
             }
 
         # 3. Derive plan from subscription metadata, default to premium
         metadata = subscription_data.get("metadata") or {}
         plan_id_raw = metadata.get("plan_id")
         try:
-            plan_id = (
-                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
-            )
+            plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
             plan_id = SubscriptionPlanIds.PREMIUM
 
@@ -1485,9 +1481,7 @@ class WebhookService:
         # cancel) case avoids an extra query. This is the P2 addition that
         # captures Stripe-initiated downgrades (proration, payment-method-
         # failure auto-cancel, plan change at period end).
-        cancel_at_period_end = bool(
-            subscription_data.get("cancel_at_period_end")
-        )
+        cancel_at_period_end = bool(subscription_data.get("cancel_at_period_end"))
         if cancel_at_period_end:
             subscription = (
                 db.query(UserSubscription)
@@ -1496,9 +1490,7 @@ class WebhookService:
             )
             if subscription is not None:
                 subscription.scheduled_downgrade = True
-                subscription.updated_at = (
-                    SubscriptionService.get_current_datetime()
-                )
+                subscription.updated_at = SubscriptionService.get_current_datetime()
 
         # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -6,6 +6,7 @@ import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from studio.app.common.core.logger import AppLogger
@@ -1501,7 +1502,7 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Sync storage quota to the plan
+        # 5. Sync storage quota to the plan (idempotent under concurrent webhooks)
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
         rows_updated = db.execute(
             update(UserStorageUsage)
@@ -1509,13 +1510,28 @@ class WebhookService:
             .values(storage_quota_bytes=storage_quota_bytes)
         ).rowcount
         if not rows_updated:
-            db.add(
-                UserStorageUsage(
-                    user_id=user_id,
-                    storage_usage_bytes=0,
-                    storage_quota_bytes=storage_quota_bytes,
+            try:
+                db.add(
+                    UserStorageUsage(
+                        user_id=user_id,
+                        storage_usage_bytes=0,
+                        storage_quota_bytes=storage_quota_bytes,
+                    )
                 )
-            )
+                db.flush()
+            except IntegrityError:
+                # checkout.session.completed already inserted the row;
+                # rollback the failed INSERT and UPDATE instead.
+                logger.warning(
+                    f"Webhook: Concurrent storage insert for user {user_id}; "
+                    f"falling back to update"
+                )
+                db.rollback()
+                db.execute(
+                    update(UserStorageUsage)
+                    .where(UserStorageUsage.user_id == user_id)
+                    .values(storage_quota_bytes=storage_quota_bytes)
+                )
 
         db.commit()
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1615,9 +1615,21 @@ class WebhookService:
           payment-method-failure auto-cancel, etc.) does not silently drift
           from Stripe.
         """
-        return WebhookService._sync_subscription_from_event(
-            db, subscription_data, event_label="updated"
-        )
+        try:
+            return WebhookService._sync_subscription_from_event(
+                db, subscription_data, event_label="updated"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Webhook: Error handling subscription.updated: {e}",
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error processing subscription.updated: {e}",
+            )
 
     @staticmethod
     async def _release_premium_assignment(

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -4,9 +4,11 @@ import os
 # Set environment variables before other imports
 os.environ["STRIPE_SECRET_KEY"] = "sk_test_fake_key_for_testing"
 
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 
@@ -127,6 +129,81 @@ class TestCheckoutIntegration:
 
         # Should fail signature verification
         assert response.status_code == 400
+
+
+class TestCreateOrUpdateSubscriptionConcurrency:
+    """create_or_update_subscription idempotency under concurrent inserts.
+
+    Guards the race in issue #629 where checkout.session.completed and
+    customer.subscription.created can both reach the INSERT branch and one
+    hits the unique constraint on subscription_users.user_id. The handler
+    catches IntegrityError and falls back to selecting + updating the row
+    the racing delivery created.
+    """
+
+    @staticmethod
+    def _mock_db(existing_first, existing_after_conflict):
+        """db whose SELECT...FOR UPDATE returns existing_first, then
+        existing_after_conflict on the post-conflict re-select."""
+        from unittest.mock import MagicMock
+
+        db = Mock()
+        first = Mock(side_effect=[existing_first, existing_after_conflict])
+        db.query.return_value.filter.return_value.with_for_update.return_value.first = (
+            first
+        )
+        # begin_nested() as a context manager that does NOT suppress exceptions.
+        cm = MagicMock()
+        cm.__enter__.return_value = cm
+        cm.__exit__.return_value = False
+        db.begin_nested.return_value = cm
+        db.add = Mock()
+        return db
+
+    def test_concurrent_insert_falls_back_to_update(self):
+        """A unique-constraint conflict on insert re-selects and updates."""
+        from studio.app.common.core.subscription.checkout_service import (
+            CheckoutService,
+        )
+
+        existing_row = Mock()
+        existing_row.id = 555
+        db = self._mock_db(existing_first=None, existing_after_conflict=existing_row)
+        # The insert flush raises a unique-violation IntegrityError.
+        db.flush = Mock(
+            side_effect=IntegrityError("INSERT", {}, Exception("duplicate user_id"))
+        )
+
+        expiration = datetime.now() + timedelta(days=30)
+        with patch.object(
+            SubscriptionService, "get_current_datetime", return_value=datetime.now()
+        ):
+            result_id = CheckoutService.create_or_update_subscription(
+                db, user_id=42, plan_id=2, expiration_date=expiration
+            )
+
+        # Fell back to updating the row the racing delivery created.
+        assert result_id == 555
+        assert existing_row.plan_id == 2
+        assert existing_row.expiration == expiration
+        assert existing_row.scheduled_downgrade is False
+
+    def test_other_integrity_error_is_not_swallowed(self):
+        """If no row exists even after the conflict, the error is re-raised."""
+        from studio.app.common.core.subscription.checkout_service import (
+            CheckoutService,
+        )
+
+        db = self._mock_db(existing_first=None, existing_after_conflict=None)
+        db.flush = Mock(
+            side_effect=IntegrityError("INSERT", {}, Exception("some other constraint"))
+        )
+
+        expiration = datetime.now() + timedelta(days=30)
+        with pytest.raises(IntegrityError):
+            CheckoutService.create_or_update_subscription(
+                db, user_id=42, plan_id=2, expiration_date=expiration
+            )
 
 
 if __name__ == "__main__":

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -162,9 +162,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_concurrent_insert_falls_back_to_update(self):
         """A unique-constraint conflict on insert re-selects and updates."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         existing_row = Mock()
         existing_row.id = 555
@@ -190,9 +188,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_other_integrity_error_is_not_swallowed(self):
         """If no row exists even after the conflict, the error is re-raised."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         db = self._mock_db(existing_first=None, existing_after_conflict=None)
         db.flush = Mock(

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 
 
@@ -177,12 +178,15 @@ class TestCreateOrUpdateSubscriptionConcurrency:
             SubscriptionService, "get_current_datetime", return_value=datetime.now()
         ):
             result_id = CheckoutService.create_or_update_subscription(
-                db, user_id=42, plan_id=2, expiration_date=expiration
+                db,
+                user_id=42,
+                plan_id=SubscriptionPlanIds.PREMIUM,
+                expiration_date=expiration,
             )
 
         # Fell back to updating the row the racing delivery created.
         assert result_id == 555
-        assert existing_row.plan_id == 2
+        assert existing_row.plan_id == SubscriptionPlanIds.PREMIUM
         assert existing_row.expiration == expiration
         assert existing_row.scheduled_downgrade is False
 
@@ -198,7 +202,10 @@ class TestCreateOrUpdateSubscriptionConcurrency:
         expiration = datetime.now() + timedelta(days=30)
         with pytest.raises(IntegrityError):
             CheckoutService.create_or_update_subscription(
-                db, user_id=42, plan_id=2, expiration_date=expiration
+                db,
+                user_id=42,
+                plan_id=SubscriptionPlanIds.PREMIUM,
+                expiration_date=expiration,
             )
 
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1214,11 +1214,24 @@ class TestSubscriptionLifecycleWebhooks:
         """Duplicate storage insert (race with checkout) falls back."""
         from sqlalchemy.exc import IntegrityError
 
-        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+        # Account lookup + user for cache invalidation
+        mock_db.query.side_effect = [
+            Mock(filter=Mock(return_value=Mock(
+                first=Mock(return_value=mock_user_account)
+            ))),
+            Mock(filter=Mock(return_value=Mock(
+                first=Mock(return_value=mock_user)
+            ))),
+        ]
 
-        # First execute() (UPDATE) returns 0 rows -> triggers INSERT path
-        # flush() raises IntegrityError -> falls back to second execute() (UPDATE)
+        # execute(UPDATE).rowcount = 0 -> triggers INSERT path
         mock_db.execute.return_value = Mock(rowcount=0)
+
+        # begin_nested() SAVEPOINT; flush raises IntegrityError
+        nested_cm = Mock()
+        nested_cm.__enter__ = Mock(return_value=None)
+        nested_cm.__exit__ = Mock(return_value=False)
+        mock_db.begin_nested.return_value = nested_cm
         mock_db.flush.side_effect = IntegrityError(
             "Duplicate entry", params=None, orig=Exception()
         )
@@ -1235,8 +1248,10 @@ class TestSubscriptionLifecycleWebhooks:
 
         assert result["success"] is True
         assert result["user_id"] == 42
-        mock_db.rollback.assert_called_once()
-        # Two execute() calls: first UPDATE (0 rows), then fallback UPDATE
+        # SAVEPOINT used, NOT full rollback
+        mock_db.begin_nested.assert_called_once()
+        mock_db.rollback.assert_not_called()
+        # execute() calls: initial UPDATE (0 rows) + fallback UPDATE
         assert mock_db.execute.call_count == 2
 
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -4,9 +4,16 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlmodel import Session
 
-from studio.app.common.core.subscription.checkout_service import CheckoutService
-from studio.app.common.core.subscription.constants import SyncStatus
-from studio.app.common.core.subscription.subscription_service import SubscriptionService
+from studio.app.common.core.subscription.checkout_service import (
+    CheckoutService,
+)
+from studio.app.common.core.subscription.constants import (
+    SubscriptionPlanIds,
+    SyncStatus,
+)
+from studio.app.common.core.subscription.subscription_service import (
+    SubscriptionService,
+)
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
@@ -898,15 +905,19 @@ class TestSubscriptionLifecycleWebhooks:
             "customer": "cus_test123",
             "status": "active",
             "current_period_end": 2000000000,  # far-future unix timestamp
-            "metadata": {"plan_id": "2"},
+            "metadata": {"plan_id": str(SubscriptionPlanIds.PREMIUM)},
         }
 
     def _setup_query_chain(self, mock_db, account, user):
-        """Sequential query results: account lookup, then user (for cache)."""
+        """Sequential query results: account, storage usage, then user (cache)."""
+        mock_storage = Mock()
+        mock_storage.storage_quota_bytes = 214748364800
         mock_db.query.side_effect = [
             # 1. SubscriptionUserAccount by customer_id
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=account)))),
-            # 2. User for cache invalidation
+            # 2. UserStorageUsage by user_id (storage quota sync)
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_storage)))),
+            # 3. User for cache invalidation
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=user)))),
         ]
 
@@ -928,11 +939,11 @@ class TestSubscriptionLifecycleWebhooks:
 
         assert result["success"] is True
         assert result["user_id"] == 42
-        assert result["plan_id"] == 2
+        assert result["plan_id"] == SubscriptionPlanIds.PREMIUM
         mock_upsert.assert_called_once()
         upsert_args = mock_upsert.call_args[0]
         assert upsert_args[1] == 42  # user_id
-        assert upsert_args[2] == 2  # plan_id from metadata
+        assert upsert_args[2] == SubscriptionPlanIds.PREMIUM
         mock_db.commit.assert_called_once()
         mock_invalidate.assert_called_once_with("user_uid_42")
 
@@ -1021,8 +1032,11 @@ class TestSubscriptionLifecycleWebhooks:
         mock_subscription.scheduled_downgrade = False
         mock_subscription.updated_at = None
 
-        # Query side_effect: account, subscription re-query (override path),
-        # then user (cache invalidation).
+        mock_storage = Mock()
+        mock_storage.storage_quota_bytes = 214748364800
+
+        # Query side_effect: account, subscription re-query (cancel path),
+        # storage usage, then user (cache invalidation).
         mock_db.query.side_effect = [
             Mock(
                 filter=Mock(
@@ -1032,6 +1046,11 @@ class TestSubscriptionLifecycleWebhooks:
             Mock(
                 filter=Mock(
                     return_value=Mock(first=Mock(return_value=mock_subscription))
+                )
+            ),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_storage))
                 )
             ),
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
@@ -1051,6 +1070,35 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["scheduled_downgrade"] is True
         assert mock_subscription.scheduled_downgrade is True
         assert mock_subscription.updated_at is not None
+
+    def test_subscription_updated_resets_scheduled_downgrade_when_uncancelled(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """`updated` with cancel_at_period_end=False resets scheduled_downgrade.
+
+        When a user un-cancels in Stripe, the upsert in Step 4
+        (_apply_subscription_update) unconditionally sets
+        scheduled_downgrade=False, so the local state is corrected.
+        """
+        subscription_event["cancel_at_period_end"] = False
+        # cancel_at_period_end=False -> helper skips the subscription
+        # re-query, so the query chain is just account + user.
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["scheduled_downgrade"] is False
+        # Verify upsert was called (it resets scheduled_downgrade=False)
+        mock_upsert.assert_called_once()
 
     def test_updated_past_due_still_marked_synced(
         self, mock_db, mock_user_account, mock_user, subscription_event

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1326,6 +1326,31 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["success"] is True
         mock_upsert.assert_called_once()
 
+    def test_subscription_updated_error_logs_traceback(
+        self, mock_db, mock_user_account, subscription_event
+    ):
+        """Errors in handle_subscription_updated log full traceback."""
+        from fastapi import HTTPException
+
+        mock_db.query.side_effect = [
+            # 1. SubscriptionUserAccount lookup succeeds
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+        ]
+
+        with patch.object(
+            CheckoutService,
+            "create_or_update_subscription",
+            side_effect=RuntimeError("db write failed"),
+        ), pytest.raises(HTTPException) as exc_info:
+            WebhookService.handle_subscription_updated(mock_db, subscription_event)
+
+        assert exc_info.value.status_code == 500
+        assert "subscription.updated" in exc_info.value.detail
+
     # --- Concurrency ---
 
     def test_concurrent_storage_insert_falls_back_to_update(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1216,12 +1216,12 @@ class TestSubscriptionLifecycleWebhooks:
 
         # Account lookup + user for cache invalidation
         mock_db.query.side_effect = [
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user_account)
-            ))),
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user)
-            ))),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 
         # execute(UPDATE).rowcount = 0 -> triggers INSERT path

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -857,5 +857,145 @@ class TestCheckoutStorageQuotaUpdate:
         assert added_obj.storage_quota_bytes == expected_quota
 
 
+class TestSubscriptionLifecycleWebhooks:
+    """Tests for customer.subscription.created handling (issue #629, P1).
+
+    Verifies that the new `created` webhook activates a subscription
+    end-to-end so users are no longer stuck on "Activation Pending" when
+    `checkout.session.completed` can't complete the activation on its own.
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        db = Mock(spec=Session)
+        db.query = Mock()
+        db.add = Mock()
+        db.flush = Mock()
+        db.commit = Mock()
+        db.rollback = Mock()
+        db.execute = Mock()
+        return db
+
+    @pytest.fixture
+    def mock_user_account(self):
+        account = Mock()
+        account.user_id = 42
+        account.provider_customer_id = "cus_test123"
+        return account
+
+    @pytest.fixture
+    def mock_user(self):
+        user = Mock()
+        user.id = 42
+        user.uid = "user_uid_42"
+        return user
+
+    @pytest.fixture
+    def subscription_event(self):
+        """A customer.subscription.created event payload (event['data']['object'])."""
+        return {
+            "id": "sub_stripe123",
+            "customer": "cus_test123",
+            "status": "active",
+            "current_period_end": 2000000000,  # far-future unix timestamp
+            "metadata": {"plan_id": "2"},
+        }
+
+    def _setup_query_chain(self, mock_db, account, user):
+        """Sequential query results: account lookup, then user (for cache)."""
+        mock_db.query.side_effect = [
+            # 1. SubscriptionUserAccount by customer_id
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=account)))),
+            # 2. User for cache invalidation
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=user)))),
+        ]
+
+    def test_subscription_created_activates_subscription(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """`created` upserts subscription_users and invalidates the tier cache."""
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ) as mock_invalidate:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["user_id"] == 42
+        assert result["plan_id"] == 2
+        mock_upsert.assert_called_once()
+        upsert_args = mock_upsert.call_args[0]
+        assert upsert_args[1] == 42  # user_id
+        assert upsert_args[2] == 2  # plan_id from metadata
+        mock_db.commit.assert_called_once()
+        mock_invalidate.assert_called_once_with("user_uid_42")
+
+    def test_dispatch_created_routes_to_handler(self, mock_db, subscription_event):
+        """dispatch routes `created` to handle_subscription_created."""
+        with patch.object(
+            WebhookService,
+            "handle_subscription_created",
+            return_value={"success": True},
+        ) as mock_created:
+            result = WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.created", subscription_event
+            )
+
+        assert result["success"] is True
+        mock_created.assert_called_once_with(mock_db, subscription_event)
+
+    def test_subscription_event_acknowledged_when_no_account(
+        self, mock_db, subscription_event
+    ):
+        """Unknown customer is acknowledged without a DB write (no Stripe retries)."""
+        mock_db.query.side_effect = [
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
+        ]
+        with patch.object(
+            CheckoutService, "create_or_update_subscription"
+        ) as mock_upsert:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "missing_user_account"
+        mock_upsert.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+    def test_subscription_event_acknowledged_when_no_period_end(
+        self, mock_db, mock_user_account, subscription_event
+    ):
+        """Missing expiration is acknowledged without a DB write."""
+        subscription_event.pop("current_period_end")
+        subscription_event.pop("trial_end", None)
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+        ]
+        with patch.object(
+            CheckoutService, "create_or_update_subscription"
+        ) as mock_upsert:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "missing_expiration"
+        mock_upsert.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1345,21 +1345,21 @@ class TestSubscriptionLifecycleWebhooks:
 
         mock_db.query.side_effect = [
             # 1. SubscriptionUserAccount by customer_id
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user_account)
-            ))),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
             # 2. UserStorageUsage -> None (triggers INSERT path)
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=None)
-            ))),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
             # 3. After rollback, re-query storage -> found
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_storage_after)
-            ))),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_storage_after))
+                )
+            ),
             # 4. User for cache invalidation
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user)
-            ))),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 
         with patch.object(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1208,6 +1208,37 @@ class TestSubscriptionLifecycleWebhooks:
         mock_upsert.assert_not_called()
         mock_db.commit.assert_not_called()
 
+    def test_concurrent_storage_insert_falls_back_to_update(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """Duplicate storage insert (race with checkout) falls back."""
+        from sqlalchemy.exc import IntegrityError
+
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        # First execute() (UPDATE) returns 0 rows -> triggers INSERT path
+        # flush() raises IntegrityError -> falls back to second execute() (UPDATE)
+        mock_db.execute.return_value = Mock(rowcount=0)
+        mock_db.flush.side_effect = IntegrityError(
+            "Duplicate entry", params=None, orig=Exception()
+        )
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ), patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["user_id"] == 42
+        mock_db.rollback.assert_called_once()
+        # Two execute() calls: first UPDATE (0 rows), then fallback UPDATE
+        assert mock_db.execute.call_count == 2
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -5,7 +5,10 @@ import pytest
 from sqlmodel import Session
 
 from studio.app.common.core.subscription.checkout_service import CheckoutService
-from studio.app.common.core.subscription.constants import SubscriptionPlanIds, SyncStatus
+from studio.app.common.core.subscription.constants import (
+    SubscriptionPlanIds,
+    SyncStatus,
+)
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1339,27 +1339,13 @@ class TestSubscriptionLifecycleWebhooks:
             # 1. SubscriptionUserAccount by customer_id
             Mock(
                 filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=mock_user_account)
-                    )
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
                 )
             ),
             # 2. UserStorageUsage -> None (triggers INSERT path)
-            Mock(
-                filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=None)
-                    )
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
             # 3. User for cache invalidation
-            Mock(
-                filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=mock_user)
-                    )
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 
         # begin_nested() SAVEPOINT; flush raises IntegrityError

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1048,11 +1048,7 @@ class TestSubscriptionLifecycleWebhooks:
                     return_value=Mock(first=Mock(return_value=mock_subscription))
                 )
             ),
-            Mock(
-                filter=Mock(
-                    return_value=Mock(first=Mock(return_value=mock_storage))
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_storage)))),
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -4,16 +4,9 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlmodel import Session
 
-from studio.app.common.core.subscription.checkout_service import (
-    CheckoutService,
-)
-from studio.app.common.core.subscription.constants import (
-    SubscriptionPlanIds,
-    SyncStatus,
-)
-from studio.app.common.core.subscription.subscription_service import (
-    SubscriptionService,
-)
+from studio.app.common.core.subscription.checkout_service import CheckoutService
+from studio.app.common.core.subscription.constants import SubscriptionPlanIds, SyncStatus
+from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1127,19 +1127,40 @@ class TestSubscriptionLifecycleWebhooks:
         mock_db.commit.assert_called_once()
         mock_invalidate.assert_called_once_with("user_uid_42")
 
-    def test_dispatch_created_routes_to_handler(self, mock_db, subscription_event):
+    @pytest.mark.asyncio
+    async def test_dispatch_created_routes_to_handler(
+        self, mock_db, subscription_event
+    ):
         """dispatch routes `created` to handle_subscription_created."""
         with patch.object(
             WebhookService,
             "handle_subscription_created",
             return_value={"success": True},
         ) as mock_created:
-            result = WebhookService.dispatch_webhook_event(
+            result = await WebhookService.dispatch_webhook_event(
                 mock_db, "customer.subscription.created", subscription_event
             )
 
         assert result["success"] is True
         mock_created.assert_called_once_with(mock_db, subscription_event)
+
+    def test_subscription_event_acknowledged_when_no_customer_id(
+        self, mock_db, subscription_event
+    ):
+        """Missing customer ID is acknowledged without a DB write."""
+        subscription_event.pop("customer")
+        with patch.object(
+            CheckoutService, "create_or_update_subscription"
+        ) as mock_upsert:
+            result = WebhookService.handle_subscription_created(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "missing_customer_id"
+        mock_upsert.assert_not_called()
+        mock_db.commit.assert_not_called()
 
     def test_subscription_event_acknowledged_when_no_account(
         self, mock_db, subscription_event

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -996,6 +996,92 @@ class TestSubscriptionLifecycleWebhooks:
         mock_upsert.assert_not_called()
         mock_db.commit.assert_not_called()
 
+    # --- P2: handle_subscription_updated ---
+
+    def test_dispatch_updated_routes_to_handler(self, mock_db, subscription_event):
+        """dispatch routes `updated` to handle_subscription_updated."""
+        with patch.object(
+            WebhookService,
+            "handle_subscription_updated",
+            return_value={"success": True},
+        ) as mock_updated:
+            result = WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.updated", subscription_event
+            )
+        assert result["success"] is True
+        mock_updated.assert_called_once_with(mock_db, subscription_event)
+
+    def test_subscription_updated_mirrors_scheduled_downgrade(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """`updated` with cancel_at_period_end=True flips scheduled_downgrade."""
+        subscription_event["cancel_at_period_end"] = True
+
+        mock_subscription = Mock()
+        mock_subscription.scheduled_downgrade = False
+        mock_subscription.updated_at = None
+
+        # Query side_effect: account, subscription re-query (override path),
+        # then user (cache invalidation).
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_subscription))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ), patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["scheduled_downgrade"] is True
+        assert mock_subscription.scheduled_downgrade is True
+        assert mock_subscription.updated_at is not None
+
+    def test_updated_past_due_still_marked_synced(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A successfully-mirrored past_due subscription stays SYNCED.
+
+        sync_status tracks DB<->Stripe sync success, not billing health: a
+        past_due event we wrote to the DB is still SYNCED. Tier is derived
+        from `expiration` at read time.
+        """
+        subscription_event["status"] = "past_due"
+        # cancel_at_period_end stays False (fixture default) -> helper skips
+        # the subscription re-query, so the query chain is just account + user.
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        # The upsert ran (mirrored); sync_status is set to SYNCED by
+        # CheckoutService.create_or_update_subscription regardless of the
+        # Stripe status field.
+        mock_upsert.assert_called_once()
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
# fix(subscription): handle `customer.subscription.created` webhook (closes #629 — Problem 1)
 
Closes #629 (Problem 1 only).
 
> **Scope.** Issue #629 documented three consequences (P1 / P2 / P3). To keep review tight, the fix is being split into a PR per problem. **This PR is P1 only** — the activation half (Scenario 1 / system test **600‑17a**). Problems P2, P3 and the follow‑up hardening surfaced in review (release timeout, active‑user email lookup) will land on their own branches: `fix/629-handle-subscription-updated`, `fix/629-release-premium-on-delete-and-sweep`, etc.
 
## Reported problem (this PR)
 
| # | Problem (issue ref) | Occurrence rate | Cause & why it wasn't caught earlier | Risk — to users | Risk — to the system |
|---|---------------------|-----------------|--------------------------------------|-----------------|----------------------|
| 1 | New paid subscription not activated locally; UI stuck on "Activation Pending" (Scenario 1 / **600‑17a**) | Conditional — whenever activation must fall back to `customer.subscription.created` (i.e. `checkout.session.completed` is delayed, fails partway, or isn't delivered). In 600‑17a it hit every new Upgrade because the flow relied on the ignored `created` event | No `case` for `customer.subscription.created` in `WebhookService.dispatch_webhook_event` → silent "Unhandled" default (200 OK, no DB write). **Not caught before** because subscription registration/activation already worked through the primary `checkout.session.completed` path, and existing tests bypassed activation with a manual `subscription_users` INSERT — so the `created` handler was never exercised until 600‑17a hit the path that depends on it | Pays but is stuck on "Activation Pending" indefinitely, no self‑service recovery — appears the user paid for nothing | Manual DB INSERT per affected user (ops burden); support load; erodes trust in billing |
 
## Summary
 
The Stripe webhook dispatcher silently ignored `customer.subscription.created` — it fell through to the `Unhandled webhook event type` default and returned `200 OK` without touching the database. When `checkout.session.completed` couldn't carry activation on its own, `subscription_users` stayed empty and the `thanks` page's `validate-checkout-session` retry never resolved to SUCCESS — the user was permanently stuck on "Activation Pending."
 
This PR wires up `customer.subscription.created` to upsert `subscription_users` with the plan and expiration from the event, syncs the storage quota, and invalidates the tier cache. It also makes the upsert helper idempotent under concurrent webhook deliveries (the `created` handler can race `checkout.session.completed` on the unique `subscription_users.user_id`) so we don't 500 into a Stripe retry.
 
## Root cause
 
`WebhookService.dispatch_webhook_event` had no `case` for `customer.subscription.created`, so the event fell to the silent "Unhandled" default. Additionally, `CheckoutService.create_or_update_subscription` does `SELECT ... FOR UPDATE` then `INSERT`; with two webhook deliveries (`checkout.session.completed` and `customer.subscription.created`) now able to reach the insert branch concurrently, one would hit the `idx_user_id_unique` constraint and the handler would 500 — triggering a Stripe retry. The retry would succeed (the row now exists, so the helper takes the UPDATE branch), but it's avoidable noise.
 
## Changes
 
**`studio/app/common/core/subscription/constants.py`**
- Added `CUSTOMER_SUBSCRIPTION_CREATED = "customer.subscription.created"` to `StripeWebhookEvent`.
**`studio/app/common/core/subscription/webhook_service.py`**
- Added `_sync_subscription_from_event(...)`, a private helper used by the new `handle_subscription_created`. It maps the Stripe `customer` → local `SubscriptionUserAccount` → `user_id`; derives expiration from `trial_end` / `current_period_end`; derives plan from `metadata.plan_id` (defaulting to premium); upserts `subscription_users` via `CheckoutService.create_or_update_subscription`; syncs the storage quota; and invalidates the tier cache. When the customer can't be mapped or the event has no period end, it acknowledges with 200 and **no** DB write to avoid Stripe retries.
- Added `handle_subscription_created(...)` that delegates to the helper with `event_label="created"`.
- Routed the new event in `dispatch_webhook_event` (the dispatch stays synchronous — no async surface added in this PR).
**`studio/app/common/core/subscription/checkout_service.py`**
- Imported `IntegrityError` from `sqlalchemy.exc`.
- Made `create_or_update_subscription` idempotent under concurrent inserts: the `INSERT`/`flush` runs inside a `SAVEPOINT` (`db.begin_nested()`); on `IntegrityError` it rolls back the savepoint, re-selects the row the racing delivery just created (`SELECT ... FOR UPDATE`), and updates it instead. If the conflict somehow leaves no row, the original error is re-raised. Extracted the standard field-update logic into a `_apply_subscription_update(...)` helper so the update and conflict-fallback paths stay in sync.
**`studio/tests/app/common/routers/test_webhook.py`**
- New `TestSubscriptionLifecycleWebhooks` suite (4 tests): the activation path, dispatch routing for `created`, and two acknowledge-without-write guards (missing account / missing period end).
**`studio/tests/app/common/routers/test_checkout.py`**
- New `TestCreateOrUpdateSubscriptionConcurrency` suite (2 tests): conflict → fallback-update; conflict-but-missing → re-raise.
## Behavior: before → after
 
| Scenario | Before | After |
| --- | --- | --- |
| `customer.subscription.created` | Ignored (logged "Unhandled", 200 OK) | Upserts `subscription_users` (plan + expiration); UI flips to premium without manual INSERT bypass |
| Concurrent `checkout.session.completed` + `created` for the same user | One delivery `IntegrityError`s → 500 → Stripe retry | Idempotent upsert: the conflict falls back to an update; both deliveries succeed |
 
## Test plan
 
CI/local: run the targeted tests in your poetry env (the sandbox can't run them — pydantic v1 isn't installed).
 
```
poetry run pytest studio/tests/app/common/routers/test_webhook.py \
                  studio/tests/app/common/routers/test_checkout.py -v
```
 
### Automated unit tests added
 
| Test | Category | Verifies |
|------|----------|----------|
| `test_subscription_created_activates_subscription` | P1 Activation | `created` upserts `subscription_users` (plan + expiration), `sync_status=synced`; tier cache invalidated |
| `test_dispatch_created_routes_to_handler` | P1 Activation | `dispatch_webhook_event` routes `customer.subscription.created` → `handle_subscription_created` |
| `test_subscription_event_acknowledged_when_no_account` | P1 Guard | Unknown customer → 200 ack, no DB write, no Stripe retry |
| `test_subscription_event_acknowledged_when_no_period_end` | P1 Guard | Event with no period end → ack, no DB write |
| `test_concurrent_insert_falls_back_to_update` | P1 Concurrency | Racing insert → `IntegrityError` → re-select + update (idempotent) |
| `test_other_integrity_error_is_not_swallowed` | P1 Concurrency | Non-conflict `IntegrityError` is re-raised |
 
Static verification (already run locally):
- `py_compile`: ✅ clean on all changed files.
- `flake8 --max-line-length=88`: ✅ clean on all changed files.
### Manual / system test cases
 
#### TC‑S1 — P1 Activation (system test 600‑17a)
 
**Objective.** Confirm `customer.subscription.created` activates a new paid subscription end‑to‑end **without** the manual `subscription_users` INSERT bypass.
 
**Preconditions.**
1. This PR is deployed to dev. Confirm by triggering a webhook (or via TC‑S3 below) and seeing `Handling customer.subscription.created` (not `Unhandled webhook event type: customer.subscription.created`) in CloudWatch (`/ecs/development-optinist-cloud-taskdef`).
2. Stripe test mode; the dev webhook endpoint is subscribed to `customer.subscription.created` and `checkout.session.completed`.
3. A dev test user with no premium subscription:
   ```sql
   SELECT id, email, active FROM users WHERE email = '<TEST_EMAIL>';
   -- Expected: 1 row, active = 1. Record <UID>.
   SELECT id, plan_id, expiration FROM subscription_users WHERE user_id = <UID>;
   -- Expected: 0 rows (or only a FREE row with no future expiration).
   ```
 
**Steps.**
1. Note start time `T0` (UTC): `date -u +%FT%TZ`.
2. Log in to the dev frontend as `<TEST_EMAIL>`.
3. Navigate to **Subscription → Upgrade** and click Upgrade.
4. On Stripe Checkout, enter test card `4242 4242 4242 4242`, exp `12/34`, CVC `123`, ZIP `12345`, then click **Pay**. The browser redirects to `/subscription/thanks`.
5. In Stripe Dashboard → *Developers → Webhooks → endpoint → Recent deliveries*, find the `customer.subscription.created` delivery for this customer; confirm status **200**.
6. Wait on `/subscription/thanks`. The page calls `POST /api/subsc/checkout/validate-checkout-session` and retries once on `WEBHOOK_FAILED`. It should resolve to "Thank you!" within ~5 s.
7. Navigate to Dashboard. The premium tier indicator/feature gates must be visible.
**Verification.**
- CloudWatch (window: `T0 − 1 min` … now):
  ```
  fields @timestamp, @message
  | filter @message like /Handling customer.subscription.created|Webhook: Synced subscription.created for user|Validating checkout session ID|valid and database is updated/
  | sort @timestamp asc
  ```
  Expected: `Handling customer.subscription.created`, `Webhook: Synced subscription.created for user <UID>`, then `Checkout session ... is valid and database is updated ... for user <UID>`.
- Negative assertion in the same window:
  ```
  filter @message like /Unhandled webhook event type: customer.subscription.created/
  ```
  Expected: **0** results.
- DB:
  ```sql
  SELECT user_id, plan_id, expiration, scheduled_downgrade, sync_status
  FROM subscription_users WHERE user_id = <UID>;
  -- Expected: 1 row, plan_id = 2 (PREMIUM), expiration in the future, sync_status = 'synced'.
 
  SELECT provider_customer_id FROM subscription_user_accounts WHERE user_id = <UID>;
  -- Expected: 1 row with the Stripe customer id (cus_…) for this checkout.
  ```
 
**Pass criteria.** Positive CW lines present; negative CW filter empty; DB rows match; UI never displays "Activation Pending."
 
**Cleanup.** Cancel the subscription in Stripe Dashboard (immediately) and/or soft‑delete the test user.
 
#### TC‑S2 — P1 Guard (acknowledge without writing)
 
**Objective.** Confirm `customer.subscription.created` events for an unknown customer or with no period end are acknowledged with 200, no DB write, no Stripe retry.
 
**Steps.**
1. From Stripe Dashboard → *Developers → Events*, pick (or trigger) a `customer.subscription.created` for a customer with no matching `subscription_user_accounts.provider_customer_id` (e.g. a freshly created Stripe customer with no checkout). Click **Resend**.
2. Separately, resend (or trigger) an event with no `current_period_end` and no `trial_end` in the payload.
**Verification.**
- CW for each delivery:
  ```
  filter @message like /Webhook: No user account for customer_id|acknowledging subscription.created without DB change|No period end in subscription|missing_user_account|missing_expiration/
  ```
  Expected: the corresponding warning line is present.
- Stripe Dashboard: both deliveries show **200**, no retries scheduled.
- DB: no rows added to `subscription_users` for the unknown user.
**Pass criteria.** 200 ack; no DB write; no Stripe retry.
 
#### TC‑S3 — P1 Concurrency (idempotent upsert under racing webhooks)
 
**Objective.** Confirm a `customer.subscription.created` racing `checkout.session.completed` on the same user no longer 500s into a Stripe retry.
 
**Practical notes.** This race is timing-sensitive; the deterministic coverage is the unit test `test_concurrent_insert_falls_back_to_update`. The manual reproduction here is best-effort:
 
**Steps.**
1. Set up a test user as in TC‑S1.
2. In Stripe Dashboard → Recent deliveries, identify the `customer.subscription.created` and `checkout.session.completed` deliveries for the test customer and **resend both** as close together as possible (or use the Stripe CLI to fan them out).
3. Watch CloudWatch for both deliveries.
**Verification.**
- CW: zero `Webhook processing error` lines for these two events.
- CW: at most one `Concurrent insert detected for subscription_users user_id=<UID>; falling back to update` warning — this is **expected and benign** under a real race.
- Stripe Dashboard: both deliveries 200, no retries.
- DB:
  ```sql
  SELECT COUNT(*) FROM subscription_users WHERE user_id = <UID>;
  -- Expected: 1 (no duplicate).
  ```
 
**Pass criteria.** Both deliveries 200; no Stripe retries; exactly one `subscription_users` row.
 
## Notes
 
- Plan resolution defaults to premium when `metadata.plan_id` is absent on the subscription object. If `plan_id` is set in the Stripe subscription metadata at checkout, that value is used.
- Dispatch remains synchronous in this PR — making it async is only required when the `customer.subscription.deleted` case needs to `await` the premium release (that lands with the P3 branch).
- The new `created` handler is intentionally narrow: it activates the subscription and invalidates the tier cache. It does **not** mirror `cancel_at_period_end` or other plan changes — that's `customer.subscription.updated` (Problem 2), which will be added on `fix/629-handle-subscription-updated`.
## Checklist
 
- [x] Tests pass in CI (the 6 new tests plus the existing webhook/checkout suites).
- [x] In dev, the Stripe webhook endpoint is subscribed to `customer.subscription.created` (in addition to the existing events).
- [x] Dev activation flow (TC‑S1) no longer requires the manual `subscription_users` INSERT bypass.
- [x] Guard cases (TC‑S2) return 200 without a DB write; no Stripe retries.
- [x] Concurrent‑delivery sanity check (TC‑S3): no 500s; exactly one `subscription_users` row per user.
## Follow‑ups (separate branches)
 
- `fix/629-handle-subscription-updated` — Problem 2 (mirror `cancel_at_period_end`/plan/expiration changes from Stripe).
- `fix/629-release-premium-on-delete-and-sweep` — Problem 3 (release premium compute on `deleted` + hourly backstop sweep).
- Plus the review-driven hardening (release-call timeout, active-user email lookup) on their own branches as agreed.