### PR TITLE
Hotfix TC339 Delete User Cancel Subscription

### DIFF
--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -727,6 +727,7 @@ async def delete_user(db: Session, user_id: int, organization_id: int) -> bool:
         # Step 2: Cancel Stripe subscription (reversible)
         # ----------------------------------------
         try:
+            SubscriptionService._ensure_stripe_initialized()
             await StripeService.handle_cancel_user_subscription(db, user_db)
             deletion_record.step = DeletionStep.STRIPE_CANCELLED.value
             db.commit()
@@ -901,6 +902,7 @@ async def resume_deletion_from_step(record: UserDeletionRecord, db: Session) -> 
 
     if current_order < _get_step_order(DeletionStep.STRIPE_CANCELLED):
         try:
+            SubscriptionService._ensure_stripe_initialized()
             await StripeService.handle_cancel_user_subscription(db, user_db)
             record.step = DeletionStep.STRIPE_CANCELLED.value
             db.commit()


### PR DESCRIPTION
 ## Summary                                                                                            
                                                                                                          
  - Adds `SubscriptionService._ensure_stripe_initialized()` call before                                   
  `StripeService.handle_cancel_user_subscription()` in both `delete_user` and `resume_deletion_from_step` 
  flows                                                                                                   
                                                                                                        
  ## Description

  The user deletion flow calls `StripeService.handle_cancel_user_subscription()` to cancel a user's Stripe
   subscription as part of the deletion process (Step 2). However, unlike the subscription API endpoints
  which use the `stripe_dependency()` FastAPI dependency to ensure Stripe is initialized, the user        
  deletion code path was calling the Stripe API without first setting the Stripe API key.               

  This caused Stripe cancellation to fail silently during user deletion (the error is caught and logged as
   a warning), meaning deleted users could retain active Stripe subscriptions that would continue to be
  billed.                                                                                                 
                                                                                                        
  The fix adds `SubscriptionService._ensure_stripe_initialized()` in two places in `crud_users.py`:       
  1. **`delete_user()`** (line 730) — the primary user deletion flow
  2. **`resume_deletion_from_step()`** (line 905) — the recovery/retry flow for partially-failed deletions
                                                                                                          
  ### Why this surfaced in v1.1.7 but not v1.1.6                                                          
                                                                                                          
  In v1.1.7, the `users_me` router (which includes `DELETE /users/me`) was moved from the free/premium    
  tier to **all tiers including the public instance** ([db066fbc](db066fbc)) so that users could log in
  even when their personal services were down.                                                            
                                                                                                        
  However, the public ECS service explicitly omits Stripe environment variables (`public_service.tf`:     
  *"Stripe vars omitted: subscriptions router is gated out on public"*), and the `subscriptions.router`
  (which provides the `stripe_dependency()` that initializes `stripe.api_key`) is not mounted on the      
  public tier.                                                                                          

  In v1.1.6, user deletion only ran on free/premium instances where `stripe.api_key` was typically already
   set by prior subscription API calls. In v1.1.7, user self-deletion (`DELETE /users/me`) can now be
  served by the public instance where Stripe was never initialized and the env var doesn't even exist —   
  causing the cancellation step to silently fail every time.                                            

  ## Test plan

  - [x] Verify user deletion correctly cancels the Stripe subscription
  - [x] TC339 works
  - [x] Confirm no regression in normal subscription cancellation via the API endpoint 