### PR TITLE
fix(subscription): handle `customer.subscription.updated` webhook (closes #629 — Problem 2)

### DIFF
--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -119,6 +119,7 @@ class StripeWebhookEvent(StrEnum):
     CHECKOUT_SESSION_COMPLETED = "checkout.session.completed"
     INVOICE_PAYMENT_FAILED = "invoice.payment_failed"
     CUSTOMER_SUBSCRIPTION_CREATED = "customer.subscription.created"
+    CUSTOMER_SUBSCRIPTION_UPDATED = "customer.subscription.updated"
     CUSTOMER_SUBSCRIPTION_DELETED = "customer.subscription.deleted"
     SUBSCRIPTION_SCHEDULE_RELEASED = "subscription_schedule.released"
     INVOICE_PAYMENT_SUCCEEDED = "invoice.payment_succeeded"

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1479,7 +1479,28 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Sync storage quota to the plan
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade. The upsert
+        # set scheduled_downgrade=False unconditionally; only override when
+        # the event carries cancel_at_period_end=True, so the common (no-
+        # cancel) case avoids an extra query. This is the P2 addition that
+        # captures Stripe-initiated downgrades (proration, payment-method-
+        # failure auto-cancel, plan change at period end).
+        cancel_at_period_end = bool(
+            subscription_data.get("cancel_at_period_end")
+        )
+        if cancel_at_period_end:
+            subscription = (
+                db.query(UserSubscription)
+                .filter(UserSubscription.user_id == user_id)
+                .first()
+            )
+            if subscription is not None:
+                subscription.scheduled_downgrade = True
+                subscription.updated_at = (
+                    SubscriptionService.get_current_datetime()
+                )
+
+        # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
         rows_updated = db.execute(
             update(UserStorageUsage)
@@ -1497,20 +1518,22 @@ class WebhookService:
 
         db.commit()
 
-        # 6. Invalidate tier cache so the GUI reflects the change promptly
+        # 7. Invalidate tier cache so the GUI reflects the change promptly
         user = db.query(User).filter(User.id == user_id).first()
         if user:
             invalidate_user_tier_cache(user.uid)
 
         logger.info(
             f"Webhook: Synced subscription.{event_label} for user {user_id} "
-            f"(plan_id={plan_id}, expiration={expiration_date})"
+            f"(plan_id={plan_id}, expiration={expiration_date}, "
+            f"scheduled_downgrade={cancel_at_period_end})"
         )
         return {
             "success": True,
             "user_id": user_id,
             "plan_id": plan_id,
             "expiration": expiration_date,
+            "scheduled_downgrade": cancel_at_period_end,
             "message": f"Subscription {event_label} synced",
         }
 
@@ -1528,6 +1551,24 @@ class WebhookService:
         """
         return WebhookService._sync_subscription_from_event(
             db, subscription_data, event_label="created"
+        )
+
+    @staticmethod
+    def handle_subscription_updated(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Handle customer.subscription.updated webhook (issue #629, Problem 2).
+
+        Mirrors Stripe-initiated subscription changes into local state:
+        - plan + expiration (via the shared upsert), and
+        - cancel_at_period_end -> scheduled_downgrade (when scheduling a
+          downgrade), so a Stripe-initiated change (proration, plan change,
+          payment-method-failure auto-cancel, etc.) does not silently drift
+          from Stripe.
+        """
+        return WebhookService._sync_subscription_from_event(
+            db, subscription_data, event_label="updated"
         )
 
     @staticmethod
@@ -1562,6 +1603,10 @@ class WebhookService:
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_CREATED:
                     logger.info("Handling customer.subscription.created")
                     return WebhookService.handle_subscription_created(db, data)
+
+                case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_UPDATED:
+                    logger.info("Handling customer.subscription.updated")
+                    return WebhookService.handle_subscription_updated(db, data)
 
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED:
                     logger.info("Handling customer.subscription.deleted")

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1475,12 +1475,11 @@ class WebhookService:
             db, user_id, plan_id, expiration_date
         )
 
-        # 5. Mirror cancel_at_period_end -> scheduled_downgrade. The upsert
-        # set scheduled_downgrade=False unconditionally; only override when
-        # the event carries cancel_at_period_end=True, so the common (no-
-        # cancel) case avoids an extra query. This is the P2 addition that
-        # captures Stripe-initiated downgrades (proration, payment-method-
-        # failure auto-cancel, plan change at period end).
+        # 5. Mirror cancel_at_period_end -> scheduled_downgrade.
+        # Step 4's upsert (_apply_subscription_update) always resets
+        # scheduled_downgrade=False, so the False case is already handled.
+        # We only need a second query when cancel_at_period_end=True to
+        # flip it back on.
         cancel_at_period_end = bool(subscription_data.get("cancel_at_period_end"))
         if cancel_at_period_end:
             subscription = (
@@ -1494,12 +1493,14 @@ class WebhookService:
 
         # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
-        rows_updated = db.execute(
-            update(UserStorageUsage)
-            .where(UserStorageUsage.user_id == user_id)
-            .values(storage_quota_bytes=storage_quota_bytes)
-        ).rowcount
-        if not rows_updated:
+        existing_usage = (
+            db.query(UserStorageUsage)
+            .filter(UserStorageUsage.user_id == user_id)
+            .first()
+        )
+        if existing_usage:
+            existing_usage.storage_quota_bytes = storage_quota_bytes
+        else:
             db.add(
                 UserStorageUsage(
                     user_id=user_id,
@@ -1631,7 +1632,7 @@ class WebhookService:
                     return WebhookService.handle_invoice_finalized(data)
 
                 case _:
-                    logger.info(f"Unhandled webhook event type: {event_type}")
+                    logger.warning(f"Unhandled webhook event type: {event_type}")
                     return {
                         "success": True,
                         "message": f"Unhandled event type: {event_type}",

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1459,18 +1459,14 @@ class WebhookService:
                 "success": True,
                 "skipped": True,
                 "reason": "missing_expiration",
-                "message": (
-                    f"No period end in subscription: {stripe_subscription_id}"
-                ),
+                "message": (f"No period end in subscription: {stripe_subscription_id}"),
             }
 
         # 3. Derive plan from subscription metadata, default to premium
         metadata = subscription_data.get("metadata") or {}
         plan_id_raw = metadata.get("plan_id")
         try:
-            plan_id = (
-                int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
-            )
+            plan_id = int(plan_id_raw) if plan_id_raw else SubscriptionPlanIds.PREMIUM
         except (TypeError, ValueError):
             plan_id = SubscriptionPlanIds.PREMIUM
 
@@ -1485,9 +1481,7 @@ class WebhookService:
         # cancel) case avoids an extra query. This is the P2 addition that
         # captures Stripe-initiated downgrades (proration, payment-method-
         # failure auto-cancel, plan change at period end).
-        cancel_at_period_end = bool(
-            subscription_data.get("cancel_at_period_end")
-        )
+        cancel_at_period_end = bool(subscription_data.get("cancel_at_period_end"))
         if cancel_at_period_end:
             subscription = (
                 db.query(UserSubscription)
@@ -1496,9 +1490,7 @@ class WebhookService:
             )
             if subscription is not None:
                 subscription.scheduled_downgrade = True
-                subscription.updated_at = (
-                    SubscriptionService.get_current_datetime()
-                )
+                subscription.updated_at = SubscriptionService.get_current_datetime()
 
         # 6. Sync storage quota to the plan
         storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1615,9 +1615,21 @@ class WebhookService:
           payment-method-failure auto-cancel, etc.) does not silently drift
           from Stripe.
         """
-        return WebhookService._sync_subscription_from_event(
-            db, subscription_data, event_label="updated"
-        )
+        try:
+            return WebhookService._sync_subscription_from_event(
+                db, subscription_data, event_label="updated"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Webhook: Error handling subscription.updated: {e}",
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error processing subscription.updated: {e}",
+            )
 
     @staticmethod
     async def _release_premium_assignment(

--- a/studio/tests/app/common/routers/test_checkout.py
+++ b/studio/tests/app/common/routers/test_checkout.py
@@ -162,9 +162,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_concurrent_insert_falls_back_to_update(self):
         """A unique-constraint conflict on insert re-selects and updates."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         existing_row = Mock()
         existing_row.id = 555
@@ -190,9 +188,7 @@ class TestCreateOrUpdateSubscriptionConcurrency:
 
     def test_other_integrity_error_is_not_swallowed(self):
         """If no row exists even after the conflict, the error is re-raised."""
-        from studio.app.common.core.subscription.checkout_service import (
-            CheckoutService,
-        )
+        from studio.app.common.core.subscription.checkout_service import CheckoutService
 
         db = self._mock_db(existing_first=None, existing_after_conflict=None)
         db.flush = Mock(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -4,9 +4,16 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlmodel import Session
 
-from studio.app.common.core.subscription.checkout_service import CheckoutService
-from studio.app.common.core.subscription.constants import SyncStatus
-from studio.app.common.core.subscription.subscription_service import SubscriptionService
+from studio.app.common.core.subscription.checkout_service import (
+    CheckoutService,
+)
+from studio.app.common.core.subscription.constants import (
+    SubscriptionPlanIds,
+    SyncStatus,
+)
+from studio.app.common.core.subscription.subscription_service import (
+    SubscriptionService,
+)
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
@@ -898,15 +905,19 @@ class TestSubscriptionLifecycleWebhooks:
             "customer": "cus_test123",
             "status": "active",
             "current_period_end": 2000000000,  # far-future unix timestamp
-            "metadata": {"plan_id": "2"},
+            "metadata": {"plan_id": str(SubscriptionPlanIds.PREMIUM)},
         }
 
     def _setup_query_chain(self, mock_db, account, user):
-        """Sequential query results: account lookup, then user (for cache)."""
+        """Sequential query results: account, storage usage, then user (cache)."""
+        mock_storage = Mock()
+        mock_storage.storage_quota_bytes = 214748364800
         mock_db.query.side_effect = [
             # 1. SubscriptionUserAccount by customer_id
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=account)))),
-            # 2. User for cache invalidation
+            # 2. UserStorageUsage by user_id (storage quota sync)
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_storage)))),
+            # 3. User for cache invalidation
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=user)))),
         ]
 
@@ -928,11 +939,11 @@ class TestSubscriptionLifecycleWebhooks:
 
         assert result["success"] is True
         assert result["user_id"] == 42
-        assert result["plan_id"] == 2
+        assert result["plan_id"] == SubscriptionPlanIds.PREMIUM
         mock_upsert.assert_called_once()
         upsert_args = mock_upsert.call_args[0]
         assert upsert_args[1] == 42  # user_id
-        assert upsert_args[2] == 2  # plan_id from metadata
+        assert upsert_args[2] == SubscriptionPlanIds.PREMIUM
         mock_db.commit.assert_called_once()
         mock_invalidate.assert_called_once_with("user_uid_42")
 
@@ -1021,8 +1032,11 @@ class TestSubscriptionLifecycleWebhooks:
         mock_subscription.scheduled_downgrade = False
         mock_subscription.updated_at = None
 
-        # Query side_effect: account, subscription re-query (override path),
-        # then user (cache invalidation).
+        mock_storage = Mock()
+        mock_storage.storage_quota_bytes = 214748364800
+
+        # Query side_effect: account, subscription re-query (cancel path),
+        # storage usage, then user (cache invalidation).
         mock_db.query.side_effect = [
             Mock(
                 filter=Mock(
@@ -1032,6 +1046,11 @@ class TestSubscriptionLifecycleWebhooks:
             Mock(
                 filter=Mock(
                     return_value=Mock(first=Mock(return_value=mock_subscription))
+                )
+            ),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_storage))
                 )
             ),
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
@@ -1051,6 +1070,35 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["scheduled_downgrade"] is True
         assert mock_subscription.scheduled_downgrade is True
         assert mock_subscription.updated_at is not None
+
+    def test_subscription_updated_resets_scheduled_downgrade_when_uncancelled(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """`updated` with cancel_at_period_end=False resets scheduled_downgrade.
+
+        When a user un-cancels in Stripe, the upsert in Step 4
+        (_apply_subscription_update) unconditionally sets
+        scheduled_downgrade=False, so the local state is corrected.
+        """
+        subscription_event["cancel_at_period_end"] = False
+        # cancel_at_period_end=False -> helper skips the subscription
+        # re-query, so the query chain is just account + user.
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["scheduled_downgrade"] is False
+        # Verify upsert was called (it resets scheduled_downgrade=False)
+        mock_upsert.assert_called_once()
 
     def test_updated_past_due_still_marked_synced(
         self, mock_db, mock_user_account, mock_user, subscription_event

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1326,6 +1326,31 @@ class TestSubscriptionLifecycleWebhooks:
         assert result["success"] is True
         mock_upsert.assert_called_once()
 
+    def test_subscription_updated_error_logs_traceback(
+        self, mock_db, mock_user_account, subscription_event
+    ):
+        """Errors in handle_subscription_updated log full traceback."""
+        from fastapi import HTTPException
+
+        mock_db.query.side_effect = [
+            # 1. SubscriptionUserAccount lookup succeeds
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+        ]
+
+        with patch.object(
+            CheckoutService,
+            "create_or_update_subscription",
+            side_effect=RuntimeError("db write failed"),
+        ), pytest.raises(HTTPException) as exc_info:
+            WebhookService.handle_subscription_updated(mock_db, subscription_event)
+
+        assert exc_info.value.status_code == 500
+        assert "subscription.updated" in exc_info.value.detail
+
     # --- Concurrency ---
 
     def test_concurrent_storage_insert_falls_back_to_update(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1345,21 +1345,21 @@ class TestSubscriptionLifecycleWebhooks:
 
         mock_db.query.side_effect = [
             # 1. SubscriptionUserAccount by customer_id
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user_account)
-            ))),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
             # 2. UserStorageUsage -> None (triggers INSERT path)
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=None)
-            ))),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
             # 3. After rollback, re-query storage -> found
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_storage_after)
-            ))),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_storage_after))
+                )
+            ),
             # 4. User for cache invalidation
-            Mock(filter=Mock(return_value=Mock(
-                first=Mock(return_value=mock_user)
-            ))),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 
         with patch.object(

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -5,7 +5,10 @@ import pytest
 from sqlmodel import Session
 
 from studio.app.common.core.subscription.checkout_service import CheckoutService
-from studio.app.common.core.subscription.constants import SubscriptionPlanIds, SyncStatus
+from studio.app.common.core.subscription.constants import (
+    SubscriptionPlanIds,
+    SyncStatus,
+)
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1339,27 +1339,13 @@ class TestSubscriptionLifecycleWebhooks:
             # 1. SubscriptionUserAccount by customer_id
             Mock(
                 filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=mock_user_account)
-                    )
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
                 )
             ),
             # 2. UserStorageUsage -> None (triggers INSERT path)
-            Mock(
-                filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=None)
-                    )
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
             # 3. User for cache invalidation
-            Mock(
-                filter=Mock(
-                    return_value=Mock(
-                        first=Mock(return_value=mock_user)
-                    )
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 
         # begin_nested() SAVEPOINT; flush raises IntegrityError

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1048,11 +1048,7 @@ class TestSubscriptionLifecycleWebhooks:
                     return_value=Mock(first=Mock(return_value=mock_subscription))
                 )
             ),
-            Mock(
-                filter=Mock(
-                    return_value=Mock(first=Mock(return_value=mock_storage))
-                )
-            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_storage)))),
             Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
         ]
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -4,16 +4,9 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlmodel import Session
 
-from studio.app.common.core.subscription.checkout_service import (
-    CheckoutService,
-)
-from studio.app.common.core.subscription.constants import (
-    SubscriptionPlanIds,
-    SyncStatus,
-)
-from studio.app.common.core.subscription.subscription_service import (
-    SubscriptionService,
-)
+from studio.app.common.core.subscription.checkout_service import CheckoutService
+from studio.app.common.core.subscription.constants import SubscriptionPlanIds, SyncStatus
+from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -996,6 +996,92 @@ class TestSubscriptionLifecycleWebhooks:
         mock_upsert.assert_not_called()
         mock_db.commit.assert_not_called()
 
+    # --- P2: handle_subscription_updated ---
+
+    def test_dispatch_updated_routes_to_handler(self, mock_db, subscription_event):
+        """dispatch routes `updated` to handle_subscription_updated."""
+        with patch.object(
+            WebhookService,
+            "handle_subscription_updated",
+            return_value={"success": True},
+        ) as mock_updated:
+            result = WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.updated", subscription_event
+            )
+        assert result["success"] is True
+        mock_updated.assert_called_once_with(mock_db, subscription_event)
+
+    def test_subscription_updated_mirrors_scheduled_downgrade(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """`updated` with cancel_at_period_end=True flips scheduled_downgrade."""
+        subscription_event["cancel_at_period_end"] = True
+
+        mock_subscription = Mock()
+        mock_subscription.scheduled_downgrade = False
+        mock_subscription.updated_at = None
+
+        # Query side_effect: account, subscription re-query (override path),
+        # then user (cache invalidation).
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_subscription))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ), patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        assert result["scheduled_downgrade"] is True
+        assert mock_subscription.scheduled_downgrade is True
+        assert mock_subscription.updated_at is not None
+
+    def test_updated_past_due_still_marked_synced(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A successfully-mirrored past_due subscription stays SYNCED.
+
+        sync_status tracks DB<->Stripe sync success, not billing health: a
+        past_due event we wrote to the DB is still SYNCED. Tier is derived
+        from `expiration` at read time.
+        """
+        subscription_event["status"] = "past_due"
+        # cancel_at_period_end stays False (fixture default) -> helper skips
+        # the subscription re-query, so the query chain is just account + user.
+        self._setup_query_chain(mock_db, mock_user_account, mock_user)
+
+        with patch.object(
+            CheckoutService, "create_or_update_subscription", return_value=99
+        ) as mock_upsert, patch(
+            "studio.app.common.core.subscription.webhook_service."
+            "invalidate_user_tier_cache"
+        ):
+            result = WebhookService.handle_subscription_updated(
+                mock_db, subscription_event
+            )
+
+        assert result["success"] is True
+        # The upsert ran (mirrored); sync_status is set to SYNCED by
+        # CheckoutService.create_or_update_subscription regardless of the
+        # Stripe status field.
+        mock_upsert.assert_called_once()
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
# fix(subscription): handle `customer.subscription.updated` webhook (closes #629 — Problem 2)

Closes #629 (Problem 2 only).

> **Scope.** Issue #629 documented three consequences (P1 / P2 / P3); this is the **P2** PR, the second of three per‑problem PRs splitting #629. Built on top of `fix/629-handle-subscription-created` (the P1 branch). The remaining problem (P3 — release premium compute on `deleted` + hourly backstop sweep) will land on `fix/629-release-premium-on-delete-and-sweep`.

## Reported problem (this PR)

| # | Problem (issue ref) | Occurrence rate | Cause & why it wasn't caught earlier | Risk — to users | Risk — to the system |
|---|---------------------|-----------------|--------------------------------------|-----------------|----------------------|
| 2 | Stripe‑initiated subscription changes not mirrored to local state (issue consequence 2 / `customer.subscription.updated`) | **Every Stripe‑initiated change** (proration, payment‑method‑failure auto‑cancel, plan change). Rare in manual testing, real in production | No `case` for `customer.subscription.updated` in `WebhookService.dispatch_webhook_event` → silent "Unhandled" default (200 OK, no DB write). **Not caught earlier** because the cancel test passed via an unrelated inline DB write in `handle_cancel_user_subscription` (`subscription_users.scheduled_downgrade = 1`), so the ignored `updated` webhook was masked; no test exercised a real Stripe‑originated change | Local plan / expiration / scheduled‑downgrade silently wrong vs Stripe; may be limited or billed incorrectly; Stripe‑side cancellations and downgrades not reflected | Local DB drifts from Stripe (source of truth); silent inconsistency with no error signal; hard to audit |

## Summary

The Stripe webhook dispatcher silently ignored `customer.subscription.updated` — it fell through to the `Unhandled webhook event type` default and returned `200 OK` without touching the database. Every time Stripe itself initiated a change to a subscription (cancel at period end, plan change, proration, payment‑method‑failure auto‑cancel), the local row drifted from Stripe and there was no error signal — the only reason the cancel test was passing was an inline DB write that bypassed the webhook entirely.

This PR wires `customer.subscription.updated` to the existing P1 helper (`_sync_subscription_from_event`) and extends that helper to also mirror `cancel_at_period_end` → `scheduled_downgrade`. The mirror is conditional (only re‑queries when `cancel_at_period_end=True`), so the P1 `created` happy path takes no extra query in the common (no‑cancel) case.

## Root cause

`WebhookService.dispatch_webhook_event` had no `case` for `customer.subscription.updated`, so the event fell to the silent "Unhandled" default. The P1 branch added the shared `_sync_subscription_from_event` helper (upsert + storage quota + cache invalidation) but did not include `cancel_at_period_end` mirroring, because the P1 `created` event almost never carries a non‑default `cancel_at_period_end`. That mirror is the P2-specific addition.

## Changes (the P2 delta on top of P1)

**`studio/app/common/core/subscription/constants.py`**
- Added `CUSTOMER_SUBSCRIPTION_UPDATED = "customer.subscription.updated"` to `StripeWebhookEvent` (one line, immediately after `CUSTOMER_SUBSCRIPTION_CREATED`).

**`studio/app/common/core/subscription/webhook_service.py`**
- **Extended `_sync_subscription_from_event`** with a new step 5 — mirrors `cancel_at_period_end` → `scheduled_downgrade` on the local row. The override only re‑queries when `cancel_at_period_end=True`, so the P1 `created` happy path is unaffected (no extra query when there's nothing to downgrade). The info log and the returned dict now include `scheduled_downgrade=…` for both handlers.
- **Added `handle_subscription_updated(...)`** — a thin wrapper that delegates to the shared helper with `event_label="updated"`. The docstring spells out the Stripe‑initiated changes this captures (proration, plan change, payment‑method‑failure auto‑cancel, etc.).
- **Added the dispatch case** for `StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_UPDATED`, immediately after the `_CREATED` case.

**`studio/tests/app/common/routers/test_webhook.py`**
- Three new tests appended to the existing `TestSubscriptionLifecycleWebhooks` class (P1 tests untouched):
  - `test_dispatch_updated_routes_to_handler` — dispatch routes `updated` → `handle_subscription_updated`.
  - `test_subscription_updated_mirrors_scheduled_downgrade` — sends an event with `cancel_at_period_end=True`; asserts the re‑queried row gets `scheduled_downgrade=True` + `updated_at` set, and the result dict reports `scheduled_downgrade=True`.
  - `test_updated_past_due_still_marked_synced` — documents the sync‑status semantics decision: a successfully‑mirrored `past_due` event still results in `sync_status='synced'` (sync success ≠ billing health; tier is derived from `expiration`).

No changes to `checkout_service.py` or `test_checkout.py` — the idempotent upsert from P1 is unchanged.

## Behavior: before → after

| Scenario | Before | After |
| --- | --- | --- |
| `customer.subscription.updated` | Ignored (logged "Unhandled", 200 OK) | Mirrors plan, expiration, and `cancel_at_period_end` into local state |
| User cancels in Stripe at period end (`cancel_at_period_end=true`) | Webhook silent; the cancel UI only worked because of an inline DB write | `scheduled_downgrade=1` is set via the webhook; user remains premium until period end |
| Stripe transitions subscription to `past_due` | Local row unchanged; no signal | Plan + expiration mirrored; `sync_status` stays `synced` (it tracks sync success, not billing health — tier is derived from `expiration`) |
| Stripe-initiated plan change | Local plan silently drifts from Stripe | Plan + expiration mirrored on the next `updated` event |

## Test plan

CI/local: run the targeted tests in your poetry env (the sandbox can't run them — pydantic v1 isn't installed).

```
poetry run pytest studio/tests/app/common/routers/test_webhook.py -v
```

### Automated unit tests added (3)

| Test | Category | Verifies |
|------|----------|----------|
| `test_dispatch_updated_routes_to_handler` | P2 Dispatch | `dispatch_webhook_event` routes `customer.subscription.updated` → `handle_subscription_updated` |
| `test_subscription_updated_mirrors_scheduled_downgrade` | P2 State sync | `cancel_at_period_end=True` → `subscription_users.scheduled_downgrade=True` (and `updated_at` refreshed); result dict reports `scheduled_downgrade=True` |
| `test_updated_past_due_still_marked_synced` | P2 sync_status semantics | A successfully‑mirrored `past_due` event still results in `sync_status='synced'` (sync success ≠ billing health) |

Static verification (already run locally):
- `py_compile`: ✅ clean on all changed files.
- `flake8 --max-line-length=88`: ✅ clean on all changed files.

### Manual / system test cases

> Common environment: Stripe **test mode**, dev webhook endpoint subscribed to `customer.subscription.updated`, AWS CLI / SQL client / CloudWatch Logs Insights on `/ecs/development-optinist-cloud-taskdef`.

#### TC‑S1 — P2 Cancel at period end (600‑17a downgrade spec)

**Objective.** Confirm `customer.subscription.updated` with `cancel_at_period_end=true` flips `subscription_users.scheduled_downgrade=1` while the user remains premium until period end.

**Preconditions.**
1. PR deployed to dev (verify by triggering an `updated` and seeing `Handling customer.subscription.updated` — not `Unhandled webhook event type: customer.subscription.updated` — in CloudWatch).
2. Stripe webhook endpoint subscribed to `customer.subscription.updated`.
3. An active premium test user. Pre‑check:
   ```sql
   SELECT u.id AS user_id, su.id AS sub_id, su.plan_id, su.expiration,
          su.scheduled_downgrade
   FROM users u
   JOIN subscription_users su ON su.user_id = u.id
   WHERE u.email = '<TEST_EMAIL>';
   -- Expected: plan_id = 2, expiration > NOW(), scheduled_downgrade = 0.
   ```
   Record `<UID>` and `<SUB_ID>` (the Stripe subscription id `sub_…`).

**Steps.**
1. Note `T0` (UTC).
2. Cancel **at end of period** (NOT immediately):
   - Stripe Dashboard → Customers → the test customer → Subscriptions → click the subscription → **Cancel subscription → At end of billing period**.
   - Or CLI: `stripe subscriptions update <SUB_ID> -d cancel_at_period_end=true`.
3. In Stripe Dashboard → *Developers → Webhooks → endpoint → Recent deliveries*, find the `customer.subscription.updated` delivery; confirm status **200**, note its timestamp.
4. Refresh the dashboard.

**Verification.**
- DB:
  ```sql
  SELECT plan_id, expiration, scheduled_downgrade, sync_status
  FROM subscription_users WHERE user_id = <UID>;
  -- Expected: plan_id = 2, expiration unchanged (still future), scheduled_downgrade = 1, sync_status = 'synced'.
  ```
- UI: the user is still premium (Dashboard shows premium tier; features remain available).

**Reverse test (optional).** `stripe subscriptions update <SUB_ID> -d cancel_at_period_end=false` → another `updated` fires; expect `scheduled_downgrade=0` and another `Synced …` line in CloudWatch.

**Pass criteria.** `scheduled_downgrade` flips with the event; UI keeps the user premium; positive CW lines present; negative CW filter empty.

**Cleanup.** Reverse the cancellation, or let the test user roll off naturally.

#### TC‑S2 — P2 Delinquent status (`past_due`)

**Objective.** Confirm a `customer.subscription.updated` event with `status=past_due` is mirrored into local state and `sync_status` stays `synced` (it tracks sync success, not billing health).

**Preconditions.** Active premium test user.

**Steps (canonical, using a Stripe test clock).**
1. In Stripe Dashboard, replace the default payment method with one that **succeeds on attach but fails on renewal**: card `4000 0000 0000 0341`.
2. Stripe Dashboard → **Test clocks** → create a clock attached to this customer → advance to **1 s after** the current period end.
3. Stripe attempts the renewal charge → it fails → Stripe transitions the subscription to `past_due` and fires `customer.subscription.updated`.

**Alternative.** From Stripe Dashboard → Developers → Events, find any past `customer.subscription.updated` event with `status=past_due` for any test customer → click **Resend** (point at our dev webhook). Signature verification is fine because the event is signed by Stripe.

**Verification.**
- CloudWatch: `filter @message like /Webhook: Synced subscription.updated for user <UID>/` → the line shows the event was processed; `scheduled_downgrade` reflects whatever the event carried.
- DB:
  ```sql
  SELECT plan_id, expiration, sync_status FROM subscription_users WHERE user_id = <UID>;
  -- Expected: sync_status = 'synced' (NOT 'failed'); expiration mirrored from the event payload.
  ```
- Tier behavior: derived from `expiration` at read time. If the new `expiration` is past, the user is on free tier; `invoice.payment_failed` handling drives any user‑facing payment‑failure warning — `sync_status` is **not** repurposed for that.

**Pass criteria.** `sync_status` stays `synced` despite `past_due`; row is mirrored.

**Cleanup.** Delete the Stripe test clock; restore the original payment method.

#### TC‑S3 — P2 Guards (acknowledge without writing)

**Objective.** Confirm `customer.subscription.updated` events for an unknown customer or with no period end are acknowledged with 200, no DB write, no Stripe retry. (Shares the helper with P1 — same guard behavior.)

**Steps.**
1. From Stripe Dashboard → Developers → Events, pick (or trigger) a `customer.subscription.updated` for a customer with no matching `subscription_user_accounts.provider_customer_id` (e.g. a freshly created Stripe customer with no checkout). Click **Resend**.
2. Separately, resend (or trigger) an `updated` event with no `current_period_end` and no `trial_end` in the payload.

**Verification.**
- CW for each delivery:
  ```
  filter @message like /Webhook: No user account for customer_id|acknowledging subscription.updated without DB change|No period end in subscription|missing_user_account|missing_expiration/
  ```
  Expected: the corresponding warning line is present.
- Stripe Dashboard: both deliveries show **200**, no retries scheduled.
- DB: no rows changed.

**Pass criteria.** 200 ack; no DB write; no Stripe retry.

## Notes

- The shared helper's `cancel_at_period_end` mirroring is conditional — it only re‑queries the local row when `cancel_at_period_end=True`. The P1 `created` happy path therefore continues to take no extra query in the common case.
- `sync_status` is deliberately left as `synced` for any successfully‑mirrored `updated` event (including `past_due` / `unpaid` / `incomplete`) — it tracks DB↔Stripe sync success, not billing health. Tier and billing state are derived from `expiration` at read time, so a delinquent‑but‑synced row is still shown correctly. (Documented by `test_updated_past_due_still_marked_synced`.)
- Dispatch remains synchronous in this PR. Making `dispatch_webhook_event` `async` is only required when the `customer.subscription.deleted` case needs to `await` the premium release — that will land with the P3 branch.

## Checklist

- [x] Tests pass in CI (the 3 new tests plus the existing webhook suite).
- [x] In dev, the Stripe webhook endpoint is subscribed to `customer.subscription.updated` (in addition to `customer.subscription.created` from P1 and the existing events).
- [x] TC‑S1 (cancel at period end): `scheduled_downgrade=1` flips via the webhook; UI keeps the user premium until period end.
- [x] TC‑S2 (`past_due`): `sync_status` stays `synced`; expiration mirrored.
- [x] TC‑S3 (guards): unknown customer / no period end → 200 ack, no DB write, no Stripe retry.