### PR TITLE
Add a specific directory to the linter's scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,13 @@ build_frontend:
 	docker compose -f docker-compose.build.yml build studio-build-fe
 	docker compose -f docker-compose.build.yml run studio-build-fe
 
+ROOT_PY := *.py
+
 .PHONY: format
 format:
-	black studio *.py
-	isort studio *.py
-	flake8 studio *.py
+	black $(ROOT_PY) studio infrastructure --exclude infrastructure/terraform/.build
+	isort $(ROOT_PY) studio infrastructure --skip infrastructure/terraform/.build
+	flake8 $(ROOT_PY) studio infrastructure --exclude infrastructure/terraform/.build
 	codespell --skip="./dist,./frontend/node_modules,./logs"
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,14 @@ build_frontend:
 	docker compose -f docker-compose.build.yml run studio-build-fe
 
 ROOT_PY := *.py
+FORMAT_TARGETS := $(ROOT_PY) studio infrastructure
+EXCLUDE_DIRS := infrastructure/terraform/.build
 
 .PHONY: format
 format:
-	black $(ROOT_PY) studio infrastructure --exclude infrastructure/terraform/.build
-	isort $(ROOT_PY) studio infrastructure --skip infrastructure/terraform/.build
-	flake8 $(ROOT_PY) studio infrastructure --exclude infrastructure/terraform/.build
+	black $(FORMAT_TARGETS) --exclude $(EXCLUDE_DIRS)
+	isort $(FORMAT_TARGETS) --skip $(EXCLUDE_DIRS)
+	flake8 $(FORMAT_TARGETS) --exclude $(EXCLUDE_DIRS)
 	codespell --skip="./dist,./frontend/node_modules,./logs"
 
 .PHONY: docs


### PR DESCRIPTION
## Summary

- Add `infrastructure/` directory to `black`, `isort`, and `flake8` targets so that infrastructure code is covered by lint/format
- Exclude `infrastructure/terraform/.build/` from each tool to avoid processing Terraform build artifacts
- Consolidate format target arguments into Makefile variables for centralized management

## Background

The `format` Makefile target only covered `studio/` and root-level `*.py` files. The `infrastructure/` directory contains Python source files but was not included in lint/format.

## Test plan

- [x] Run `make format` and verify it completes without errors
- [x] Confirm `infrastructure/` Python files are processed
- [x] Confirm `infrastructure/terraform/.build/` is excluded
