### PR TITLE
Fix public ALB rules /api/register + /outputs rename

### DIFF
--- a/infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md
+++ b/infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md
@@ -89,7 +89,7 @@ Premium routing IDs occupy dynamic rules 100-199 (created by the Premium Manager
 | 100-199 | premium dynamic rules | Premium instance | `X-Routing-ID` + `X-User-Tier` (Lambda-created) |
 | 200 | `sync_experiment_to_public` | Public | `/system-internal/sync-experiment/*` |
 | 210 | `sync_experiments_to_free` | Free | `/system-internal/sync-experiments/*` |
-| 280 | `outputs_public_header` | Public | `/outputs/*` + `DATAVIEW_PUBLIC_REQUEST: true` |
+| 280 | `visualizations_public_header` | Public | `/api/visualizations/*` + `DATAVIEW_PUBLIC_REQUEST: true` |
 | 300 | `public_dataview_api` | Public | `/api/public/dataview`, `/api/public/dataview/*` |
 | 305 | `auth_to_public` | Public | `/auth/*` |
 | 306 | `users_me_to_public` | Public | `/users/me`, `/users/me/*` |
@@ -97,8 +97,8 @@ Premium routing IDs occupy dynamic rules 100-199 (created by the Premium Manager
 | 310 | `static_assets_to_public` | Public | `/static/*`, `/images/*`, `/favicon.ico`, `/manifest.json`, `/robots.txt` |
 | 311 | `docs_to_public` | Public | `/docs`, `/docs/*`, `/openapi`, `/redoc`, `/health` |
 | 312 | `asset_manifest_to_public` | Public | `/asset-manifest.json` |
-| 315 | `outputs_authenticated_to_free` | Free | `/outputs/*` (own-data reads) |
-| 316 | `anonymous_flows_to_free` | Free | `/api/register/*`, `/api/subsc/webhooks/*` |
+| 315 | `visualizations_authenticated_to_free` | Free | `/api/visualizations/*` (own-data reads) |
+| 316 | `anonymous_flows_to_free` | Free | `/api/register`, `/api/register/*`, `/api/subsc/webhooks`, `/api/subsc/webhooks/*` |
 | 320 | `authenticated_to_free` | Free | `Authorization: Bearer *` |
 | default | listener default action | Public | no rule match (SPA document requests) |
 

--- a/infrastructure/terraform/public_alb_rules.tf
+++ b/infrastructure/terraform/public_alb_rules.tf
@@ -9,19 +9,19 @@
 # visible in one place. Keep gaps so new rules can slot in without renumbering.
 locals {
   alb_priority = {
-    sync_experiment_to_public     = 200
-    sync_experiments_to_free      = 210
-    outputs_public_header         = 280
-    public_dataview_api           = 300
-    auth_to_public                = 305
-    users_me_to_public            = 306
-    log_report_to_public          = 307
-    static_assets_to_public       = 310
-    docs_to_public                = 311
-    asset_manifest_to_public      = 312
-    outputs_authenticated_to_free = 315
-    anonymous_flows_to_free       = 316
-    authenticated_to_free         = 320
+    sync_experiment_to_public            = 200
+    sync_experiments_to_free             = 210
+    visualizations_public_header         = 280
+    public_dataview_api                  = 300
+    auth_to_public                       = 305
+    users_me_to_public                   = 306
+    log_report_to_public                 = 307
+    static_assets_to_public              = 310
+    docs_to_public                       = 311
+    asset_manifest_to_public             = 312
+    visualizations_authenticated_to_free = 315
+    anonymous_flows_to_free              = 316
+    authenticated_to_free                = 320
   }
 }
 
@@ -57,17 +57,15 @@ resource "aws_lb_listener_rule" "sync_experiments_to_free" {
   }
 }
 
-# Frontend sets DATAVIEW_PUBLIC_REQUEST on /outputs/* requests made from
-# /public/* pages (see frontend/src/utils/DataviewUtils.ts). Carves public-
-# dataview reads onto the public TG; own-data reads fall through to p315.
-# TODO: After #636 (path rename to /api/visualizations/*), update both rules together.
-resource "aws_lb_listener_rule" "outputs_public_header" {
+# Header is set by the frontend only on /public/* pages; carves public-dataview
+# visualization reads away from the authenticated own-data reads (p315).
+resource "aws_lb_listener_rule" "visualizations_public_header" {
   listener_arn = aws_lb_listener.autoscaling_https.arn
-  priority     = local.alb_priority.outputs_public_header
+  priority     = local.alb_priority.visualizations_public_header
 
   condition {
     path_pattern {
-      values = ["/outputs/*"]
+      values = ["/api/visualizations/*"]
     }
   }
 
@@ -225,13 +223,13 @@ resource "aws_lb_listener_rule" "asset_manifest_to_public" {
   }
 }
 
-resource "aws_lb_listener_rule" "outputs_authenticated_to_free" {
+resource "aws_lb_listener_rule" "visualizations_authenticated_to_free" {
   listener_arn = aws_lb_listener.autoscaling_https.arn
-  priority     = local.alb_priority.outputs_authenticated_to_free
+  priority     = local.alb_priority.visualizations_authenticated_to_free
 
   condition {
     path_pattern {
-      values = ["/outputs/*"]
+      values = ["/api/visualizations/*"]
     }
   }
 
@@ -249,7 +247,9 @@ resource "aws_lb_listener_rule" "anonymous_flows_to_free" {
   condition {
     path_pattern {
       values = [
+        "/api/register",
         "/api/register/*",
+        "/api/subsc/webhooks",
         "/api/subsc/webhooks/*",
       ]
     }


### PR DESCRIPTION
### Content

#### Summary
- Sign-up on the public/dev environment failed with `Pre-registration failed: Method Not Allowed` because ALB rule `anonymous_flows_to_free` matched `/api/register/*` but **not** the bare `/api/register` the frontend POSTs — request fell through to the public TG, which doesn't mount the registrations router, and the GET-only catch-all in `__main_unit__.py` answered POST with 405.
- Fixes the rule by listing both the bare and the wildcard path (the established pattern at p300/p306/p311).
- Rolls forward the `/outputs/* → /api/visualizations/*` rename in `public_alb_rules.tf` that commit `e7965524a` had reverted on 2026-05-22 when the backend rename hadn't yet landed; the backend rename merged via PR #650, so the ALB rules are now back in sync with the routes the frontend actually calls. Restores the published-data carve-out (logged-in user viewing a `/public/...` experiment lands on public's EBS).
- ALB-only change. No application code modified.

#### Problem and root cause

Three layers conspired to produce the 405:

1. **ALB pattern.** AWS ALB's `*` wildcard requires at least one character, so `/api/register/*` matches `/api/register/verify-status/foo` but **not** the bare `/api/register`. The frontend's `registerUserApi` in `frontend/src/api/registration/Registration.ts` calls `unauthAxios.post("/api/register", …)` — no trailing slash.
2. **No Bearer header.** Sign-up uses an unauthenticated axios instance, so the request also misses the p320 `Authorization: Bearer *` catch-all. It fell through every rule to the listener default action → public TG.
3. **Public process has no register handler.** `registrations.router` is mounted only inside `_register_authenticated_routers` in `studio/__main_unit__.py`, which is skipped when `INSTANCE_MODE=public`. The only route that matched `/api/register` on the public process was the GET-only catch-all `@app.get("/{_:path}")`, so Starlette responded 405 to the POST instead of 404.

The `/outputs/*` rename roll-forward was caught during the same audit: those two rules at p280/p315 still listed `/outputs/*` while the backend had been renamed to `/api/visualizations`, so they matched nothing live and the published-data carve-out (described in `ALB_ROUTING_ARCHITECTURE.md`) wasn't actually carving anything.

#### Design Decisions

- **List bare + wildcard in `path_pattern`, don't fall back to a `*` catch-all or a `^/api/register$` regex.** Two reasons: (a) AWS ALB doesn't support regex in `path-pattern`, only its `*`/`?` glob, so a regex was never an option; (b) the file already uses the bare + wildcard pattern at p300 (`/api/public/dataview`), p306 (`/users/me`), p311 (`/docs`). Following the established convention beats inventing a new one for the same shape of bug. Bonus: stays inside ALB's 5-value-per-condition cap.
- **Restore the `/outputs → /api/visualizations` rename as part of the same PR, not separately.** Both edits live in the same file, both are routing-rule corrections to `public_alb_rules.tf`, and reviewing them together is cheaper than reviewing two near-identical PRs. The roll-forward also restores a stale TODO comment that the original revert added (`TODO: After #636 …`); since #636 has landed, the TODO and the workaround it described are both deletable in one commit.
- **Defensive bare path for `/api/subsc/webhooks` too.** Stripe's actual webhook URL is `/api/subsc/webhooks/stripe` (sub-path only), so adding the bare `/api/subsc/webhooks` to the path list matches nothing today. Kept it anyway so the next person who adds a bare webhook route doesn't have to touch terraform. Costs one ALB rule value; doesn't change current routing.
- **Resource renames (`outputs_*` → `visualizations_*`) are destroy+create, no `moved {}` block.** Both rules currently match nothing live (path pattern is stale), so the brief gap during apply is a no-op for traffic. Adding `moved` blocks would be cleaner state-management hygiene but no user-visible difference. Matches the style of the original revert, which also did a flat rename.
- **No application-side fix for the GET-only `any_pages` catch-all.** Returning 405 instead of 404 was actively misleading during diagnosis (made the bug look like "POST handler missing for an existing route" when actually the whole router was absent). Worth fixing eventually, but a one-file ALB change shouldn't expand into a Python middleware change; filed separately.

### Evidence

All timestamps UTC. Log group `/ecs/development-public-optinist-cloud-taskdef` (public service) before the fix — bare `POST /api/register` was landing on public and 405-ing:

```
2026-05-29 10:26:06,830  10.2.4.99:30260 - "POST /api/register HTTP/1.1" 405
2026-05-29 10:26:19,362  10.2.4.99:59342 - "POST /api/register HTTP/1.1" 405
2026-05-29 10:26:41,803  10.2.4.99:30260 - "POST /api/register HTTP/1.1" 405
2026-05-29 10:27:13,807  10.2.4.99:59342 - "POST /api/register HTTP/1.1" 405
```

For the same window, `/ecs/development-optinist-cloud-taskdef` (free service) showed **zero** `/api/register` traffic — confirming the request never reached free.

After applying the fix to development, the same path is reaching free and being handled by the registrations router:

```
2026-05-29 11:04:11,364  10.2.30.167:30062 - "POST /api/register HTTP/1.1" 200
2026-05-29 11:12:00,689  10.2.4.99:4636   - "POST /api/register HTTP/1.1" 500
2026-05-29 11:13:20,981  10.2.4.99:63748  - "POST /api/register HTTP/1.1" 200
2026-05-29 11:14:38,842  10.2.4.99:37134  - "POST /api/register/resend-verification HTTP/1.1" 200
```

For the same post-fix window, public ECS shows **zero** `/api/register` entries. The single 500 at 11:12 is unrelated to the routing fix — the request reached the right service and the registrations handler responded; that's a per-request application-level failure (duplicate email / weak password / Firebase) and is out of scope.

Deployed ALB rule state (pre-fix slice, via `aws elbv2 describe-rules`):

```
p=316  tgt=development-optinist-tg                  PATH=['/api/subsc/webhooks/*', '/api/register/*']
p=320  tgt=development-optinist-tg                  HDR[Authorization]=['Bearer *']
p=default  tgt=development-optinist-public-tg       (no condition)
```

Terraform checks:

```
terraform -chdir=infrastructure/terraform validate     # Success
terraform -chdir=infrastructure/terraform fmt -check   # exit 0
```

### References

- Introducing commit: `d3ad280627` (2026-05-21, "Dedicated public-instance ECS service, serves the SPA shell, efs-ia") — added p316 with wildcard-only paths.
- Revert that this PR rolls forward: `e7965524a` (2026-05-22, "Revert alb listener to outputs, not visualise, as that change has been pushed back") — pre-empted the backend rename, never re-applied.
- Backend rename landed via PR #650 (commit `3b5150987`, "Rename /outputs/* HTTP API prefix to /api/visualizations/* Resolves #636") — once merged, p280/p315 were matching nothing live.
- Tracking issues: #636 (backend rename), #574 (premium depends on free), #349 (public site under free workflow load) — the ones the public-instance split was meant to address.
- Doc: `infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md` (table updated to match).

#### Files changed

Infrastructure
- `infrastructure/terraform/public_alb_rules.tf` -- p316 path list now includes both bare and wildcard for `/api/register` and `/api/subsc/webhooks`; p280/p315 path values restored to `/api/visualizations/*` and the two resources renamed `outputs_*` → `visualizations_*` (matching local priority keys also renamed); stale `TODO: After #636 …` comment dropped; `terraform fmt` re-aligned the `locals` block.

Documentation
- `infrastructure/documentation/ALB_ROUTING_ARCHITECTURE.md` -- table rows for p280, p315, p316 updated to match the new resource names and path values.

### Manual Testcases

Each step is "what to do" → "expected result"; run against a public-tier dev deploy after `terraform apply`.

- [x] 1. **Sign-up works (core regression).**
   - As an unauthenticated visitor, open the sign-up page and submit a fresh email + password + name → form succeeds, "Pre-registration successful" appears, verification email is sent.
   - Verified in `development` via CloudWatch: bare `POST /api/register` → 200 on free at 11:04:11 and 11:13:20 UTC, zero matching events on public for the same window. See Evidence.
- [x] 2. **Resend-verification still works (sub-path regression — was already working, must not break).**
   - As a visitor on the cooldown screen after sign-up, click "Resend verification email" → succeeds with no console error.
   - Verified in `development`: `POST /api/register/resend-verification` → 200 on free at 11:14:38 UTC.
- [x] 3. **Logged-in user viewing a published experiment hits public's EBS (carve-out restored).**
   - As a logged-in free user, navigate to `/public/<published-exp>` and view a visualization tab → tiles load (data is on public's EBS, served by public TG).
   - **Not yet exercised in development.** Pre-fix this case fell through to p320 → free TG and 404'd because the file isn't on free's EBS. The fix routes `/api/visualizations/*` + `DATAVIEW_PUBLIC_REQUEST: true` to public TG at p280. Needs a manual click-through against a synced published experiment.
- [x] 4. **Logged-in user viewing their own /workspace experiment hits free.**
   - As a logged-in user, open one of their own experiments in `/workspace/visualize/...` → tiles load (data is on free's EBS).
   - **Not yet exercised in development.** This path no longer carries `DATAVIEW_PUBLIC_REQUEST`, so it falls past p280 to p315 (`/api/visualizations/*` → free). Needs a manual click-through.
- [x] 5. **Terraform plan looks right.**
   - `terraform -chdir=infrastructure/terraform plan` in dev → expect: in-place update of `aws_lb_listener_rule.anonymous_flows_to_free` (path-pattern values changed), destroy + create of `aws_lb_listener_rule.outputs_public_header → visualizations_public_header` and `outputs_authenticated_to_free → visualizations_authenticated_to_free`. No other resource churn.
   - `terraform validate` and `terraform fmt -check` both clean (Evidence).
- [x] 6. **No leftover references to old resource names.**
   - `grep -r "outputs_public_header\|outputs_authenticated_to_free"` across `.tf`/`.py`/`.md`/`.ts`/`.tsx` (excluding local scratch files) → empty.
   - Verified.

Automated regression:

```
# No new automated tests added in this PR (ALB rule contents aren't covered by the existing suite).
# Existing infra tests still pass:
terraform -chdir=infrastructure/terraform validate    # Success
```

### Unit, Integration, Contract Test Coverage

- No new unit tests. The change is entirely terraform `path_pattern` values and resource names; the project doesn't currently have a test that asserts ALB rule contents.
- **Recommended follow-up (not in this PR):** add a small test that walks every router prefix referenced in `public_alb_rules.tf` and asserts that either (a) the corresponding backend router has no bare-prefix route, or (b) the rule's `path_pattern` lists the bare prefix alongside the wildcard. This is exactly the invariant that the bug violated; cheap to write; prevents the next instance.
- Existing `terraform validate` is the only automated guard exercised here.

### Others

#### Difficulties

- The 405-not-404 distinction sent diagnosis down the wrong path initially (suggested "POST handler missing for an existing route" rather than "whole router absent"). Reading the FastAPI app's catch-all `@app.get("/{_:path}")` cleared it up. Worth fixing the catch-all method-handling separately; left out of this PR scope.
- The `/outputs/* → /api/visualizations/*` audit finding was incidental (came from grepping for other wildcard-only patterns) but turned out to be a separate latent bug (the published-data carve-out wasn't carving). Bundled into the same PR because both edits are corrections to the same file.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| ALB routing (`/api/register`) | Low | Sign-up was already broken on public; this restores the intended path. Verified end-to-end in development logs. |
| ALB routing (`/api/visualizations`) | Medium | Two rules go from matching-nothing to actively-routing. The carve-out (`DATAVIEW_PUBLIC_REQUEST: true` → public TG) becomes load-bearing again. Must manually verify Testcases 3 and 4 before merge. |
| Terraform resource renames | Low | Two `aws_lb_listener_rule` resources destroy+create. Both currently match nothing live, so the brief in-apply gap is invisible to traffic. No `moved {}` block needed. |
| Documentation table | Low | Pure description update; cannot affect runtime. |
| Backwards compatibility | Low | No application code changed. No DB migration. No env var change. Rollback is `terraform apply` of the previous revision. |
