### PR TITLE
Fix background service ghosts

### DIFF
--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -83,7 +83,7 @@ graph TB
 |---------|-------|---------------------|
 | Custom AMI selection at deploy time | Terraform local | `local.effective_ami_id` in `compute.tf` |
 | Bake-aware boot logic (skip packages) | User-data script | `ecs-user-data.sh` |
-| ECS agent checkpoint clear (every boot) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
+| ECS agent checkpoint clear (premium boot only) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
 | Swap volume (instant swap setup) | Launch template EBS | `block_device_mappings` `/dev/xvds` in `compute.tf` |
 | AMI ID storage | SSM Parameter Store | `/${environment}/optinist/custom-ami-id` |
 | AMI build orchestration | EC2 Image Builder pipeline | `image_builder.tf` |
@@ -249,11 +249,11 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 
 **Solution:** The SSM parameter is initially set to the stock ECS-optimized AMI ID. Until a successful build overwrites it, all launch templates use the stock AMI. The user-data `else` branch handles stock AMI boot correctly.
 
-### 6. Stale ECS Agent Checkpoint on Stop/Start
+### 6. Stale ECS Agent Checkpoint (Bake-time vs. Stop/Start)
 
-**Problem:** A stopped instance keeps `/var/lib/ecs/data/agent.db` across stop/start, but ECS deregisters the disconnected container instance while the instance is stopped. On restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. This affects every tier that is stopped and started rather than terminated — notably the **background** instance (stopped nightly/weekends by the dev scheduler) and **premium** standby instances, neither of which is covered by a one-time bake-time clear alone.
+**Problem:** Two distinct cases. **(a)** An instance launched from a custom AMI inherits whatever `/var/lib/ecs/data/agent.db` was baked into the image, so without cleanup every instance from that image would register under the same container-instance identity. **(b)** The **premium** standby pool stops idle instances, and the premium manager deregisters their container instance while they are stopped (`cleanup_ghost_ecs_registrations()`, which is filtered to the premium tier); on restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. Tiers that are stopped but **not** reaped — notably the **background** instance (stopped nightly by the dev scheduler, with no managing Lambda) — keep a still-valid registration and must *not* wipe it: doing so strands the old registration as a ghost and registers a fresh duplicate on every restart.
 
-**Solution:** Two layers. At runtime, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service`, a oneshot systemd unit ordered `Before=ecs.service` that removes `agent.db` (and the legacy `ecs_agent_data.json`) on **every boot**, so the agent always registers fresh. It is host-side and needs no orchestrator, which is why it covers the background instance (which has no managing Lambda). At bake time, `CleanEcsAgentState` removes the same files from the AMI artifact so a freshly built image carries no container-instance identity, and `ValidateEcsAgentStateCleaned` fails the build if they persist.
+**Solution:** Two layers, each scoped to where it is needed. At **bake time**, `CleanEcsAgentState` removes `agent.db`/`ecs_agent_data.json` from the AMI artifact so a freshly built image carries no container-instance identity (case a), and `ValidateEcsAgentStateCleaned` fails the build if they persist. At **runtime**, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service` — a oneshot unit ordered `Before=ecs.service` that wipes the checkpoint on every boot — **only on the premium tier** (case b). Every other tier, including background, keeps its identity across stop/start and reconnects to its existing registration instead of creating a ghost.
 
 ---
 
@@ -574,9 +574,9 @@ grep "swap" /var/log/ecs-setup.log
 curl -s http://localhost:51678/v1/metadata | python -m json.tool
 # Expected: valid JSON with Cluster name matching expected cluster
 
-# 8. Confirm the checkpoint-clear unit is enabled (runs before ecs.service on every boot)
+# 8. On a PREMIUM instance, confirm the checkpoint-clear unit is enabled (premium tier only)
 systemctl is-enabled ecs-clear-checkpoint.service
-# Expected: enabled
+# Expected: enabled on premium; not installed on other tiers (background, free, public)
 ```
 
 ---

--- a/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
+++ b/infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md
@@ -83,6 +83,7 @@ graph TB
 |---------|-------|---------------------|
 | Custom AMI selection at deploy time | Terraform local | `local.effective_ami_id` in `compute.tf` |
 | Bake-aware boot logic (skip packages) | User-data script | `ecs-user-data.sh` |
+| ECS agent checkpoint clear (every boot) | User-data systemd unit | `ecs-clear-checkpoint.service` in `ecs-user-data.sh` |
 | Swap volume (instant swap setup) | Launch template EBS | `block_device_mappings` `/dev/xvds` in `compute.tf` |
 | AMI ID storage | SSM Parameter Store | `/${environment}/optinist/custom-ami-id` |
 | AMI build orchestration | EC2 Image Builder pipeline | `image_builder.tf` |
@@ -186,6 +187,7 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 | `EnableDockerService` | `systemctl enable docker` | Enabled but NOT started (instance shuts down for snapshot) |
 | `CreateBakeMarker` | Write `/etc/optinist-ami-baked` with timestamp and package list | Detected by user-data at boot |
 | `CleanupYumCache` | `yum clean all` + `rm -rf /var/cache/yum` | Reduces AMI snapshot size |
+| `CleanEcsAgentState` | Stop `ecs`, remove `agent.db` + `ecs_agent_data.json` | AMI artifact carries no container-instance identity (see Edge Case 6) |
 
 **AWSTOE error handling:** Each step uses a single `|` block with `set -e` at the top. This prevents error masking — AWSTOE evaluates the exit code of the **last** item in `commands`, so trailing `echo` statements would mask failures in preceding commands.
 
@@ -203,6 +205,7 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 | `ValidateDockerEnabled` | `systemctl is-enabled docker` |
 | `ValidateBakeMarker` | `test -f /etc/optinist-ami-baked` |
 | `ValidateEFSUtils` | Check `/usr/bin/mount.efs` or `/sbin/mount.efs` |
+| `ValidateEcsAgentStateCleaned` | Fail the build if `agent.db` / `ecs_agent_data.json` persist |
 
 **Test phase (fresh instance from AMI):**
 
@@ -245,6 +248,12 @@ The swap section of `ecs-user-data.sh` uses a two-strategy approach:
 **Problem:** If the Image Builder pipeline fails, no custom AMI is available.
 
 **Solution:** The SSM parameter is initially set to the stock ECS-optimized AMI ID. Until a successful build overwrites it, all launch templates use the stock AMI. The user-data `else` branch handles stock AMI boot correctly.
+
+### 6. Stale ECS Agent Checkpoint on Stop/Start
+
+**Problem:** A stopped instance keeps `/var/lib/ecs/data/agent.db` across stop/start, but ECS deregisters the disconnected container instance while the instance is stopped. On restart the agent would resume the now-deregistered identity and never re-register, so its ECS task never places. This affects every tier that is stopped and started rather than terminated — notably the **background** instance (stopped nightly/weekends by the dev scheduler) and **premium** standby instances, neither of which is covered by a one-time bake-time clear alone.
+
+**Solution:** Two layers. At runtime, `ecs-user-data.sh` installs `ecs-clear-checkpoint.service`, a oneshot systemd unit ordered `Before=ecs.service` that removes `agent.db` (and the legacy `ecs_agent_data.json`) on **every boot**, so the agent always registers fresh. It is host-side and needs no orchestrator, which is why it covers the background instance (which has no managing Lambda). At bake time, `CleanEcsAgentState` removes the same files from the AMI artifact so a freshly built image carries no container-instance identity, and `ValidateEcsAgentStateCleaned` fails the build if they persist.
 
 ---
 
@@ -564,6 +573,10 @@ grep "swap" /var/log/ecs-setup.log
 # 7. Confirm ECS agent registered
 curl -s http://localhost:51678/v1/metadata | python -m json.tool
 # Expected: valid JSON with Cluster name matching expected cluster
+
+# 8. Confirm the checkpoint-clear unit is enabled (runs before ecs.service on every boot)
+systemctl is-enabled ecs-clear-checkpoint.service
+# Expected: enabled
 ```
 
 ---

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -460,7 +460,7 @@ Runs every 15 minutes. Step numbering matches the comments in the source. Some s
 9.   cleanup_excess_standby_instances()    - Trim standby pool to PREMIUM_STANDBY_POOL_SIZE
 10a. finalize_expired_pending_releases()   - Tear down ALB resources for assignments past soft-release grace
 10b. cleanup_ghost_ecs_registrations()     - Deregister ECS container instances whose EC2 is gone
-11.  cleanup_orphaned_ec2_instances()      - Stop premium-tagged EC2 not in the ECS cluster (15-min grace)
+11.  cleanup_orphaned_ec2_instances()      - Stop premium-tagged EC2 not in the ECS cluster (10-min launch-age grace)
 12.  fix_incorrect_is_shared_flags() then
      process_shared_instance_optimization() - Promote shared users to dedicated, or fire invoke_migration_async() if none free
 ```
@@ -717,7 +717,7 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 ┌──────────────────────────────────────────────────────────┐
 │ 11. cleanup_orphaned_ec2_instances()                     │
 │    → Stop premium-tagged EC2 not in ECS                  │
-│    → 15-minute grace period for booting instances        │
+│    → 10-minute launch-age grace for booting instances    │
 └──────────────────────────────────────────────────────────┘
                          ↓
 ┌──────────────────────────────────────────────────────────┐
@@ -797,8 +797,8 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 **Problem:** EC2 instances stopped/terminated outside normal flow leave orphaned ECS registrations that confuse the ECS scheduler.
 
 **Solution:** Premium Manager's `cleanup_ghost_ecs_registrations()`:
-- Finds container instances with disconnected agents or stopped/terminated EC2
-- Force-deregisters them from the ECS cluster
+- Finds premium container instances with disconnected agents or stopped/terminated EC2
+- Stopped/terminated/unmapped instances are deregistered immediately; a running EC2 with a disconnected agent is tagged `optinist:agent-disconnected-at` on first sighting and deregistered only after `_AGENT_DISCONNECT_GRACE_SECONDS = 300` (5 minutes), with the tag cleared if the agent reconnects
 - Runs every 15 minutes as part of scheduled monitoring
 
 
@@ -808,8 +808,10 @@ The timeout is configurable via the `PREMIUM_IDLE_TIMEOUT_HOURS` environment var
 
 **Solution:** Premium Manager's `cleanup_orphaned_ec2_instances()`:
 - Finds premium-tagged EC2 instances not in the ECS cluster
-- 15-minute grace period (`ORPHAN_GRACE_PERIOD_MINUTES = 15`) to avoid stopping still-booting instances
-- Stops orphaned instances
+- `launch_time`-age grace (`ORPHAN_GRACE_PERIOD_MINUTES = 10` minutes) to avoid stopping still-booting instances; symmetric with the `booting_count` window in `update_premium_service_desired_count()`
+- Stops orphaned instances (and registers them as standby for later aged termination)
+
+> This and the ghost-CI cleanup (Edge Case 4) are independent timers measured from different events — agent-disconnect (300s) vs instance launch (10 min) — and both run in the same 15-minute cycle, so a single run can deregister a ghost container instance and stop the orphaned EC2 behind it.
 
 
 ### 6. Race Condition Between Manager and Cleanup
@@ -1483,7 +1485,7 @@ Note the log template is literal: it says `attempt N failed, retrying...`, not `
 | `Using free tier while premium instance provisions` | `axios.ts` | Single occurrence accompanies one `instance_unreachable` UI event; the circuit breaker will probe for recovery. Investigate only if the paired `instance_reachable` never arrives (see A.1.7) |
 | `Premium-(un)?reachable listener threw: ${e}` | `RoutingService.ts` | One listener crashed during dispatch; the pool continues delivering to others |
 | `Agent disconnected on ${i-xxx}, starting grace period` and its "within grace period" follow-up | `premium_manager.py` ghost ECS cleanup | 5-min grace before deregistering ECS container instance |
-| `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 15-min grace before stopping orphan EC2 |
+| `Orphan ${i-xxx} running ${N}m, within grace period` | `premium_manager.py` orphan cleanup | 10-min launch-age grace before stopping orphan EC2 |
 | `Warning: Error closing database connection: ${e}` | both lambdas | Cleanup-path warning on teardown; does not affect the work already done |
 | `Transaction rolled back due to error: ${e}` | `premium_manager.py` | Expected when a `@with_transaction` path encounters an exception and rolls back cleanly |
 | `Conditions not met for auto-assignment: { isPremiumUser: false, ... }` | `PremiumAssignmentContext.tsx` | Non-premium user; the provider correctly short-circuits |

--- a/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
+++ b/infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md
@@ -175,8 +175,9 @@ sequenceDiagram
     else Tier 3: Start Standby
         DB-->>PM: Found standby instance (is_standby=1)
         PM->>EC2: Start Instance
-        PM->>PM: clear_ecs_agent_checkpoint()
         EC2-->>PM: Instance running (5-15s)
+        Note over EC2: ecs-clear-checkpoint.service wipes stale agent.db before ECS agent starts
+        PM->>PM: check_instance_readiness_with_retry()
         PM->>ALB: Create Target Group + Rule
         PM->>PM: create_and_stop_standby_instance() (replenish)
         PM-->>User: Assigned (5-15s wait)
@@ -498,7 +499,7 @@ that are merely rebooting their agent.
 **Pre-assignment Steps:**
 1. Restore any `pending_release` assignment (beacon fired but the user is back) -- returns with `assignment_source: "restored_from_pending_release"`
 2. Check for existing assignment:
-   - If the EC2 is `stopped`/`stopping`, restart it, clear the ECS checkpoint, wait up to 120s for ECS readiness, and return `assignment_source: "restarted_instance"`
+   - If the EC2 is `stopped`/`stopping`, restart it and wait up to 120s for ECS readiness, then return `assignment_source: "restarted_instance"` (the instance's `ecs-clear-checkpoint.service` wipes the stale agent checkpoint on boot so it re-registers)
    - If the EC2 is `terminated`/`shutting-down`/gone, remove the stale DB entry and fall through to fresh assignment
    - If the assignment is on `autoscaling-pool` or a shared instance, attempt an **inline migration** to a ready dedicated instance first (`assignment_source: "inline_migration"`); fall back to `invoke_migration_async()` if no instance is ready
    - Otherwise return the existing assignment (`assignment_source: "existing"`)
@@ -785,11 +786,12 @@ assignment. This function only handles the **start** transition; it does
 **not** touch the standby placeholder row itself.
 **Input:** instance_id (str)
 **Output:** True on success, False on failure
-**Calls:** `ec2.start_instances()` -> `ec2.get_waiter('instance_running')` -> `clear_ecs_agent_checkpoint()`
+**Calls:** `ec2.start_instances()` -> `ec2.get_waiter('instance_running')` -> `check_instance_readiness_with_retry()`
 
 **Key behaviors:**
 - Waits for running state (delay=5s, max 24 attempts)
-- Clears stale ECS agent checkpoint so it re-registers
+- Stale ECS agent checkpoint is cleared host-side on boot by `ecs-clear-checkpoint.service` (before `ecs.service`), so the restarted agent re-registers instead of resuming a deregistered container instance
+- Waits for ECS readiness via `check_instance_readiness_with_retry()` (max 120s) and returns False on timeout, before any DB update
 - Updates `instance_state` to `'running'` for any pre-existing **non-standby**
   assignment rows on this instance (there should be none on a true Tier 3
   path; the clause is defensive)
@@ -916,7 +918,7 @@ subscribers.
 - Blocked if launching instances exist or `CREATE_RUNNING_LOCK` held
 - No-op if `running_count >= active_users` (sufficient capacity). Note this is distinct from [`scale_down_if_possible()`](#scale-down-scale_down_if_possible), which keeps `max(1, active_users + 1)` -- scale-up has no `+ 1` safety margin, so the scale-down headroom only exists after a full monitor cycle runs
 - Prefers starting stopped instances (fastest) over creating new
-- Clears ECS agent checkpoints after starting stopped instances
+- Started instances clear their stale ECS agent checkpoint host-side on boot (via `ecs-clear-checkpoint.service`); no Lambda-side action is needed
 - Falls back to `_create_running_instances_locked()` under
   distributed lock
 - Always calls `invoke_migration_async()` and
@@ -1361,7 +1363,7 @@ Shared instance optimization complete: 1 users migrated
 | Function | Purpose |
 |----------|---------|
 | `create_and_stop_standby_instance()` | Create instance, stop for pool (distributed lock) |
-| `start_standby_instance()` | Start standby + clear ECS checkpoint (does NOT delete placeholder row) |
+| `start_standby_instance()` | Start standby + wait for ECS readiness; checkpoint cleared host-side on boot (does NOT delete placeholder row) |
 | `convert_idle_instances_to_standby_immediate()` | Stop idle running instances and convert to standby in-line during scale-down (see [spec](#convert_idle_instances_to_standby_immediate)) |
 | `get_available_standby_instances()` | Query standby pool (is_standby=1) |
 | `register_orphaned_stopped_instances()` | Adopt AWS-stopped / DB-less instances into the standby pool |

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -141,5 +141,5 @@ phases:
               set -e
               echo "$(date): Clearing ECS agent checkpoint so the baked AMI carries no container-instance identity"
               systemctl stop ecs 2>/dev/null || true
-              rm -rf /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
+              rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
               echo "$(date): ECS agent state cleared"

--- a/infrastructure/image_builder/components/optinist-packages.yml
+++ b/infrastructure/image_builder/components/optinist-packages.yml
@@ -132,3 +132,14 @@ phases:
               # Remove non-default SSH authorized keys
               rm -f /root/.ssh/authorized_keys
               echo "$(date): Credential sanitization complete"
+
+      - name: CleanEcsAgentState
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -e
+              echo "$(date): Clearing ECS agent checkpoint so the baked AMI carries no container-instance identity"
+              systemctl stop ecs 2>/dev/null || true
+              rm -rf /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
+              echo "$(date): ECS agent state cleared"

--- a/infrastructure/image_builder/components/optinist-validate.yml
+++ b/infrastructure/image_builder/components/optinist-validate.yml
@@ -116,6 +116,18 @@ phases:
               fi
               echo "OK: No credential leak detected"
 
+      - name: ValidateEcsAgentStateCleaned
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "=== Validating ECS agent checkpoint was cleared ==="
+            - |
+              if [ -f /var/lib/ecs/data/agent.db ] || [ -f /var/lib/ecs/data/ecs_agent_data.json ]; then
+                echo "FAIL: ECS agent checkpoint present — instances from this AMI would register as duplicate container instances"
+                exit 1
+              fi
+              echo "OK: ECS agent state cleared"
+
   - name: test
     steps:
       - name: TestBakeMarkerPersisted

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -20,7 +20,7 @@ After=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db
+ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data.json
 
 [Install]
 WantedBy=multi-user.target

--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -10,8 +10,9 @@ echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
 echo ECS_INSTANCE_ATTRIBUTES='{"tier":"${tier}"}' >> /etc/ecs/ecs.config
 
-# Systemd service to clear stale ECS agent checkpoint on every boot.
-cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
+# Only premium standbys are reaped while stopped, so only they must wipe the stale checkpoint on boot to re-register.
+if [ "${tier}" = "premium" ]; then
+  cat > /etc/systemd/system/ecs-clear-checkpoint.service << 'UNIT_EOF'
 [Unit]
 Description=Clear stale ECS agent checkpoint before startup
 Before=ecs.service
@@ -26,8 +27,9 @@ ExecStart=/bin/rm -f /var/lib/ecs/data/agent.db /var/lib/ecs/data/ecs_agent_data
 WantedBy=multi-user.target
 UNIT_EOF
 
-systemctl daemon-reload
-systemctl enable ecs-clear-checkpoint.service
+  systemctl daemon-reload
+  systemctl enable ecs-clear-checkpoint.service
+fi
 
 # Install packages (skip if AMI is pre-baked by Image Builder)
 if [ -f /etc/optinist-ami-baked ]; then

--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -4,7 +4,7 @@ app_setup.sh
 
 # Terraform state files and directories
 terraform.*
-.terraform*
+.terraform/
 *.tfstate
 *.tfstate.backup
 

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -1,0 +1,131 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:D8uNiOpl3UkAX4zI5T47ALMiRFXTa1XfdQC+TBu3RmE=",
+    "zh:0072806bb262c6d86bc25b4a75750e469881144c14818afdba7b82db840e1588",
+    "zh:1ebc2dae335dad7a8b16a1985b69a63a14954282bb44fdba7d5103f77551ac7b",
+    "zh:2dab48fe8f3193b8216d578ac1e3674fa566435cc7dbce2953d55b72e31d0241",
+    "zh:2fc3d3029c2b7429472391ef339672e1fca8e6ff32c8a519bf3acedafa7e24fe",
+    "zh:38a36e64e7212f6cedac861ea4d449cce07131b3378de601bf9d49a99e000208",
+    "zh:3ac70758ed251ce78b7f541a5a79cc6fe56474412783ae1decef719bdd0f30bf",
+    "zh:4385d3903e685bddb2b8005b4eb7db89f030267d4d03c7d792d2f5e739cc874a",
+    "zh:4cce0760b87fbafd51f30faec2a737f4183b7c615f4a86557f7d3c893a610dc5",
+    "zh:4feaeed18694239b896c6415d9a1e5ef89e1da4f4ad60924aa0522adeb1f6599",
+    "zh:502fca2be1c95f443c3e67d0555601d1de65b4ca82d197c059e9c868360e3a0a",
+    "zh:57d037f6fdd045f2660909c3bdface9622d81165ce647479cba98d1f353c5eab",
+    "zh:5dc5a0b915c2ac5256d909458f5c8e40b35f78b3a36ea893c86624eaf6c54e37",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b84c87c58a320adbb2c74a4cad03ae5aac7f2eae21db26f00fdde98c8c4d4523",
+    "zh:c895f1d5cbcbeff77850ac99efd36bde0048d4e909b296882331b9b9ebf48cfa",
+    "zh:ead82831683619124597a1f170dd31e9b293e9cf22f558cb166d5e734fcd11e4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.9.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
+    "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
+    "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
+    "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
+    "zh:29d0b03e5343a80677ebfeb2e2c31cbe4b1f65e736e53417454a4277fec2544c",
+    "zh:4896bfa6cf1d2fd562b47ef2e87f47862ae92a04f8ad5d764380f0c6653473b8",
+    "zh:531f8529cbca49f681883e57761a05a8398afaef6d1ab0d205d26bf12f4428e8",
+    "zh:6aaf5011d83161c86d2bfb80c0923ec934e578288758da2f37acb7aec129004b",
+    "zh:7430275253d3d3c40aa6179e0ec0d63212874dbbc06c5a51b9d07ec590f9756c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:be17dc611e95e26cdf6cad79dfccf1064f0e32032a2efeb939a9bbe7fb1cbfe9",
+    "zh:f0e3b0aa644202e1d79d2000dca91f6019425da71e9800fa23f27e51c034f195",
+    "zh:f62bae4519e4ead49182ddc8afe8cf61e2a4c3ba3973b0fbba967736a2696aa3",
+    "zh:fcafa360a5b0b96244f26f4e3a6d642b716a376557142c2442ff2fb12d11da18",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.1"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/image_builder.tf
+++ b/infrastructure/terraform/image_builder.tf
@@ -14,7 +14,7 @@
 # Kept in git rather than tfvars so every apply uses the same version.
 locals {
   custom_ami_version = {
-    development = "2.0.0"
+    development = "2.0.1"
     subscr      = "2.0.0"
   }[var.environment]
 }

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.14.8"
+
+  required_providers {
+    aws     = { source = "hashicorp/aws", version = "~> 6.0" }
+    archive = { source = "hashicorp/archive", version = "~> 2.7" }
+    local   = { source = "hashicorp/local", version = "~> 2.5" }
+    null    = { source = "hashicorp/null", version = "~> 3.2" }
+    random  = { source = "hashicorp/random", version = "~> 3.7" }
+    tls     = { source = "hashicorp/tls", version = "~> 4.1" }
+  }
+}


### PR DESCRIPTION
### Content

#### Summary
- **The symptom:** the background ECS service intermittently showed **two running tasks when its desired count is one**.
- **The cause (non-obvious):** a startup helper, `ecs-clear-checkpoint.service`, deleted the file where the ECS agent records which "container instance" it is (`/var/lib/ecs/data/agent.db`) on *every* boot, **on every tier**. The background service runs on a single standalone EC2 host that the dev scheduler shuts down and restarts every night, so each morning the host rejoined the cluster as a **brand-new container instance** and left the previous one behind as a disconnected "ghost" — and each ghost still advertised a leftover ("phantom") RUNNING task.
- **The fix (two scoped layers):**
  - **Runtime:** install the boot-time wipe **only on the premium tier**. Premium is the only tier whose container instance is deregistered *while it is stopped* (by the premium manager), so it alone must wipe its now-stale checkpoint to re-register on restart. Background/free/public no longer install the unit, so the background host **keeps its identity** across the nightly stop/start and reconnects to its existing registration instead of forming a ghost.
  - **Bake time:** a new `CleanEcsAgentState` build step removes `agent.db`/`ecs_agent_data.json` from the AMI artifact so a freshly-built image carries no baked-in container-instance identity (otherwise every instance from that image would register under the same identity). `ValidateEcsAgentStateCleaned` fails the build if a checkpoint persists.
- **Why it targets `feature/ami-update-to-AL2023`:** the runtime change only takes effect when a host is recreated onto a rebuilt AMI (user-data runs at first launch, not on stop/start). The AL2023 branch already bumps the recipe to v2.0.0 and replaces the instances, so the fix lands in the same rebuild rather than forcing a second, redundant one.

#### Design Decisions
- **Gate the boot-time wipe to premium — don't delete it.** The wipe exists for a real reason and premium *depends* on it: the premium manager deregisters a premium container instance while its EC2 is stopped (`cleanup_ghost_ecs_registrations()`, filtered to `attribute:tier == premium`), and the Lambda no longer clears the checkpoint itself — `start_standby_instance()` relies entirely on the host-side unit (`# Checkpoint clear is handled by the ecs-clear-checkpoint.service systemd unit ... no SSM action needed here`). So a premium standby that restarts *must* wipe its checkpoint or it resumes a deregistered identity and never re-registers. **Deleting the unit outright would silently break premium restart.** The correct scope is per-tier: keep it for premium, drop it for every tier that is stopped-but-not-reaped (background) or never restarted (free/public ASG).
- **The bug was scope, not the wipe itself.** The unit was `WantedBy=multi-user.target`, so it ran on every boot of every tier. For the ASG fleet that is harmless — those instances are immutable, booted once then terminated — which is why it went unnoticed for months. The standalone `aws_instance.background` (`tier=background`) is stopped/started daily by the dev scheduler and *is not* reaped while stopped, so wiping its identity on each start was both unnecessary and actively harmful.
- **Clean the checkpoint at bake time, and assert it.** `CleanEcsAgentState` stops the agent and removes `agent.db`/`ecs_agent_data.json` just before the snapshot (AWS's documented pre-AMI cleanup), so no container-instance identity is ever baked into the image. `ValidateEcsAgentStateCleaned` fails the build if either file persists, so a future change that reintroduces a baked-in identity is caught at bake time rather than discovered as duplicate registrations in production. This is a distinct concern from the background ghost — it prevents *all* tiers from inheriting one shared identity out of the image.
- **Widen the wipe to `ecs_agent_data.json`.** Both the premium unit and the bake step now remove `ecs_agent_data.json` alongside `agent.db`, so the cleanup is independent of which on-disk state file the agent build uses.
- **Stacked onto the AL2023 branch rather than `develop-main`.** The runtime change is inert until a host is recreated from a rebuilt AMI; the AL2023 branch already rebuilds and replaces the instances, so targeting it lands the fix in the same bake instead of forcing a second AMI rebuild.

### Evidence
- **ECS duplicate-registration diagnosis** (live dev cluster `development-optinist-cloud-cluster`, ap-northeast-1, 2026-06-10): the single background host `i-05fffac1b6485cd76` appeared **5 times** in the cluster as separate container-instance registrations — roughly one per recent stop/start — of which 4 were `agentConnected=false` ghosts. The two "extra" background tasks were each pinned to a different disconnected ghost (registered 06-05 and 06-08) and both ended with `stoppedReason: Host EC2 (instance i-05fffac1b6485cd76) stopped.` The service is `desiredCount=1`; once ECS confirmed the host stop it self-healed to a single running task with one PRIMARY deployment. Traced to `ecs-clear-checkpoint.service` deleting the checkpoint before `ecs.service` starts on each boot.
- **Tier wiring confirms the gate fires correctly:** `aws_launch_template.premium` (and thus both the static base and every Lambda-created standby) renders `tier = "premium"`, so the `if [ "${tier}" = "premium" ]` guard installs the unit on exactly the instances that need it; `aws_instance.background` renders `tier = "background"`, so it does not.
- **Premium already depends on the host-side unit on the base branch:** `premium_manager.py` no longer calls any SSM-based checkpoint clear; `start_standby_instance()` waits on `check_instance_readiness_with_retry()` and leaves the wipe to the systemd unit. This is why gating (not deleting) is the correct shape.
- **Component YAMLs parse and the script is syntactically valid:** `CleanEcsAgentState` is last in the packages build phase, `ValidateEcsAgentStateCleaned` is in the validate build phase, and the recipe runs the packages component before the validate component; `bash -n infrastructure/scripts/ecs-user-data.sh` passes.

### References
- [AWS: prepare a container instance before creating a custom AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html) — stop the agent and remove `/var/lib/ecs/data/*` before snapshot.
- Parent migration branch `feature/ami-update-to-AL2023` — provides the v2.0.0 AMI rebuild this fix rides on.
- GitHub issue #664 — AL2 end-of-support migration (context for the shared AMI rebuild).

#### Files changed
- `infrastructure/scripts/ecs-user-data.sh` -- gate the `ecs-clear-checkpoint.service` install behind `tier == premium` (was installed on every tier and wiped on every boot); also widen the wipe to remove `ecs_agent_data.json`. Background/free/public now keep their ECS identity across stop/start.
- `infrastructure/image_builder/components/optinist-packages.yml` -- new `CleanEcsAgentState` build step: stops the agent and removes `agent.db`/`ecs_agent_data.json` just before the snapshot.
- `infrastructure/image_builder/components/optinist-validate.yml` -- new `ValidateEcsAgentStateCleaned` build-phase step: fails the build if a checkpoint is baked into the image.
- `infrastructure/documentation/CUSTOM_AMI_ARCHITECTURE.md` -- document the premium-only boot-time clear, the bake-time `CleanEcsAgentState`/`ValidateEcsAgentStateCleaned` steps, and the bake-time-vs-stop/start edge case.
- `infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md` -- doc-accuracy update for the existing premium-manager behavior the gate relies on (ghost-CI cleanup is premium-filtered with a 300s agent-disconnect grace; orphan-EC2 cleanup uses a 10-min launch-age grace). No code change.
- `infrastructure/documentation/PREMIUM_USER_ASSIGNMENT.md` -- doc-accuracy update reflecting that the standby start path clears the checkpoint host-side on boot rather than via the Lambda. No code change.

### Manual Testcases
1. Infra admin: **bake-time validation** — when the v2.0.0 AMI builds (as part of the AL2023 rollout), the validate component's `ValidateEcsAgentStateCleaned` step passes (`OK: ECS agent state cleared`) and no `agent.db`/`ecs_agent_data.json` is present in the image.
2. Infra admin: **per-tier unit presence** — on a recreated host, `systemctl is-enabled ecs-clear-checkpoint.service` returns `enabled` on a **premium** instance and "not installed" (non-zero) on **background/free/public**.
3. Infra admin: **background duplicate-registration regression check** — with the background host running on the rebuilt AMI, `aws ecs list-container-instances --cluster <env>-optinist-cloud-cluster` shows exactly one registration for it. Stop/start the background instance (dev scheduler, or `aws ec2 stop-instances`/`start-instances`) and confirm it re-attaches under the **same** container-instance ARN — no new registration, no `agentConnected=false` ghost — and `<env>-background-optinist-cloud-service` stays at `runningCount=1` with no phantom tasks left on the stopped host.
4. Infra admin: **premium restart regression check** (guards against gating breaking premium) — stop a premium standby so the manager deregisters it, then assign a user / start it. Confirm the host wipes its stale checkpoint on boot, **re-registers** as a fresh container instance, and its task reaches RUNNING (i.e. `check_instance_readiness_with_retry()` succeeds rather than timing out at 120s).
5. Infra admin: **clear pre-existing ghosts (required rollout step)** — deregister leftover ghost registrations from before the fix: for each `agentConnected=false` ARN, `aws ecs deregister-container-instance --cluster <env>-optinist-cloud-cluster --container-instance <arn> --force` (keep the one live ARN). ECS reaps the phantom tasks attached to them. The old background host that is *replaced* by the AL2023 rebuild also leaves one such ghost.
- Automated checks: `bash -n infrastructure/scripts/ecs-user-data.sh` passes; `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" infrastructure/image_builder/components/optinist-packages.yml infrastructure/image_builder/components/optinist-validate.yml` parses both components.

### Unit, Integration, Contract Test Coverage
No application code changed — the diff is two Image Builder component steps, one user-data gate, and documentation. No automated harness covers host provisioning; verification is the bake-time assertion (testcase 1) plus the live stop/start regression checks for both background (testcase 3) and premium (testcase 4).

### Others

#### Difficulties (if any)
- **Inert until the host is recreated, not merely re-pointed.** User-data runs at first launch, not on stop/start, so the currently-live background host keeps its already-installed unit and keeps wiping nightly until it is **replaced**. The AL2023 AMI change is replace-forcing on `aws_instance.background`, so the rollout recreates it with the gated user-data; merging this PR alone does not change the running host.
- **Background ghosts from *termination* are not auto-reaped.** `cleanup_ghost_ecs_registrations()` is premium-only, so when the old background host is terminated during the rebuild (or any future replacement) its container instance becomes a ghost until manually deregistered — hence testcase 5 is a required rollout step, not optional cleanup.
- **Build-time ordering matters:** `CleanEcsAgentState` must remain the **last** build step in the packages component, and the packages component runs before the validate component with no reboot in between, so the assertion sees the cleaned state. `ValidateEcsAgentStateCleaned` fails the build if that assumption is ever violated.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Premium re-registration | Low | Premium keeps the boot-time wipe, which it depends on (Lambda no longer clears the checkpoint via SSM). Gating preserves existing premium behavior; testcase 4 confirms it. |
| Background ECS identity | Low | Background stops installing the wipe, so it keeps its registration across the nightly stop/start. Behavioural change is limited to the standalone host; the ASG fleet was never affected. |
| Existing / replacement ghost registrations | Low | Inert (no real compute). Deregistered during rollout (testcase 5); until then they only inflate the cluster's container-instance count. No automatic reaping for non-premium terminated hosts. |
| Image Builder bake | Low | One added build step (stop agent + `rm`) and one validation step; both fail closed (`set -e` / explicit `exit 1`). If the agent isn't running at bake time the `stop` is a harmless no-op. |
| Rollout coupling | Medium | The runtime fix takes effect only when instances are recreated onto the AL2023 v2.0.0 AMI; it is not active the moment this PR merges. Tracked as part of the AL2023 deployment. |
