### PR TITLE
Fix premium logout IAM permissions and orphaned target-group alarms

### DIFF
--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -69,6 +69,10 @@ resource "aws_lambda_function" "common_user_manager" {
       # User inactivity timeout configuration
       FREE_IDLE_TIMEOUT_HOURS    = "2" # Hours before free users are logged out
       PREMIUM_IDLE_TIMEOUT_HOURS = "2" # Hours before premium users are logged out
+
+      # Premium logout cleanup: skip the shared TG, and derive per-TG alarm names
+      AUTOSCALING_TARGET_GROUP_ARN = aws_lb_target_group.autoscaling.arn
+      ENV_PREFIX                   = var.environment
     }
   }
 
@@ -139,6 +143,24 @@ resource "aws_iam_role_policy" "common_user_manager_lambda_policy" {
           "cloudwatch:GetMetricStatistics"
         ]
         Resource = "*"
+      },
+      # Premium logout cleanup: delete the user's listener rule and target group
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:DeleteTargetGroup"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:listener-rule/*",
+          "arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:targetgroup/premium-*"
+        ]
+      },
+      # CloudWatch alarm cleanup for the per-user TGs deleted above
+      {
+        Effect   = "Allow"
+        Action   = "cloudwatch:DeleteAlarms"
+        Resource = "arn:aws:cloudwatch:${var.aws_region}:${data.aws_caller_identity.current.account_id}:alarm:${var.environment}-premium-*-unhealthy-hosts"
       }
     ]
   })

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -344,7 +344,7 @@ def check_free_user_inactivity() -> Dict[str, int]:
 
 
 # Mirrored in premium_manager.py & premium_cleanup.py — keep all three in sync.
-def _tg_unhealthy_alarm_name(tg_arn: str) -> "str | None":
+def _premium_tg_alarm_name(tg_arn: str) -> "str | None":
     """Derive the UnHealthyHostCount alarm name for a premium target group ARN."""
     idx = tg_arn.find(":targetgroup/")
     suffix = tg_arn[idx + 1 :] if idx != -1 else tg_arn
@@ -357,7 +357,7 @@ def _tg_unhealthy_alarm_name(tg_arn: str) -> "str | None":
 def _delete_tg_unhealthy_alarm(cw: Any, tg_arn: str) -> None:
     """Best-effort, idempotent delete of a target group's UnHealthyHostCount alarm."""
     try:
-        alarm_name = _tg_unhealthy_alarm_name(tg_arn)
+        alarm_name = _premium_tg_alarm_name(tg_arn)
         if alarm_name:
             cw.delete_alarms(AlarmNames=[alarm_name])
     except Exception as e:

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -21,7 +21,12 @@ import boto3
 import pymysql
 
 # Shared constants from Lambda Layer (mounted at /opt/python by AWS Lambda)
-from aws_constants import DatabaseConfig, PremiumAssignment, SubscriptionType
+from aws_constants import (
+    DatabaseConfig,
+    EnvironmentConfig,
+    PremiumAssignment,
+    SubscriptionType,
+)
 
 if TYPE_CHECKING:
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
@@ -338,6 +343,26 @@ def check_free_user_inactivity() -> Dict[str, int]:
         return {"logged_out": 0, "error": str(e)}
 
 
+def _tg_unhealthy_alarm_name(tg_arn: str) -> "str | None":
+    """Derive the UnHealthyHostCount alarm name for a premium target group ARN."""
+    idx = tg_arn.find(":targetgroup/")
+    suffix = tg_arn[idx + 1 :] if idx != -1 else tg_arn
+    parts = suffix.split("/")
+    if len(parts) < 2:
+        return None
+    return f"{EnvironmentConfig.get_env_prefix()}-{parts[1]}-unhealthy-hosts"
+
+
+def _delete_tg_unhealthy_alarm(cw: Any, tg_arn: str) -> None:
+    """Best-effort, idempotent delete of a target group's UnHealthyHostCount alarm."""
+    try:
+        alarm_name = _tg_unhealthy_alarm_name(tg_arn)
+        if alarm_name:
+            cw.delete_alarms(AlarmNames=[alarm_name])
+    except Exception as e:
+        print(f"WARNING: Failed to delete unhealthy-host alarm for {tg_arn}: {e}")
+
+
 def check_premium_user_inactivity() -> Dict[str, int]:
     """Check and logout inactive premium users"""
     try:
@@ -347,6 +372,7 @@ def check_premium_user_inactivity() -> Dict[str, int]:
             )
         )
         elbv2: "ElasticLoadBalancingv2Client" = boto3.client("elbv2")
+        cw = boto3.client("cloudwatch")
 
         with get_db_connection() as conn:
             with conn.cursor() as cursor:
@@ -415,6 +441,7 @@ def check_premium_user_inactivity() -> Dict[str, int]:
                                 print(
                                     f"Target group already deleted for user {user_id}"
                                 )
+                            _delete_tg_unhealthy_alarm(cw, user["target_group_arn"])
 
                         logged_out += 1
 

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -343,6 +343,7 @@ def check_free_user_inactivity() -> Dict[str, int]:
         return {"logged_out": 0, "error": str(e)}
 
 
+# Mirrored in premium_manager.py & premium_cleanup.py — keep all three in sync.
 def _tg_unhealthy_alarm_name(tg_arn: str) -> "str | None":
     """Derive the UnHealthyHostCount alarm name for a premium target group ARN."""
     idx = tg_arn.find(":targetgroup/")

--- a/infrastructure/terraform/common_user_manager_package/test_common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/test_common_user_manager.py
@@ -18,6 +18,7 @@ os.environ["RDS_PASSWORD"] = "test_password"
 os.environ["RDS_DATABASE"] = "test_db"
 os.environ["FREE_IDLE_TIMEOUT_HOURS"] = "2"
 os.environ["PREMIUM_IDLE_TIMEOUT_HOURS"] = "2"
+os.environ["ENV_PREFIX"] = "test"
 os.environ[
     "AUTOSCALING_TARGET_GROUP_ARN"
 ] = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/abc123"
@@ -160,10 +161,10 @@ class TestCheckPremiumUserInactivity:
         mock_context, mock_cursor = mock_db_connection
         mock_cursor.fetchall.return_value = [
             {
-                "user_id": "premium1",
+                "user_id": 123,
                 "target_group_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"
-                    "targetgroup/premium1/xyz"
+                    "targetgroup/premium-123-tg/xyz"
                 ),
                 "alb_rule_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"
@@ -182,6 +183,10 @@ class TestCheckPremiumUserInactivity:
         # Verify ALB cleanup was called
         mock_elbv2.delete_rule.assert_called_once()
         mock_elbv2.delete_target_group.assert_called_once()
+        # Verify the per-TG unhealthy-host alarm was cleaned up
+        mock_elbv2.delete_alarms.assert_called_once_with(
+            AlarmNames=["test-premium-123-tg-unhealthy-hosts"]
+        )
         # Verify database deletion
         mock_context.commit.assert_called_once()
 
@@ -205,16 +210,17 @@ class TestCheckPremiumUserInactivity:
         # Verify ALB cleanup was NOT called for standby
         mock_elbv2.delete_rule.assert_not_called()
         mock_elbv2.delete_target_group.assert_not_called()
+        mock_elbv2.delete_alarms.assert_not_called()
 
     def test_partial_failure(self, mock_db_connection, mock_boto3):
         """Test when some users fail to logout"""
         mock_context, mock_cursor = mock_db_connection
         mock_cursor.fetchall.return_value = [
             {
-                "user_id": "user1",
+                "user_id": 123,
                 "target_group_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"
-                    "targetgroup/user1/xyz"
+                    "targetgroup/premium-123-tg/xyz"
                 ),
                 "alb_rule_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"
@@ -222,10 +228,10 @@ class TestCheckPremiumUserInactivity:
                 ),
             },
             {
-                "user_id": "user2",
+                "user_id": 456,
                 "target_group_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"
-                    "targetgroup/user2/xyz"
+                    "targetgroup/premium-456-tg/xyz"
                 ),
                 "alb_rule_arn": (
                     "arn:aws:elasticloadbalancing:us-east-1:123456789012:"

--- a/infrastructure/terraform/common_user_manager_package/test_common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/test_common_user_manager.py
@@ -55,6 +55,19 @@ def mock_boto3():
         yield mock_boto
 
 
+def split_boto3_clients(mock_boto3):
+    """Wire boto3.client to return a distinct mock per service name.
+
+    The Lambda creates separate elbv2 and cloudwatch clients; sharing one mock
+    would let an alarm delete on the wrong client pass undetected.
+    """
+    mock_elbv2 = MagicMock()
+    mock_cloudwatch = MagicMock()
+    clients = {"elbv2": mock_elbv2, "cloudwatch": mock_cloudwatch}
+    mock_boto3.client.side_effect = lambda service, *a, **k: clients[service]
+    return mock_elbv2, mock_cloudwatch
+
+
 class TestRecoverStaleWorkflowCounts:
     """Tests for recover_stale_workflow_counts function"""
 
@@ -173,8 +186,7 @@ class TestCheckPremiumUserInactivity:
             }
         ]
 
-        mock_elbv2 = MagicMock()
-        mock_boto3.client.return_value = mock_elbv2
+        mock_elbv2, mock_cloudwatch = split_boto3_clients(mock_boto3)
 
         result = common_user_manager.check_premium_user_inactivity()
 
@@ -183,8 +195,8 @@ class TestCheckPremiumUserInactivity:
         # Verify ALB cleanup was called
         mock_elbv2.delete_rule.assert_called_once()
         mock_elbv2.delete_target_group.assert_called_once()
-        # Verify the per-TG unhealthy-host alarm was cleaned up
-        mock_elbv2.delete_alarms.assert_called_once_with(
+        # Verify the per-TG unhealthy-host alarm was cleaned up on CloudWatch
+        mock_cloudwatch.delete_alarms.assert_called_once_with(
             AlarmNames=["test-premium-123-tg-unhealthy-hosts"]
         )
         # Verify database deletion
@@ -201,8 +213,7 @@ class TestCheckPremiumUserInactivity:
             }
         ]
 
-        mock_elbv2 = MagicMock()
-        mock_boto3.client.return_value = mock_elbv2
+        mock_elbv2, mock_cloudwatch = split_boto3_clients(mock_boto3)
 
         result = common_user_manager.check_premium_user_inactivity()
 
@@ -210,7 +221,7 @@ class TestCheckPremiumUserInactivity:
         # Verify ALB cleanup was NOT called for standby
         mock_elbv2.delete_rule.assert_not_called()
         mock_elbv2.delete_target_group.assert_not_called()
-        mock_elbv2.delete_alarms.assert_not_called()
+        mock_cloudwatch.delete_alarms.assert_not_called()
 
     def test_partial_failure(self, mock_db_connection, mock_boto3):
         """Test when some users fail to logout"""
@@ -240,10 +251,9 @@ class TestCheckPremiumUserInactivity:
             },
         ]
 
-        mock_elbv2 = MagicMock()
+        mock_elbv2, mock_cloudwatch = split_boto3_clients(mock_boto3)
         # First user succeeds, second fails
         mock_elbv2.delete_rule.side_effect = [None, Exception("ALB error")]
-        mock_boto3.client.return_value = mock_elbv2
 
         result = common_user_manager.check_premium_user_inactivity()
 


### PR DESCRIPTION
### Content

#### Summary
- The `common-user-manager` Lambda's premium-inactivity logout calls `elbv2.delete_rule` / `elbv2.delete_target_group`, but its IAM role was never granted any `elasticloadbalancing` permissions — so that cleanup has been failing with `AccessDenied` on every run since v1.0.0, leaving the logout to report users as `failed` and leaning entirely on the hourly `premium_cleanup` orphan-sweep as a safety net.
- This PR grants the missing, least-privilege ELB and CloudWatch delete permissions, so the Lambda can finish its own ALB cleanup inline.
- It also closes a resource leak: when a premium user's dedicated target group is deleted at logout, the matching `UnHealthyHostCount` alarm (created per-TG by `premium_manager`) is now deleted in the same place, using the exact same name derivation as the creator.
- Finally, it activates a previously-inert guard — `AUTOSCALING_TARGET_GROUP_ARN` is now passed to the Lambda, so an idle premium user parked on the **shared** autoscaling TG no longer triggers a delete against that shared TG.
- Resolves #669 (severity: High), filed from the v1.1.7 post-release log review.

#### Design Decisions
- **Least-privilege IAM scoping over wildcards.** `DeleteTargetGroup` is scoped to `targetgroup/premium-*` and `DeleteAlarms` to `{env}-premium-*-unhealthy-hosts`, matching the production naming (`premium-{user_id}-tg` from `create_or_get_target_group`, and the alarm name built in `_premium_tg_alarm_name`). `DeleteRule` is scoped to `listener-rule/*` because a per-user rule ARN's rule-id is non-deterministic and cannot be pattern-matched per user.
- **Alarm cleanup is best-effort and cannot block logout.** `_delete_tg_unhealthy_alarm` swallows its own exceptions, and `delete_alarms` is idempotent (it ignores names that don't exist). It is called *after* the `delete_target_group` try/except so the alarm is removed even when the TG was already gone — the alarm can outlive the TG.
- **Derivation duplicated, not centralised (for now).** The alarm-name derivation is intentionally identical to the copies in `premium_manager.py` and `premium_cleanup.py`; a one-line "keep all three in sync" comment was added. Consolidating into the shared `aws_constants` layer is a reasonable follow-up but was kept out of a fix-scoped PR.
- **`ENV_PREFIX` is required, not defaulted.** The derivation goes through `EnvironmentConfig.get_env_prefix()`, which raises if `ENV_PREFIX` is unset — this prevents the Lambda from silently building alarm names for the wrong environment (the dev and prod stacks share one AWS account).
- **Scoped tighter than the premium-manager role.** `premium_manager.tf`'s ELB statement also covers `targetgroup/${var.environment}-*` (it creates those), but `common-user-manager` only ever deletes a premium user's dedicated `premium-{user_id}-tg`, so its `DeleteTargetGroup` is scoped to `targetgroup/premium-*` only. Per the audit suggested in #669, the Lambda's only `elbv2` calls are `delete_rule` and `delete_target_group` (plus their exception classes, which need no IAM), so the action list is complete.

### Evidence
- `pytest` — 15/15 pass (see Manual Testcases).
- `terraform fmt -check` — clean on `common_user_manager.tf`.
- `flake8` (max-line-length 88) — clean on both Python files.
- History check: `git log -S "elasticloadbalancing:DeleteTargetGroup" -- infrastructure/terraform/common_user_manager.tf` returns no prior commit, confirming the ELB delete permission is introduced here for the first time, while the `delete_target_group` call has shipped since v1.0.0.
- Runtime symptom captured in #669 (`/aws/lambda/subscr-common-user-manager`, 2026-06-04 19:40 JST): `Failed to logout user 6120: ... (AccessDenied) when calling the DeleteRule operation ... because no identity-based policy allows the elasticloadbalancing:DeleteRule action`, followed by `Logged out 0 inactive premium users, 1 failed: [6120]`.
- #669 also confirms no permanent leak for that occurrence: listener rule `773dcbe9280d86e3` (user 6120) had already been removed by the premium-manager/cleanup lambdas — corroborating the `premium_cleanup` orphan-sweep safety net described above.

### References
- Resolves #669 — *common-user-manager lambda lacks ELB delete permissions* (label: bug, severity High; found in the v1.1.7 post-release log review): https://github.com/arayabrain/araya-optinist/issues/669
- `premium_manager.tf` "ELB Management actions (scoped to this ALB)" statement — the per-user ELB scoping this PR mirrors (minus the `${var.environment}-*` target groups, which this Lambda never deletes).
- `premium_manager.py` `_ensure_premium_tg_unhealthy_alarm` / `_premium_tg_alarm_name` — where the per-TG alarms are created and named.
- `premium_cleanup.py` `cleanup_orphaned_alb_resources` — the hourly orphan-sweep that has been the safety net for the leaked rules/TGs.

#### Files changed
- `infrastructure/terraform/common_user_manager.tf` — add `AUTOSCALING_TARGET_GROUP_ARN` and `ENV_PREFIX` to the Lambda env; add IAM statements for `DeleteRule` (`listener-rule/*`), `DeleteTargetGroup` (`targetgroup/premium-*`), and `DeleteAlarms` (`{env}-premium-*-unhealthy-hosts`).
- `infrastructure/terraform/common_user_manager_package/common_user_manager.py` — import `EnvironmentConfig`; add `_tg_unhealthy_alarm_name` and best-effort `_delete_tg_unhealthy_alarm`; create a CloudWatch client and delete the per-TG `UnHealthyHostCount` alarm after the target group is deleted.
- `infrastructure/terraform/common_user_manager_package/test_common_user_manager.py` — set `ENV_PREFIX`; assert the per-TG alarm is deleted (and not deleted for standby markers); make fixtures use the production `premium-{user_id}-tg` naming.

### Manual Testcases
- Operator: confirm an idle premium user with a dedicated TG is fully cleaned up — DB row deleted, listener rule deleted, target group deleted, and `{env}-premium-{user_id}-tg-unhealthy-hosts` alarm deleted. Expected: logout succeeds, no `AccessDenied` in the Lambda log, no orphaned alarm remains.
- Operator: confirm an idle premium user parked on the shared autoscaling TG is logged out **without** deleting the shared TG or its alarm. Expected: the autoscaling TG and its alarm are untouched.
- Operator: confirm a standby/reserving placeholder row is skipped for all ALB/alarm calls. Expected: no `delete_rule` / `delete_target_group` / `delete_alarms` calls.
- `cd infrastructure/terraform/common_user_manager_package && PYTHONPATH="$PWD:$PWD/../..:$PWD/../../.." python -m pytest test_common_user_manager.py -v` — all 15 tests pass.

### Unit, Integration, Contract Test Coverage
- Unit: `TestCheckPremiumUserInactivity` covers the happy path (rule + TG + alarm deleted with the derived name), the standby-skip path (no ALB/alarm calls), and partial failure (one user fails, the other still logs out).
- Not covered by automated tests: the IAM policy itself (resource-pattern scoping is verified by matching it against the production naming, not by an integration test). A post-deploy smoke test against a real idle premium assignment is recommended.

### Others

#### Difficulties (if any)
- The bug was latent: the broken ALB cleanup was masked by the hourly `premium_cleanup` orphan-sweep, so the only runtime symptom was `AccessDenied` log noise and inflated `failed` counts rather than a visible leak.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| ELB/CloudWatch IAM | Low | New permissions are additive and least-privilege; resource patterns verified against production TG/alarm names. Worst case is the same `AccessDenied` as today (no regression). |
| Premium logout behavior | Low | Alarm cleanup is best-effort and exception-swallowing; it cannot block a logout or mark a user failed. |
| Shared autoscaling TG | Low (improvement) | Wiring `AUTOSCALING_TARGET_GROUP_ARN` makes a previously-inert guard effective, removing a path that could attempt to delete the shared TG. |
| `ENV_PREFIX` requirement | Low | If unset, `get_env_prefix()` raises and is caught by the best-effort alarm wrapper; logout still proceeds. Terraform now always sets it. |
