### PR TITLE
Fix backend env file dependency

### DIFF
--- a/infrastructure/terraform/environments/development.tfvars.example
+++ b/infrastructure/terraform/environments/development.tfvars.example
@@ -34,9 +34,6 @@ mysql_database      = "studio"
 mysql_user          = "test_db_admin"
 mysql_password      = "<PLACEHOLDER-generate-new>"
 
-USE_FIREBASE_TOKEN = True
-IS_STANDALONE      = False
-
 # Stripe TEST mode keys
 stripe_secret_key     = "sk_test_<PLACEHOLDER>"
 stripe_webhook_secret = "whsec_test_<PLACEHOLDER>"

--- a/infrastructure/terraform/environments/production.tfvars.example
+++ b/infrastructure/terraform/environments/production.tfvars.example
@@ -34,9 +34,6 @@ mysql_database      = "studio"
 mysql_user          = "<PLACEHOLDER-db-admin-username>"
 mysql_password      = "<PLACEHOLDER-generate-with-openssl-rand-base64-24>"
 
-USE_FIREBASE_TOKEN = True
-IS_STANDALONE      = False
-
 # Stripe configuration (LIVE mode keys)
 stripe_secret_key     = "sk_live_<PLACEHOLDER>"
 stripe_webhook_secret = "whsec_<PLACEHOLDER>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ testpaths = "/app/studio/tests"
 env = [
   "OPTINIST_DIR=/app/studio/test_data",
   "IS_TEST=True",
+  "IS_STANDALONE=True",
   "REMOTE_STORAGE_TYPE=1",  # See .env
   "MOCK_STORAGE_DIR=/tmp/studio/mock_storage",  # See .env
 

--- a/studio/app/common/core/mode.py
+++ b/studio/app/common/core/mode.py
@@ -4,7 +4,7 @@ from studio.app.dir_path import DIRPATH
 
 
 class Mode(BaseSettings):
-    IS_STANDALONE: bool = Field(default=True, env="IS_STANDALONE")
+    IS_STANDALONE: bool = Field(default=False, env="IS_STANDALONE")
     IS_TEST: bool = Field(default=False, env="IS_TEST")
 
     @property

--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -35,7 +35,6 @@ from studio.app.common.schemas.subscriptions import (
 )
 
 logger = AppLogger.get_logger()
-STRIPE_CALLBACK_URL = SubscriptionService.get_base_url()
 
 
 class CheckoutService:
@@ -729,6 +728,7 @@ class CheckoutService:
                 is_first_time_user = not (has_db_purchase or has_stripe_purchase)
 
                 # Prepare subscription parameters
+                stripe_callback_url = SubscriptionService.get_base_url()
                 subscription_params = {
                     "payment_method_types": [
                         PAYMENT_METHOD_TYPE_CARD,
@@ -742,10 +742,10 @@ class CheckoutService:
                     ],
                     "mode": "subscription",
                     "success_url": (
-                        f"{STRIPE_CALLBACK_URL}/subscription/thanks"
+                        f"{stripe_callback_url}/subscription/thanks"
                         "?session_id={CHECKOUT_SESSION_ID}"
                     ),
-                    "cancel_url": f"{STRIPE_CALLBACK_URL}/subscription",
+                    "cancel_url": f"{stripe_callback_url}/subscription",
                     "customer": customer_id,
                     "client_reference_id": str(user.id),
                     "metadata": {


### PR DESCRIPTION
## Summary

- Change `IS_STANDALONE` default from `True` to `False` so cloud (ECS) deployments run in multi-user mode without requiring an explicit env var or `.env` file
- Defer `STRIPE_CALLBACK_URL` evaluation from import-time to call-time to prevent startup crashes on services that don't define the variable
- Remove dead `IS_STANDALONE` / `USE_FIREBASE_TOKEN` entries from `.tfvars.example` files since they were never consumed by Terraform

## Problem

After deploying to AWS **without** `studio/config/.env` in the Docker image, two issues were observed:

1. **`IS_STANDALONE` defaulted to `True`** — The application started in standalone mode, silently disabling Firebase auth, background jobs, workflow tracking, and other multi-user features.
2. **`STRIPE_CALLBACK_URL` crashed at import time** — The `public_service` ECS task (which doesn't need Stripe checkout) failed to start because `checkout_service.py` evaluated `get_env_var("STRIPE_CALLBACK_URL", required=True)` at module level.

### Root cause of IS_STANDALONE

The `.tfvars.example` files defined `IS_STANDALONE = False`, but:
- No `variable "IS_STANDALONE" {}` block existed in any `.tf` file
- No ECS task definition passed `IS_STANDALONE` in its `environment` block
- The `Mode` class defaulted to `True` when the env var was absent

Since `IS_STANDALONE` and `USE_FIREBASE_TOKEN` are always fixed in cloud deployments (`False` and `True` respectively), the simplest fix is to align the application defaults and remove the unused `.tfvars` entries.

## Changes

### `studio/app/common/core/mode.py`
- `IS_STANDALONE` default: `True` → `False`

### `studio/app/common/core/subscription/checkout_service.py`
- Remove module-level `STRIPE_CALLBACK_URL = SubscriptionService.get_base_url()`
- Move the call into `handle_checkout_session()` as a local variable

### `infrastructure/terraform/environments/development.tfvars.example`
- Remove `USE_FIREBASE_TOKEN` and `IS_STANDALONE` (never consumed by Terraform)

### `infrastructure/terraform/environments/production.tfvars.example`
- Remove `USE_FIREBASE_TOKEN` and `IS_STANDALONE` (never consumed by Terraform)

## Test plan

- [x] Verify local standalone mode still works with `studio/config/.env` containing `IS_STANDALONE=True`
- [x] Verify ECS deployment starts in multi-user mode (check `/is_standalone` endpoint returns `false`)
- [x] Verify `public_service` container starts without `STRIPE_CALLBACK_URL` error
- [x] Verify Stripe checkout flow still works on services that define `STRIPE_CALLBACK_URL`
- [x] Run existing unit tests (`pytest`)
