### PR TITLE
Fix RDS alarm dimensions and quiet premium TG alarm churn

### DIFF
--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -110,19 +110,6 @@ resource "aws_cloudwatch_metric_alarm" "memory_low" {
   }
 }
 
-
-resource "aws_cloudwatch_log_metric_filter" "user_cpu_usage" {
-  name           = "user-cpu-usage"
-  log_group_name = aws_cloudwatch_log_group.ecs.name
-  pattern        = "[timestamp, level, user_id, cpu_usage]"
-
-  metric_transformation {
-    name      = "UserCPUUsage"
-    namespace = "OptiNiSt/Application/${var.environment}"
-    value     = "$cpu_usage"
-  }
-}
-
 # ==================================================
 # Load Average Monitoring
 # ==================================================
@@ -208,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
   ok_actions          = local.critical_alerts_actions
 
   dimensions = {
-    DBInstanceIdentifier = aws_db_instance.main.id
+    DBInstanceIdentifier = aws_db_instance.main.identifier
   }
 }
 
@@ -226,7 +213,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
   ok_actions          = local.critical_alerts_actions
 
   dimensions = {
-    DBInstanceIdentifier = aws_db_instance.main.id
+    DBInstanceIdentifier = aws_db_instance.main.identifier
   }
 }
 
@@ -244,7 +231,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
   ok_actions          = local.critical_alerts_actions
 
   dimensions = {
-    DBInstanceIdentifier = aws_db_instance.main.id
+    DBInstanceIdentifier = aws_db_instance.main.identifier
   }
 }
 
@@ -533,7 +520,6 @@ resource "aws_cloudwatch_dashboard" "main" {
             ["OptiNiSt/FreeUsers/${var.environment}", "ActiveLogins", { "label" : "Active Free Tier Users", "yAxis" : "left" }],
             ["OptiNiSt/Premium/${var.environment}", "ActiveAssignments", { "label" : "Active Premium Users", "yAxis" : "left" }],
             ["OptiNiSt/Premium/${var.environment}", "InstanceUtilization", { "label" : "Premium Instance Utilization %", "yAxis" : "right" }],
-            ["OptiNiSt/Application/${var.environment}", "UserCPUUsage", { "label" : "User CPU Usage", "stat" : "Average", "yAxis" : "right" }],
             ["AWS/Lambda", "Duration", "FunctionName", aws_lambda_function.premium_manager.function_name, { "label" : "Premium Manager Duration (ms)", "yAxis" : "right" }],
             ["AWS/Lambda", "Errors", "FunctionName", aws_lambda_function.premium_manager.function_name, { "label" : "Premium Manager Errors", "yAxis" : "left" }]
           ]
@@ -610,9 +596,9 @@ resource "aws_cloudwatch_dashboard" "main" {
         height = 6
         properties = {
           metrics = [
-            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", aws_db_instance.main.id, { "label" : "RDS CPU %", "yAxis" : "left" }],
-            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", aws_db_instance.main.id, { "label" : "RDS Connections", "yAxis" : "right" }],
-            ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", aws_db_instance.main.id, { "label" : "RDS Free Storage (Bytes)", "yAxis" : "right" }],
+            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", aws_db_instance.main.identifier, { "label" : "RDS CPU %", "yAxis" : "left" }],
+            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", aws_db_instance.main.identifier, { "label" : "RDS Connections", "yAxis" : "right" }],
+            ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", aws_db_instance.main.identifier, { "label" : "RDS Free Storage (Bytes)", "yAxis" : "right" }],
             ["AWS/EFS", "ClientConnections", "FileSystemId", aws_efs_file_system.snmk.id, { "label" : "EFS Connections", "yAxis" : "right" }],
             ["AWS/EFS", "PercentIOLimit", "FileSystemId", aws_efs_file_system.snmk.id, { "label" : "EFS I/O Limit %", "yAxis" : "left" }],
             ["AWS/EFS", "BurstCreditBalance", "FileSystemId", aws_efs_file_system.snmk.id, { "label" : "EFS Burst Credits", "yAxis" : "right" }]

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -86,6 +86,7 @@ def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
     try:
         cloudwatch = _get_cloudwatch_client()
         cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+        print(f"[premium-alarm] action=delete name={alarm_name} tg={tg_arn}")
     except Exception as e:
         print(f"Warning: Failed to delete unhealthy-host alarm {alarm_name}: {e}")
 

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -2623,13 +2623,16 @@ def _ensure_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
                 "instance may be failing health checks."
             ),
             AlarmActions=actions,
-            OKActions=actions,
+            # Ephemeral per-assign/release alarm; OK actions would page a
+            # "recovered" notice to the critical topic on every recreate.
+            OKActions=[],
             TreatMissingData="missing",
             Dimensions=[
                 {"Name": "LoadBalancer", "Value": _alb_arn_suffix(alb_arn)},
                 {"Name": "TargetGroup", "Value": _tg_arn_suffix(tg_arn)},
             ],
         )
+        print(f"[premium-alarm] action=create name={alarm_name} tg={tg_arn}")
     except Exception as e:
         print(f"WARNING: Failed to create unhealthy-host alarm {alarm_name}: {e}")
 
@@ -2647,6 +2650,7 @@ def _delete_premium_tg_unhealthy_alarm(tg_arn: str) -> None:
     try:
         cloudwatch = _get_cloudwatch_client()
         cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+        print(f"[premium-alarm] action=delete name={alarm_name} tg={tg_arn}")
     except Exception as e:
         print(f"WARNING: Failed to delete unhealthy-host alarm {alarm_name}: {e}")
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -4214,9 +4214,7 @@ class TestPremiumTgUnhealthyAlarm:
             "CRITICAL_ALERTS_TOPIC_ARN": self.TOPIC_ARN,
         }
 
-    def test_create_pages_on_alarm_but_not_on_ok(
-        self, mock_env_vars_premium, capsys
-    ):
+    def test_create_pages_on_alarm_but_not_on_ok(self, mock_env_vars_premium, capsys):
         with patch.dict("os.environ", self._env(mock_env_vars_premium)):
             import premium_manager
 
@@ -4249,9 +4247,7 @@ class TestPremiumTgUnhealthyAlarm:
             assert kwargs["AlarmActions"] == []
             assert kwargs["OKActions"] == []
 
-    def test_delete_removes_alarm_by_derived_name(
-        self, mock_env_vars_premium, capsys
-    ):
+    def test_delete_removes_alarm_by_derived_name(self, mock_env_vars_premium, capsys):
         with patch.dict("os.environ", self._env(mock_env_vars_premium)):
             import premium_manager
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -4187,3 +4187,81 @@ class TestPublishPremiumMetricsDriftKwargs:
             metric_by_name = {m["MetricName"]: m["Value"] for m in kwargs["MetricData"]}
             assert metric_by_name["TargetGroupPortDriftDetected"] == 0
             assert metric_by_name["TargetGroupPortDriftFixed"] == 0
+
+
+class TestPremiumTgUnhealthyAlarm:
+    """Ephemeral per-user UnHealthyHostCount alarm, created on assign and
+    deleted on release. Because it is recreated on every assign/release, OK
+    actions are intentionally dropped so churn does not page "recovered" to
+    the critical SNS topic; alarm actions are kept so genuine health failures
+    still page."""
+
+    TG_ARN = (
+        "arn:aws:elasticloadbalancing:region:account:"
+        "targetgroup/premium-6120-tg/abc123"
+    )
+    ALB_ARN = (
+        "arn:aws:elasticloadbalancing:region:account:"
+        "loadbalancer/app/test-alb/def456"
+    )
+    TOPIC_ARN = "arn:aws:sns:region:account:test-optinist-critical-alerts"
+    EXPECTED_NAME = "test-premium-6120-tg-unhealthy-hosts"
+
+    def _env(self, base):
+        return {
+            **base,
+            "ALB_ARN": self.ALB_ARN,
+            "CRITICAL_ALERTS_TOPIC_ARN": self.TOPIC_ARN,
+        }
+
+    def test_create_pages_on_alarm_but_not_on_ok(
+        self, mock_env_vars_premium, capsys
+    ):
+        with patch.dict("os.environ", self._env(mock_env_vars_premium)):
+            import premium_manager
+
+            mock_cw = MagicMock()
+            with patch.object(
+                premium_manager, "_get_cloudwatch_client", return_value=mock_cw
+            ):
+                premium_manager._ensure_premium_tg_unhealthy_alarm(self.TG_ARN)
+
+            mock_cw.put_metric_alarm.assert_called_once()
+            kwargs = mock_cw.put_metric_alarm.call_args.kwargs
+            assert kwargs["AlarmName"] == self.EXPECTED_NAME
+            assert kwargs["AlarmActions"] == [self.TOPIC_ARN]
+            assert kwargs["OKActions"] == []
+            assert "[premium-alarm] action=create" in capsys.readouterr().out
+
+    def test_create_without_topic_wires_no_actions(self, mock_env_vars_premium):
+        env = self._env(mock_env_vars_premium)
+        env["CRITICAL_ALERTS_TOPIC_ARN"] = ""
+        with patch.dict("os.environ", env):
+            import premium_manager
+
+            mock_cw = MagicMock()
+            with patch.object(
+                premium_manager, "_get_cloudwatch_client", return_value=mock_cw
+            ):
+                premium_manager._ensure_premium_tg_unhealthy_alarm(self.TG_ARN)
+
+            kwargs = mock_cw.put_metric_alarm.call_args.kwargs
+            assert kwargs["AlarmActions"] == []
+            assert kwargs["OKActions"] == []
+
+    def test_delete_removes_alarm_by_derived_name(
+        self, mock_env_vars_premium, capsys
+    ):
+        with patch.dict("os.environ", self._env(mock_env_vars_premium)):
+            import premium_manager
+
+            mock_cw = MagicMock()
+            with patch.object(
+                premium_manager, "_get_cloudwatch_client", return_value=mock_cw
+            ):
+                premium_manager._delete_premium_tg_unhealthy_alarm(self.TG_ARN)
+
+            mock_cw.delete_alarms.assert_called_once_with(
+                AlarmNames=[self.EXPECTED_NAME]
+            )
+            assert "[premium-alarm] action=delete" in capsys.readouterr().out


### PR DESCRIPTION
### Content

#### Summary
- The three RDS CloudWatch alarms (CPU, connections, free storage) and the RDS dashboard widgets keyed their `DBInstanceIdentifier` dimension off `aws_db_instance.main.id`. Under the pinned AWS provider (`~> 6.0`), `.id` resolves to the immutable resource ID (`db-…`), not the instance name — so the dimension matched no published metric and all three alarms have sat in `INSUFFICIENT_DATA`, never paging. This switches them to `.identifier` (the `…-cloud-rds` name AWS actually keys RDS metrics by), matching every other RDS reference in the stack.
- The per-premium-user `UnHealthyHostCount` alarm is created on assign and deleted on release. It had `OKActions` wired to the **critical** SNS topic, so each recreate fired a false "recovered" page. OK actions are now dropped; the alarm still pages on genuine unhealthy hosts via `AlarmActions`.
- Removes the dead `user_cpu_usage` log-metric filter and its `UserCPUUsage` dashboard widget — no code emits the `[timestamp, level, user_id, cpu_usage]` log line, so the metric was never populated.
- Adds `[premium-alarm] action=create|delete` log lines around the ephemeral alarm lifecycle for operational traceability.

#### Design Decisions
- **`.identifier`, not `.id`.** AWS provider v5+ changed `aws_db_instance.id` to return the resource ID (`db-…`) instead of the identifier; CloudWatch keys RDS metrics on the identifier name. `.identifier` is what `dev_schedule.tf` and `infrastructure.tf` already use — `monitoring.tf` was the lone outlier. This is an in-place dimension update on apply, not a replacement.
- **Drop OK actions rather than mute the whole alarm.** Keeping `AlarmActions` preserves genuine unhealthy-host paging; only the `INSUFFICIENT_DATA → OK` and recreate-churn "recovered" notifications are suppressed. The trade-off — no recovery notification mid-assignment — is acceptable for a short-lived per-user alarm that is deleted on release. `put_metric_alarm` rewrites the full config each call, so `OKActions=[]` reliably clears them on every recreate.
- **Remove the dead metric instead of wiring an emitter.** The `[timestamp, level, user_id, cpu_usage]` filter has never had a producer, so its metric and dashboard widget only added noise. Removing both declutters the dashboard and drops a never-firing resource on the next apply.
- **Logging via `print`.** Matches the existing `print("WARNING: …")` convention in these Lambda modules (no logger framework is used); output lands in the function's CloudWatch log stream. Volume is bounded by assign/release count and carries no PII.

### Evidence
- `pytest tests/infrastructure/test_premium_manager.py` — **111 passed** (3 new in `TestPremiumTgUnhealthyAlarm`).
- `flake8 --max-line-length 88` — clean on `premium_manager.py` and `premium_cleanup.py`.
- Consistency check: `grep -rn "aws_db_instance.main" infrastructure/terraform` shows every other RDS-metric reference already uses `.identifier`; `monitoring.tf` held the only `.id`.
- Dead-metric check: `grep -rni "cpu_usage" studio --include="*.py"` returns no emitter, confirming `UserCPUUsage` was never populated.

### References
- AWS provider pinned at `~> 6.0` in `versions.tf`; the v5 upgrade guide changed `aws_db_instance.id` from the identifier to the resource ID — the root cause of the broken dimension.
- `aws_db_instance.main` in `infrastructure.tf` — `identifier = "${local.env_prefix}-cloud-rds"`, the value AWS uses for the `DBInstanceIdentifier` dimension.
- `_ensure_premium_tg_unhealthy_alarm` / `_delete_premium_tg_unhealthy_alarm` / `_premium_tg_alarm_name` in `premium_manager.py` — where the ephemeral per-TG alarm is created, deleted, and named.

#### Files changed
- `infrastructure/terraform/monitoring.tf` — switch the three RDS alarms and three RDS dashboard widgets from `aws_db_instance.main.id` to `.identifier`; remove the dead `user_cpu_usage` log-metric filter and its `UserCPUUsage` dashboard widget.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — set `OKActions=[]` on the ephemeral per-TG `UnHealthyHostCount` alarm; add create/delete lifecycle log lines.
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` — add a delete lifecycle log line mirroring `premium_manager`.
- `studio/tests/infrastructure/test_premium_manager.py` — add `TestPremiumTgUnhealthyAlarm`: assert paging on alarm but not OK, the no-topic branch, and delete-by-derived-name plus the log lines.

### Manual Testcases
- Operator: trigger a premium assign, then inspect the alarm in CloudWatch. Expected: `{env}-premium-{user_id}-tg-unhealthy-hosts` exists with the critical topic under Alarm actions and **no** OK actions; no "recovered" notification arrives on the critical topic when the instance becomes healthy.
- Operator: release the premium user. Expected: the alarm is deleted, `[premium-alarm] action=delete` appears in the Lambda log, and the recreate churn fires no OK/recovered page.
- Operator: after `terraform apply`, confirm the three RDS alarms (`{env}-…-rds-*`) leave `INSUFFICIENT_DATA` and report `OK`/data, and the RDS dashboard widgets render. Expected: the dimension now matches `…-cloud-rds`.
- `cd studio && python -m pytest tests/infrastructure/test_premium_manager.py -q` — all 111 tests pass.

### Unit, Integration, Contract Test Coverage
- Unit: `TestPremiumTgUnhealthyAlarm` covers create-with-topic (AlarmActions set, OKActions empty, create log emitted), create-without-topic (both action lists empty), and delete (correct derived name, delete log emitted).
- Not covered by automated tests: the terraform dimension change (verified by code consistency plus a post-apply check that alarms leave `INSUFFICIENT_DATA`) and the dead-metric removal (no producer exists to test).

### Others

#### Difficulties (if any)
- The RDS-alarm bug was silent: a wrong dimension value raises no error — the alarms simply stay in `INSUFFICIENT_DATA` and never page, so the gap was invisible until review. The provider-version change to `aws_db_instance.id` semantics is the non-obvious root cause.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| RDS alarms (`monitoring.tf`) | Low (improvement) | In-place dimension update that restores alerting which was inert; worst case is the same non-firing state as today (no regression). |
| Premium ephemeral alarm (`OKActions`) | Low | Removes only recovery/churn notifications; genuine ALARM paging is unchanged; creation is best-effort and cannot block provisioning. |
| Dead metric removal | Low | `UserCPUUsage` had no producer and no other consumer (its widget is removed in the same change). `LOGGING_ARCHITECTURE.md` still lists `user-cpu-usage` — stale-doc follow-up. |
| Lambda log lines | Low | Additive stdout; bounded volume; no PII. |
