### PR TITLE
Fix blocking standby replenishment on premium assignment

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1772,14 +1772,16 @@ def start_standby_instance(instance_id: str):
             )
             return False
 
-        # Update state in database (only for non-standby assignments)
+        # The only row for this instance now is its standby placeholder
+        # (is_standby = 1); scope the update to it so a stray regular
+        # assignment row for the same instance can never be touched.
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
                     """UPDATE premium_user_assignments
                        SET instance_state = %s,
                            last_state_check = NOW()
-                       WHERE instance_id = %s AND is_standby = 0""",
+                       WHERE instance_id = %s AND is_standby = 1""",
                     (InstanceState.RUNNING, instance_id),
                 )
                 connection.commit()  # Commit the state update
@@ -2111,13 +2113,22 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
             # PREMIUM_STOPPED_MAX_AGE_HOURS
             terminate_aged_stopped_instances()
 
-            # 9. Trim standby pool if it exceeds target size
+            # 9. Converge standby pool toward target size. Trimming excess
+            # was always here; the replenish branch is the backstop for the
+            # best-effort async create on the assign path, so a dropped or
+            # lock-skipped invocation can't leave the pool depleted.
             standby_count = get_standby_count()
             standby_pool_size = int(os.environ.get("PREMIUM_STANDBY_POOL_SIZE", "1"))
             if standby_count > standby_pool_size:
                 excess = standby_count - standby_pool_size
                 print(f"Standby pool has {excess} excess instances, trimming")
                 cleanup_excess_standby_instances(excess)
+            elif standby_count < standby_pool_size:
+                print(
+                    f"Standby pool below target "
+                    f"({standby_count}/{standby_pool_size}), replenishing"
+                )
+                invoke_standby_replenishment_async()
 
             # 10a. Finalize expired pending_release assignments
             try:
@@ -2327,6 +2338,15 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     print(f"Lambda context: {context.function_name if context else 'No context'}")
 
     try:
+        # Handle async standby replenishment invocation
+        if event.get("action") == "create_standby":
+            print("Running async standby replenishment...")
+            instance_id = create_and_stop_standby_instance()
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"created_instance_id": instance_id}),
+            }
+
         # Handle async migration invocation
         if event.get("action") == "migrate_shared_users":
             return _handle_migrate_shared_users(event)
@@ -3255,9 +3275,9 @@ def assign_premium_user(
 
             # Start the standby instance
             if start_standby_instance(standby_instance_id):
-                # Create replacement standby instance asynchronously
-                print("Creating replacement standby instance")
-                create_and_stop_standby_instance()  # Create a single standby
+                # Create replacement standby instance asynchronously so the
+                # 3-5 min create/stop chain does not block this assignment.
+                invoke_standby_replenishment_async()
 
                 # Proceed with assignment to the started instance
                 instance_to_use = {"instance_id": standby_instance_id}
@@ -3772,6 +3792,42 @@ def invoke_migration_async():
 
     except Exception as e:
         print(f"Warning: Failed to trigger async migration: {str(e)}")
+        # Don't fail the main request if async invocation fails
+
+
+def invoke_standby_replenishment_async():
+    """
+    Invoke this Lambda asynchronously to create one replacement standby.
+    Skips invocation if a standby-creation Lambda already holds the lock.
+    """
+    if is_creation_lock_held(CREATE_STANDBY_LOCK):
+        print("Standby creation Lambda already running, skipping async replenishment")
+        return
+
+    try:
+        lambda_client: "LambdaClient" = boto3.client("lambda")
+        function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
+
+        if not function_name:
+            print(
+                "Warning: Cannot invoke async standby replenishment "
+                "- function name not available"
+            )
+            return
+
+        lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="Event",  # Async invocation
+            Payload=json.dumps({"action": "create_standby"}),
+        )
+
+        print(
+            f"Triggered async standby replenishment via "
+            f"Lambda function: {function_name}"
+        )
+
+    except Exception as e:
+        print(f"Warning: Failed to trigger async standby replenishment: {str(e)}")
         # Don't fail the main request if async invocation fails
 
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aws_constants import ECSTaskStatus, PremiumInstanceConfig
+from aws_constants import ECSTaskStatus, InstanceState, PremiumInstanceConfig
 from conftest import MockRow, setup_db_mock
 
 TEST_USER_ID = "test_user_12345"
@@ -1674,6 +1674,50 @@ class TestStartStandbyInstance:
             )
             mock_connection.commit.assert_called()
 
+            # The state UPDATE must be scoped to the standby placeholder row
+            # (is_standby = 1), not the regular-assignment guard (is_standby = 0).
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            update_calls = [
+                c
+                for c in mock_cursor.execute.call_args_list
+                if "UPDATE premium_user_assignments" in c.args[0]
+            ]
+            assert len(update_calls) == 1
+            sql, params = update_calls[0].args
+            assert "is_standby = 1" in sql
+            assert "is_standby = 0" not in sql
+            assert params == (InstanceState.RUNNING, "i-standby1")
+
+    def test_updates_standby_placeholder_row(self, mock_env_vars_premium):
+        """State UPDATE commits even when the only matching DB row is the
+        standby placeholder (is_standby = 1)."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch(
+            "premium_manager.pymysql.connect"
+        ) as mock_pymysql, patch(
+            "premium_manager.check_instance_readiness_with_retry",
+            return_value=True,
+        ):
+            mock_ec2 = MagicMock()
+            mock_boto3.return_value = mock_ec2
+            mock_ec2.get_waiter.return_value = MagicMock()
+
+            mock_connection = setup_db_mock()
+            mock_pymysql.return_value = mock_connection
+
+            from premium_manager import start_standby_instance
+
+            result = start_standby_instance("i-standby1")
+
+            assert result is True
+            mock_connection.commit.assert_called()
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            update_sql = mock_cursor.execute.call_args.args[0]
+            assert "UPDATE premium_user_assignments" in update_sql
+            assert "is_standby = 1" in update_sql
+            assert "is_standby = 0" not in update_sql
+
     def test_readiness_fails(self, mock_env_vars_premium):
         """ECS task not ready after start returns False without DB update."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
@@ -1719,6 +1763,156 @@ class TestStartStandbyInstance:
 
             result = start_standby_instance("i-standby2")
             assert result is False
+
+
+class TestStandbyReplenishmentAsync:
+    """invoke_standby_replenishment_async + create_standby dispatch + cascade."""
+
+    def test_skips_when_lock_held(self, mock_env_vars_premium):
+        """Creation lock held -> no Lambda self-invoke."""
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            with patch.object(
+                premium_manager, "is_creation_lock_held", return_value=True
+            ), patch("boto3.client") as mock_boto3:
+                premium_manager.invoke_standby_replenishment_async()
+                mock_boto3.assert_not_called()
+
+    def test_invokes_lambda_when_lock_free(self, mock_env_vars_premium):
+        """Lock free -> self-invoke with Event + create_standby action."""
+        env = {**mock_env_vars_premium, "AWS_LAMBDA_FUNCTION_NAME": "premium-manager"}
+        with patch.dict("os.environ", env):
+            import premium_manager
+
+            with patch.object(
+                premium_manager, "is_creation_lock_held", return_value=False
+            ), patch("boto3.client") as mock_boto3:
+                mock_lambda = MagicMock()
+                mock_boto3.return_value = mock_lambda
+
+                premium_manager.invoke_standby_replenishment_async()
+
+                mock_lambda.invoke.assert_called_once()
+                kwargs = mock_lambda.invoke.call_args.kwargs
+                assert kwargs["FunctionName"] == "premium-manager"
+                assert kwargs["InvocationType"] == "Event"
+                assert json.loads(kwargs["Payload"])["action"] == "create_standby"
+
+    def test_no_op_when_function_name_absent(self, mock_env_vars_premium):
+        """AWS_LAMBDA_FUNCTION_NAME absent -> warning, no invoke, no exception."""
+        env = {
+            k: v
+            for k, v in mock_env_vars_premium.items()
+            if k != "AWS_LAMBDA_FUNCTION_NAME"
+        }
+        with patch.dict("os.environ", env, clear=True):
+            import premium_manager
+
+            with patch.object(
+                premium_manager, "is_creation_lock_held", return_value=False
+            ), patch("boto3.client") as mock_boto3:
+                mock_lambda = MagicMock()
+                mock_boto3.return_value = mock_lambda
+
+                premium_manager.invoke_standby_replenishment_async()
+
+                mock_lambda.invoke.assert_not_called()
+
+    def test_handler_routes_create_standby_action(self, mock_env_vars_premium):
+        """handler dispatches action=create_standby to create_and_stop_standby."""
+        mock_context = MagicMock()
+        mock_context.function_name = "premium-manager"
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            with patch.object(
+                premium_manager,
+                "create_and_stop_standby_instance",
+                return_value="i-newstandby",
+            ) as mock_create:
+                result = premium_manager.handler(
+                    {"action": "create_standby"}, mock_context
+                )
+
+                mock_create.assert_called_once_with()
+                assert result["statusCode"] == 200
+                body = json.loads(result["body"])
+                assert body["created_instance_id"] == "i-newstandby"
+
+    def test_tier3_cascade_uses_async_replenishment(self, mock_env_vars_premium):
+        """Standby start succeeds -> async replenishment fires and the blocking
+        create_and_stop_standby_instance is never called from the assign path."""
+        with patch.dict("os.environ", mock_env_vars_premium):
+            import premium_manager
+
+            with patch.object(
+                premium_manager, "restore_pending_release", return_value=None
+            ), patch.object(
+                premium_manager, "get_existing_user_assignment", return_value=None
+            ), patch.object(
+                premium_manager, "register_orphaned_stopped_instances"
+            ), patch.object(
+                premium_manager,
+                "get_all_premium_instances_with_states",
+                return_value=[],
+            ), patch.object(
+                premium_manager, "count_active_premium_users", return_value=0
+            ), patch.object(
+                premium_manager,
+                "get_available_standby_instances",
+                return_value=[{"instance_id": "i-standby1"}],
+            ), patch.object(
+                premium_manager, "start_standby_instance", return_value=True
+            ), patch.object(
+                premium_manager, "invoke_standby_replenishment_async"
+            ) as mock_replenish, patch.object(
+                premium_manager, "create_and_stop_standby_instance"
+            ) as mock_create_stop, patch.object(
+                premium_manager, "_enable_sticky_sessions"
+            ), patch.object(
+                premium_manager, "_ensure_premium_tg_unhealthy_alarm"
+            ), patch.object(
+                premium_manager,
+                "cleanup_duplicate_rules_for_routing_id",
+                return_value=0,
+            ), patch.object(
+                premium_manager,
+                "create_alb_rule",
+                return_value={"Rules": [{"RuleArn": "arn:rule"}]},
+            ), patch.object(
+                premium_manager, "store_user_assignment"
+            ), patch.object(
+                premium_manager, "update_user_activity", return_value=True
+            ), patch(
+                "premium_manager.pymysql.connect"
+            ) as mock_pymysql, patch(
+                "boto3.client"
+            ) as mock_boto3:
+                mock_pymysql.return_value = setup_db_mock()
+
+                mock_elbv2 = MagicMock()
+                mock_elbv2.describe_target_groups.return_value = {"TargetGroups": []}
+                mock_elbv2.create_target_group.return_value = {
+                    "TargetGroups": [{"TargetGroupArn": "arn:aws:tg/standby"}]
+                }
+
+                def boto3_client_side_effect(service):
+                    if service == "elbv2":
+                        return mock_elbv2
+                    return MagicMock()
+
+                mock_boto3.side_effect = boto3_client_side_effect
+
+                result = premium_manager.assign_premium_user(
+                    12345, {"tier": "premium"}, "firebase_uid_cascade"
+                )
+
+                assert result["statusCode"] == 200
+                body = json.loads(result["body"])
+                assert body["assignment_source"] == "standby"
+                mock_replenish.assert_called_once_with()
+                mock_create_stop.assert_not_called()
 
 
 class TestDesiredCountReservesBootingStandbys:
@@ -3971,6 +4165,7 @@ class TestHandleScheduledMonitoringReconcile:
             ),
             "terminate_aged": patch("premium_manager.terminate_aged_stopped_instances"),
             "standby_count": patch("premium_manager.get_standby_count", return_value=0),
+            "replenish": patch("premium_manager.invoke_standby_replenishment_async"),
             "finalize": patch(
                 "premium_manager.finalize_expired_pending_releases",
                 return_value=[],
@@ -4081,6 +4276,65 @@ class TestHandleScheduledMonitoringReconcile:
         # reconcile_summary fell back to {"errors": 1}; drift kwargs default to 0.
         assert publish_calls[0][1]["tg_port_drift_detected"] == 0
         assert publish_calls[0][1]["tg_port_drift_fixed"] == 0
+
+
+class TestScheduledMonitoringStandbyConvergence:
+    """handle_scheduled_monitoring must converge the standby pool toward
+    target: replenish when below, trim when above, do nothing at target.
+    This is the backstop for the best-effort async create on the assign path."""
+
+    def _run(self, mock_env_vars_premium, standby_count, pool_size):
+        base = TestHandleScheduledMonitoringReconcile()
+        patches = base._common_patches(
+            mock_env_vars_premium, [], {"drift_detected": 0, "drift_fixed": 0}
+        )
+        patches["env"] = patch.dict(
+            "os.environ",
+            {**mock_env_vars_premium, "PREMIUM_STANDBY_POOL_SIZE": str(pool_size)},
+        )
+        patches["standby_count"] = patch(
+            "premium_manager.get_standby_count", return_value=standby_count
+        )
+        replenish = MagicMock()
+        trim = MagicMock()
+        patches["replenish"] = patch(
+            "premium_manager.invoke_standby_replenishment_async", replenish
+        )
+        patches["trim"] = patch(
+            "premium_manager.cleanup_excess_standby_instances", trim
+        )
+        ctx_managers = list(patches.values())
+        for cm in ctx_managers:
+            cm.__enter__()
+        try:
+            from premium_manager import handle_scheduled_monitoring
+
+            result = handle_scheduled_monitoring({"source": "test"}, None)
+        finally:
+            for cm in reversed(ctx_managers):
+                cm.__exit__(None, None, None)
+        return result, replenish, trim
+
+    def test_replenishes_when_below_target(self, mock_env_vars_premium):
+        """standby_count < pool_size -> async replenishment, no trim."""
+        result, replenish, trim = self._run(mock_env_vars_premium, 0, 2)
+        assert result["statusCode"] == 200
+        replenish.assert_called_once_with()
+        trim.assert_not_called()
+
+    def test_no_action_when_at_target(self, mock_env_vars_premium):
+        """standby_count == pool_size -> neither replenish nor trim."""
+        result, replenish, trim = self._run(mock_env_vars_premium, 2, 2)
+        assert result["statusCode"] == 200
+        replenish.assert_not_called()
+        trim.assert_not_called()
+
+    def test_trims_when_above_target(self, mock_env_vars_premium):
+        """standby_count > pool_size -> trim excess, no replenish."""
+        result, replenish, trim = self._run(mock_env_vars_premium, 3, 2)
+        assert result["statusCode"] == 200
+        trim.assert_called_once_with(1)
+        replenish.assert_not_called()
 
 
 class TestMigrateUserToDedicatedInstanceOrder:


### PR DESCRIPTION
### Content

#### Summary
- When a premium user was assigned to a started standby instance, the assignment path **synchronously** created a replacement standby — a 3–5 min EC2 `create → wait-running → stop → wait-stopped` chain that blocked the user's assignment response the whole time.
- Replacement creation is now **asynchronous** via a Lambda self-invoke, so the assignment returns as soon as the standby is started (~5–15s). A new convergence branch in the 15-min scheduled monitor replenishes the pool whenever it is below target, so a dropped or lock-skipped async invoke can no longer leave the pool depleted.
- Also fixes a latent bug in `start_standby_instance`: the state UPDATE carried an `is_standby = 0` guard that never matched the started standby's placeholder row (`is_standby = 1`), so its DB state was never advanced to `running`.

#### Design Decisions
- **Async via Lambda self-invoke (`InvocationType="Event"`).** `invoke_standby_replenishment_async` mirrors the existing `invoke_migration_async` pattern exactly — same self-invoke, same `is_creation_lock_held` pre-check, same fire-and-forget error handling. This reuses an already-proven mechanism (the `lambda:InvokeFunction` self-invoke permission is already required and exercised by migration). Heavier alternatives (SQS, Step Functions, a dedicated EventBridge ensure-rule) were rejected as over-engineering against an established in-repo pattern.
- **Duplicate-create safety is preserved by defense-in-depth.** The `is_creation_lock_held` pre-check is only an optimization to avoid a needless invoke; the real guard is inside `create_and_stop_standby_instance`, which re-acquires `CREATE_STANDBY_LOCK` and re-checks `standby_count >= PREMIUM_STANDBY_POOL_SIZE` before launching. A monitor-fired invoke racing an assign-path invoke cannot double-create.
- **No recursion.** The `create_standby` handler branch calls `create_and_stop_standby_instance()` directly, never the async invoker, so there is no self-invoke loop.
- **Scheduled convergence backstop.** `handle_scheduled_monitoring` previously only *trimmed* excess standbys; it now also *replenishes* below target. This turns the assign-path async create from the **sole** creation trigger into a fast-path optimization — the every-15-min monitor guarantees the pool converges to target even if an async invoke is throttled/dropped or skipped by the fail-closed lock check. It fires one create per cycle, so for `PREMIUM_STANDBY_POOL_SIZE > 1` a multi-instance deficit converges over multiple cycles (default pool size here is 2).
- **State UPDATE scoped to the placeholder, not unguarded.** `start_standby_instance`'s UPDATE is scoped to `is_standby = 1` rather than simply dropping the guard. This targets exactly the placeholder (the only row for the instance at that point), stays symmetric with the sibling `_update_instance_state_to_running` (which scopes to `is_standby = 0` for real assignments), and removes any risk of touching an unrelated row that shares the `instance_id`.

### Evidence
- Automated: `cd studio && python -m pytest tests/infrastructure/test_premium_manager.py` → **120 passed**. `black --check` clean on both changed files.
- Post-deploy CloudWatch log lines to confirm runtime behavior (runtime evidence pending a dev-env deploy):
  - Assign path: `Triggered async standby replenishment via Lambda function: <name>` (and the absence of a multi-minute gap before the assignment response).
  - `create_standby` invocation: `Running async standby replenishment...` followed by `Successfully created and stopped standby instance <id>`.
  - Backstop: `Standby pool below target (<n>/<size>), replenishing`.

### References
- No external ticket. Internal reliability/latency fix to the premium standby pool subsystem (`premium_manager` Lambda).

#### Files changed
- `infrastructure/terraform/premium_manager_package/premium_manager.py`
  - Add `invoke_standby_replenishment_async()` (self-invoke with `action=create_standby`, lock pre-check).
  - Route `action == "create_standby"` in `handler` to `create_and_stop_standby_instance()`.
  - `assign_premium_user`: replace the blocking `create_and_stop_standby_instance()` with `invoke_standby_replenishment_async()`.
  - `handle_scheduled_monitoring`: add the below-target replenish branch alongside the existing trim-excess branch.
  - `start_standby_instance`: scope the state UPDATE to `is_standby = 1` so the started placeholder row advances to `running`.
- `studio/tests/infrastructure/test_premium_manager.py`
  - Add `TestStandbyReplenishmentAsync` (lock-skip, lock-free invoke, missing function name, handler routing, tier-3 cascade uses async + never calls blocking create).
  - Add `TestScheduledMonitoringStandbyConvergence` (replenish below target / no-op at target / trim above target).
  - Tighten `TestStartStandbyInstance` assertions to pin `is_standby = 1` scoping.
  - Patch `invoke_standby_replenishment_async` in the shared scheduled-monitor scaffolding; scope the function-name-absent test env to the real lookup.

### Manual Testcases
- **Standby fast-path (latency fix):** As a premium user with no running instance but one stopped standby, log in / call `/premium/assign`. Expected: assignment returns in ~5–15s (standby start time), not blocked ~3–5 min; CloudWatch shows `Triggered async standby replenishment...` and a separate `create_standby` Lambda invocation creating the replacement.
- **Pool depletion backstop:** Drop the standby pool below `PREMIUM_STANDBY_POOL_SIZE` (consume/terminate standbys) and wait for the 15-min monitor. Expected: log line `Standby pool below target (...), replenishing` and the pool returns to target without any new assignment occurring.
- **No duplicate creation:** Trigger two assignments that each consume a standby near-simultaneously. Expected: only one new standby is created (lock + count gate); the second invoke logs the skip or no-ops on the count check.
- **Automated:** `cd studio && python -m pytest tests/infrastructure/test_premium_manager.py` — **120 passed**.

### Unit, Integration, Contract Test Coverage
- **Unit:** `invoke_standby_replenishment_async` (lock held → skip; lock free → `Event` invoke with `create_standby` payload; missing `AWS_LAMBDA_FUNCTION_NAME` → warn + no invoke); `handler` routes `create_standby` to `create_and_stop_standby_instance`.
- **Integration:** tier-3 assignment cascade fires async replenishment and never calls the blocking create directly; scheduled-monitor convergence (below/at/above target); `start_standby_instance` advances the placeholder row to `running` and commits.

### Others

#### Difficulties (if any)
- None notable. The convergence tests reuse the existing `TestHandleScheduledMonitoringReconcile` patch scaffolding to avoid duplicating the monitor's large mock surface; `invoke_standby_replenishment_async` was added to that shared scaffolding so the pre-existing reconcile tests (which run below target) don't reach the real function.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Premium assignment latency path | Low | Async pattern clones the proven `invoke_migration_async`; assignment no longer blocks on standby creation. Duplicate creation prevented by `CREATE_STANDBY_LOCK` + count gate. |
| Standby pool convergence (scheduled monitor) | Medium | New replenish branch fires an async create when below target; idempotent via lock/count. Watch: one create per 15-min cycle, so a multi-instance deficit converges over several cycles. |
| DB state-update scoping | Low | UPDATE narrowed from `is_standby = 0` (never matched) to `is_standby = 1` (the placeholder); no happy-path behavior change, downstream still deletes the placeholder before the real assignment INSERT. |
| IAM — Lambda self-invoke | Low | `lambda:InvokeFunction` on self is already required and used by `invoke_migration_async`; no new permission needed. |
