### PR TITLE
Fix ghost ECS container instance registrations

### DIFF
--- a/infrastructure/terraform/common_user_manager.tf
+++ b/infrastructure/terraform/common_user_manager.tf
@@ -69,6 +69,9 @@ resource "aws_lambda_function" "common_user_manager" {
       # User inactivity timeout configuration
       FREE_IDLE_TIMEOUT_HOURS    = "2" # Hours before free users are logged out
       PREMIUM_IDLE_TIMEOUT_HOURS = "2" # Hours before premium users are logged out
+
+      # Ghost reaper: deregister container instances whose EC2 is terminated/gone
+      CLUSTER_NAME = aws_ecs_cluster.main.name
     }
   }
 
@@ -138,6 +141,32 @@ resource "aws_iam_role_policy" "common_user_manager_lambda_policy" {
           "cloudwatch:GetMetricData",
           "cloudwatch:GetMetricStatistics"
         ]
+        Resource = "*"
+      },
+      # Ghost reaper: list/deregister container instances (cluster passed as param)
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:ListContainerInstances",
+          "ecs:DeregisterContainerInstance"
+        ]
+        Resource = "*"
+      },
+      # Ghost reaper: describe container instances, scoped to this cluster
+      {
+        Effect   = "Allow"
+        Action   = "ecs:DescribeContainerInstances"
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = aws_ecs_cluster.main.arn
+          }
+        }
+      },
+      # Ghost reaper: resolve backing EC2 state (no resource-level support)
+      {
+        Effect   = "Allow"
+        Action   = "ec2:DescribeInstances"
         Resource = "*"
       }
     ]

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -21,7 +21,13 @@ import boto3
 import pymysql
 
 # Shared constants from Lambda Layer (mounted at /opt/python by AWS Lambda)
-from aws_constants import DatabaseConfig, PremiumAssignment, SubscriptionType
+from aws_constants import (
+    DatabaseConfig,
+    InstanceState,
+    PremiumAssignment,
+    SubscriptionType,
+)
+from botocore.exceptions import ClientError
 
 if TYPE_CHECKING:
     from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
@@ -442,6 +448,103 @@ def check_premium_user_inactivity() -> Dict[str, int]:
         return {"logged_out": 0, "error": str(e)}
 
 
+def reap_terminated_ecs_registrations() -> Dict[str, int]:
+    """Deregister container instances whose backing EC2 is terminated or gone.
+
+    Tier-independent and termination-only: a stopped instance is a legitimate
+    registration it reconnects to on restart, so only terminated /
+    shutting-down / nonexistent / unmapped container instances are reaped.
+    """
+    try:
+        cluster_name = get_required_env_var("CLUSTER_NAME")
+    except ValueError as e:
+        print(f"Cannot reap ghost registrations: {e}")
+        return {"deregistered": 0}
+
+    ecs = boto3.client("ecs")
+    ec2 = boto3.client("ec2")
+
+    try:
+        arns = []
+        paginator = ecs.get_paginator("list_container_instances")
+        for page in paginator.paginate(cluster=cluster_name, status="ACTIVE"):
+            arns.extend(page.get("containerInstanceArns", []))
+
+        if not arns:
+            print("No ACTIVE container instances in cluster - nothing to reap")
+            return {"deregistered": 0}
+
+        container_instances = []
+        for i in range(0, len(arns), 100):
+            desc = ecs.describe_container_instances(
+                cluster=cluster_name, containerInstances=arns[i : i + 100]
+            )
+            container_instances.extend(desc.get("containerInstances", []))
+
+        ec2_ids = [
+            ci["ec2InstanceId"] for ci in container_instances if ci.get("ec2InstanceId")
+        ]
+        ec2_state_by_id: Dict[str, str] = {}
+
+        def _record(reservations):
+            for reservation in reservations:
+                for instance in reservation.get("Instances", []):
+                    inst_id = instance.get("InstanceId")
+                    if inst_id:
+                        ec2_state_by_id[inst_id] = instance["State"]["Name"]
+
+        if ec2_ids:
+            try:
+                resp = ec2.describe_instances(InstanceIds=ec2_ids)
+                _record(resp.get("Reservations", []))
+            except ClientError as e:
+                if e.response["Error"]["Code"] != "InvalidInstanceID.NotFound":
+                    raise
+                for ec2_id in ec2_ids:
+                    try:
+                        resp = ec2.describe_instances(InstanceIds=[ec2_id])
+                        _record(resp.get("Reservations", []))
+                    except ClientError as inner:
+                        code = inner.response["Error"]["Code"]
+                        if code != "InvalidInstanceID.NotFound":
+                            raise
+
+        gone_states = {InstanceState.TERMINATED, InstanceState.SHUTTING_DOWN}
+        deregistered = 0
+        for ci in container_instances:
+            arn = ci.get("containerInstanceArn")
+            ec2_id = ci.get("ec2InstanceId")
+
+            if not ec2_id:
+                reason = "no EC2 mapping"
+            elif ec2_id not in ec2_state_by_id:
+                reason = "EC2 does not exist"
+            elif ec2_state_by_id[ec2_id] in gone_states:
+                reason = f"EC2 is {ec2_state_by_id[ec2_id]}"
+            else:
+                continue
+
+            try:
+                print(
+                    f"Reaping container instance {arn} "
+                    f"(EC2: {ec2_id}, reason: {reason})"
+                )
+                ecs.deregister_container_instance(
+                    cluster=cluster_name, containerInstance=arn, force=True
+                )
+                deregistered += 1
+            except Exception as e:
+                print(f"Failed to deregister {arn}: {e}")
+
+        print(f"Reaped {deregistered} terminated container instances")
+        return {"deregistered": deregistered}
+
+    except Exception as e:
+        print(f"Failed to reap terminated ECS registrations: {e}")
+        traceback.print_exc()
+        return {"deregistered": 0, "error": str(e)}
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     Common user manager handler - runs every 10 minutes
@@ -467,6 +570,11 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # 3. Check premium user inactivity
         print("\n=== Step 3: Checking premium user inactivity ===")
         results["premium_inactivity"] = check_premium_user_inactivity()
+
+        # 4. Reap terminated/gone container instances (tier-independent)
+        if os.environ.get("CLUSTER_NAME"):
+            print("\n=== Step 4: Reaping terminated ECS registrations ===")
+            results["ghost_reap"] = reap_terminated_ecs_registrations()
 
         free_logged_out = results["free_inactivity"].get("logged_out", 0)
         premium_logged_out = results["premium_inactivity"].get("logged_out", 0)

--- a/infrastructure/terraform/common_user_manager_package/common_user_manager.py
+++ b/infrastructure/terraform/common_user_manager_package/common_user_manager.py
@@ -481,9 +481,13 @@ def reap_terminated_ecs_registrations() -> Dict[str, int]:
             )
             container_instances.extend(desc.get("containerInstances", []))
 
-        ec2_ids = [
-            ci["ec2InstanceId"] for ci in container_instances if ci.get("ec2InstanceId")
-        ]
+        ec2_ids = list(
+            {
+                ci["ec2InstanceId"]
+                for ci in container_instances
+                if ci.get("ec2InstanceId")
+            }
+        )
         ec2_state_by_id: Dict[str, str] = {}
 
         def _record(reservations):
@@ -493,14 +497,15 @@ def reap_terminated_ecs_registrations() -> Dict[str, int]:
                     if inst_id:
                         ec2_state_by_id[inst_id] = instance["State"]["Name"]
 
-        if ec2_ids:
+        for i in range(0, len(ec2_ids), 100):
+            chunk = ec2_ids[i : i + 100]
             try:
-                resp = ec2.describe_instances(InstanceIds=ec2_ids)
+                resp = ec2.describe_instances(InstanceIds=chunk)
                 _record(resp.get("Reservations", []))
             except ClientError as e:
                 if e.response["Error"]["Code"] != "InvalidInstanceID.NotFound":
                     raise
-                for ec2_id in ec2_ids:
+                for ec2_id in chunk:
                     try:
                         resp = ec2.describe_instances(InstanceIds=[ec2_id])
                         _record(resp.get("Reservations", []))

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -239,10 +239,21 @@ def _get_ecs_container_instance_arn(
         desc = ecs.describe_container_instances(
             cluster=cluster_name, containerInstances=arns
         )
-        for ci in desc.get("containerInstances", []):
-            if ci.get("ec2InstanceId") == ec2_instance_id:
-                return ci.get("containerInstanceArn")
-        return None
+        matches = [
+            ci
+            for ci in desc.get("containerInstances", [])
+            if ci.get("ec2InstanceId") == ec2_instance_id
+        ]
+        # Prefer the live CI; a fresh CI can overlay a disconnected ghost on one EC2.
+        chosen = next(
+            (
+                ci
+                for ci in matches
+                if ci.get("agentConnected") and ci.get("status") == "ACTIVE"
+            ),
+            matches[0] if matches else None,
+        )
+        return chosen.get("containerInstanceArn") if chosen else None
     except Exception as e:
         print(f"Error mapping EC2 to ECS container instance: " f"{str(e)}")
         return None

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3959,16 +3959,31 @@ def get_ecs_container_instance_id(
             cluster=cluster_name, containerInstances=container_instance_arns
         )
 
-        for container_instance in describe_response.get("containerInstances", []):
-            if container_instance.get("ec2InstanceId") == ec2_instance_id:
-                container_instance_id = container_instance.get("containerInstanceArn")
-                print(f" Found ECS container instance: {container_instance_id}")
-                print(
-                    f"[premium-ecs-map] ec2={ec2_instance_id} "
-                    f"cluster={cluster_name} "
-                    f"result={container_instance_id} reason=found"
-                )
-                return container_instance_id
+        matches = [
+            ci
+            for ci in describe_response.get("containerInstances", [])
+            if ci.get("ec2InstanceId") == ec2_instance_id
+        ]
+        # Prefer the live CI; a fresh CI can overlay a disconnected ghost on one EC2.
+        chosen = next(
+            (
+                ci
+                for ci in matches
+                if ci.get("agentConnected") and ci.get("status") == "ACTIVE"
+            ),
+            matches[0] if matches else None,
+        )
+
+        if chosen:
+            container_instance_id = chosen.get("containerInstanceArn")
+            print(f" Found ECS container instance: {container_instance_id}")
+            print(
+                f"[premium-ecs-map] ec2={ec2_instance_id} "
+                f"cluster={cluster_name} "
+                f"result={container_instance_id} reason=found "
+                f"agent_connected={chosen.get('agentConnected')}"
+            )
+            return container_instance_id
 
         print(f"No ECS container instance found for EC2 instance " f"{ec2_instance_id}")
         print(
@@ -5481,6 +5496,14 @@ def cleanup_ghost_ecs_registrations():
 
         container_instances = describe_response.get("containerInstances", [])
 
+        ec2_with_live_ci = {
+            ci["ec2InstanceId"]
+            for ci in container_instances
+            if ci.get("agentConnected")
+            and ci.get("status") == "ACTIVE"
+            and ci.get("ec2InstanceId")
+        }
+
         # Batched describe_instances has no partial-result mode
         # — any unknown ID fails the call.
         ec2_ids = [
@@ -5569,7 +5592,19 @@ def cleanup_ghost_ecs_registrations():
                 reconnected_ec2_ids.append(ec2_instance_id)
                 continue
 
-            # EC2 alive + agent disconnected — apply grace period.
+            # Disconnected CI sharing its EC2 with a live CI is superseded; reap now.
+            if ec2_instance_id in ec2_with_live_ci:
+                ghost_instances.append(
+                    {
+                        "container_instance_arn": container_instance_arn,
+                        "ec2_instance_id": ec2_instance_id,
+                        "reason": "superseded by live container instance on same EC2",
+                        "status": status,
+                    }
+                )
+                continue
+
+            # EC2 alive + agent disconnected, no live sibling — apply grace period.
             tags = ec2_tags_by_id.get(ec2_instance_id, {})
             first_seen = tags.get(_DISCONNECT_TAG_KEY)
 

--- a/studio/tests/infrastructure/conftest.py
+++ b/studio/tests/infrastructure/conftest.py
@@ -107,6 +107,7 @@ MOCK_ENV_VARS_COMMON = {
     "AUTOSCALING_TARGET_GROUP_ARN": (
         "arn:aws:elasticloadbalancing:region:account:" "targetgroup/asg"
     ),
+    "CLUSTER_NAME": "test-cluster",
     "FREE_IDLE_TIMEOUT_HOURS": "2",
     "PREMIUM_IDLE_TIMEOUT_HOURS": "2",
 }

--- a/studio/tests/infrastructure/test_common_user_manager.py
+++ b/studio/tests/infrastructure/test_common_user_manager.py
@@ -551,6 +551,98 @@ class TestReapTerminatedECSRegistrations:
             == "arn-b"
         )
 
+    def test_dedupes_shared_ec2(self, mock_env_vars_common):
+        """Two CIs on the same EC2 (dual-CI) collapse to one describe_instances
+        ID; both CIs on a terminated EC2 are still reaped."""
+        cis = [
+            {"containerInstanceArn": "arn-a", "ec2InstanceId": "i-shared"},
+            {"containerInstanceArn": "arn-b", "ec2InstanceId": "i-shared"},
+        ]
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"containerInstanceArns": ["arn-a", "arn-b"]}
+        ]
+        mock_ecs.get_paginator.return_value = paginator
+        mock_ecs.describe_container_instances.return_value = {"containerInstances": cis}
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {"InstanceId": "i-shared", "State": {"Name": "terminated"}}
+                    ]
+                }
+            ]
+        }
+
+        def _client(service, *a, **k):
+            return {"ecs": mock_ecs, "ec2": mock_ec2}[service]
+
+        env = {**mock_env_vars_common, "CLUSTER_NAME": "test-cluster"}
+        with patch.dict("os.environ", env):
+            import common_user_manager
+
+            with patch.object(common_user_manager.boto3, "client", side_effect=_client):
+                result = common_user_manager.reap_terminated_ecs_registrations()
+
+        mock_ec2.describe_instances.assert_called_once()
+        assert mock_ec2.describe_instances.call_args.kwargs["InstanceIds"] == [
+            "i-shared"
+        ]
+        assert result["deregistered"] == 2
+
+    def test_chunks_describe_instances_over_100(self, mock_env_vars_common):
+        """describe_instances is chunked at 100 IDs so a large cluster cannot
+        exceed the EC2 max-IDs-per-request limit."""
+        cis = [
+            {"containerInstanceArn": f"arn-{n}", "ec2InstanceId": f"i-{n}"}
+            for n in range(150)
+        ]
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"containerInstanceArns": [ci["containerInstanceArn"] for ci in cis]}
+        ]
+        mock_ecs.get_paginator.return_value = paginator
+        by_arn = {ci["containerInstanceArn"]: ci for ci in cis}
+
+        def _describe_cis(cluster, containerInstances):
+            return {"containerInstances": [by_arn[a] for a in containerInstances]}
+
+        mock_ecs.describe_container_instances.side_effect = _describe_cis
+
+        chunk_sizes = []
+
+        def _describe(InstanceIds):
+            chunk_sizes.append(len(InstanceIds))
+            return {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {"InstanceId": iid, "State": {"Name": "running"}}
+                            for iid in InstanceIds
+                        ]
+                    }
+                ]
+            }
+
+        mock_ec2.describe_instances.side_effect = _describe
+
+        def _client(service, *a, **k):
+            return {"ecs": mock_ecs, "ec2": mock_ec2}[service]
+
+        env = {**mock_env_vars_common, "CLUSTER_NAME": "test-cluster"}
+        with patch.dict("os.environ", env):
+            import common_user_manager
+
+            with patch.object(common_user_manager.boto3, "client", side_effect=_client):
+                result = common_user_manager.reap_terminated_ecs_registrations()
+
+        assert sorted(chunk_sizes, reverse=True) == [100, 50]
+        assert result["deregistered"] == 0
+
 
 class TestGetRequiredEnvVar:
     """Environment variable validation tests."""

--- a/studio/tests/infrastructure/test_common_user_manager.py
+++ b/studio/tests/infrastructure/test_common_user_manager.py
@@ -1,6 +1,7 @@
 """Tests for common_user_manager Lambda function."""
 
 import json
+import os
 from unittest.mock import MagicMock, Mock, patch
 
 
@@ -309,10 +310,13 @@ class TestHandler:
             "common_user_manager.check_free_user_inactivity"
         ) as mock_free, patch(
             "common_user_manager.check_premium_user_inactivity"
-        ) as mock_premium:
+        ) as mock_premium, patch(
+            "common_user_manager.reap_terminated_ecs_registrations"
+        ) as mock_reap:
             mock_recover.return_value = {"recovered": 2}
             mock_free.return_value = {"logged_out": 1}
             mock_premium.return_value = {"logged_out": 0}
+            mock_reap.return_value = {"deregistered": 0}
 
             from common_user_manager import handler
 
@@ -328,6 +332,7 @@ class TestHandler:
             mock_recover.assert_called_once()
             mock_free.assert_called_once()
             mock_premium.assert_called_once()
+            mock_reap.assert_called_once()
 
     def test_handler_error_returns_500(self, mock_env_vars_common):
         """Unhandled exception returns 500."""
@@ -347,6 +352,204 @@ class TestHandler:
             assert result["statusCode"] == 500
             body = json.loads(result["body"])
             assert "Unexpected crash" in body["error"]
+
+
+class TestHandlerGhostReap:
+    """Handler gates the ghost reaper on CLUSTER_NAME being set."""
+
+    def _patches(self):
+        return (
+            patch(
+                "common_user_manager.recover_stale_workflow_counts",
+                return_value={"recovered": 0},
+            ),
+            patch(
+                "common_user_manager.check_free_user_inactivity",
+                return_value={"logged_out": 0},
+            ),
+            patch(
+                "common_user_manager.check_premium_user_inactivity",
+                return_value={"logged_out": 0},
+            ),
+            patch(
+                "common_user_manager.reap_terminated_ecs_registrations",
+                return_value={"deregistered": 1},
+            ),
+        )
+
+    def test_reap_runs_when_cluster_set(self, mock_env_vars_common):
+        env = {**mock_env_vars_common, "CLUSTER_NAME": "test-cluster"}
+        p_recover, p_free, p_premium, p_reap = self._patches()
+        with patch.dict(
+            "os.environ", env
+        ), p_recover, p_free, p_premium, p_reap as mock_reap:
+            from common_user_manager import handler
+
+            result = handler({"source": "aws.events"}, MagicMock())
+
+            assert result["statusCode"] == 200
+            mock_reap.assert_called_once()
+
+    def test_reap_skipped_when_cluster_unset(self, mock_env_vars_common):
+        p_recover, p_free, p_premium, p_reap = self._patches()
+        with patch.dict(
+            "os.environ", mock_env_vars_common
+        ), p_recover, p_free, p_premium, p_reap as mock_reap:
+            os.environ.pop("CLUSTER_NAME", None)
+
+            from common_user_manager import handler
+
+            result = handler({"source": "aws.events"}, MagicMock())
+
+            assert result["statusCode"] == 200
+            mock_reap.assert_not_called()
+
+
+class TestReapTerminatedECSRegistrations:
+    """Tier-independent terminated-EC2 ghost reaper."""
+
+    def _run(self, container_instances, ec2_states, mock_env_vars_common):
+        """Invoke the reaper with mocked ECS/EC2; return (ecs_mock, result)."""
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "containerInstanceArns": [
+                    ci["containerInstanceArn"] for ci in container_instances
+                ]
+            }
+        ]
+        mock_ecs.get_paginator.return_value = paginator
+        mock_ecs.describe_container_instances.return_value = {
+            "containerInstances": container_instances
+        }
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": iid, "State": {"Name": state}}]}
+                for iid, state in ec2_states.items()
+            ]
+        }
+
+        def _client(service, *a, **k):
+            return {"ecs": mock_ecs, "ec2": mock_ec2}[service]
+
+        env = {**mock_env_vars_common, "CLUSTER_NAME": "test-cluster"}
+        with patch.dict("os.environ", env):
+            import common_user_manager
+
+            with patch.object(common_user_manager.boto3, "client", side_effect=_client):
+                result = common_user_manager.reap_terminated_ecs_registrations()
+        return mock_ecs, result
+
+    def test_reaps_terminated_shutting_down_nomap_and_gone(self, mock_env_vars_common):
+        cis = [
+            {"containerInstanceArn": "arn-term", "ec2InstanceId": "i-term"},
+            {"containerInstanceArn": "arn-shut", "ec2InstanceId": "i-shut"},
+            {"containerInstanceArn": "arn-nomap"},
+            {"containerInstanceArn": "arn-gone", "ec2InstanceId": "i-gone"},
+        ]
+        # i-gone deliberately omitted from states → resolves as nonexistent.
+        states = {"i-term": "terminated", "i-shut": "shutting-down"}
+        mock_ecs, result = self._run(cis, states, mock_env_vars_common)
+
+        assert result["deregistered"] == 4
+        reaped = {
+            c.kwargs["containerInstance"]
+            for c in mock_ecs.deregister_container_instance.call_args_list
+        }
+        assert reaped == {"arn-term", "arn-shut", "arn-nomap", "arn-gone"}
+        for c in mock_ecs.deregister_container_instance.call_args_list:
+            assert c.kwargs["force"] is True
+
+    def test_does_not_reap_stopped(self, mock_env_vars_common):
+        """Regression guard (PR #676): a stopped instance must survive so it
+        reconnects on the next restart."""
+        cis = [{"containerInstanceArn": "arn-stop", "ec2InstanceId": "i-stop"}]
+        mock_ecs, result = self._run(cis, {"i-stop": "stopped"}, mock_env_vars_common)
+
+        assert result["deregistered"] == 0
+        mock_ecs.deregister_container_instance.assert_not_called()
+
+    def test_does_not_reap_running(self, mock_env_vars_common):
+        cis = [
+            {
+                "containerInstanceArn": "arn-run",
+                "ec2InstanceId": "i-run",
+                "agentConnected": True,
+                "status": "ACTIVE",
+            }
+        ]
+        mock_ecs, result = self._run(cis, {"i-run": "running"}, mock_env_vars_common)
+
+        assert result["deregistered"] == 0
+        mock_ecs.deregister_container_instance.assert_not_called()
+
+    def test_missing_cluster_name_is_noop(self, mock_env_vars_common):
+        with patch.dict("os.environ", mock_env_vars_common):
+            os.environ.pop("CLUSTER_NAME", None)
+            import common_user_manager
+
+            with patch.object(common_user_manager.boto3, "client") as mock_client:
+                result = common_user_manager.reap_terminated_ecs_registrations()
+
+        assert result["deregistered"] == 0
+        mock_client.assert_not_called()
+
+    def test_batch_notfound_falls_back_per_id(self, mock_env_vars_common):
+        from botocore.exceptions import ClientError
+
+        cis = [
+            {"containerInstanceArn": "arn-a", "ec2InstanceId": "i-a"},
+            {"containerInstanceArn": "arn-b", "ec2InstanceId": "i-b"},
+        ]
+        mock_ecs = MagicMock()
+        mock_ec2 = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"containerInstanceArns": ["arn-a", "arn-b"]}
+        ]
+        mock_ecs.get_paginator.return_value = paginator
+        mock_ecs.describe_container_instances.return_value = {"containerInstances": cis}
+        notfound = ClientError(
+            {"Error": {"Code": "InvalidInstanceID.NotFound"}}, "DescribeInstances"
+        )
+
+        def _describe(InstanceIds):
+            if len(InstanceIds) > 1:
+                raise notfound
+            if InstanceIds == ["i-a"]:
+                return {
+                    "Reservations": [
+                        {
+                            "Instances": [
+                                {"InstanceId": "i-a", "State": {"Name": "running"}}
+                            ]
+                        }
+                    ]
+                }
+            raise notfound
+
+        mock_ec2.describe_instances.side_effect = _describe
+
+        def _client(service, *a, **k):
+            return {"ecs": mock_ecs, "ec2": mock_ec2}[service]
+
+        env = {**mock_env_vars_common, "CLUSTER_NAME": "test-cluster"}
+        with patch.dict("os.environ", env):
+            import common_user_manager
+
+            with patch.object(common_user_manager.boto3, "client", side_effect=_client):
+                result = common_user_manager.reap_terminated_ecs_registrations()
+
+        # i-a running → kept; i-b NotFound → gone → reaped.
+        assert result["deregistered"] == 1
+        mock_ecs.deregister_container_instance.assert_called_once()
+        assert (
+            mock_ecs.deregister_container_instance.call_args.kwargs["containerInstance"]
+            == "arn-b"
+        )
 
 
 class TestGetRequiredEnvVar:

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -1116,3 +1116,70 @@ class TestGetAllPremiumInstancesEnvFilter:
 
             result = get_all_premium_instances_with_states()
             assert len(result) == 0
+
+
+class TestGetEcsContainerInstanceArnPrefersLive:
+    """_get_ecs_container_instance_arn must resolve the live CI when a fresh
+    CI overlays a disconnected ghost on the same EC2 (dual-CI case)."""
+
+    def _ecs(self, mock_boto3):
+        mock_ecs = MagicMock()
+        mock_boto3.return_value = mock_ecs
+        return mock_ecs
+
+    def test_prefers_connected_active_ci(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = self._ecs(mock_boto3)
+            ghost_arn = "arn:aws:ecs:r:a:ci/ghost"
+            live_arn = "arn:aws:ecs:r:a:ci/live"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ghost_arn, live_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ghost_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "containerInstanceArn": live_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+
+            from premium_cleanup import _get_ecs_container_instance_arn
+
+            result = _get_ecs_container_instance_arn("i-shared", "test-cluster")
+            assert result == live_arn
+
+    def test_single_ci_unchanged(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = self._ecs(mock_boto3)
+            arn = "arn:aws:ecs:r:a:ci/only"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": arn,
+                        "ec2InstanceId": "i-solo",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_cleanup import _get_ecs_container_instance_arn
+
+            result = _get_ecs_container_instance_arn("i-solo", "test-cluster")
+            assert result == arn

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -3381,6 +3381,152 @@ class TestCleanupGhostECSRegistrations:
             )
             mock_ec2.describe_instances.assert_not_called()
 
+    def test_superseded_sibling_deregistered_immediately(self, mock_env_vars_premium):
+        """Disconnected CI sharing an EC2 with a live CI is reaped with no
+        grace; the live sibling is left untouched (dual-CI case)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs, mock_ec2 = self._make_clients(mock_boto3)
+            live_arn = "arn:aws:ecs:r:a:ci/live"
+            ghost_arn = "arn:aws:ecs:r:a:ci/ghost"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [live_arn, ghost_arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": live_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "containerInstanceArn": ghost_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-shared",
+                                "State": {"Name": "running"},
+                                "Tags": [],
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            from premium_manager import cleanup_ghost_ecs_registrations
+
+            cleanup_ghost_ecs_registrations()
+
+            mock_ecs.deregister_container_instance.assert_called_once_with(
+                cluster="test-cluster",
+                containerInstance=ghost_arn,
+                force=True,
+            )
+            # The live sibling's EC2 must not be tagged for a disconnect grace.
+            mock_ec2.create_tags.assert_not_called()
+
+
+class TestGetEcsContainerInstanceIdPrefersLive:
+    """get_ecs_container_instance_id must resolve the live CI when a fresh
+    CI overlays a disconnected ghost on the same EC2 (dual-CI case)."""
+
+    def _ecs(self, mock_boto3):
+        mock_ecs = MagicMock()
+        mock_boto3.return_value = mock_ecs
+        return mock_ecs
+
+    def test_prefers_connected_active_ci(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = self._ecs(mock_boto3)
+            ghost_arn = "arn:aws:ecs:r:a:ci/ghost"
+            live_arn = "arn:aws:ecs:r:a:ci/live"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [ghost_arn, live_arn]
+            }
+            # Ghost listed first to prove order does not decide the winner.
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": ghost_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": False,
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "containerInstanceArn": live_arn,
+                        "ec2InstanceId": "i-shared",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+
+            from premium_manager import get_ecs_container_instance_id
+
+            result = get_ecs_container_instance_id("i-shared", "test-cluster")
+            assert result == live_arn
+
+    def test_single_ci_unchanged(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = self._ecs(mock_boto3)
+            arn = "arn:aws:ecs:r:a:ci/only"
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": [arn]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": arn,
+                        "ec2InstanceId": "i-solo",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_manager import get_ecs_container_instance_id
+
+            result = get_ecs_container_instance_id("i-solo", "test-cluster")
+            assert result == arn
+
+    def test_no_match_returns_none(self, mock_env_vars_premium):
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3:
+            mock_ecs = self._ecs(mock_boto3)
+            mock_ecs.list_container_instances.return_value = {
+                "containerInstanceArns": ["arn:aws:ecs:r:a:ci/other"]
+            }
+            mock_ecs.describe_container_instances.return_value = {
+                "containerInstances": [
+                    {
+                        "containerInstanceArn": "arn:aws:ecs:r:a:ci/other",
+                        "ec2InstanceId": "i-different",
+                        "agentConnected": True,
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+
+            from premium_manager import get_ecs_container_instance_id
+
+            result = get_ecs_container_instance_id("i-missing", "test-cluster")
+            assert result is None
+
 
 class TestGetHostPortForInstance:
     """get_host_port_for_instance polls describe_tasks → networkBindings,


### PR DESCRIPTION
### Content

#### Summary
- A "ghost" ECS container instance (CI) keeps advertising a phantom RUNNING task after its backing EC2 is gone or superseded, and nothing reaps it — confusing the scheduler and masking instance-readiness checks. Issue #632 covers two independent gaps, in two Lambdas, fixed together here.
- **Part A — premium dual-CI (premium_manager + premium_cleanup).** Right after an EC2 restart, two ACTIVE CIs can map to the *same* premium EC2: one fresh (`agentConnected=true`) and one stale ghost (`agentConnected=false`). A *first-match-wins* per-EC2 lookup plus an *EC2-keyed* disconnect-grace tag hide the ghost until the live CI is removed or AWS's ~10-min auto-deregister fires. It also masks `check_instance_readiness()`, which resolves the ghost CI, sees 0 tasks, and reports the EC2 "not ready".
- **Part B — terminated non-premium reap (common_user_manager).** Nothing on a schedule reaps a *terminated* non-premium host (background/free/public); its CI lingers as a permanent ghost until someone deregisters it by hand. A new tier-agnostic, terminated-only reaper closes this.
- Both parts are complementary and non-overlapping: Part A is premium-tier, dual-CI, disconnect-driven; Part B is all-tier, single-CI, EC2-termination-driven.

#### Design Decisions
- **Prefer the live CI in per-EC2 lookups, fall back to first match.** Both `get_ecs_container_instance_id` (premium_manager) and `_get_ecs_container_instance_arn` (premium_cleanup) now collect *all* matches for an EC2 and pick the `agentConnected and status == "ACTIVE"` one, falling back to the first match only when none is live. This makes the lookup order-independent (a ghost can be listed first) and routes readiness/deregistration to the real registration. Deregister callers benefit too: `deregister_container_instance_from_ecs` now targets the live CI — exactly the one that would otherwise become a ghost when the EC2 stops.
- **Reap a superseded sibling immediately, with no grace period.** In `cleanup_ghost_ecs_registrations`, a disconnected CI that shares its EC2 with a live CI is now deregistered at once instead of entering the EC2-keyed disconnect-grace path. A single host runs exactly one ECS agent, so a second, disconnected CI on the same `ec2InstanceId` is definitively a stale registration — the grace period only delays the inevitable. The live sibling can never reap itself: it hits the `agentConnected` reconnect branch and `continue`s before the superseded check.
- **The new reaper is tier-agnostic but termination-only — deliberately not `stopped`.** `reap_terminated_ecs_registrations` reaps CIs whose EC2 is `terminated` / `shutting-down` / nonexistent / unmapped, but intentionally leaves `stopped` instances alone. A stopped instance keeps its on-disk ECS-agent checkpoint and reconnects to the *same* CI on restart; reaping it would break that reconnection. (Premium's own reaper handles stopped premium CIs separately, by tier-specific design.)
- **Batched EC2 lookup with a per-id fallback.** `describe_instances` is all-or-nothing: one unknown ID fails the whole call with `InvalidInstanceID.NotFound`. The reaper tries the batch first, and on `NotFound` falls back to per-id calls so a single recently-terminated instance doesn't blind the reaper to the rest. An instance that resolves to no state at all is treated as "EC2 does not exist" → reaped.
- **Gated on `CLUSTER_NAME`; placed in the every-10-min common Lambda.** Part B lives in `common_user_manager` (already tier-independent, already scheduled) as a new Step 4, guarded by `if os.environ.get("CLUSTER_NAME")` in the handler and re-checked inside the function. Absent var = clean no-op, preserving back-compat.
- **Least-privilege IAM.** `DescribeContainerInstances` is scoped to this cluster via an `ecs:cluster` ArnEquals condition. `ListContainerInstances` / `DeregisterContainerInstance` use `Resource = "*"` (the cluster is a request parameter, not a condition key for List — matching the existing premium policy's documented pattern), and `ec2:DescribeInstances` uses `"*"` because it has no resource-level support.

### Evidence
- `cd studio && python -m pytest tests/infrastructure/test_common_user_manager.py tests/infrastructure/test_premium_cleanup.py tests/infrastructure/test_premium_manager.py -q` — **161 passed**.
- `black --check` and `flake8` — clean across all six changed Python files.
- `terraform fmt -check common_user_manager.tf` — clean; `aws_ecs_cluster.main` resolves (`compute.tf`).
- Runtime-import safety confirmed: `InstanceState` exists in the attached `aws_constants` Lambda layer, and `common_user_manager` already attaches that layer.

### References
- Issue #632 — "Ghost instance not deregistered in some conditions" (Part A is the original body; Part B is the 2026-06-15 follow-up comment).
- PR #676 — fixed the nightly stop/start ghost for the standalone background host; this PR adds the missing *terminated*-path reaper for the same class of host.
- Issue #549 — adjacent fix for the `agentConnected=true` short-circuit on a terminated EC2 in the same premium function; neither part re-treads it.

#### Files changed
- `infrastructure/terraform/common_user_manager.tf` — pass `CLUSTER_NAME` to the Lambda env; add IAM for `ecs:ListContainerInstances` / `ecs:DeregisterContainerInstance` (`*`), `ecs:DescribeContainerInstances` (scoped to `aws_ecs_cluster.main` via `ecs:cluster`), and `ec2:DescribeInstances` (`*`).
- `infrastructure/terraform/common_user_manager_package/common_user_manager.py` — add `reap_terminated_ecs_registrations()` (Part B) and wire it as handler Step 4, gated on `CLUSTER_NAME`; import `ClientError` and `InstanceState`.
- `infrastructure/terraform/premium_manager_package/premium_manager.py` — `get_ecs_container_instance_id` prefers the live CI (Part A1); `cleanup_ghost_ecs_registrations` reaps a disconnected CI superseded by a live sibling on the same EC2 with no grace (Part A2).
- `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` — `_get_ecs_container_instance_arn` prefers the live CI (Part A1, second copy).
- `studio/tests/infrastructure/conftest.py` — add `CLUSTER_NAME` to `MOCK_ENV_VARS_COMMON`.
- `studio/tests/infrastructure/test_common_user_manager.py` — handler gating tests (reap runs only when `CLUSTER_NAME` set) and a `TestReapTerminatedECSRegistrations` suite covering terminated/shutting-down/no-map/nonexistent, the stopped/running regression guards, and the batch-`NotFound` per-id fallback.
- `studio/tests/infrastructure/test_premium_manager.py` — superseded-sibling immediate-reap test (live sibling untouched, no disconnect tag written) and prefer-live-CI lookup tests including ghost-listed-first ordering.
- `studio/tests/infrastructure/test_premium_cleanup.py` — prefer-live-CI tests for `_get_ecs_container_instance_arn` (dual-CI and single-CI cases).

### Manual Testcases
- Operator (Part B): terminate a background/free EC2 whose CI is still ACTIVE in the cluster, then invoke `common-user-manager`. Expected: Step 4 logs the reap and the terminated host's CI is deregistered (`force=True`); a separately *stopped* instance's CI is left registered so it reconnects on restart.
- Operator (Part A): on a premium EC2 that has just restarted and shows two ACTIVE CIs (one `agentConnected=true`, one `false`), invoke `premium-manager`'s ghost cleanup. Expected: the disconnected sibling is deregistered immediately with no `optinist:agent-disconnected-at` tag written, and the live CI is untouched. `check_instance_readiness()` for that EC2 now resolves the live CI and reports ready.
- Operator: run a dev `terraform plan`. Expected: only the `CLUSTER_NAME` env var and the three new IAM statements on `common_user_manager` — no instance/ASG/ECS churn.
- `cd studio && python -m pytest tests/infrastructure/test_common_user_manager.py tests/infrastructure/test_premium_cleanup.py tests/infrastructure/test_premium_manager.py -q` — all 161 tests pass.

### Unit, Integration, Contract Test Coverage
- Part B: `test_reaps_terminated_shutting_down_nomap_and_gone` (all four reap reasons), `test_does_not_reap_stopped` (PR #676 regression guard), `test_does_not_reap_running`, `test_missing_cluster_name_is_noop`, `test_batch_notfound_falls_back_per_id`, plus handler-gating tests `test_reap_runs_when_cluster_set` / `test_reap_skipped_when_cluster_unset`.
- Part A2: `test_superseded_sibling_deregistered_immediately` asserts the ghost is reaped once and `create_tags` is never called (no grace path).
- Part A1: `test_prefers_connected_active_ci` (ghost listed first to prove order doesn't decide the winner), `test_single_ci_unchanged`, and `test_no_match_returns_none`, across both `premium_manager` and `premium_cleanup`.
- Not covered by automated tests: the terraform IAM/env changes, verified by `terraform fmt`/reference resolution plus a post-apply `terraform plan` showing no churn.

### Others

#### Difficulties (if any)
- **Why `stopped` must not be reaped.** The hard part of Part B was scoping it narrowly: the obvious "reap any CI whose EC2 isn't running" would have re-broken stop/start reconnection (the ECS-agent checkpoint that PR #676 relies on). The reaper is therefore termination-only and tier-agnostic, which is provably safe because a terminated EC2 can never reconnect.
- **Two races, both benign.** Part B's reaper and premium's `cleanup_ghost_ecs_registrations` can both target the same CI on overlapping schedules; the second `deregister_container_instance` simply fails and is caught/logged. The common reaper also lists with `status="ACTIVE"`, so an already-deregistered CI drops out of the list.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `reap_terminated_ecs_registrations` (Part B) | Low | New, env-var-guarded, termination-only; never touches `stopped`/`running` CIs. Idempotent and safe to re-run every 10 min. 7 new tests. |
| Prefer-live-CI lookup (Part A1) | Low | Strictly better than first-match-wins for all four call sites; falls back to the prior behavior when no live CI exists. Order-independent. |
| Superseded-sibling reap (Part A2) | Low | Only fires when a live CI shares the EC2; live CI short-circuits earlier so it cannot self-reap. Skips a grace period that only delayed deregistration. |
| IAM (`common_user_manager.tf`) | Low | Additive; `DescribeContainerInstances` cluster-scoped, others `*` only where no resource-level support exists. Mirrors the existing premium policy. |
| Cross-Lambda race on deregister | Low | Concurrent deregister of the same CI fails harmlessly and is logged; `status="ACTIVE"` listing avoids re-selecting reaped CIs. |
| Prod | Low | Behavior is identical across envs; the reaper only deregisters CIs whose EC2 is already terminated/gone, which is always safe. |
