### PR TITLE
Update AMI to AL2023

### DIFF
--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -83,7 +83,7 @@ graph TB
 |---------|-------|---------------------|
 | Custom AMI selection at deploy time | Terraform local | `local.effective_ami_id` in `compute.tf` |
 | Bake-aware boot logic (skip packages) | User-data script | `ecs-user-data.sh` |
-| ECS agent checkpoint clear (every boot) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
+| ECS agent checkpoint clear (premium boot only) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
 | Swap volume (instant swap setup) | Launch template EBS | `block_device_mappings` `/dev/xvds` in `compute.tf` |
 | AMI ID storage | SSM Parameter Store | `/${environment}/optinist/custom-ami-id` |
 | AMI build orchestration | EC2 Image Builder pipeline | `image_builder.tf` |
@@ -249,11 +249,11 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 
 **Solution:** The SSM parameter is initially set to the stock ECS-optimized AMI ID. Until a successful build overwrites it, all launch templates use the stock AMI. The user-data `else` branch handles stock AMI boot correctly.
 
-### 6. Stale ECS Agent Checkpoint on Stop/Start
+### 6. Stale ECS Agent Checkpoint (Bake-time vs. Stop/Start)
 
-**Problem:** A stopped instance keeps `/var/lib/ecs/data/agent.db` across stop/start, but ECS deregisters the disconnected container instance while the instance is stopped. On restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. This affects every tier that is stopped and started rather than terminated — notably the **background** instance (stopped nightly/weekends by the dev scheduler) and **premium** standby instances, neither of which is covered by a one-time bake-time clear alone.
+**Problem:** Two distinct cases. **(a)** An instance launched from a custom AMI inherits whatever `/var/lib/ecs/data/agent.db` was baked into the image, so without cleanup every instance from that image would register under the same container-instance identity. **(b)** The **premium** standby pool stops idle instances, and the premium manager deregisters their container instance while they are stopped (`cleanup_ghost_ecs_registrations()`, which is filtered to the premium tier); on restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. Tiers that are stopped but **not** reaped — notably the **background** instance (stopped nightly by the dev scheduler, with no managing Lambda) — keep a still-valid registration and must *not* wipe it: doing so strands the old registration as a ghost and registers a fresh duplicate on every restart.
 
-**Solution:** Two layers. At runtime, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service`, a oneshot systemd unit ordered `Before=ecs.service` that removes `agent.db` (and the legacy `ecs_agent_data.json`) on **every boot**, so the agent always registers fresh. It is host-side and needs no orchestrator, which is why it covers the background instance (which has no managing Lambda). At bake time, `CleanEcsAgentState` removes the same files from the AMI artifact so a freshly built image carries no container-instance identity, and `ValidateEcsAgentStateCleaned` fails the build if they persist.
+**Solution:** Two layers, each scoped to where it is needed. At **bake time**, `CleanEcsAgentState` removes `agent.db`/`ecs_agent_data.json` from the AMI artifact so a freshly built image carries no container-instance identity (case a), and `ValidateEcsAgentStateCleaned` fails the build if they persist. At **runtime**, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service` — a oneshot unit ordered `Before=ecs.service` that wipes the checkpoint on every boot — **only on the premium tier** (case b). Every other tier, including background, keeps its identity across stop/start and reconnects to its existing registration instead of creating a ghost.
 
 ---
 
@@ -574,9 +574,9 @@ grep "swap" /var/log/ecs-setup.log
 curl -s http://localhost:51678/v1/metadata | python -m json.tool
 # Expected: valid JSON with Cluster name matching expected cluster
 
-# 8. Confirm the checkpoint-clear unit is enabled (runs before ecs.service on every boot)
+# 8. On a PREMIUM instance, confirm the checkpoint-clear unit is enabled (premium tier only)
 systemctl is-enabled ecs-clear-checkpoint.service
-# Expected: enabled
+# Expected: enabled on premium; not installed on other tiers (background, free, public)
 ```
 
 ---

--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -31,7 +31,7 @@
 
 4. **Immutable Build Components and Recipes**
    - EC2 Image Builder components and recipes are immutable in AWS — content changes require a version bump
-   - `var.custom_ami_version` controls all version strings; bumping it forces Terraform to create new resources via `create_before_destroy`
+   - `local.custom_ami_version` (in `image_builder.tf`) controls all version strings; bumping it forces Terraform to create new resources via `create_before_destroy`. It is defined in git-tracked code, not tfvars, so every developer applies the same version
 
 5. **Encrypted AMI with Same-Account Distribution**
    - Recipe specifies `encrypted = true` (AWS-managed CMK) for the root EBS volume
@@ -137,7 +137,7 @@ if [ -f /etc/optinist-ami-baked ]; then
 else
     echo "$(date): Stock AMI detected, installing packages"
     yum update -y
-    yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+    yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent
     curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
     cd /tmp && unzip -qo awscliv2.zip
     /tmp/aws/install --update
@@ -147,8 +147,8 @@ fi
 ```
 
 **Package fix notes (also applied to stock AMI path):**
-- `mysql-client` removed — does not exist in Amazon Linux 2; `mysql` package provides the client binary
-- `awscli` v1 replaced — yum package no longer available in AL2 repos; standalone AWS CLI v2 installer used instead
+- `mariadb105` provides the MySQL client binary (`/usr/bin/mysql`) — Amazon Linux 2023 has no `mysql` or `mysql-client` package
+- `awscli` v1 replaced — yum package not available; standalone AWS CLI v2 installer used instead
 - `export PATH="/usr/local/bin:$PATH"` — required for pre-baked AMI because AWS CLI v2 installs to `/usr/local/bin`, which is not in the default PATH at user-data execution time
 
 **Swap setup optimization (dedicated EBS volume):**
@@ -181,7 +181,7 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 | Step | Action | Notes |
 |------|--------|-------|
 | `SystemUpdate` | `yum update -y` | Apply latest patches |
-| `InstallYumPackages` | `yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent` | Core packages |
+| `InstallYumPackages` | `yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent` | Core packages |
 | `InstallAWSCLIv2` | Remove awscli v1, install standalone v2, verify with `grep -q "aws-cli/2"` | Replaces broken v1 yum package |
 | `EnableDockerService` | `systemctl enable docker` | Enabled but NOT started (instance shuts down for snapshot) |
 | `CreateBakeMarker` | Write `/etc/optinist-ami-baked` with timestamp and package list | Detected by user-data at boot |
@@ -254,13 +254,17 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 
 Before bumping `custom_ami_version` or running `terraform apply`, confirm the currently active version using the methods below. This check is referenced by [Procedure B](#procedure-b-initial-setup-first-time-deployment) and [Procedure C](#procedure-c-ami-content-fix--rebuild).
 
-#### Method 1: Check tfvars (Local Source of Truth)
+#### Method 1: Check image_builder.tf (Git Source of Truth)
 
-The `custom_ami_version` value set in the tfvars file is the version that Terraform will use on next `apply`.
+The `local.custom_ami_version` map in `image_builder.tf` holds the per-environment version that Terraform will use on next `apply`.
 
 ```bash
-grep custom_ami_version infrastructure/terraform/environments/<env>.tfvars
-# Example output: custom_ami_version = "1.0.2"
+grep -A3 'custom_ami_version = {' infrastructure/terraform/image_builder.tf
+# Example output:
+#   custom_ami_version = {
+#     development = "2.0.0"
+#     subscr      = "2.0.0"
+#   }[var.environment]
 ```
 
 #### Method 2: Query Image Builder Pipeline (AWS Source of Truth)
@@ -314,7 +318,7 @@ The version is encoded in the component name suffix (dots replaced with hyphens:
 
 | What | Where | Command / Location |
 |------|-------|--------------------|
-| Version to be deployed next | tfvars file | `grep custom_ami_version <env>.tfvars` |
+| Version to be deployed next | `image_builder.tf` locals | `grep -A3 'custom_ami_version = {' image_builder.tf` |
 | Version currently active in AWS | Pipeline → Recipe | `aws imagebuilder get-image-recipe` (see Method 2) |
 | All versions ever created | Components list | `aws imagebuilder list-components --owner Self` |
 | Visual confirmation | AWS Console | EC2 Image Builder → Image pipelines → Recipe |
@@ -327,7 +331,7 @@ This procedure enables the custom AMI feature, builds the first AMI via Image Bu
 ┌──────────────────────────────────────────────────────────┐
 │ Step 1: Enable Feature Flag                              │
 │    → Set use_custom_ami = true in terraform.tfvars       │
-│    → Set custom_ami_version = "1.0.0"                    │
+│    → Set local.custom_ami_version (image_builder.tf)     │
 │                                                          │
 │    ℹ Before setting custom_ami_version, verify the       │
 │      current version state.                              │
@@ -414,7 +418,7 @@ When the pre-baked package set changes (component YAML files modified), a versio
 ┌──────────────────────────────────────────────────────────┐
 │ Step 1: Edit YAML and Bump Version                       │
 │    → Modify component YAML files as needed               │
-│    → Bump custom_ami_version in terraform.tfvars         │
+│    → Bump local.custom_ami_version in image_builder.tf   │
 │      (e.g., "1.0.0" → "1.0.1")                          │
 │                                                          │
 │    ℹ Before bumping, verify the current version.         │
@@ -529,7 +533,7 @@ cat /etc/optinist-ami-baked
 # Expected:
 #   BAKED_DATE=2026-04-21T11:16:57Z
 #   BAKED_BY=ec2-image-builder
-#   PACKAGES=amazon-ssm-agent,mysql,...
+#   PACKAGES=amazon-ssm-agent,mariadb105,...
 
 # 2. Confirm user-data skipped package installation
 grep "Pre-baked AMI detected" /var/log/ecs-setup.log
@@ -548,7 +552,7 @@ aws --version
 # Expected: aws-cli/2.x.x ...
 
 # 5. Verify packages
-rpm -q amazon-ssm-agent amazon-efs-utils amazon-cloudwatch-agent git docker
+rpm -q amazon-ssm-agent amazon-efs-utils amazon-cloudwatch-agent git docker mariadb105
 which mysql nc
 
 # 6. Confirm swap is on dedicated block device (free/premium tiers)
@@ -571,7 +575,8 @@ curl -s http://localhost:51678/v1/metadata | python -m json.tool
 | Variable | Type | Default | Purpose |
 |----------|------|---------|---------|
 | `use_custom_ami` | `bool` | `false` | Feature flag: enable/disable Image Builder and custom AMI usage |
-| `custom_ami_version` | `string` | `"1.0.0"` | Component and recipe version; bump to force new resources |
+
+The component/recipe version is intentionally **not** a variable: `local.custom_ami_version` in `image_builder.tf` maps each environment to its version. It lives in git-tracked code (not tfvars) so all developers apply the same value; bump it to force new components and a new recipe.
 
 ### AMI Build Pipeline Settings (EC2 Image Builder)
 
@@ -632,7 +637,7 @@ aws imagebuilder get-image \
 <timestamp>: Pre-baked AMI detected, skipping package installation
 BAKED_DATE=2026-04-21T03:15:22Z
 BAKED_BY=ec2-image-builder
-PACKAGES=amazon-ssm-agent,mysql,...
+PACKAGES=amazon-ssm-agent,mariadb105,...
 ```
 
 **Stock AMI fallback:**
@@ -770,11 +775,11 @@ All resource names are prefixed with the Terraform `environment` variable (shown
 |------|---------|
 | `infrastructure/terraform/compute.tf` | Custom AMI selection logic (`local.effective_ami_id`), free and premium launch templates |
 | `infrastructure/scripts/ecs-user-data.sh` | Bake marker detection and conditional package installation |
-| `infrastructure/terraform/image_builder.tf` | EC2 Image Builder Terraform resources (IAM, components, recipe, pipeline, lifecycle, SSM, outputs) |
+| `infrastructure/terraform/image_builder.tf` | EC2 Image Builder Terraform resources (IAM, components, recipe, pipeline, lifecycle, SSM, outputs) and `local.custom_ami_version` |
 | `infrastructure/image_builder/components/optinist-packages.yml` | Build component: package installation steps |
 | `infrastructure/image_builder/components/optinist-validate.yml` | Validate component: installation verification |
 | `infrastructure/terraform/background_service.tf` | Background launch template (uses `local.effective_ami_id`) |
-| `infrastructure/terraform/main.tf` | Variable definitions (`use_custom_ami`, `custom_ami_version`) |
+| `infrastructure/terraform/main.tf` | Variable definitions (`use_custom_ami`) |
 | `infrastructure/terraform/infrastructure.tf` | S3 lifecycle rule for `image-builder-logs/` |
 | `infrastructure/terraform/environments/development.tfvars.example` | Example tfvars with custom AMI settings |
 | `infrastructure/terraform/environments/production.tfvars.example` | Example tfvars with custom AMI settings |

--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -83,6 +83,7 @@ graph TB
 |---------|-------|---------------------|
 | Custom AMI selection at deploy time | Terraform local | `local.effective_ami_id` in `compute.tf` |
 | Bake-aware boot logic (skip packages) | User-data script | `ecs-user-data.sh` |
+| ECS agent checkpoint clear (every boot) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
 | Swap volume (instant swap setup) | Launch template EBS | `block_device_mappings` `/dev/xvds` in `compute.tf` |
 | AMI ID storage | SSM Parameter Store | `/${environment}/optinist/custom-ami-id` |
 | AMI build orchestration | EC2 Image Builder pipeline | `image_builder.tf` |
@@ -186,6 +187,7 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 | `EnableDockerService` | `systemctl enable docker` | Enabled but NOT started (instance shuts down for snapshot) |
 | `CreateBakeMarker` | Write `/etc/optinist-ami-baked` with timestamp and package list | Detected by user-data at boot |
 | `CleanupYumCache` | `yum clean all` + `rm -rf /var/cache/yum` | Reduces AMI snapshot size |
+| `CleanEcsAgentState` | Stop `ecs`, remove `agent.db` + `ecs_agent_data.json` | AMI artifact carries no container-instance identity (see Edge Case 6) |
 
 **AWSTOE error handling:** Each step uses a single `|` block with `set -e` at the top. This prevents error masking — AWSTOE evaluates the exit code of the **last** item in `commands`, so trailing `echo` statements would mask failures in preceding commands.
 
@@ -203,6 +205,7 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 | `ValidateDockerEnabled` | `systemctl is-enabled docker` |
 | `ValidateBakeMarker` | `test -f /etc/optinist-ami-baked` |
 | `ValidateEFSUtils` | Check `/usr/bin/mount.efs` or `/sbin/mount.efs` |
+| `ValidateEcsAgentStateCleaned` | Fail the build if `agent.db` / `ecs_agent_data.json` persist |
 
 **Test phase (fresh instance from AMI):**
 
@@ -245,6 +248,12 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 **Problem:** If the Image Builder pipeline fails, no custom AMI is available.
 
 **Solution:** The SSM parameter is initially set to the stock ECS-optimized AMI ID. Until a successful build overwrites it, all launch templates use the stock AMI. The user-data `else` branch handles stock AMI boot correctly.
+
+### 6. Stale ECS Agent Checkpoint on Stop/Start
+
+**Problem:** A stopped instance keeps `/var/lib/ecs/data/agent.db` across stop/start, but ECS deregisters the disconnected container instance while the instance is stopped. On restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. This affects every tier that is stopped and started rather than terminated — notably the **background** instance (stopped nightly/weekends by the dev scheduler) and **premium** standby instances, neither of which is covered by a one-time bake-time clear alone.
+
+**Solution:** Two layers. At runtime, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service`, a oneshot systemd unit ordered `Before=ecs.service` that removes `agent.db` (and the legacy `ecs_agent_data.json`) on **every boot**, so the agent always registers fresh. It is host-side and needs no orchestrator, which is why it covers the background instance (which has no managing Lambda). At bake time, `CleanEcsAgentState` removes the same files from the AMI artifact so a freshly built image carries no container-instance identity, and `ValidateEcsAgentStateCleaned` fails the build if they persist.
 
 ---
 
@@ -564,6 +573,10 @@ grep "swap" /var/log/ecs-setup.log
 # 7. Confirm ECS agent registered
 curl -s http://localhost:51678/v1/metadata | python -m json.tool
 # Expected: valid JSON with Cluster name matching expected cluster
+
+# 8. Confirm the checkpoint-clear unit is enabled (runs before ecs.service on every boot)
+systemctl is-enabled ecs-clear-checkpoint.service
+# Expected: enabled
 ```
 
 ---

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -460,7 +460,7 @@ Runs every 15 minutes. Step numbering matches the comments in the source. Some s
 9.   cleanup_excess_standby_instances()    - Trim standby pool to PREMIUM_STANDBY_POOL_SIZE
 10a. finalize_expired_pending_releases()   - Tear down ALB resources for assignments past soft-release grace
 10b. cleanup_ghost_ecs_registrations()     - Deregister ECS container instances whose EC2 is gone
-11.  cleanup_orphaned_ec2_instances()      - Stop premium-tagged EC2 not in the ECS cluster (15-min grace)
+11.  cleanup_orphaned_ec2_instances()      - Stop premium-tagged EC2 not in the ECS cluster (10-min launch-age grace)
 12.  fix_incorrect_is_shared_flags() then
      process_shared_instance_optimization() - Promote shared users to dedicated, or fire invoke_migration_async() if none free
 ```
@@ -717,7 +717,7 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 ┌──────────────────────────────────────────────────────────┐
 │ 11. cleanup_orphaned_ec2_instances()                     │
 │    → Stop premium-tagged EC2 not in ECS                  │
-│    → 15-minute grace period for booting instances        │
+│    → 10-minute launch-age grace for booting instances    │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
@@ -797,8 +797,8 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 **Problem:** EC2 instances stopped/terminated outside normal flow leave orphaned ECS registrations that confuse the ECS scheduler.
 
 **Solution:** Premium Manager's `cleanup_ghost_ecs_registrations()`:
-- Finds container instances with disconnected agents or stopped/terminated EC2
-- Force-deregisters them from the ECS cluster
+- Finds premium container instances with disconnected agents or stopped/terminated EC2
+- Stopped/terminated/unmapped instances are deregistered immediately; a running EC2 with a disconnected agent is tagged `optinist:agent-disconnected-at` on first sighting and deregistered only after `_AGENT_DISCONNECT_GRACE_SECONDS = 300` (5 minutes), with the tag cleared if the agent reconnects
 - Runs every 15 minutes as part of scheduled monitoring
 
 
@@ -808,8 +808,10 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 **Solution:** Premium Manager's `cleanup_orphaned_ec2_instances()`:
 - Finds premium-tagged EC2 instances not in the ECS cluster
-- 15-minute grace period (`ORPHAN_GRACE_PERIOD_MINUTES = 15`) to avoid stopping still-booting instances
-- Stops orphaned instances
+- `launch_time`-age grace (`ORPHAN_GRACE_PERIOD_MINUTES = 10` minutes) to avoid stopping still-booting instances; symmetric with the `booting_count` window in `update_premium_service_desired_count()`
+- Stops orphaned instances (and registers them as standby for later aged termination)
+
+> This and the ghost-CI cleanup (Edge Case 4) are independent timers measured from different events — agent-disconnect (300s) vs instance launch (10 min) — and both run in the same 15-minute cycle, so a single run can deregister a ghost container instance and stop the orphaned EC2 behind it.
 
 
 ### 6. Race Condition Between Manager and Cleanup
@@ -1483,7 +1485,7 @@ Note the log template is literal: it says `attempt N failed, retrying...`, not `
 | `Using free tier while premium instance provisions` | `axios.ts` | Single occurrence accompanies one `instance_unreachable` UI event; the circuit breaker will probe for recovery. Investigate only if the paired `instance_reachable` never arrives (see A.1.7) |
 | `Premium-(un)?reachable listener threw: ${e}` | `RoutingService.ts` | One listener crashed during dispatch; the pool continues delivering to others |
 | `Agent disconnected on ${i-xxx}, starting grace period` and its "within grace period" follow-up | `premium_manager.py` ghost ECS cleanup | 5-min grace before deregistering ECS container instance |
-| `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 15-min grace before stopping orphan EC2 |
+| `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 10-min launch-age grace before stopping orphan EC2 |
 | `Warning: Error closing database connection: ${e}` | both lambdas | Cleanup-path warning on teardown; does not affect the work already done |
 | `Transaction rolled back due to error: ${e}` | `premium_manager.py` | Expected when a `@with_transaction` path encounters an exception and rolls back cleanly |
 | `Conditions not met for auto-assignment: { isPremiumUser: false, ... }` | `PremiumAssignmentContext.tsx` | Non-premium user; the provider correctly short-circuits |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -175,8 +175,9 @@ sequenceDiagram
     else Tier 3: Start Standby
         DB-->>PM: Found standby instance (is_standby=1)
         PM->>EC2: Start Instance
-        PM->>PM: clear_ecs_agent_checkpoint()
         EC2-->>PM: Instance running (5-15s)
+        Note over EC2: ecs-clear-checkpoint.service wipes stale agent.db before ECS agent starts
+        PM->>PM: check_instance_readiness_with_retry()
         PM->>ALB: Create Target Group + Rule
         PM->>PM: create_and_stop_standby_instance() (replenish)
         PM-->>User: Assigned (5-15s wait)
@@ -498,7 +499,7 @@ that are merely rebooting their agent.
 **Pre-assignment Steps:**
 1. Restore any `pending_release` assignment (beacon fired but the user is back) -- returns with `assignment_source: "restored_from_pending_release"`
 2. Check for existing assignment:
-   - If the EC2 is `stopped`/`stopping`, restart it, clear the ECS checkpoint, wait up to 120s for ECS readiness, and return `assignment_source: "restarted_instance"`
+   - If the EC2 is `stopped`/`stopping`, restart it and wait up to 120s for ECS readiness, then return `assignment_source: "restarted_instance"` (the instance's `ecs-clear-checkpoint.service` wipes the stale agent checkpoint on boot so it re-registers)
    - If the EC2 is `terminated`/`shutting-down`/gone, remove the stale DB entry and fall through to fresh assignment
    - If the assignment is on `autoscaling-pool` or a shared instance, attempt an **inline migration** to a ready dedicated instance first (`assignment_source: "inline_migration"`); fall back to `invoke_migration_async()` if no instance is ready
    - Otherwise return the existing assignment (`assignment_source: "existing"`)
@@ -785,11 +786,12 @@ assignment. This function only handles the **start** transition; it does
 **not** touch the standby placeholder row itself.
 **Input:** instance_id (str)
 **Output:** True on success, False on failure
-**Calls:** `ec2.start_instances()` -> `ec2.get_waiter('instance_running')` -> `clear_ecs_agent_checkpoint()`
+**Calls:** `ec2.start_instances()` -> `ec2.get_waiter('instance_running')` -> `check_instance_readiness_with_retry()`
 
 **Key behaviors:**
 - Waits for running state (delay=5s, max 24 attempts)
-- Clears stale ECS agent checkpoint so it re-registers
+- Stale ECS agent checkpoint is cleared host-side on boot by `ecs-clear-checkpoint.service` (before `ecs.service`), so the restarted agent re-registers instead of resuming a deregistered container instance
+- Waits for ECS readiness via `check_instance_readiness_with_retry()` (max 120s) and returns False on timeout, before any DB update
 - Updates `instance_state` to `'running'` for any pre-existing **non-standby**
   assignment rows on this instance (there should be none on a true Tier 3
   path; the clause is defensive)
@@ -916,7 +918,7 @@ subscribers.
 - Blocked if launching instances exist or `CREATE_RUNNING_LOCK` held
 - No-op if `running_count >= active_users` (sufficient capacity). Note this is distinct from [`scale_down_if_possible()`](#scale-down-scale_down_if_possible), which keeps `max(1, active_users + 1)` -- scale-up has no `+ 1` safety margin, so the scale-down headroom only exists after a full monitor cycle runs
 - Prefers starting stopped instances (fastest) over creating new
-- Clears ECS agent checkpoints after starting stopped instances
+- Started instances clear their stale ECS agent checkpoint host-side on boot (via `ecs-clear-checkpoint.service`); no Lambda-side action is needed
 - Falls back to `_create_running_instances_locked()` under
   distributed lock
 - Always calls `invoke_migration_async()` and
@@ -1361,7 +1363,7 @@ Shared instance optimization complete: 1 users migrated
 | Function | Purpose |
 |----------|---------|
 | `create_and_stop_standby_instance()` | Create instance, stop for pool (distributed lock) |
-| `start_standby_instance()` | Start standby + clear ECS checkpoint (does NOT delete placeholder row) |
+| `start_standby_instance()` | Start standby + wait for ECS readiness; checkpoint cleared host-side on boot (does NOT delete placeholder row) |
 | `convert_idle_instances_to_standby_immediate()` | Stop idle running instances and convert to standby in-line during scale-down (see [spec](#convert_idle_instances_to_standby_immediate)) |
 | `get_available_standby_instances()` | Query standby pool (is_standby=1) |
 | `register_orphaned_stopped_instances()` | Adopt AWS-stopped / DB-less instances into the standby pool |

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -141,5 +141,5 @@ phases:
               set -e
               echo "$(date): Clearing ECS agent checkpoint so the baked AMI carries no container-instance identity"
               systemctl stop ecs 2>/dev/null || true
-              rm -rf /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
+              rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
               echo "$(date): ECS agent state cleared"

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -132,3 +132,14 @@ phases:
               # Remove non-default SSH authorized keys
               rm -f /root/.ssh/authorized_keys
               echo "$(date): Credential sanitization complete"
+
+      - name: CleanEcsAgentState
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "$(date): Clearing ECS agent checkpoint so the baked AMI carries no container-instance identity"
+              systemctl stop ecs 2>/dev/null || true
+              rm -rf /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
+              echo "$(date): ECS agent state cleared"

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -22,7 +22,7 @@ phases:
             - |
               set -e
               echo "$(date): Installing yum packages"
-              yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
+              yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent
               echo "$(date): Yum packages installed"
 
       - name: InstallAWSCLIv2
@@ -32,7 +32,7 @@ phases:
             - |
               set -e
               echo "$(date): Installing AWS CLI v2"
-              # Remove awscli v1 if present (no longer in AL2 repos)
+              # Remove awscli v1 if present (standalone v2 is used instead)
               yum remove -y awscli 2>/dev/null || true
               # Ensure unzip is available (not always present on ECS-optimized AMI)
               yum install -y unzip
@@ -66,7 +66,7 @@ phases:
               cat > /etc/optinist-ami-baked <<MARKER
               BAKED_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
               BAKED_BY=ec2-image-builder
-              PACKAGES=amazon-ssm-agent,mysql,amazon-efs-utils,nc,git,docker,amazon-cloudwatch-agent,awscli-v2
+              PACKAGES=amazon-ssm-agent,mariadb105,amazon-efs-utils,nc,git,docker,amazon-cloudwatch-agent,awscli-v2
               MARKER
               chmod 644 /etc/optinist-ami-baked
               echo "$(date): Bake marker created"

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -12,7 +12,7 @@ phases:
             - echo "=== Validating yum package installations ==="
             - |
               FAILED=0
-              for pkg in amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent; do
+              for pkg in amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent; do
                 if rpm -q "$pkg" >/dev/null 2>&1 || which "$pkg" >/dev/null 2>&1; then
                   echo "OK: $pkg"
                 else

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -116,6 +116,18 @@ phases:
               fi
               echo "OK: No credential leak detected"
 
+      - name: ValidateEcsAgentStateCleaned
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating ECS agent checkpoint was cleared ==="
+            - |
+              if [ -f /var/lib/ecs/data/agent.db ] || [ -f /var/lib/ecs/data/ecs_agent_data.json ]; then
+                echo "FAIL: ECS agent checkpoint present — instances from this AMI would register as duplicate container instances"
+                exit 1
+              fi
+              echo "OK: ECS agent state cleared"
+
   - name: test
     steps:
       - name: TestBakeMarkerPersisted

--- a/infrastructure/scripts/app_setup.sh
+++ b/infrastructure/scripts/app_setup.sh
@@ -256,7 +256,8 @@ echo "$(date): Starting database initialization"
 # Install MySQL client for database initialization
 echo "$(date): Installing MySQL client"
 if command -v yum &>/dev/null; then
-    yum install -y mysql python3-pip
+    # mariadb105 on AL2023; fall back to mysql on AL2 hosts
+    yum install -y mariadb105 python3-pip || yum install -y mysql python3-pip
 elif command -v apt-get &>/dev/null; then
     apt-get update
     apt-get install -y mysql-client-core-8.0 python3-pip

--- a/infrastructure/scripts/app_setup.sh
+++ b/infrastructure/scripts/app_setup.sh
@@ -257,7 +257,8 @@ echo "$(date): Starting database initialization"
 echo "$(date): Installing MySQL client"
 if command -v yum &>/dev/null; then
     # mariadb105 on AL2023; fall back to mysql on AL2 hosts
-    yum install -y mariadb105 python3-pip || yum install -y mysql python3-pip
+    yum install -y mariadb105 || yum install -y mysql
+    yum install -y python3-pip
 elif command -v apt-get &>/dev/null; then
     apt-get update
     apt-get install -y mysql-client-core-8.0 python3-pip

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -20,7 +20,7 @@ After=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db
+ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
 
 [Install]
 WantedBy=multi-user.target

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -38,7 +38,7 @@ if [ -f /etc/optinist-ami-baked ]; then
 else
     echo "$(date): Stock AMI detected, installing packages"
     yum update -y
-    yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent
+    yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent unzip
     # Install AWS CLI v2 (awscli v1 yum package no longer available)
     curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
     cd /tmp && unzip -qo awscliv2.zip

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -38,8 +38,8 @@ if [ -f /etc/optinist-ami-baked ]; then
 else
     echo "$(date): Stock AMI detected, installing packages"
     yum update -y
-    yum install -y amazon-ssm-agent mysql amazon-efs-utils nc git docker amazon-cloudwatch-agent
-    # Install AWS CLI v2 (awscli v1 package no longer available in AL2 repos)
+    yum install -y amazon-ssm-agent mariadb105 amazon-efs-utils nc git docker amazon-cloudwatch-agent
+    # Install AWS CLI v2 (awscli v1 yum package no longer available)
     curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
     cd /tmp && unzip -qo awscliv2.zip
     /tmp/aws/install --update
@@ -62,7 +62,7 @@ if [ "$SWAP_SIZE_MB" -gt 0 ]; then
     # Strategy 1: Dedicated EBS swap volume (instant, preferred)
     if [ -n "$SWAP_DEVICE_NAME" ]; then
         # On Nitro instances (t3, m5, etc.), /dev/xvds may appear as /dev/nvme*n1.
-        # Amazon Linux 2 ECS AMI creates symlinks via udev rules (ec2-utils).
+        # The ECS-optimized AMI creates symlinks via udev rules (ec2-utils).
         if [ -b "$SWAP_DEVICE_NAME" ]; then
             SWAP_TARGET="$SWAP_DEVICE_NAME"
             echo "$(date): Found swap device at $SWAP_DEVICE_NAME"
@@ -70,8 +70,9 @@ if [ "$SWAP_SIZE_MB" -gt 0 ]; then
             echo "$(date): $SWAP_DEVICE_NAME not found, scanning NVMe devices..."
             for nvme_dev in /dev/nvme*n1; do
                 [ -b "$nvme_dev" ] || continue
+                # ebsnvme-id prints the attachment name without the /dev/ prefix
                 mapped_name=$(/sbin/ebsnvme-id -b "$nvme_dev" 2>/dev/null || true)
-                if [ "$mapped_name" = "$SWAP_DEVICE_NAME" ]; then
+                if [ "$mapped_name" = "$(basename "$SWAP_DEVICE_NAME")" ]; then
                     SWAP_TARGET="$nvme_dev"
                     echo "$(date): Found swap device at $nvme_dev (mapped from $SWAP_DEVICE_NAME)"
                     break

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -10,8 +10,9 @@ echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
 echo ECS_INSTANCE_ATTRIBUTES='{"tier":"${tier}"}' >> /etc/ecs/ecs.config
 
-# Systemd service to clear stale ECS agent checkpoint on every boot.
-cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
+# Only premium standbys are reaped while stopped, so only they must wipe the stale checkpoint on boot to re-register.
+if [ "${tier}" = "premium" ]; then
+  cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
 [Unit]
 Description=Clear stale ECS agent checkpoint before startup
 Before=ecs.service
@@ -26,8 +27,9 @@ ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data
 WantedBy=multi-user.target
 UNIT_EOF
 
-systemctl daemon-reload
-systemctl enable ecs-clear-checkpoint.service
+  systemctl daemon-reload
+  systemctl enable ecs-clear-checkpoint.service
+fi
 
 # Install packages (skip if AMI is pre-baked by Image Builder)
 if [ -f /etc/optinist-ami-baked ]; then

--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -4,7 +4,7 @@ app_setup.sh
 
 # Terraform state files and directories
 terraform.*
-.terraform*
+.terraform/
 *.tfstate
 *.tfstate.backup
 

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -1,0 +1,131 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:D8uNiOpl3UkAX4zI5T47ALMiRFXTa1XfdQC+TBu3RmE=",
+    "zh:0072806bb262c6d86bc25b4a75750e469881144c14818afdba7b82db840e1588",
+    "zh:1ebc2dae335dad7a8b16a1985b69a63a14954282bb44fdba7d5103f77551ac7b",
+    "zh:2dab48fe8f3193b8216d578ac1e3674fa566435cc7dbce2953d55b72e31d0241",
+    "zh:2fc3d3029c2b7429472391ef339672e1fca8e6ff32c8a519bf3acedafa7e24fe",
+    "zh:38a36e64e7212f6cedac861ea4d449cce07131b3378de601bf9d49a99e000208",
+    "zh:3ac70758ed251ce78b7f541a5a79cc6fe56474412783ae1decef719bdd0f30bf",
+    "zh:4385d3903e685bddb2b8005b4eb7db89f030267d4d03c7d792d2f5e739cc874a",
+    "zh:4cce0760b87fbafd51f30faec2a737f4183b7c615f4a86557f7d3c893a610dc5",
+    "zh:4feaeed18694239b896c6415d9a1e5ef89e1da4f4ad60924aa0522adeb1f6599",
+    "zh:502fca2be1c95f443c3e67d0555601d1de65b4ca82d197c059e9c868360e3a0a",
+    "zh:57d037f6fdd045f2660909c3bdface9622d81165ce647479cba98d1f353c5eab",
+    "zh:5dc5a0b915c2ac5256d909458f5c8e40b35f78b3a36ea893c86624eaf6c54e37",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b84c87c58a320adbb2c74a4cad03ae5aac7f2eae21db26f00fdde98c8c4d4523",
+    "zh:c895f1d5cbcbeff77850ac99efd36bde0048d4e909b296882331b9b9ebf48cfa",
+    "zh:ead82831683619124597a1f170dd31e9b293e9cf22f558cb166d5e734fcd11e4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.9.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
+    "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
+    "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
+    "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
+    "zh:29d0b03e5343a80677ebfeb2e2c31cbe4b1f65e736e53417454a4277fec2544c",
+    "zh:4896bfa6cf1d2fd562b47ef2e87f47862ae92a04f8ad5d764380f0c6653473b8",
+    "zh:531f8529cbca49f681883e57761a05a8398afaef6d1ab0d205d26bf12f4428e8",
+    "zh:6aaf5011d83161c86d2bfb80c0923ec934e578288758da2f37acb7aec129004b",
+    "zh:7430275253d3d3c40aa6179e0ec0d63212874dbbc06c5a51b9d07ec590f9756c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:be17dc611e95e26cdf6cad79dfccf1064f0e32032a2efeb939a9bbe7fb1cbfe9",
+    "zh:f0e3b0aa644202e1d79d2000dca91f6019425da71e9800fa23f27e51c034f195",
+    "zh:f62bae4519e4ead49182ddc8afe8cf61e2a4c3ba3973b0fbba967736a2696aa3",
+    "zh:fcafa360a5b0b96244f26f4e3a6d642b716a376557142c2442ff2fb12d11da18",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.1"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -115,7 +115,7 @@ data "aws_ami" "ecs_optimized" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
+    values = ["al2023-ami-ecs-hvm-*-x86_64"]
   }
 
   filter {
@@ -300,7 +300,7 @@ resource "aws_autoscaling_group" "main" {
     strategy = "Rolling"
     preferences {
       instance_warmup        = 300
-      min_healthy_percentage = 0
+      min_healthy_percentage = 50
     }
   }
 

--- a/infrastructure/terraform/environments/development.tfvars.example
+++ b/infrastructure/terraform/environments/development.tfvars.example
@@ -86,9 +86,9 @@ asg_desired_capacity = 1
 
 # EC2 Image Builder — Custom AMI (reduces instance boot from ~8 min to ~2 min)
 # Set to true after initial terraform apply to create the Image Builder pipeline.
-# See image_builder.tf for deployment workflow.
+# See image_builder.tf for deployment workflow. The AMI version is tracked in
+# image_builder.tf (local.custom_ami_version), not here.
 use_custom_ami = false
-# custom_ami_version = "1.0.0"   # Bump to force a new AMI build
 
 # No test users initially
 test_users = []

--- a/infrastructure/terraform/environments/production.tfvars.example
+++ b/infrastructure/terraform/environments/production.tfvars.example
@@ -83,9 +83,9 @@ asg_max_size = 3
 
 # EC2 Image Builder — Custom AMI (reduces instance boot from ~8 min to ~2 min)
 # Set to true after initial terraform apply to create the Image Builder pipeline.
-# See image_builder.tf for deployment workflow.
+# See image_builder.tf for deployment workflow. The AMI version is tracked in
+# image_builder.tf (local.custom_ami_version), not here.
 use_custom_ami = false
-# custom_ami_version = "1.0.0"   # Bump to force a new AMI build
 
 # Test user configuration
 test_users = []

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -10,6 +10,15 @@
 # Gated by var.use_custom_ami (default false).  When disabled, launch
 # templates fall back to the stock Amazon ECS-optimized AMI.
 
+# Recipe/component version — bump per environment to force a new AMI build.
+# Kept in git rather than tfvars so every apply uses the same version.
+locals {
+  custom_ami_version = {
+    development = "2.0.0"
+    subscr      = "2.0.0"
+  }[var.environment]
+}
+
 # =====================
 # IAM — Build Instance
 # =====================
@@ -135,12 +144,12 @@ resource "aws_iam_role_policy_attachment" "image_builder_lifecycle" {
 resource "aws_imagebuilder_component" "optinist_packages" {
   count = var.use_custom_ami ? 1 : 0
 
-  name        = "${local.env_prefix}-packages-v${replace(var.custom_ami_version, ".", "-")}"
+  name        = "${local.env_prefix}-packages-v${replace(local.custom_ami_version, ".", "-")}"
   platform    = "Linux"
-  version     = var.custom_ami_version
+  version     = local.custom_ami_version
   description = "Install system packages and AWS CLI v2 for OptiNiSt ECS instances"
 
-  supported_os_versions = ["Amazon Linux 2"]
+  supported_os_versions = ["Amazon Linux 2023"]
 
   data = file("${path.module}/../image_builder/components/optinist-packages.yml")
 
@@ -157,12 +166,12 @@ resource "aws_imagebuilder_component" "optinist_packages" {
 resource "aws_imagebuilder_component" "optinist_validate" {
   count = var.use_custom_ami ? 1 : 0
 
-  name        = "${local.env_prefix}-validate-v${replace(var.custom_ami_version, ".", "-")}"
+  name        = "${local.env_prefix}-validate-v${replace(local.custom_ami_version, ".", "-")}"
   platform    = "Linux"
-  version     = var.custom_ami_version
+  version     = local.custom_ami_version
   description = "Validate OptiNiSt ECS AMI package installations"
 
-  supported_os_versions = ["Amazon Linux 2"]
+  supported_os_versions = ["Amazon Linux 2023"]
 
   data = file("${path.module}/../image_builder/components/optinist-validate.yml")
 
@@ -182,9 +191,9 @@ resource "aws_imagebuilder_component" "optinist_validate" {
 resource "aws_imagebuilder_image_recipe" "optinist" {
   count = var.use_custom_ami ? 1 : 0
 
-  name         = "${local.env_prefix}-ecs-recipe-v${replace(var.custom_ami_version, ".", "-")}"
+  name         = "${local.env_prefix}-ecs-recipe-v${replace(local.custom_ami_version, ".", "-")}"
   parent_image = data.aws_ami.ecs_optimized.id
-  version      = var.custom_ami_version
+  version      = local.custom_ami_version
   description  = "ECS-optimized AMI with pre-installed OptiNiSt packages"
 
   component {

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -14,7 +14,7 @@
 # Kept in git rather than tfvars so every apply uses the same version.
 locals {
   custom_ami_version = {
-    development = "2.0.0"
+    development = "2.0.1"
     subscr      = "2.0.0"
   }[var.environment]
 }

--- a/infrastructure/terraform/infrastructure.tf
+++ b/infrastructure/terraform/infrastructure.tf
@@ -75,16 +75,20 @@ locals {
     # The iptables binary is not preinstalled on the AL2023 base AMI
     yum install -y iptables-nft
 
-    # Enable IP forwarding (idempotent — only appends if not present)
-    grep -q 'net.ipv4.ip_forward' /etc/sysctl.conf || echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
-    sysctl -p
+    # Authoritative drop-in so a pre-existing sysctl.conf entry cannot win
+    echo 'net.ipv4.ip_forward = 1' > /etc/sysctl.d/99-nat.conf
+    sysctl --system
 
     # Detect the egress interface at boot — AL2023 uses predictable
     # interface names (ens5/enX0 on Nitro), so eth0 cannot be assumed.
     cat > /usr/local/sbin/configure-nat.sh << 'SCRIPT'
     #!/bin/bash
-    set -e
+    set -euo pipefail
     IFACE=$(ip -o -4 route show to default | awk '{print $5; exit}')
+    if [ -z "$IFACE" ]; then
+      echo "configure-nat: no default-route interface found" >&2
+      exit 1
+    fi
     iptables -P FORWARD ACCEPT
     iptables -t nat -C POSTROUTING -o "$IFACE" -j MASQUERADE 2>/dev/null \
       || iptables -t nat -A POSTROUTING -o "$IFACE" -j MASQUERADE
@@ -96,7 +100,8 @@ locals {
     cat > /etc/systemd/system/nat-iptables.service << 'UNIT'
     [Unit]
     Description=Configure NAT iptables rules
-    After=network.target
+    Wants=network-online.target
+    After=network-online.target
 
     [Service]
     Type=oneshot

--- a/infrastructure/terraform/infrastructure.tf
+++ b/infrastructure/terraform/infrastructure.tf
@@ -68,6 +68,51 @@ resource "aws_subnet" "private2" {
 # ============
 # NAT Instance
 # ============
+locals {
+  nat_user_data = <<-EOF
+    #!/bin/bash
+    yum update -y
+    # The iptables binary is not preinstalled on the AL2023 base AMI
+    yum install -y iptables-nft
+
+    # Enable IP forwarding (idempotent — only appends if not present)
+    grep -q 'net.ipv4.ip_forward' /etc/sysctl.conf || echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
+    sysctl -p
+
+    # Detect the egress interface at boot — AL2023 uses predictable
+    # interface names (ens5/enX0 on Nitro), so eth0 cannot be assumed.
+    cat > /usr/local/sbin/configure-nat.sh << 'SCRIPT'
+    #!/bin/bash
+    set -e
+    IFACE=$(ip -o -4 route show to default | awk '{print $5; exit}')
+    iptables -P FORWARD ACCEPT
+    iptables -t nat -C POSTROUTING -o "$IFACE" -j MASQUERADE 2>/dev/null \
+      || iptables -t nat -A POSTROUTING -o "$IFACE" -j MASQUERADE
+    SCRIPT
+    chmod +x /usr/local/sbin/configure-nat.sh
+
+    # Run via a systemd service on every boot, not just first boot —
+    # iptables rules can be lost after stop/start cycles.
+    cat > /etc/systemd/system/nat-iptables.service << 'UNIT'
+    [Unit]
+    Description=Configure NAT iptables rules
+    After=network.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=yes
+    ExecStart=/usr/local/sbin/configure-nat.sh
+
+    [Install]
+    WantedBy=multi-user.target
+    UNIT
+
+    systemctl daemon-reload
+    systemctl enable nat-iptables.service
+    systemctl start nat-iptables.service
+  EOF
+}
+
 resource "aws_instance" "nat" {
   ami                    = data.aws_ami.nat_instance.id
   instance_type          = "t3.nano"
@@ -82,36 +127,7 @@ resource "aws_instance" "nat" {
     volume_type = "gp3"
   }
 
-  user_data = <<-EOF
-              #!/bin/bash
-              yum update -y
-
-              # Enable IP forwarding (idempotent — only appends if not present)
-              grep -q 'net.ipv4.ip_forward' /etc/sysctl.conf || echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
-              sysctl -p
-
-              # Create a systemd service to configure NAT iptables on every boot.
-              # User data only runs on first boot, but iptables rules can be lost
-              # after stop/start cycles. This service ensures NAT forwarding works
-              # reliably on every boot.
-              cat > /etc/systemd/system/nat-iptables.service << 'UNIT'
-              [Unit]
-              Description=Configure NAT iptables rules
-              After=network.target
-
-              [Service]
-              Type=oneshot
-              RemainAfterExit=yes
-              ExecStart=/bin/bash -c 'iptables -P FORWARD ACCEPT && iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE 2>/dev/null || iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE'
-
-              [Install]
-              WantedBy=multi-user.target
-              UNIT
-
-              systemctl daemon-reload
-              systemctl enable nat-iptables.service
-              systemctl start nat-iptables.service
-              EOF
+  user_data = local.nat_user_data
 
   tags = {
     Name = "${local.env_prefix}-nat-instance"
@@ -134,36 +150,7 @@ resource "aws_instance" "nat2" {
     volume_type = "gp3"
   }
 
-  user_data = <<-EOF
-              #!/bin/bash
-              yum update -y
-
-              # Enable IP forwarding (idempotent — only appends if not present)
-              grep -q 'net.ipv4.ip_forward' /etc/sysctl.conf || echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
-              sysctl -p
-
-              # Create a systemd service to configure NAT iptables on every boot.
-              # User data only runs on first boot, but iptables rules can be lost
-              # after stop/start cycles. This service ensures NAT forwarding works
-              # reliably on every boot.
-              cat > /etc/systemd/system/nat-iptables.service << 'UNIT'
-              [Unit]
-              Description=Configure NAT iptables rules
-              After=network.target
-
-              [Service]
-              Type=oneshot
-              RemainAfterExit=yes
-              ExecStart=/bin/bash -c 'iptables -P FORWARD ACCEPT && iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE 2>/dev/null || iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE'
-
-              [Install]
-              WantedBy=multi-user.target
-              UNIT
-
-              systemctl daemon-reload
-              systemctl enable nat-iptables.service
-              systemctl start nat-iptables.service
-              EOF
+  user_data = local.nat_user_data
 
   tags = {
     Name = "${local.env_prefix}-nat-instance-2"
@@ -198,7 +185,7 @@ data "aws_ami" "nat_instance" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
 
   filter {

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -334,12 +334,6 @@ variable "use_custom_ami" {
   default     = false
 }
 
-variable "custom_ami_version" {
-  description = "Image Builder recipe version string (bump to force a new AMI build)"
-  type        = string
-  default     = "1.0.0"
-}
-
 # Data sources
 data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.14.8"
+
+  required_providers {
+    aws     = { source = "hashicorp/aws", version = "~> 6.0" }
+    archive = { source = "hashicorp/archive", version = "~> 2.7" }
+    local   = { source = "hashicorp/local", version = "~> 2.5" }
+    null    = { source = "hashicorp/null", version = "~> 3.2" }
+    random  = { source = "hashicorp/random", version = "~> 3.7" }
+    tls     = { source = "hashicorp/tls", version = "~> 4.1" }
+  }
+}


### PR DESCRIPTION
# Pull Request: Migrate EC2 hosts and AMI pipeline from Amazon Linux 2 to AL2023

**Current Branch:** feature/ami-update-to-AL2023
**Target Branch:** develop-main

----------
### Content

#### Summary
- AWS ends Amazon Linux 2 support on 2026-06-30; after that date no security patches are published. Every EC2 instance this infrastructure provisions (ECS cluster hosts across all four launch templates, both NAT instances, and the EC2 Image Builder pipeline) runs AL2.
- This PR repoints both AMI data-source filters to AL2023, adapts the provisioning scripts and Image Builder components for AL2023 package/interface changes, and re-baselines the Image Builder recipe.
- The MySQL client package swap (`mysql` → `mariadb105`) and the NAT user-data rewrite were validated on live AL2023 instances before these edits were written; application containers (`python:3.11-slim`) are unaffected — the AL2 dependency is entirely at the host/AMI layer.
- `custom_ami_version` also moves from tfvars into a git-tracked per-environment locals map so all developers apply the same version.

#### Design Decisions
- **`mariadb105` replaces `mysql`.** The `mysql` package does not exist in AL2023 repos (`dnf list available mysql` returns nothing), and the install lines run under `set -e` — unpatched, first-boot provisioning would abort silently and the ASG would cycle instances forever. `mariadb105` owns `/usr/bin/mysql`, so every existing `mysql ...` invocation works unchanged, and it stays in the same MariaDB client lineage AL2 already shipped. Bare `--ssl` (used by `app_setup.sh` against RDS Proxy with `require_tls = true`) was verified to negotiate TLS on the new client. `app_setup.sh` additionally falls back to `yum install -y mysql` because its SSM association re-runs every 30 min against the existing fleet, which stays on AL2 until the custom-AMI SSM parameter is repointed — without the fallback the association fails on every AL2 host during the migration window.
- **NAT egress interface is detected at boot instead of hardcoded.** AL2023 uses predictable interface naming — on the real NAT instance type (`t3.nano`) there is no `eth0` at all, only `ens5`, so the previous `MASQUERADE -o eth0` rule would match nothing and all private-subnet egress (ECR pulls, git clone, package installs) would break. The rule now targets the default-route interface resolved at boot. `iptables-nft` is installed explicitly because the AL2023 base AMI ships without the iptables binary. The previously duplicated user-data for `nat`/`nat2` is deduplicated into one `local.nat_user_data`.
- **AMI filter patterns are not a mechanical `amzn2`→`al2023` swap.** The AL2023 ECS-optimized name has no `-ebs` suffix (`al2023-ami-ecs-hvm-*-x86_64`); keeping the suffix matches zero AMIs and fails `terraform plan`. The NAT filter is pinned to `al2023-ami-2023.*-x86_64` because a broad `al2023-ami-*` glob with `most_recent = true` resolves to the ECS-optimized image — the wrong (heavy) base for a t3.nano NAT box.
- **`custom_ami_version` is now a git-tracked local, not a variable.** A per-environment map (`development` / `subscr`) at the top of `image_builder.tf` replaces the tfvars value, and the variable is deleted from `main.tf` so a leftover tfvars line surfaces as an undeclared-variable warning instead of silently forking the version between developers. The map (rather than a single string) preserves the existing bump-dev-first workflow. Set to `2.0.0` as the AL2023 re-baseline — the recipe has `ignore_changes = [parent_image]`, so only a version bump picks up the new base image.
- **`min_healthy_percentage` raised 0 → 50.** With the old value, a rolling instance refresh could terminate every healthy host before any replacement passed health checks; combined with a silent provisioning failure that means zero serving capacity. 50 forces launch-before-terminate.
- **NVMe swap-scan fallback fixed while touching the file.** `ebsnvme-id -b` prints the attachment name without the `/dev/` prefix, so the fallback compared `xvds` to `/dev/xvds` and could never match (dead code on AL2 and AL2023 alike). It now compares against `basename`. Harmless today because the udev symlink path works, but the safety net is now real.

### Evidence
All validation ran in account 637423646530 / ap-northeast-1 on throwaway instances (tag `Purpose=issue-664-al2023-test`, terminated same day), driven via SSM Run Command.

- **Run 1 — package set + TLS client path** (t3.micro, AL2023 ECS-optimized AMI, SSM command `a64395ae-bb19-4afa-9b59-bca401263c54`):
  ```
  $ dnf -q list available mysql
  Error: No matching Packages to list
  owner of /usr/bin/mysql: mariadb105-10.5.29-1.amzn2023.0.1.x86_64
  $ mysql ... --ssl sandbox < /tmp/init.sql      (server: require_secure_transport=ON)
  Ssl_cipher  TLS_AES_256_GCM_SHA384   (exit 0)
  ```
  Also confirmed: docker/ssm-agent/efs-utils preinstalled on the ECS AMI; `git` and `amazon-cloudwatch-agent` are not (so they stay in the install line).
- **Run 2 — swap volume + agents** (t3.micro + 32 GB gp3 volume at `/dev/xvds`, SSM command `23f641bf-2780-4e43-bf10-b061a1deb666`):
  ```
  /dev/xvds -> nvme1n1 (32G)        # udev symlink via ec2-utils 2.2.0, same as AL2
  $ swapon --show
  /dev/nvme1n1 partition 32G        # full block-device swap, no 8 GB file fallback
  ```
  CloudWatch agent config validation succeeded, agent `running`; hardcoded `/opt/aws/amazon-cloudwatch-agent/...` paths valid.
- **Run 3 — NAT recipe on the base AMI** (t3.nano, proposed user-data executed via real cloud-init, SSM command `9a65b667-26c9-4f96-a30f-ca1c89a33258`):
  ```
  interfaces: lo, ens5    eth0 exists? no
  iptables binary: MISSING pre-install → yum install -y iptables-nft → exit 0 (v1.8.8 nf_tables)
  Chain POSTROUTING: MASQUERADE all -- * ens5    (exactly 1 rule, stable across service restarts)
  Cloud-init ... finished ... Up 32.98 seconds
  ```

### References
- GitHub issue #664 — AL2 end-of-support migration tracking issue
- [AWS: Amazon Linux 2 FAQs / end-of-support 2026-06-30](https://aws.amazon.com/amazon-linux-2/faqs/)
- [Amazon ECS-optimized AMI reference (AL2023 naming)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

#### Files changed
- `infrastructure/terraform/compute.tf` -- ECS AMI filter → `al2023-ami-ecs-hvm-*-x86_64` (feeds all four launch templates + Image Builder parent); `min_healthy_percentage` 0 → 50
- `infrastructure/terraform/infrastructure.tf` -- NAT AMI filter → `al2023-ami-2023.*-x86_64`; both NAT `user_data` blocks replaced by shared `local.nat_user_data` with boot-time interface detection and explicit `iptables-nft` install
- `infrastructure/terraform/image_builder.tf` -- new git-tracked `local.custom_ami_version` per-environment map (`2.0.0`); `supported_os_versions` → `"Amazon Linux 2023"` on both components; `var.` → `local.` references
- `infrastructure/terraform/main.tf` -- `custom_ami_version` variable removed (now a local in `image_builder.tf`)
- `infrastructure/scripts/ecs-user-data.sh` -- `mysql` → `mariadb105`; NVMe-scan swap fallback compares against `basename` (was dead code); stale AL2 comment wording
- `infrastructure/scripts/app_setup.sh` -- `mysql` → `mariadb105` with a `|| yum install -y mysql` fallback so the 30-min SSM association keeps succeeding on still-AL2 hosts during the migration window (client is invoked with `--ssl` against RDS Proxy at line `mysql -h "$RDS_HOST" ...`)
- `infrastructure/image_builder/components/optinist-packages.yml` -- `mysql` → `mariadb105` in install line and bake-marker package list
- `infrastructure/image_builder/components/optinist-validate.yml` -- `mysql` → `mariadb105` in the package validation loop
- `infrastructure/terraform/environments/development.tfvars.example` -- version line removed; comment points at `image_builder.tf`
- `infrastructure/terraform/environments/production.tfvars.example` -- same as development example
- `infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md` -- AL2023 package notes, version source-of-truth procedures (tfvars → `image_builder.tf` locals), verification commands

### Manual Testcases

**Staged deployment plan.** A single `terraform apply` is mechanically valid but is split into stages for two reasons: (1) the Terraform-managed premium/background instances are force-recreated by the launch-template update in the same apply that replaces the NAT — their first-boot user-data needs egress (git clone, ECR auth) through the NAT that is mid-replacement, so booting inside the NAT gap aborts provisioning silently under `set -e`; (2) the fleet AMI swap is gated on the manual SSM parameter update regardless, so "all at once" is not actually possible. The development rollout doubles as the production rehearsal — record the measured egress-outage duration and per-stage timings for the production window.

**Stage 0 — baseline (before any apply)**
1. Infra admin: run `aws ec2 describe-images --owners amazon --filters "Name=name,Values=al2023-ami-ecs-hvm-*-x86_64"` (and the NAT pattern `al2023-ami-2023.*-x86_64`) in ap-northeast-1 -- each returns a current `ami-...` ID.
2. Infra admin: record running instance IDs + AMI IDs (rollback reference); `terraform plan` -- both data sources resolve; only expected resources change (NAT instance, launch templates, Image Builder components/recipe at 2.0.0, SSM document/S3 object, ASG refresh preferences); no resource shows an empty `image_id`.

**Stage 1 — NAT replacement (targeted apply, scheduled window)**
3. Infra admin: targeted apply — the EIP and both route tables **must** be in the target set (`-target` pulls in dependencies, not dependents; targeting only the instance leaves the routes pointing at the deleted ENI):
   ```bash
   terraform plan -var-file=environments/<env>.tfvars \
     -target=aws_instance.nat -target=aws_eip.nat_instance \
     -target=aws_route_table.private1 -target=aws_route_table.private2 -out=nat.plan
   terraform apply nat.plan
   ```
4. Infra admin: during the apply, measure the egress gap from an ECS host in a private subnet (`while true; do curl -sS -m 2 -o /dev/null -w '%{http_code} ' https://checkip.amazonaws.com || printf 'X '; sleep 2; done`) -- connectivity returns within minutes; record the duration.
5. Infra admin: on the new NAT host `systemctl is-active nat-iptables.service` -- `active`; `iptables -t nat -L POSTROUTING -n -v` shows exactly one MASQUERADE rule on the detected interface (`ens5`); `source_dest_check` is `False`; from a private-subnet host `curl -sS -o /dev/null -w '%{http_code}' https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip` -- `200`.

**Stage 2 — everything else (full apply)**
6. Infra admin: full `terraform apply` -- new launch-template versions land; premium/background instances are recreated onto the *unchanged* AL2 custom AMI (bake marker skips package installs); Image Builder components/recipe recreated at 2.0.0; no instance-cycling in ASG activity.
7. Infra admin: confirm the next `app_setup` SSM association run (≤30 min) succeeds on the still-AL2 fleet -- the `mariadb105 || mysql` fallback resolves; association status green.

**Stage 3 — fleet migration to AL2023 (manual, after Stage 2)**
8. Infra admin: `aws imagebuilder start-image-pipeline-execution --image-pipeline-arn $(terraform output -raw image_builder_pipeline_arn)` -- after ~20–30 min the build is `AVAILABLE` with an Amazon Linux 2023 `osVersion` and the validate component passed.
9. Infra admin: `aws ssm put-parameter --name "/<env>/optinist/custom-ami-id" --value <new-ami-id> --type String --overwrite`, then `terraform apply` -- launch templates pick up the AL2023 AMI; premium/background recreate onto it.
10. Infra admin: the free ASG will not roll itself (it pins launch-template version `"$Latest"` as a literal, so Terraform sees no ASG diff) -- check ASG activity and start an instance refresh manually if quiet (`aws autoscaling start-instance-refresh`); `min_healthy_percentage = 50` enforces launch-before-terminate.
11. Infra admin: on one new AL2023 host: `/var/log/ecs-setup.log` ends cleanly with no package errors and no `[CRITICAL] Swap device` line; `rpm -q mariadb105` and `command -v mysql` succeed; `swapon --show` reports ~32 GB on a block device; host `ACTIVE` in the ECS cluster and `healthy` in the ALB target group; all running hosts resolve to `al2023-` AMI names with no AL2 stragglers and no cycling over ~30 min.
12. User: open the app and run a known memory-heavy workflow end-to-end -- completes without OOM (`dmesg | grep -i "out of memory"` is empty on the host); `/health` returns `200` through the load balancer (validates cgroup-v2 swap accounting under load).
- `terraform validate && terraform fmt -check` -- passes; `bash -n` on both edited shell scripts -- passes.

### Unit, Integration, Contract Test Coverage
No application code changed; coverage is unaffected. Terraform-level checks (`terraform validate`, `terraform fmt -check`) pass, and the component YAMLs parse. The behavioral changes were validated on live AL2023 instances (see Evidence) since no automated test harness covers host provisioning.

### Others

#### Difficulties (if any)
- The deployed environments run `use_custom_ami = true` (unlike the `.tfvars.example` defaults), so live hosts boot the custom AMI from the SSM parameter (`ignore_changes = [value]`). Two consequences: the ECS AMI filter change alone does **not** repoint the live fleet, and the Image Builder rebuild + manual SSM parameter update are on the critical path of the rollout, not optional follow-ups.
- After merging, developers must delete `custom_ami_version` from their local tfvars; a leftover line produces an undeclared-variable warning on every plan.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| NAT instances | High | Replaced on apply → brief private-subnet egress outage until the new instance boots and `nat-iptables.service` runs. Apply separately from the ASG refresh, one NAT at a time. User-data was verified via real cloud-init on the exact instance type. |
| ECS host fleet | Medium | Fleet only rolls after the manual SSM parameter update, and `min_healthy_percentage = 50` forces launch-before-terminate (needs transient +1 capacity). Silent first-boot failures were the main hazard and the failing package was fixed and verified. |
| Image Builder | Medium | Components/recipe recreated at `2.0.0` (`create_before_destroy`); pipeline must be re-run and the SSM parameter repointed manually before hosts pick up AL2023. |
| MySQL client (`app_setup.sh` / hosts) | Low | `mariadb105` verified on AL2023 including bare `--ssl` piped SQL against a TLS-required server; binary path unchanged. AL2 fallback keeps the SSM association green until the fleet migrates. |
| Application containers | Low | `python:3.11-slim` images unaffected. Residual unknown: cgroup-v2 swap accounting for task `maxSwap`/`swappiness` limits — covered by the memory-heavy-workflow test case during rollout. |
