### PR TITLE
Add Public to dev scheduler

### DIFF
--- a/infrastructure/terraform/dev_schedule.tf
+++ b/infrastructure/terraform/dev_schedule.tf
@@ -6,6 +6,7 @@
 #
 # Resources managed:
 #   - Free tier ASG (scale 0 <-> 1)
+#   - Public tier ASG (scale 0 <-> 2)
 #   - Background service EC2 instance (stop/start)
 #   - Premium EC2 instances (stop/start)
 #   - NAT instance (stop/start)
@@ -136,6 +137,12 @@ resource "aws_lambda_function" "dev_scheduler" {
         aws_ecs_service.premium.name,
         aws_ecs_service.background.name,
       ])
+
+      PUBLIC_ASG_NAME             = aws_autoscaling_group.public.name
+      PUBLIC_ASG_MIN_SIZE         = tostring(var.public_asg_min_size)
+      PUBLIC_ASG_MAX_SIZE         = tostring(var.public_asg_max_size)
+      PUBLIC_ASG_DESIRED_CAPACITY = tostring(var.public_asg_desired_capacity)
+      PUBLIC_ECS_SERVICE_NAME     = aws_ecs_service.public.name
     }
   }
 
@@ -285,13 +292,16 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
         ]
         Resource = "*"
       },
-      # ASG management (scoped to specific ASG)
+      # ASG management (scoped to specific ASGs)
       {
         Effect = "Allow"
         Action = [
           "autoscaling:UpdateAutoScalingGroup",
         ]
-        Resource = aws_autoscaling_group.main.arn
+        Resource = [
+          aws_autoscaling_group.main.arn,
+          aws_autoscaling_group.public.arn,
+        ]
       },
       # EventBridge rule enable/disable (scoped to environment prefix)
       {
@@ -335,6 +345,7 @@ resource "aws_iam_role_policy" "dev_scheduler_permissions" {
           aws_ecs_service.autoscaling.id,
           aws_ecs_service.premium.id,
           aws_ecs_service.background.id,
+          aws_ecs_service.public.id,
         ]
       },
     ]

--- a/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
+++ b/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
@@ -49,7 +49,9 @@ Resources managed:
 - Background service EC2 instance (stop/start)
 - Premium EC2 instances (stop/start)
 - Free tier ASG (scale 0/1)
+- Public tier ASG (scale 0/2 — terminate/recreate, no stale checkpoint)
 - ECS services (desired_count 0/1 — prevents failed placement noise)
+- Public ECS service (desired_count 0/2)
 - Lambda schedule rules (disable/enable)
 - CloudWatch alarm actions (disable/enable)
 
@@ -289,6 +291,18 @@ def start_environment():
             max_size=int(os.environ.get("ASG_MAX_SIZE", "3")),
         )
 
+        # 5b. Scale up the public ASG. Terminate/recreate (not stop/start) so
+        #     each start gets fresh instances with no stale ECS-agent checkpoint.
+        public_asg = os.environ.get("PUBLIC_ASG_NAME")
+        if public_asg:
+            results["public_asg"] = with_retry(
+                scale_asg,
+                public_asg,
+                min_size=int(os.environ.get("PUBLIC_ASG_MIN_SIZE", "0")),
+                desired=int(os.environ.get("PUBLIC_ASG_DESIRED_CAPACITY", "0")),
+                max_size=int(os.environ.get("PUBLIC_ASG_MAX_SIZE", "0")),
+            )
+
         # 6. Restore ECS service desired counts (so tasks start scheduling
         #    once container instances register)
         ecs_services = json.loads(os.environ.get("ECS_SERVICE_NAMES", "[]"))
@@ -296,6 +310,20 @@ def start_environment():
             results.update(
                 update_ecs_services(
                     os.environ["CLUSTER_NAME"], ecs_services, desired_count=1
+                )
+            )
+
+        # 6b. Restore the public service to its HA desired count, not the
+        #     desired=1 used for the single-task services above.
+        public_service = os.environ.get("PUBLIC_ECS_SERVICE_NAME")
+        if public_service:
+            results.update(
+                update_ecs_services(
+                    os.environ["CLUSTER_NAME"],
+                    [public_service],
+                    desired_count=int(
+                        os.environ.get("PUBLIC_ASG_DESIRED_CAPACITY", "1")
+                    ),
                 )
             )
 
@@ -393,10 +421,24 @@ def stop_environment(stop_mode="destroy"):
             )
         )
 
+    # 3b. Scale down the public service (drain tasks before its ASG terminates).
+    public_service = os.environ.get("PUBLIC_ECS_SERVICE_NAME")
+    if public_service:
+        results.update(
+            update_ecs_services(
+                os.environ["CLUSTER_NAME"], [public_service], desired_count=0
+            )
+        )
+
     # 4. Scale down ASG (terminates free tier instances)
     results["asg"] = with_retry(
         scale_asg, os.environ["ASG_NAME"], min_size=0, desired=0
     )
+
+    # 4b. Scale down the public ASG (terminate instances).
+    public_asg = os.environ.get("PUBLIC_ASG_NAME")
+    if public_asg:
+        results["public_asg"] = with_retry(scale_asg, public_asg, min_size=0, desired=0)
 
     # 5. Stop base premium instances (Terraform-managed)
     premium_ids = [

--- a/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
+++ b/infrastructure/terraform/dev_scheduler_package/dev_scheduler.py
@@ -298,9 +298,9 @@ def start_environment():
             results["public_asg"] = with_retry(
                 scale_asg,
                 public_asg,
-                min_size=int(os.environ.get("PUBLIC_ASG_MIN_SIZE", "0")),
-                desired=int(os.environ.get("PUBLIC_ASG_DESIRED_CAPACITY", "0")),
-                max_size=int(os.environ.get("PUBLIC_ASG_MAX_SIZE", "0")),
+                min_size=int(os.environ["PUBLIC_ASG_MIN_SIZE"]),
+                desired=int(os.environ["PUBLIC_ASG_DESIRED_CAPACITY"]),
+                max_size=int(os.environ["PUBLIC_ASG_MAX_SIZE"]),
             )
 
         # 6. Restore ECS service desired counts (so tasks start scheduling
@@ -321,9 +321,7 @@ def start_environment():
                 update_ecs_services(
                     os.environ["CLUSTER_NAME"],
                     [public_service],
-                    desired_count=int(
-                        os.environ.get("PUBLIC_ASG_DESIRED_CAPACITY", "1")
-                    ),
+                    desired_count=int(os.environ["PUBLIC_ASG_DESIRED_CAPACITY"]),
                 )
             )
 

--- a/infrastructure/terraform/public_service.tf
+++ b/infrastructure/terraform/public_service.tf
@@ -139,6 +139,7 @@ resource "aws_autoscaling_group" "public" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [desired_capacity]
   }
 }
 

--- a/studio/tests/infrastructure/test_dev_scheduler.py
+++ b/studio/tests/infrastructure/test_dev_scheduler.py
@@ -872,6 +872,18 @@ class TestStartEnvironment:
             "test-cluster", ["svc-public"], desired_count=2
         )
 
+    def test_start_raises_when_public_gated_on_but_size_var_missing(
+        self, patched, monkeypatch
+    ):
+        """Fail-fast: with PUBLIC_ASG_NAME set but a required size var absent,
+        start must raise rather than silently scaling public to 0."""
+        module, _, helpers = patched
+        monkeypatch.delenv("PUBLIC_ASG_MAX_SIZE", raising=False)
+        with pytest.raises(KeyError):
+            module.start_environment()
+        # clear_override still runs on the way out (try/finally).
+        helpers["clear_override"].assert_called_once()
+
     def test_start_skips_public_when_unset(self, patched, monkeypatch):
         """Back-compat: with the public env vars absent, start touches neither
         a public ASG nor a public service — only the free ASG and 3-service

--- a/studio/tests/infrastructure/test_dev_scheduler.py
+++ b/studio/tests/infrastructure/test_dev_scheduler.py
@@ -31,6 +31,11 @@ SCHEDULER_ENV = {
     "ASG_MAX_SIZE": "2",
     "CLUSTER_NAME": "test-cluster",
     "ECS_SERVICE_NAMES": json.dumps(["svc-a", "svc-b"]),
+    "PUBLIC_ASG_NAME": "test-public-asg",
+    "PUBLIC_ASG_MIN_SIZE": "2",
+    "PUBLIC_ASG_MAX_SIZE": "4",
+    "PUBLIC_ASG_DESIRED_CAPACITY": "2",
+    "PUBLIC_ECS_SERVICE_NAME": "svc-public",
     "SCHEDULE_RULE_NAMES": json.dumps(["rule-a"]),
     "DELAYED_RULE_NAMES": json.dumps(["delayed-a"]),
     "ALARM_PREFIX": "test-",
@@ -855,6 +860,30 @@ class TestStartEnvironment:
         # The error message should mention the ASG failure, not the proxy.
         assert "capacity" in str(exc_info.value)
 
+    def test_start_scales_public_asg_and_service_to_two(self, patched):
+        """Public scales up via its own ASG and its service restores to the
+        HA desired count (2), not the desired=1 used for the other services."""
+        module, _, helpers = patched
+        module.start_environment()
+        helpers["scale_asg"].assert_any_call(
+            "test-public-asg", min_size=2, desired=2, max_size=4
+        )
+        helpers["update_ecs_services"].assert_any_call(
+            "test-cluster", ["svc-public"], desired_count=2
+        )
+
+    def test_start_skips_public_when_unset(self, patched, monkeypatch):
+        """Back-compat: with the public env vars absent, start touches neither
+        a public ASG nor a public service — only the free ASG and 3-service
+        restore run."""
+        module, _, helpers = patched
+        monkeypatch.delenv("PUBLIC_ASG_NAME", raising=False)
+        monkeypatch.delenv("PUBLIC_ECS_SERVICE_NAME", raising=False)
+        result = module.start_environment()
+        assert result["statusCode"] == 200
+        assert helpers["scale_asg"].call_count == 1
+        assert helpers["update_ecs_services"].call_count == 1
+
 
 # ===========================================================================
 # stop_environment
@@ -944,6 +973,26 @@ class TestStopEnvironment:
         result = module.stop_environment(stop_mode="destroy")
         assert result["statusCode"] == 200
         assert result["results"]["rds"] == "already_deleting"
+
+    def test_stop_scales_public_asg_and_service_to_zero(self, patched):
+        """Public service drains to 0 and the public ASG terminates (desired=0
+        and min=0) so no instances linger."""
+        module, _, helpers = patched
+        module.stop_environment(stop_mode="stop")
+        helpers["update_ecs_services"].assert_any_call(
+            "test-cluster", ["svc-public"], desired_count=0
+        )
+        helpers["scale_asg"].assert_any_call("test-public-asg", min_size=0, desired=0)
+
+    def test_stop_skips_public_when_unset(self, patched, monkeypatch):
+        """Back-compat: with the public env vars absent, stop scales only the
+        free ASG and the 3-service set."""
+        module, _, helpers = patched
+        monkeypatch.delenv("PUBLIC_ASG_NAME", raising=False)
+        monkeypatch.delenv("PUBLIC_ECS_SERVICE_NAME", raising=False)
+        module.stop_environment(stop_mode="stop")
+        assert helpers["scale_asg"].call_count == 1
+        assert helpers["update_ecs_services"].call_count == 1
 
 
 # ===========================================================================


### PR DESCRIPTION
### Content

#### Summary
- The public tier (`public_service.tf`) was invisible to the dev scheduler: the `dev-scheduler` Lambda only scaled the free `main` ASG and the three `autoscaling`/`premium`/`background` ECS services, and its IAM only permitted those. Dev never overrides the public ASG vars, so it ran the defaults (**min=2 / desired=2 / max=4**) — two `t3.small` instances plus 2 ECS tasks billing 24/7, never stopping with the rest of the env at 22:00 JST.
- This wires public into both halves of the scheduler: `start_environment` scales the public ASG up and restores the public ECS service to its HA count, and `stop_environment` drains the service then terminates the ASG. IAM gains the public ASG and public ECS service as scoped resources.
- The public ASG is scaled via **terminate/recreate** (ASG desired up/down), never stop/start, so each start gets fresh instances and sidesteps the stale ECS-agent checkpoint problem entirely.
- Scheduler-managed scaling is dev-only: `enable_dev_schedule` defaults `false` and prod does not set it, so **prod public stays 2/2/4 untouched**.

#### Design Decisions
- **Scale public via its ASG, never stop/start.** The startup "ghost registration" problem is the ECS-agent checkpoint (`agent.db` + `ecs_agent_data.json`): a *fixed* instance that is stopped/started keeps its disk and its stale container-instance registration. The fix (`ecs-clear-checkpoint.service` in `ecs-user-data.sh`) is gated to `tier == premium` because only premium standbys are stop/started; ASG-backed tiers terminate and recreate, so they boot on a fresh disk with no stale checkpoint. Public has no checkpoint-clear unit, so it **must** be ASG-scaled. Stop/starting it would reintroduce the ghost-registration bug.
- **Restore public to its own HA desired count, in a separate call.** The free/premium/background path restores `desired_count=1`; public needs `desired_count=2` (HA SPA delivery). Rather than thread a per-service count through the existing 3-service restore, public gets its own `update_ecs_services` call keyed off `PUBLIC_ASG_DESIRED_CAPACITY`. The well-tested `desired=1` path is left completely untouched.
- **Env-var presence gates the whole feature.** Every new block is guarded by `if os.environ.get("PUBLIC_ASG_NAME")` / `PUBLIC_ECS_SERVICE_NAME`. Absent vars = skip, preserving back-compat for any config that predates the public tier and keeping the existing tests' baseline intact.
- **Ordering falls out of the existing step order.** Public talks to the DB through the RDS Proxy and runs a startup S3 cache-warm, so its scale-up belongs after RDS restore + proxy registration. The existing order gives this (scale-up is steps 5b/6b; RDS restore + proxy is steps 2/2b). On stop, public ECS → 0 (step 3b) precedes public ASG → 0 (step 4b) so tasks drain before instances terminate. Caveat: on an *initial* start the proxy step often returns `deferred_still_creating`, so public can boot before the proxy target is registered — acceptable, as it matches the free tier exactly and self-heals on the +15 min verify-start.
- **`ignore_changes = [desired_capacity]` on the public ASG.** Mirrors the free `aws_autoscaling_group.main` so a `terraform apply` does not reset the scheduler's desired count and fight it. `min_size` is deliberately *not* ignored — matching the free ASG's existing pattern (see Risk Assessment).

### Evidence
- `cd studio && python -m pytest tests/infrastructure/test_dev_scheduler.py -q` — **123 passed** (4 new).
- `flake8 --max-line-length 88 dev_scheduler.py test_dev_scheduler.py` — clean.
- `terraform fmt -check` — clean; `terraform validate` — **Success!** (the new `aws_autoscaling_group.public` / `aws_ecs_service.public` references resolve).
- Consistency check: `ecs-user-data.sh` gates `ecs-clear-checkpoint.service` to `if [ "${tier}" = "premium" ]`; the public launch template passes `tier = "public"` and `efs_id = ""`, confirming public has no checkpoint-clear unit and relies on terminate/recreate.

### References
- Issue #681.
- `fff1078e5` ("Gate the ECS checkpoint-clear unit to the premium tier") — the commit that scoped `ecs-clear-checkpoint.service` to premium, which is why public must be ASG-scaled rather than stop/started.
- `aws_autoscaling_group.main` in `compute.tf` — the free ASG whose `lifecycle { ignore_changes = [desired_capacity] }` this PR mirrors for public.
- `public_asg_min_size` / `public_asg_max_size` / `public_asg_desired_capacity` in `main.tf` — defaults 2/4/2, the values dev now restores public to.

#### Files changed
- `infrastructure/terraform/dev_scheduler_package/dev_scheduler.py` — `start_environment`: add step **5b** (scale the public ASG up via `scale_asg`) and step **6b** (restore the public ECS service to `PUBLIC_ASG_DESIRED_CAPACITY`); `stop_environment`: add step **3b** (public service → 0) and step **4b** (public ASG → min=0/desired=0); update the "Resources managed" docstring.
- `infrastructure/terraform/dev_schedule.tf` — add 5 Lambda env vars (`PUBLIC_ASG_NAME`, `PUBLIC_ASG_MIN_SIZE`, `PUBLIC_ASG_MAX_SIZE`, `PUBLIC_ASG_DESIRED_CAPACITY`, `PUBLIC_ECS_SERVICE_NAME`); add `aws_autoscaling_group.public.arn` to the `autoscaling:UpdateAutoScalingGroup` resource list and `aws_ecs_service.public.id` to the `ecs:UpdateService` resource list; update the managed-resources comment.
- `infrastructure/terraform/public_service.tf` — add `ignore_changes = [desired_capacity]` to the `aws_autoscaling_group.public` lifecycle.
- `studio/tests/infrastructure/test_dev_scheduler.py` — add the 5 public vars to `SCHEDULER_ENV`; add tests for start scaling public ASG+service to 2, stop scaling both to 0, and back-compat skip on each path when the vars are unset.

### Manual Testcases
- Operator: invoke `development-dev-scheduler` with `{"action":"stop","stop_mode":"stop"}` then `{"action":"start"}`. Expected: the public ASG goes 2 → 0 → 2 and `aws_ecs_service.public` `desiredCount` tracks it (2 → 0 → 2), with no stale container-instance registrations after the restart.
- Operator: run a dev `terraform plan`. Expected: only the 5 new Lambda env vars, the two IAM resource-list additions, and the public ASG `ignore_changes` — **no** instance/ASG/ECS churn.
- Operator: after the first real scheduled start, confirm `${env}-public-tg-unhealthy-hosts` does not fire a spurious critical page during the 08:00→08:15 cold-boot window; compare against `${env}-free-tg-unhealthy-hosts` to confirm parity (see Difficulties).
- `cd studio && python -m pytest tests/infrastructure/test_dev_scheduler.py -q` — all 123 tests pass.

### Unit, Integration, Contract Test Coverage
- Unit: `test_start_scales_public_asg_and_service_to_two` (public ASG → 2/2/4, service → 2), `test_stop_scales_public_asg_and_service_to_zero` (service → 0, ASG → min=0/desired=0), and `test_start_skips_public_when_unset` / `test_stop_skips_public_when_unset` (back-compat: only the free ASG and 3-service set are touched when the public env vars are absent).
- The existing 3-service start/stop tests are unchanged; the new public calls are additive and no assertion counts `scale_asg`/`update_ecs_services` in those tests.
- Not covered by automated tests: the terraform changes (env vars, IAM resources, ASG `ignore_changes`), verified by `terraform validate` plus a post-apply `terraform plan` showing no churn.

### Others

#### Difficulties (if any)
- The original motivation was framed as "failed-placement noise," but that is inaccurate: because the scheduler never touched the public ASG, its instances stayed up (capacity present), and `/health` (`health_check` in `__main_unit__.py`) returns a static `{"status":"healthy"}` with no DB dependency — so running tasks stayed ELB-healthy even with RDS destroyed. The real driver is **cost** (plus clean DB reconnection on restart). Noise only appears if a public task/instance recycles while RDS is gone (e.g. the 04:00 EFS `public-cleanup` over a long weekend).
- Morning alarm timing is the one interaction to watch: `${env}-public-tg-unhealthy-hosts` (`tg_unhealthy_hosts` in `monitoring.tf`) wires both `alarm_actions` and `ok_actions` to the critical topic with no `treat_missing_data`. Today public runs 24/7 so the alarm sits OK; after this change public goes 0↔2 like free. The stop side is quiet (actions disabled within seconds, well before the 2×60s evaluation), but a registered-but-failing target during the cold-boot window could trip ALARM. The free tier has a byte-identical alarm and the same DB dependency, so this is shared behavior — verify against free before relying on it. A fix (drop `ok_actions` / set `treat_missing_data = "notBreaching"`) is out of scope for #681.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `dev_scheduler.py` start/stop | Low | New blocks are env-var-guarded, idempotent, and re-run safely on the verify-start/verify-stop re-invocations. Covered by 4 new tests. Dev-only (`enable_dev_schedule`). |
| IAM (`dev_schedule.tf`) | Low | Additive, resource-scoped to `aws_autoscaling_group.public.arn` and `aws_ecs_service.public.id`; no wildcard widening. |
| Public ASG `ignore_changes` | Low | Mirrors the free `main` ASG; prevents applies from fighting the scheduler. |
| Off-hours `terraform apply` drift | Medium | `min_size` (ASG) and `desired_count` (`aws_ecs_service.public`) are not ignored, so an off-hours apply resets public min→2 and ECS desired→2 and could boot public against a destroyed RDS. Pre-existing pattern shared with the free ASG/service; applies normally land in business hours. Optional hardening: `ignore_changes` `min_size` on both ASGs. |
| Morning unhealthy-host alarm | Low | `${env}-public-tg-unhealthy-hosts` could page during the cold-boot window; identical to the existing free alarm. Verify parity at the first scheduled start (see Difficulties). |
| Prod | None | `enable_dev_schedule` defaults false and prod does not set it; prod public remains 2/2/4. |
