### PR TITLE
# fix(subscription): release premium compute on `customer.subscription.deleted` + hourly backstop sweep + bounded fail‑open release timeout (closes #629 — Problems 3 & 4)

### DIFF
--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -33,6 +33,7 @@ from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.core.subscription.constants import (
     ExpirationDeletion,
+    PremiumExpirationSweep,
     StorageReconciliation,
     SyncStatusConstants,
 )
@@ -42,6 +43,9 @@ if not MODE.IS_STANDALONE:
     from studio.app.common.core.background.cleanup_job import DataCleanupJob
     from studio.app.common.core.background.expiration_lifecycle_job import (
         ExpirationLifecycleJob,
+    )
+    from studio.app.common.core.background.premium_expiration_sweep_job import (
+        PremiumExpirationSweepJob,
     )
     from studio.app.common.core.background.scheduler import BackgroundScheduler
     from studio.app.common.core.background.storage_reconciliation_job import (
@@ -163,6 +167,16 @@ async def lifespan(app: FastAPI):
             func=ExpirationLifecycleJob.run,
             interval_minutes=ExpirationDeletion.JOB_INTERVAL_MINUTES,
             job_id=ExpirationDeletion.JOB_ID,
+        )
+
+        # Backstop: release dangling premium assignments after expiration
+        # (covers missed customer.subscription.deleted events / direct DB
+        # expirations such as test 600-17b). Event-driven release in
+        # WebhookService is unchanged; this is purely a safety net.
+        BackgroundScheduler.add_job(
+            func=PremiumExpirationSweepJob.run,
+            interval_minutes=PremiumExpirationSweep.JOB_INTERVAL_MINUTES,
+            job_id=PremiumExpirationSweep.JOB_ID,
         )
 
         # Start scheduler

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -22,6 +22,9 @@ from sqlalchemy import and_, exists
 from sqlalchemy.orm import aliased
 
 from studio.app.common.core.logger import AppLogger
+# Top-level import is safe here (no circular dependency).  webhook_service.py
+# must use a local import because it is itself imported by the subscription
+# package, but this background-job module has no such cycle.
 from studio.app.common.core.premium.premium_assignment_service import (
     premium_assignment_service,
 )
@@ -116,10 +119,13 @@ class PremiumExpirationSweepJob:
         )
 
         # Exclude users who have any currently-active subscription row.
+        # Correlate on PremiumUserAssignment.user_id (the outer entity) so the
+        # subquery remains correct even if the unique constraint on
+        # UserSubscription.user_id is ever relaxed.
         active_sub = aliased(UserSubscription)
         has_active_sub = exists().where(
             and_(
-                active_sub.user_id == UserSubscription.user_id,
+                active_sub.user_id == PremiumUserAssignment.user_id,
                 active_sub.expiration > current_time,
             )
         )
@@ -146,6 +152,10 @@ class PremiumExpirationSweepJob:
                 .all()
             )
 
+            # Defensive dedup: UserSubscription.user_id currently has a unique
+            # constraint so the JOIN cannot produce duplicates.  The dedup is
+            # kept as a safety net in case the constraint is ever relaxed (e.g.
+            # for subscription history tracking).
             seen = set()
             candidates: List[Tuple[int, str]] = []
             for user_id, user_uid in rows:

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -52,7 +52,8 @@ class PremiumExpirationSweepJob:
             candidates = cls._find_dangling_assignments()
         except Exception as e:
             logger.error(
-                f"Premium expiration sweep: failed to query candidates: {e}",
+                "Premium expiration sweep: failed to query candidates: %s",
+                e,
                 exc_info=True,
             )
             return
@@ -62,8 +63,8 @@ class PremiumExpirationSweepJob:
             return
 
         logger.info(
-            f"Premium expiration sweep: {len(candidates)} dangling "
-            f"assignment(s) to release"
+            "Premium expiration sweep: %d dangling assignment(s) to release",
+            len(candidates),
         )
 
         processed = 0
@@ -79,25 +80,31 @@ class PremiumExpirationSweepJob:
                 if result.get("success"):
                     processed += 1
                     logger.info(
-                        f"Premium expiration sweep: released user {user_id} "
-                        f"({result.get('message')})"
+                        "Premium expiration sweep: released user %s (%s)",
+                        user_id,
+                        result.get("message"),
                     )
                 else:
                     errors += 1
                     logger.warning(
                         "Premium expiration sweep: release returned failure for "
-                        f"user {user_id}: {result.get('message')}"
+                        "user %s: %s",
+                        user_id,
+                        result.get("message"),
                     )
             except Exception as e:
                 errors += 1
                 logger.error(
-                    f"Premium expiration sweep: error releasing user {user_id}: {e}",
+                    "Premium expiration sweep: error releasing user %s: %s",
+                    user_id,
+                    e,
                     exc_info=True,
                 )
 
         logger.info(
-            f"Premium expiration sweep completed: {processed} released, "
-            f"{errors} errors"
+            "Premium expiration sweep completed: %d released, %d errors",
+            processed,
+            errors,
         )
 
     @staticmethod
@@ -145,6 +152,7 @@ class PremiumExpirationSweepJob:
                     UserSubscription.expiration <= grace_cutoff,
                     ~has_active_sub,
                 )
+                .distinct()
                 # Oldest expirations first so the per-run cap is deterministic
                 # and never starves long-expired assignments.
                 .order_by(UserSubscription.expiration.asc())

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -68,7 +68,10 @@ class PremiumExpirationSweepJob:
         for user_id, user_uid in candidates:
             try:
                 result = await premium_assignment_service.release_premium_user(
-                    user_id=user_id, user_uid=user_uid, hard=True
+                    user_id=user_id,
+                    user_uid=user_uid,
+                    hard=True,
+                    timeout=PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS,
                 )
                 if result.get("success"):
                     processed += 1

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -22,6 +22,7 @@ from sqlalchemy import and_, exists
 from sqlalchemy.orm import aliased
 
 from studio.app.common.core.logger import AppLogger
+
 # Top-level import is safe here (no circular dependency).  webhook_service.py
 # must use a local import because it is itself imported by the subscription
 # package, but this background-job module has no such cycle.

--- a/studio/app/common/core/background/premium_expiration_sweep_job.py
+++ b/studio/app/common/core/background/premium_expiration_sweep_job.py
@@ -1,0 +1,153 @@
+"""
+Backstop sweep: release dangling premium assignments after expiration.
+
+Runs periodically as a safety net for the event-driven path. Normally a
+premium compute assignment is released when Stripe sends
+``customer.subscription.deleted`` (handled in ``WebhookService``). If that
+event is missed or never sent (e.g. a lost webhook, or a local expiration
+applied by a direct DB update such as test 600-17b), the per-user EC2/ALB
+assignment can dangle, still attached to a user who is now effectively free.
+
+This job finds users whose PREMIUM subscription expired more than
+``GRACE_PERIOD_DAYS`` ago, who have no currently-active subscription, and who
+still hold an ``active`` (non-standby) premium assignment, and hard-releases
+them. It complements (and is more precise than) the activity-based stale
+sweep performed by the Premium Cleanup Lambda.
+"""
+
+from datetime import timedelta
+from typing import List, Tuple
+
+from sqlalchemy import and_, exists
+from sqlalchemy.orm import aliased
+
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.premium.premium_assignment_service import (
+    premium_assignment_service,
+)
+from studio.app.common.core.subscription.constants import (
+    PremiumExpirationSweep,
+    SubscriptionPeriods,
+    SubscriptionPlanIds,
+)
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
+from studio.app.common.db.database import session_scope
+from studio.app.common.models.premium_user import PremiumUserAssignment
+from studio.app.common.models.subscription import UserSubscription
+from studio.app.common.models.user import User
+
+logger = AppLogger.get_logger()
+
+
+class PremiumExpirationSweepJob:
+    @classmethod
+    async def run(cls):
+        """Periodic backstop: release premium assignments for expired users."""
+        logger.info("Starting premium expiration sweep job")
+
+        try:
+            candidates = cls._find_dangling_assignments()
+        except Exception as e:
+            logger.error(
+                f"Premium expiration sweep: failed to query candidates: {e}",
+                exc_info=True,
+            )
+            return
+
+        if not candidates:
+            logger.debug("Premium expiration sweep: no dangling assignments found")
+            return
+
+        logger.info(
+            f"Premium expiration sweep: {len(candidates)} dangling "
+            f"assignment(s) to release"
+        )
+
+        processed = 0
+        errors = 0
+        for user_id, user_uid in candidates:
+            try:
+                result = await premium_assignment_service.release_premium_user(
+                    user_id=user_id, user_uid=user_uid, hard=True
+                )
+                if result.get("success"):
+                    processed += 1
+                    logger.info(
+                        f"Premium expiration sweep: released user {user_id} "
+                        f"({result.get('message')})"
+                    )
+                else:
+                    errors += 1
+                    logger.warning(
+                        "Premium expiration sweep: release returned failure for "
+                        f"user {user_id}: {result.get('message')}"
+                    )
+            except Exception as e:
+                errors += 1
+                logger.error(
+                    f"Premium expiration sweep: error releasing user {user_id}: {e}",
+                    exc_info=True,
+                )
+
+        logger.info(
+            f"Premium expiration sweep completed: {processed} released, "
+            f"{errors} errors"
+        )
+
+    @staticmethod
+    def _find_dangling_assignments() -> List[Tuple[int, str]]:
+        """
+        Return ``[(user_id, user_uid), ...]`` for users who:
+        - hold an ``active`` non-standby premium assignment,
+        - have a PREMIUM subscription expired more than GRACE_PERIOD_DAYS ago, and
+        - have no currently-active subscription (i.e. have not re-subscribed).
+
+        Oldest expirations first so the per-run cap is deterministic and never
+        starves long-expired assignments. DB primitives are extracted inside
+        the session so it can close before the async release calls (which talk
+        to AWS Lambda) run.
+        """
+        current_time = get_current_datetime()
+        grace_cutoff = current_time - timedelta(
+            days=SubscriptionPeriods.GRACE_PERIOD_DAYS
+        )
+
+        # Exclude users who have any currently-active subscription row.
+        active_sub = aliased(UserSubscription)
+        has_active_sub = exists().where(
+            and_(
+                active_sub.user_id == UserSubscription.user_id,
+                active_sub.expiration > current_time,
+            )
+        )
+
+        with session_scope() as db:
+            rows = (
+                db.query(PremiumUserAssignment.user_id, User.uid)
+                .join(User, User.id == PremiumUserAssignment.user_id)
+                .join(
+                    UserSubscription,
+                    UserSubscription.user_id == PremiumUserAssignment.user_id,
+                )
+                .filter(
+                    PremiumUserAssignment.status == "active",
+                    PremiumUserAssignment.is_standby == False,  # noqa: E712
+                    UserSubscription.plan_id == SubscriptionPlanIds.PREMIUM,
+                    UserSubscription.expiration <= grace_cutoff,
+                    ~has_active_sub,
+                )
+                # Oldest expirations first so the per-run cap is deterministic
+                # and never starves long-expired assignments.
+                .order_by(UserSubscription.expiration.asc())
+                .limit(PremiumExpirationSweep.MAX_RELEASES_PER_RUN)
+                .all()
+            )
+
+            seen = set()
+            candidates: List[Tuple[int, str]] = []
+            for user_id, user_uid in rows:
+                if user_id in seen:
+                    continue
+                seen.add(user_id)
+                candidates.append((user_id, user_uid))
+            return candidates

--- a/studio/app/common/core/background/scheduler.py
+++ b/studio/app/common/core/background/scheduler.py
@@ -153,6 +153,7 @@ class BackgroundScheduler:
             trigger=IntervalTrigger(minutes=interval_minutes),
             id=job_id,
             replace_existing=True,
+            misfire_grace_time=60,
             **kwargs,
         )
 

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -35,6 +35,10 @@ class PremiumStatusCheckError(Exception):
 LAMBDA_TIMEOUT_SECONDS = 60
 LAMBDA_MAX_RETRIES = 2
 LAMBDA_RETRY_BASE_DELAY_SECONDS = 2
+# Short bound for latency-sensitive callers (e.g. the Stripe webhook path),
+# which must respond quickly. Cleanup that exceeds this is handled by the
+# periodic premium-expiration sweep, so failing open here is safe.
+WEBHOOK_RELEASE_TIMEOUT_SECONDS = 10
 
 
 class PremiumAssignmentService:
@@ -297,7 +301,12 @@ class PremiumAssignmentService:
             }
 
     async def release_premium_user(
-        self, user_id: int, user_uid: str, *, hard: bool = False
+        self,
+        user_id: int,
+        user_uid: str,
+        *,
+        hard: bool = False,
+        timeout: float = LAMBDA_TIMEOUT_SECONDS,
     ) -> Dict[str, any]:
         """
         Release a premium user from their assigned instance and clear rate limiting.
@@ -308,12 +317,17 @@ class PremiumAssignmentService:
             hard: If True, immediately delete assignment + ALB resources.
                   If False (default), soft-release with grace period so a
                   page refresh can restore the assignment instantly.
+            timeout: Max seconds to wait for the release Lambda before failing
+                  open. Latency-sensitive callers (e.g. the Stripe webhook)
+                  should pass a short value (see WEBHOOK_RELEASE_TIMEOUT_SECONDS);
+                  defaults to LAMBDA_TIMEOUT_SECONDS for logout/beacon/sweep.
 
         Returns:
             Dict containing release result:
             - success: bool
             - message: str
             - released_instance: str (if successful)
+            - timed_out: bool (present and True if the Lambda call timed out)
         """
         try:
             release_type = "hard" if hard else "soft"
@@ -352,9 +366,32 @@ class PremiumAssignmentService:
                 )
                 return response
 
-            # Run in thread pool to avoid blocking
+            # Run in thread pool with a bounded timeout so a slow/hung Lambda
+            # cannot stall the caller indefinitely (e.g. the Stripe webhook
+            # path, where this would otherwise risk webhook timeouts/retries).
+            # Fail open on timeout: the assignment may not be torn down yet,
+            # but the periodic premium-expiration sweep is the backstop that
+            # will release it.
             loop = asyncio.get_event_loop()
-            response = await loop.run_in_executor(None, invoke_lambda)
+            try:
+                response = await asyncio.wait_for(
+                    loop.run_in_executor(None, invoke_lambda),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Release Lambda timed out after {timeout}s for user "
+                    f"{user_id}; deferring to background cleanup"
+                )
+                return {
+                    "success": False,
+                    "timed_out": True,
+                    "message": (
+                        f"Release timed out after {timeout}s; "
+                        "will be retried by the background sweep"
+                    ),
+                    "warnings": [f"Release Lambda timed out after {timeout}s"],
+                }
 
             # Parse the response
             response_payload = json.loads(response["Payload"].read())

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -473,6 +473,11 @@ class PremiumExpirationSweep:
     JOB_ID = "premium_expiration_sweep"
     JOB_INTERVAL_MINUTES = 60  # Hourly backstop
     MAX_RELEASES_PER_RUN = 50  # Bound work per run
+    # Short per-release timeout so one slow/hung Lambda can't stall the whole
+    # sweep. This is a backstop: a skipped release is retried next run.
+    # Worst case per run ~= MAX_RELEASES_PER_RUN * RELEASE_TIMEOUT_SECONDS,
+    # which stays well under JOB_INTERVAL_MINUTES.
+    RELEASE_TIMEOUT_SECONDS = 15
 
 
 class S3Pagination:

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -460,6 +460,21 @@ class ExpirationDeletion:
     METRIC_ERRORS = "ExpirationDeletionErrors"
 
 
+class PremiumExpirationSweep:
+    """Constants for the premium expiration -> release backstop sweep job.
+
+    Safety net for the event-driven path: releases dangling premium
+    assignments for users whose subscription expired past the grace period
+    when no Stripe ``customer.subscription.deleted`` event released them
+    (e.g. a missed webhook, or a local expiration applied via direct DB
+    UPDATE such as test 600-17b).
+    """
+
+    JOB_ID = "premium_expiration_sweep"
+    JOB_INTERVAL_MINUTES = 60  # Hourly backstop
+    MAX_RELEASES_PER_RUN = 50  # Bound work per run
+
+
 class S3Pagination:
     """Constants for S3 pagination and streaming"""
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1439,8 +1439,9 @@ class WebhookService:
         )
         if not row:
             logger.info(
-                f"Webhook: No user account/user for customer {customer_id}; "
-                "no premium assignment to release"
+                "Webhook: No user account/user for customer %s; "
+                "no premium assignment to release",
+                customer_id,
             )
             return
         user_account, user = row
@@ -1454,21 +1455,26 @@ class WebhookService:
             )
             if result.get("success"):
                 logger.info(
-                    f"Webhook: Released premium assignment for user {user.id} "
-                    f"on subscription delete: {result.get('message')}"
+                    "Webhook: Released premium assignment for user %s "
+                    "on subscription delete: %s",
+                    user.id,
+                    result.get("message"),
                 )
             else:
                 # Not released in-band (e.g. timed out). The background sweep
                 # will release it; acknowledge the webhook regardless.
                 logger.warning(
-                    f"Webhook: Premium release not confirmed for user "
-                    f"{user.id}: {result.get('message')}; "
-                    "deferring to background sweep"
+                    "Webhook: Premium release not confirmed for user "
+                    "%s: %s; deferring to background sweep",
+                    user.id,
+                    result.get("message"),
                 )
         except Exception as e:
             logger.error(
-                f"Webhook: Failed to release premium assignment for user "
-                f"{user_account.user_id}: {e}",
+                "Webhook: Failed to release premium assignment for user "
+                "%s: %s",
+                user_account.user_id,
+                e,
                 exc_info=True,
             )
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1471,8 +1471,7 @@ class WebhookService:
                 )
         except Exception as e:
             logger.error(
-                "Webhook: Failed to release premium assignment for user "
-                "%s: %s",
+                "Webhook: Failed to release premium assignment for user %s: %s",
                 user_account.user_id,
                 e,
                 exc_info=True,

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1404,7 +1404,62 @@ class WebhookService:
         return webhook_secret
 
     @staticmethod
-    def dispatch_webhook_event(
+    async def _release_premium_assignment(
+        db: Session, subscription_data: Dict[str, Any]
+    ) -> None:
+        """
+        Release a dangling premium compute assignment when a subscription
+        ends (issue #629, Problem 3).
+
+        ``handle_subscription_cancelled`` only expires the DB row; without
+        this the per-user EC2/ALB resources stay attached to a now-free user
+        until logout / tab-close / the activity-based stale-sweep. Best-
+        effort: logs but does not raise, so a release failure can never
+        block webhook acknowledgement.
+        """
+        # Local import avoids any import cycle with the subscription package.
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        customer_id = subscription_data.get("customer")
+        user_account = (
+            db.query(SubscriptionUserAccount)
+            .filter(SubscriptionUserAccount.provider_customer_id == customer_id)
+            .first()
+        )
+        if not user_account:
+            logger.info(
+                f"Webhook: No user account for customer {customer_id}; "
+                "no premium assignment to release"
+            )
+            return
+
+        user = db.query(User).filter(User.id == user_account.user_id).first()
+        if not user:
+            logger.warning(
+                f"Webhook: User {user_account.user_id} not found; "
+                "cannot release premium assignment"
+            )
+            return
+
+        try:
+            result = await premium_assignment_service.release_premium_user(
+                user_id=user.id, user_uid=user.uid, hard=True
+            )
+            logger.info(
+                f"Webhook: Released premium assignment for user {user.id} on "
+                f"subscription delete: {result.get('message')}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Webhook: Failed to release premium assignment for user "
+                f"{user_account.user_id}: {e}",
+                exc_info=True,
+            )
+
+    @staticmethod
+    async def dispatch_webhook_event(
         db: Session, event_type: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
@@ -1435,6 +1490,9 @@ class WebhookService:
                 case StripeWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED:
                     logger.info("Handling customer.subscription.deleted")
                     WebhookService.handle_subscription_cancelled(db, data)
+                    # Release the dangling premium compute assignment so a
+                    # now-free user does not keep a dedicated EC2/ALB.
+                    await WebhookService._release_premium_assignment(db, data)
                     return {
                         "success": True,
                         "message": "Subscription cancellation processed",

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1416,9 +1416,15 @@ class WebhookService:
         until logout / tab-close / the activity-based stale-sweep. Best-
         effort: logs but does not raise, so a release failure can never
         block webhook acknowledgement.
+
+        Uses a short timeout (``WEBHOOK_RELEASE_TIMEOUT_SECONDS``) so a
+        slow/hung release Lambda cannot stall the webhook response (which
+        would trigger Stripe retries). On timeout the call fails open and
+        the periodic premium-expiration sweep releases the assignment later.
         """
         # Local import avoids any import cycle with the subscription package.
         from studio.app.common.core.premium.premium_assignment_service import (
+            WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             premium_assignment_service,
         )
 
@@ -1445,12 +1451,24 @@ class WebhookService:
 
         try:
             result = await premium_assignment_service.release_premium_user(
-                user_id=user.id, user_uid=user.uid, hard=True
+                user_id=user.id,
+                user_uid=user.uid,
+                hard=True,
+                timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             )
-            logger.info(
-                f"Webhook: Released premium assignment for user {user.id} on "
-                f"subscription delete: {result.get('message')}"
-            )
+            if result.get("success"):
+                logger.info(
+                    f"Webhook: Released premium assignment for user {user.id} "
+                    f"on subscription delete: {result.get('message')}"
+                )
+            else:
+                # Not released in-band (e.g. timed out). The background sweep
+                # will release it; acknowledge the webhook regardless.
+                logger.warning(
+                    f"Webhook: Premium release not confirmed for user "
+                    f"{user.id}: {result.get('message')}; "
+                    "deferring to background sweep"
+                )
         except Exception as e:
             logger.error(
                 f"Webhook: Failed to release premium assignment for user "

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -1429,25 +1429,21 @@ class WebhookService:
         )
 
         customer_id = subscription_data.get("customer")
-        user_account = (
-            db.query(SubscriptionUserAccount)
+        # Single JOIN query to reduce DB round-trips on the latency-sensitive
+        # webhook path (was two sequential queries before).
+        row = (
+            db.query(SubscriptionUserAccount, User)
+            .join(User, User.id == SubscriptionUserAccount.user_id)
             .filter(SubscriptionUserAccount.provider_customer_id == customer_id)
             .first()
         )
-        if not user_account:
+        if not row:
             logger.info(
-                f"Webhook: No user account for customer {customer_id}; "
+                f"Webhook: No user account/user for customer {customer_id}; "
                 "no premium assignment to release"
             )
             return
-
-        user = db.query(User).filter(User.id == user_account.user_id).first()
-        if not user:
-            logger.warning(
-                f"Webhook: User {user_account.user_id} not found; "
-                "cannot release premium assignment"
-            )
-            return
+        user_account, user = row
 
         try:
             result = await premium_assignment_service.release_premium_user(

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -743,7 +743,7 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
 
         logger.info(f"Processing event type: {event_type}")
 
-        WebhookService.dispatch_webhook_event(db, event_type, data)
+        await WebhookService.dispatch_webhook_event(db, event_type, data)
 
         logger.info(f"Successfully processed {event_type}")
         return {"received": True, "processed": event_type}

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -1,0 +1,110 @@
+"""Tests for the premium expiration -> release backstop sweep job (issue #629 P3)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from studio.app.common.core.background.premium_expiration_sweep_job import (
+    PremiumExpirationSweepJob,
+)
+
+MODULE = "studio.app.common.core.background.premium_expiration_sweep_job"
+
+
+def _self_returning_query(rows):
+    """A query mock where join/filter/order_by/limit chain back to itself."""
+    q = MagicMock()
+    q.join.return_value = q
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.limit.return_value = q
+    q.all.return_value = rows
+    return q
+
+
+def _mock_session_scope(mock_db):
+    """Patch target for session_scope() used as a context manager."""
+    scope = MagicMock()
+    scope.return_value.__enter__ = MagicMock(return_value=mock_db)
+    scope.return_value.__exit__ = MagicMock(return_value=False)
+    return scope
+
+
+class TestRun:
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_no_candidates_no_release(self, mock_find):
+        mock_find.return_value = []
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(),
+        ) as mock_release:
+            await PremiumExpirationSweepJob.run()
+        mock_release.assert_not_awaited()
+
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_releases_each_candidate_hard(self, mock_find):
+        mock_find.return_value = [(1, "uid_a"), (2, "uid_b")]
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(return_value={"success": True, "message": "released"}),
+        ) as mock_release:
+            await PremiumExpirationSweepJob.run()
+
+        assert mock_release.await_count == 2
+        mock_release.assert_any_await(user_id=1, user_uid="uid_a", hard=True)
+        mock_release.assert_any_await(user_id=2, user_uid="uid_b", hard=True)
+
+    @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
+    @pytest.mark.asyncio
+    async def test_continues_after_release_error(self, mock_find):
+        """One failing release must not stop the rest of the batch."""
+        mock_find.return_value = [(1, "uid_a"), (2, "uid_b")]
+        with patch(
+            f"{MODULE}.premium_assignment_service.release_premium_user",
+            new=AsyncMock(
+                side_effect=[Exception("boom"), {"success": True, "message": "ok"}]
+            ),
+        ) as mock_release:
+            # Should not raise.
+            await PremiumExpirationSweepJob.run()
+
+        assert mock_release.await_count == 2
+
+
+class TestFindDanglingAssignments:
+    @patch(f"{MODULE}.get_current_datetime")
+    @patch(f"{MODULE}.session_scope")
+    def test_returns_deduped_candidates(self, mock_scope, mock_now):
+        from datetime import datetime
+
+        mock_now.return_value = datetime(2026, 5, 22)
+        mock_db = MagicMock()
+        # Duplicate user_id should be collapsed to a single candidate.
+        mock_db.query.return_value = _self_returning_query(
+            [(1, "uid_a"), (1, "uid_a"), (2, "uid_b")]
+        )
+        mock_scope.return_value = _mock_session_scope(mock_db).return_value
+
+        result = PremiumExpirationSweepJob._find_dangling_assignments()
+
+        assert result == [(1, "uid_a"), (2, "uid_b")]
+
+    @patch(f"{MODULE}.get_current_datetime")
+    @patch(f"{MODULE}.session_scope")
+    def test_returns_empty_when_no_rows(self, mock_scope, mock_now):
+        from datetime import datetime
+
+        mock_now.return_value = datetime(2026, 5, 22)
+        mock_db = MagicMock()
+        mock_db.query.return_value = _self_returning_query([])
+        mock_scope.return_value = _mock_session_scope(mock_db).return_value
+
+        result = PremiumExpirationSweepJob._find_dangling_assignments()
+
+        assert result == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -7,6 +7,7 @@ import pytest
 from studio.app.common.core.background.premium_expiration_sweep_job import (
     PremiumExpirationSweepJob,
 )
+from studio.app.common.core.subscription.constants import PremiumExpirationSweep
 
 MODULE = "studio.app.common.core.background.premium_expiration_sweep_job"
 
@@ -53,8 +54,13 @@ class TestRun:
             await PremiumExpirationSweepJob.run()
 
         assert mock_release.await_count == 2
-        mock_release.assert_any_await(user_id=1, user_uid="uid_a", hard=True)
-        mock_release.assert_any_await(user_id=2, user_uid="uid_b", hard=True)
+        timeout = PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS
+        mock_release.assert_any_await(
+            user_id=1, user_uid="uid_a", hard=True, timeout=timeout
+        )
+        mock_release.assert_any_await(
+            user_id=2, user_uid="uid_b", hard=True, timeout=timeout
+        )
 
     @patch.object(PremiumExpirationSweepJob, "_find_dangling_assignments")
     @pytest.mark.asyncio

--- a/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
+++ b/studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py
@@ -17,6 +17,7 @@ def _self_returning_query(rows):
     q = MagicMock()
     q.join.return_value = q
     q.filter.return_value = q
+    q.distinct.return_value = q
     q.order_by.return_value = q
     q.limit.return_value = q
     q.all.return_value = rows

--- a/studio/tests/app/common/core/premium/test_release_timeout.py
+++ b/studio/tests/app/common/core/premium/test_release_timeout.py
@@ -1,0 +1,58 @@
+"""
+Tests for the bounded timeout on PremiumAssignmentService.release_premium_user.
+
+Regression coverage for issue #629 Problem 4: the release Lambda call must
+not stall the caller (e.g. the Stripe webhook path) indefinitely. On timeout
+it fails open (returns a dict, does not raise) so the caller can proceed; the
+periodic premium-expiration sweep is the cleanup backstop.
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from studio.app.common.core.premium.premium_assignment_service import (
+    PremiumAssignmentService,
+)
+
+_OK_PAYLOAD = {"Payload": AsyncMock(read=lambda: b'{"statusCode": 200, "body": "{}"}')}
+
+
+class TestReleaseTimeout:
+    @pytest.mark.asyncio
+    async def test_release_times_out_fails_open(self):
+        """A slow Lambda triggers the timeout and returns a fail-open result."""
+        service = PremiumAssignmentService()
+
+        def slow_invoke(*args, **kwargs):
+            time.sleep(0.3)  # exceeds the 0.05s timeout below
+            return _OK_PAYLOAD
+
+        with patch.object(service, "_get_lambda_client") as mock_client:
+            mock_client.return_value.invoke.side_effect = slow_invoke
+            result = await service.release_premium_user(
+                user_id=1, user_uid="uid", hard=True, timeout=0.05
+            )
+
+        assert result["success"] is False
+        assert result["timed_out"] is True
+        assert "timed out" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_release_succeeds_within_timeout(self):
+        """The timeout parameter does not break the happy path."""
+        service = PremiumAssignmentService()
+
+        with patch.object(service, "_get_lambda_client") as mock_client:
+            mock_client.return_value.invoke.return_value = _OK_PAYLOAD
+            result = await service.release_premium_user(
+                user_id=1, user_uid="uid", hard=True, timeout=5
+            )
+
+        assert result["success"] is True
+        assert result.get("timed_out") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -913,9 +913,7 @@ class TestCustomerSubscriptionDeleted:
                 return_value=Mock(
                     filter=Mock(
                         return_value=Mock(
-                            first=Mock(
-                                return_value=(mock_user_account, mock_user)
-                            )
+                            first=Mock(return_value=(mock_user_account, mock_user))
                         )
                     )
                 )
@@ -952,9 +950,7 @@ class TestCustomerSubscriptionDeleted:
                 return_value=Mock(
                     filter=Mock(
                         return_value=Mock(
-                            first=Mock(
-                                return_value=(mock_user_account, mock_user)
-                            )
+                            first=Mock(return_value=(mock_user_account, mock_user))
                         )
                     )
                 )
@@ -989,9 +985,7 @@ class TestCustomerSubscriptionDeleted:
         mock_db.query.return_value = Mock(
             join=Mock(
                 return_value=Mock(
-                    filter=Mock(
-                        return_value=Mock(first=Mock(return_value=None))
-                    )
+                    filter=Mock(return_value=Mock(first=Mock(return_value=None)))
                 )
             )
         )
@@ -1019,9 +1013,7 @@ class TestCustomerSubscriptionDeleted:
                 return_value=Mock(
                     filter=Mock(
                         return_value=Mock(
-                            first=Mock(
-                                return_value=(mock_user_account, mock_user)
-                            )
+                            first=Mock(return_value=(mock_user_account, mock_user))
                         )
                     )
                 )

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -907,16 +907,20 @@ class TestCustomerSubscriptionDeleted:
             premium_assignment_service,
         )
 
-        mock_db.query.side_effect = [
-            # account by customer_id
-            Mock(
-                filter=Mock(
-                    return_value=Mock(first=Mock(return_value=mock_user_account))
+        # Single JOIN query: SubscriptionUserAccount + User by customer_id
+        mock_db.query.return_value = Mock(
+            join=Mock(
+                return_value=Mock(
+                    filter=Mock(
+                        return_value=Mock(
+                            first=Mock(
+                                return_value=(mock_user_account, mock_user)
+                            )
+                        )
+                    )
                 )
-            ),
-            # User by id
-            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
-        ]
+            )
+        )
         with patch.object(
             premium_assignment_service,
             "release_premium_user",
@@ -942,14 +946,20 @@ class TestCustomerSubscriptionDeleted:
             premium_assignment_service,
         )
 
-        mock_db.query.side_effect = [
-            Mock(
-                filter=Mock(
-                    return_value=Mock(first=Mock(return_value=mock_user_account))
+        # Single JOIN query: SubscriptionUserAccount + User by customer_id
+        mock_db.query.return_value = Mock(
+            join=Mock(
+                return_value=Mock(
+                    filter=Mock(
+                        return_value=Mock(
+                            first=Mock(
+                                return_value=(mock_user_account, mock_user)
+                            )
+                        )
+                    )
                 )
-            ),
-            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
-        ]
+            )
+        )
         timed_out = {
             "success": False,
             "timed_out": True,
@@ -975,9 +985,16 @@ class TestCustomerSubscriptionDeleted:
             premium_assignment_service,
         )
 
-        mock_db.query.side_effect = [
-            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
-        ]
+        # JOIN query returns None -> no account/user found
+        mock_db.query.return_value = Mock(
+            join=Mock(
+                return_value=Mock(
+                    filter=Mock(
+                        return_value=Mock(first=Mock(return_value=None))
+                    )
+                )
+            )
+        )
         with patch.object(
             premium_assignment_service, "release_premium_user", new=AsyncMock()
         ) as mock_release:
@@ -996,14 +1013,20 @@ class TestCustomerSubscriptionDeleted:
             premium_assignment_service,
         )
 
-        mock_db.query.side_effect = [
-            Mock(
-                filter=Mock(
-                    return_value=Mock(first=Mock(return_value=mock_user_account))
+        # Single JOIN query: SubscriptionUserAccount + User by customer_id
+        mock_db.query.return_value = Mock(
+            join=Mock(
+                return_value=Mock(
+                    filter=Mock(
+                        return_value=Mock(
+                            first=Mock(
+                                return_value=(mock_user_account, mock_user)
+                            )
+                        )
+                    )
                 )
-            ),
-            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
-        ]
+            )
+        )
         with patch.object(
             premium_assignment_service,
             "release_premium_user",

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from sqlmodel import Session
@@ -855,6 +855,145 @@ class TestCheckoutStorageQuotaUpdate:
 
         expected_quota = StorageQuota.bytes_for_plan(SubscriptionPlanIds.PREMIUM)
         assert added_obj.storage_quota_bytes == expected_quota
+
+
+class TestCustomerSubscriptionDeleted:
+    """Tests for the release-on-delete webhook path (issue #629, P3).
+
+    Verifies that customer.subscription.deleted now releases the dangling
+    premium compute assignment via release_premium_user (in addition to the
+    existing DB-row expiration in handle_subscription_cancelled).
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        db = Mock(spec=Session)
+        db.query = Mock()
+        db.add = Mock()
+        db.flush = Mock()
+        db.commit = Mock()
+        db.rollback = Mock()
+        return db
+
+    @pytest.fixture
+    def mock_user_account(self):
+        account = Mock()
+        account.user_id = 42
+        return account
+
+    @pytest.fixture
+    def mock_user(self):
+        user = Mock()
+        user.id = 42
+        user.uid = "user_uid_42"
+        return user
+
+    @pytest.fixture
+    def subscription_event(self):
+        """A customer.subscription.deleted event payload."""
+        return {
+            "id": "sub_stripe123",
+            "customer": "cus_test123",
+            "status": "canceled",
+        }
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_on_delete(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """The delete path hard-releases the user's premium assignment."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            # account by customer_id
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            # User by id
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+        with patch.object(
+            premium_assignment_service,
+            "release_premium_user",
+            new=AsyncMock(return_value={"success": True, "message": "released"}),
+        ) as mock_release:
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+        mock_release.assert_awaited_once_with(
+            user_id=42, user_uid="user_uid_42", hard=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_no_account_is_noop(
+        self, mock_db, subscription_event
+    ):
+        """No local account -> nothing to release, no error."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))),
+        ]
+        with patch.object(
+            premium_assignment_service, "release_premium_user", new=AsyncMock()
+        ) as mock_release:
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+        mock_release.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_release_failure_does_not_raise(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A release exception is swallowed so the webhook still acks."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+        with patch.object(
+            premium_assignment_service,
+            "release_premium_user",
+            new=AsyncMock(side_effect=Exception("Lambda boom")),
+        ):
+            # Must not raise.
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_delete_mirrors_and_releases(
+        self, mock_db, subscription_event
+    ):
+        """dispatch routes delete to the cancel handler AND the release helper."""
+        with patch.object(
+            WebhookService, "handle_subscription_cancelled"
+        ) as mock_cancel, patch.object(
+            WebhookService, "_release_premium_assignment", new=AsyncMock()
+        ) as mock_release:
+            result = await WebhookService.dispatch_webhook_event(
+                mock_db, "customer.subscription.deleted", subscription_event
+            )
+
+        assert result["success"] is True
+        mock_cancel.assert_called_once_with(mock_db, subscription_event)
+        mock_release.assert_awaited_once_with(mock_db, subscription_event)
 
 
 if __name__ == "__main__":

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -901,8 +901,9 @@ class TestCustomerSubscriptionDeleted:
     async def test_release_premium_assignment_on_delete(
         self, mock_db, mock_user_account, mock_user, subscription_event
     ):
-        """The delete path hard-releases the user's premium assignment."""
+        """The delete path hard-releases with the short webhook timeout."""
         from studio.app.common.core.premium.premium_assignment_service import (
+            WEBHOOK_RELEASE_TIMEOUT_SECONDS,
             premium_assignment_service,
         )
 
@@ -926,8 +927,44 @@ class TestCustomerSubscriptionDeleted:
             )
 
         mock_release.assert_awaited_once_with(
-            user_id=42, user_uid="user_uid_42", hard=True
+            user_id=42,
+            user_uid="user_uid_42",
+            hard=True,
+            timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS,
         )
+
+    @pytest.mark.asyncio
+    async def test_release_premium_assignment_continues_on_timeout(
+        self, mock_db, mock_user_account, mock_user, subscription_event
+    ):
+        """A fail-open (timed-out) release must not raise; webhook still acks."""
+        from studio.app.common.core.premium.premium_assignment_service import (
+            premium_assignment_service,
+        )
+
+        mock_db.query.side_effect = [
+            Mock(
+                filter=Mock(
+                    return_value=Mock(first=Mock(return_value=mock_user_account))
+                )
+            ),
+            Mock(filter=Mock(return_value=Mock(first=Mock(return_value=mock_user)))),
+        ]
+        timed_out = {
+            "success": False,
+            "timed_out": True,
+            "message": "Release timed out",
+        }
+        with patch.object(
+            premium_assignment_service,
+            "release_premium_user",
+            new=AsyncMock(return_value=timed_out),
+        ) as mock_release:
+            # Must not raise even though release reports failure.
+            await WebhookService._release_premium_assignment(
+                mock_db, subscription_event
+            )
+        mock_release.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_release_premium_assignment_no_account_is_noop(


### PR DESCRIPTION
# fix(subscription): release premium compute on `customer.subscription.deleted` + hourly backstop sweep + bounded fail‑open release timeout (closes #629 — Problems 3 & 4)

Closes #629 (Problems 3 and 4).

> **Scope.** Issue #629 documented three consequences (P1 / P2 / P3); P4 was found during the review of the release work. **This PR delivers P3 and P4 together** because they're directly coupled: P3 introduces an inline release call on the webhook path, and P4 is the hardening that makes that call safe (bounded latency, fail‑open). **Based on `main` independently of P1 and P2** — the delete‑release path, the hourly backstop sweep, and the bounded timeout are functionally self‑contained (they don't depend on `customer.subscription.created` or `.updated` handling). Expect minor mechanical merge conflicts in `webhook_service.py` (dispatch becomes `async`) and `subscriptions.py` (the dispatch call gains an `await`) when P1/P2 land; nothing semantic.

## Reported problems

| # | Problem (issue ref) | Occurrence rate | Cause & why it wasn't caught earlier | Risk — to users | Risk — to the system |
|---|---------------------|-----------------|--------------------------------------|-----------------|----------------------|
| 3 | Premium compute not released when a subscription ends (Scenario 2 / **600‑17b**) | **~Every expiration/cancellation.** Released only on logout / tab‑close, or eventually by the activity‑based stale‑sweep (up to ~3h) | `handle_subscription_cancelled` (the `customer.subscription.deleted` handler) expired the DB row but never called `release_premium_user`; no expiration→release path existed (release was only triggered by the logout and tab‑close beacon paths in `users_me.py`). The 600‑17b dev‑only path (a direct `UPDATE subscription_users SET expiration = ...` past grace) had **no** code path at all. **Not caught before** because the UI tier flips to free correctly (derived per request from `subscription_users.expiration` in `_enrich_user_with_subscription_status`), so the screen looked right; the dangling `premium_user_assignments` row is only visible in DB/infra, and cleanup eventually fired via unrelated paths (logout / beacon / stale‑sweep) | Low direct UI impact (user is correctly downgraded), but a free‑tier account retaining dedicated compute is a fairness / isolation concern | A dedicated EC2/ALB assignment stays attached to a now‑free user for up to ~3h per expiry → **direct cost leak** and wasted capacity; scales with churn |
| 4 | Inline release on `deleted` could stall the webhook (found in review of P3) | When the release Lambda is slow or hung | `release_premium_user` awaited a bare `loop.run_in_executor(...)` with no `asyncio.wait_for` (unlike `assign_premium_user`), and the Lambda client is built without a botocore `Config` — so a slow/hung Lambda could block the caller ~60 s (the botocore default). **Newly relevant** only because P3 adds the inline release on the webhook path; previously `release_premium_user` ran from logout/beacon where the latency mattered less | Cancel/expire flow hangs; possible duplicate side effects from retried Stripe deliveries | Webhook response blocked → Stripe marks delivery failed and **retries** → duplicate `deleted` deliveries; executor‑thread pressure |

**Why none of this was caught before.** The premium‑release path was wired only to logout/beacon. Subscription expiration drove a UI flip via `_enrich_user_with_subscription_status` (which reads `subscription_users.expiration` per request), so the screen looked correct even when the dedicated compute kept running — making P3 invisible without a DB/infra query. P4 only became a risk once P3 put the release call on the latency‑sensitive webhook path; `release_premium_user` already had the unbounded `run_in_executor` issue, but no caller cared until now.

## Summary

`customer.subscription.deleted` expired the `subscription_users` row but never released the user's dedicated premium compute, leaving an orphaned per‑user EC2/ALB assignment attached to a now‑free user until logout / tab‑close / the activity‑based stale‑sweep (~3h). Separately, the dev‑only path of "force expiry by direct DB UPDATE" (test 600‑17b) had no release path at all — it relied entirely on whatever side door happened to fire next.

This PR:

- Wires `customer.subscription.deleted` to also `await` a new `_release_premium_assignment` helper (hard release via `release_premium_user`).
- Adds an **hourly backstop sweep** (`PremiumExpirationSweepJob`) that scans `subscription_users` for premium subscriptions expired more than `GRACE_PERIOD_DAYS` ago with no currently‑active subscription and releases any `active`, non‑standby `premium_user_assignments` row still attached. Defense‑in‑depth for the 600‑17b case and any genuinely missed `deleted` event.
- **Bounds the release call with `asyncio.wait_for` and fails open** on timeout, so a slow/hung Lambda can't stall the webhook (and can't tie up sweep iterations either). The webhook caller passes a short `WEBHOOK_RELEASE_TIMEOUT_SECONDS` (10 s); the sweep passes a short `RELEASE_TIMEOUT_SECONDS` (15 s); other callers (logout/beacon) keep the default `LAMBDA_TIMEOUT_SECONDS`.

## Root cause

`handle_subscription_cancelled` only marked the subscription expired in `subscription_users` — it never called `release_premium_user`. The only callers of `release_premium_user` were the explicit logout endpoint and the tab‑close beacon endpoint in `users_me.py`; nothing in the subscription‑lifecycle path released the assignment. The local‑expiration path (a direct DB update past grace) had no event to drive a release at all.

Separately (P4), `release_premium_user` awaited `loop.run_in_executor(None, invoke_lambda)` with no `asyncio.wait_for`, and the Lambda client (`boto3.client("lambda")`) was built without a `Config`, so a slow/hung Lambda could block the caller for ~60 s (the botocore default) before returning — fine for logout/beacon, dangerous on the webhook path that P3 introduces.

## Changes

**`studio/app/common/core/subscription/constants.py`**
- Added `PremiumExpirationSweep` (job id, hourly interval, per‑run cap, **short per‑release timeout**) for the new backstop job. `RELEASE_TIMEOUT_SECONDS = 15` so worst‑case per run ≈ `MAX_RELEASES_PER_RUN * RELEASE_TIMEOUT_SECONDS` stays well under `JOB_INTERVAL_MINUTES`.

**`studio/app/common/core/premium/premium_assignment_service.py`**
- Added `WEBHOOK_RELEASE_TIMEOUT_SECONDS = 10` for latency‑sensitive callers (the Stripe webhook).
- `release_premium_user` takes a new `timeout` kwarg (default `LAMBDA_TIMEOUT_SECONDS`) and wraps its Lambda invoke in `asyncio.wait_for`. On timeout it **fails open**: logs a warning and returns `{"success": False, "timed_out": True, "message": …}` instead of hanging or raising. Other callers (logout/beacon/sweep) keep the default 60 s.

**`studio/app/common/core/subscription/webhook_service.py`**
- Added async `_release_premium_assignment(...)`: maps the Stripe `customer` → `SubscriptionUserAccount` → `user_id`, then looks up the `User` for its Firebase `uid`, and calls `release_premium_user(hard=True, timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS)`. Best‑effort: it logs but never raises, and on a non‑confirmed/timed‑out release it logs a warning and continues so a slow Lambda can't stall the webhook or trigger Stripe retries (the sweep handles cleanup).
- Made `dispatch_webhook_event` `async`. In the existing `case CUSTOMER_SUBSCRIPTION_DELETED:`, after the sync `handle_subscription_cancelled(db, data)` call, it now also `await`s `_release_premium_assignment(db, data)`.

**`studio/app/common/routers/subscriptions.py`**
- `await` the now‑async `dispatch_webhook_event` in the `/stripe/webhook` handler.

**`studio/app/common/core/background/premium_expiration_sweep_job.py`** (new)
- `PremiumExpirationSweepJob.run()` — the hourly backstop. `_find_dangling_assignments()` joins `PremiumUserAssignment` → `User` → `UserSubscription`, filtering for an `active`, non‑standby assignment whose user's PREMIUM subscription expired more than `GRACE_PERIOD_DAYS` ago **and** who has no currently‑active subscription (correlated `EXISTS`), ordered by `expiration` ascending so the oldest expirations are released first and the per‑run cap is deterministic. `run()` hard‑releases each via `release_premium_user(hard=True, timeout=PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS)`, best‑effort per user, bounded by `MAX_RELEASES_PER_RUN`. DB primitives are extracted before the async release calls so the session isn't held during Lambda invocations.

**`studio/__main_unit__.py`**
- Registers `PremiumExpirationSweepJob.run` with `BackgroundScheduler` (hourly), alongside the existing background jobs. Runs only on the background scheduler service (`DISABLE_BACKGROUND_SCHEDULER` / standalone mode skip it). Event‑driven release in `WebhookService` is unchanged; this is purely a safety net.

**`studio/tests/app/common/routers/test_webhook.py`**
- New `TestCustomerSubscriptionDeleted` suite (5 tests): the delete‑release path (asserts the short `WEBHOOK_RELEASE_TIMEOUT_SECONDS` is passed); the no‑account no‑op; the fail‑open behavior (release raises → swallowed); a fail‑open on the new timed‑out return (`success: False` is logged as a warning, not raised); and dispatch routing (`deleted` triggers both the cancel mirror and the release).

**`studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py`** (new)
- 5 tests covering the release loop (asserts hard‑release per candidate **with the sweep's short `RELEASE_TIMEOUT_SECONDS`**, continue‑on‑error, no‑candidates no‑op) and `_find_dangling_assignments` (dedup, empty result).

**`studio/tests/app/common/core/premium/test_release_timeout.py`** (new)
- 2 tests covering `release_premium_user`'s bounded timeout: a slow Lambda returns the fail‑open dict within the timeout, and the happy path within the timeout still succeeds.

## Behavior: before → after

| Scenario | Before | After |
| --- | --- | --- |
| `customer.subscription.deleted` (immediate cancel in Stripe) | Expired the DB row only; premium compute left dangling | Expires DB row **and** hard‑releases the premium assignment (bounded, fail‑open) |
| Local expiration applied past grace with no Stripe event (test 600‑17b: direct `UPDATE subscription_users SET expiration = …`) | Assignment dangles until the activity‑based stale‑sweep TTL (~3h) | Hourly backstop releases it once expired past `GRACE_PERIOD_DAYS` |
| Missed / never‑delivered `deleted` webhook | Same dangle until stale‑sweep | Same backstop catches it on the next hourly run |
| Slow / hung release Lambda | Release `await` could block the webhook ~60 s → Stripe marks failed and retries (duplicate deliveries); could also stall the sweep | Bounded to `WEBHOOK_RELEASE_TIMEOUT_SECONDS` (webhook) / `RELEASE_TIMEOUT_SECONDS` (sweep); fails open and acknowledges; sweep cleans up next run |

## Test plan

CI/local: run the targeted tests in your poetry env (the sandbox can't run them — pydantic v1 isn't installed).

```
poetry run pytest \
  studio/tests/app/common/routers/test_webhook.py \
  studio/tests/app/common/core/background/test_premium_expiration_sweep_job.py \
  studio/tests/app/common/core/premium/test_release_timeout.py -v
```

### Automated unit tests added (12)

| Test | Category | Verifies |
|------|----------|----------|
| `test_release_premium_assignment_on_delete` | P3 Release (+P4) | `_release_premium_assignment` hard‑releases via `release_premium_user(hard=True, timeout=WEBHOOK_RELEASE_TIMEOUT_SECONDS)` with the correct user_id / user_uid |
| `test_release_premium_assignment_no_account_is_noop` | P3 Release | No mapped account → no release call, no error |
| `test_release_failure_does_not_raise` | P3 Release (resilience) | A release exception is swallowed so the webhook still acks |
| `test_release_premium_assignment_continues_on_timeout` | P4 Resilience | A fail‑open (`success: False, timed_out: True`) release is logged as a warning, not raised; webhook still acks |
| `test_dispatch_delete_mirrors_and_releases` | P3 Dispatch | dispatch routes `customer.subscription.deleted` → cancellation mirror **and** awaits the release helper |
| `test_no_candidates_no_release` | P3 Backstop | Empty candidate set → no release calls |
| `test_releases_each_candidate_hard` | P3 Backstop (+P4) | `run()` hard‑releases each candidate with `timeout=PremiumExpirationSweep.RELEASE_TIMEOUT_SECONDS` |
| `test_continues_after_release_error` | P3 Backstop (resilience) | One failing release doesn't stop the batch |
| `test_returns_deduped_candidates` | P3 Backstop (query) | Dedup; exercises the ordered query path |
| `test_returns_empty_when_no_rows` | P3 Backstop (query) | Empty result handled |
| `test_release_times_out_fails_open` | P4 Resilience | `release_premium_user` returns a fail‑open dict on timeout (does not hang/raise) |
| `test_release_succeeds_within_timeout` | P4 Resilience | The new `timeout` kwarg doesn't break the happy path |

Static verification (already run locally):
- `py_compile`: ✅ clean on all changed files.
- `flake8 --max-line-length=88`: ✅ clean on all changed files.

### Manual / system test cases

> Common environment: Stripe **test mode**, dev webhook endpoint subscribed to `customer.subscription.deleted`, AWS CLI / SQL client / CloudWatch Logs Insights on `/ecs/development-optinist-cloud-taskdef` (the API task) and the background‑scheduler service log group.

#### TC‑S1 — P3 Backstop sweep (system test 600‑17b)

**Objective.** Confirm that a subscription expired past the 30‑day grace **without** a Stripe `deleted` event still releases the dangling `premium_user_assignments` row via the hourly backstop sweep.

**Preconditions.**
1. PR deployed. The `premium_expiration_sweep` job is registered — verify in CloudWatch:
   ```
   filter @message like /Added background job: premium_expiration_sweep/
   ```
2. A premium test user with an `active` assignment:
   ```sql
   SELECT u.id AS user_id, u.uid, su.id AS sub_id, su.plan_id, su.expiration,
          pua.id AS asg_id, pua.instance_id, pua.status, pua.is_standby
   FROM users u
   JOIN subscription_users su ON su.user_id = u.id
   LEFT JOIN premium_user_assignments pua ON pua.user_id = u.id
   WHERE u.email = '<TEST_EMAIL>';
   -- Expected: plan_id = 2, expiration > NOW(), pua.status = 'active', pua.is_standby = 0.
   ```
   Record `<UID>`, `<SID>`, `<ASGID>`, `<INSTID>`.

**Steps.**
1. Note `T0` (UTC).
2. Force the subscription 35 days past expiry (no Stripe event):
   ```sql
   UPDATE subscription_users
      SET expiration = DATE_SUB(NOW(), INTERVAL 35 DAY)
    WHERE user_id = <UID> AND id = <SID>;
   ```
3. Trigger the sweep — pick **A** or **B**:
   - **A. Wait.** Default interval `JOB_INTERVAL_MINUTES = 60`. Wait until the next firing.
   - **B. Invoke manually.** Exec into the background ECS task and run:
     ```
     python -c "import asyncio; from studio.app.common.core.background.premium_expiration_sweep_job import PremiumExpirationSweepJob; asyncio.run(PremiumExpirationSweepJob.run())"
     ```
4. Re‑query the assignment and ALB resources.

**Verification.**
- CloudWatch (window: `T0` … `T0 + 65 min`):
  ```
  fields @timestamp, @message
  | filter @message like /Starting premium expiration sweep job|Premium expiration sweep: .*dangling assignment|Premium expiration sweep: released user <UID>|Premium expiration sweep completed/
  | sort @timestamp asc
  ```
- DB:
  ```sql
  SELECT id, instance_id, status FROM premium_user_assignments WHERE id = <ASGID>;
  -- Expected: row deleted (hard release), OR status = 'terminating'.
  ```
- AWS:
  ```
  aws elbv2 describe-rules --region ap-northeast-1 --listener-arn <DEV_ALB_LISTENER_ARN> \
    --query "Rules[?Conditions[?Field=='path-pattern' && contains(Values[0], '/user/<UID>/')]]"
  # Expected: []
  aws elbv2 describe-target-groups --region ap-northeast-1 \
    --query "TargetGroups[?TargetGroupName=='premium-user-<UID>']"
  # Expected: []
  ```

**Pass criteria.** Sweep release log present; assignment row gone or `terminating`; ALB resources removed.

**Cleanup.** Restore the test user's `expiration` (or terminate the test user) before re‑running.

#### TC‑S2 — P3 Backstop guardrails (negative)

| Case | Setup | Expected |
|------|-------|----------|
| User re‑subscribed (future expiration) | Active assignment + a `subscription_users` row with `expiration > NOW()` | Sweep → no release for this user |
| Premium expired but within 30‑day grace | `expiration = NOW() - INTERVAL 5 DAY` | Sweep → no release |
| Standby / non‑`active` assignment | `is_standby = 1` (or `status != 'active'`) | Sweep → no release |
| Free user with old expiration | `plan_id = 1` (FREE), no premium assignment | Not picked up; no release attempted |

#### TC‑S3 — P4 Webhook resilience under a slow release Lambda

**Objective.** Confirm a slow/hung release Lambda does not stall the webhook (Stripe gets 200 within bounded time), the fail‑open log fires, and the sweep cleans up the assignment afterwards.

**Setup (dev only — revert when done).**
1. Temporarily set `WEBHOOK_RELEASE_TIMEOUT_SECONDS = 1` in `studio/app/common/core/premium/premium_assignment_service.py`. Deploy to dev.
2. Add a temporary `time.sleep(5)` at the top of the `release` handler in `infrastructure/terraform/.build/premium_manager/premium_manager.py` (so the Lambda exceeds the new timeout). Deploy that Lambda.
3. Set up a premium test user with an `active` assignment (as in TC‑S2). Capture `<UID>`, `<ASGID>`, `<SUB_ID>`.

**Steps.**
1. Trigger an immediate cancel (TC‑S2 step 1).
2. In Stripe Dashboard → Recent deliveries, measure the response time for the `customer.subscription.deleted` delivery.
3. Watch CloudWatch and the DB.

**Verification.**
- Stripe Dashboard: delivery response time **≤ ~1.5 s** (the webhook returned 200 within the bounded timeout instead of waiting the full 5 s). No retries appear.
- CloudWatch (window: T0 … T0+2 min):
  ```
  filter @message like /Release Lambda timed out after .* for user <UID>|deferring to background cleanup|Webhook: Premium release not confirmed for user <UID>/
  ```
  Expected: timeout warning lines present; no `Webhook processing error` or Stripe‑retry lines.
- DB immediately after: the assignment is **still present** (release didn't confirm in time).
- After the next sweep run (or a manual invoke per TC‑S1 step 3B): the assignment is released.

**Pass criteria.** Webhook responded within the bounded timeout; timeout log present; no Stripe retries; sweep eventually cleans up.

**Cleanup (mandatory).** Revert `WEBHOOK_RELEASE_TIMEOUT_SECONDS` to its original value and remove the `time.sleep` from the Lambda. Redeploy both.

## Notes

- `release_premium_user` is invoked with `hard=True` (both the webhook delete path and the sweep) so the assignment and ALB resources are torn down immediately (no grace period).
- The webhook release is fail‑open: if the release Lambda is slow and exceeds `WEBHOOK_RELEASE_TIMEOUT_SECONDS`, the webhook is still acknowledged (200) and the assignment is released on the next sweep run. This is why the short webhook timeout is safe.
- The sweep is defense‑in‑depth and runs only on the background scheduler service (`DISABLE_BACKGROUND_SCHEDULER` / standalone mode skip it). It complements — does not replace — the event‑driven release and the existing activity‑based Premium Cleanup Lambda.
- This PR makes `dispatch_webhook_event` `async`. The other existing sync handlers (`checkout.session.completed`, `invoice.*`, etc.) are still called synchronously inside the async dispatch — that's fine. When the P1 (`created`) and P2 (`updated`) PRs land, the merge is mechanical: their `case` blocks slot into the async dispatch unchanged.

## Checklist

- [x] Tests pass in CI (the 12 new tests plus the existing webhook suite).
- [x] The Stripe webhook endpoint is subscribed to `customer.subscription.deleted` in the relevant environments.
- [x] TC‑S1 (backstop sweep / 600‑17b): direct `UPDATE` expiration → assignment released within an hour.
- [x] TC‑S2 guardrails (re‑subscribed / within grace / standby / free) do not trigger a release.
- [x] TC‑S3 P4 resilience: a slow release Lambda no longer stalls the webhook; sweep cleans up.

## Follow‑ups (separate branches)

- **`fix/629-handle-subscription-created` (P1)** — activation via `customer.subscription.created` (already on its own branch).
- **`fix/629-handle-subscription-updated` (P2)** — mirror Stripe‑initiated subscription changes via `customer.subscription.updated` (already on its own branch).
- **Active‑user email lookup hardening** (review‑driven) — filter `User.active=True` in `validate_checkout_session` and `handle_subscription_schedule_released` so a soft‑deleted + re‑registered user can't resolve to the wrong row.
