### PR TITLE
Fix aws s3 sync to use ECS task role

### DIFF
--- a/infrastructure/documentation/DATAVIEW_PUBLISHING_ARCHITECTURE.md
+++ b/infrastructure/documentation/DATAVIEW_PUBLISHING_ARCHITECTURE.md
@@ -304,8 +304,8 @@ Key fields for publishing:
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `S3_DEFAULT_BUCKET_NAME` | S3 bucket for published experiments | None (required) |
-| `AWS_ACCESS_KEY_ID` | AWS credentials (or IAM role) | None |
-| `AWS_SECRET_ACCESS_KEY` | AWS credentials (or IAM role) | None |
+| `AWS_ACCESS_KEY_ID` | Optional static AWS credentials (local/dev only; unset in ECS, which uses the Task Role) | None |
+| `AWS_SECRET_ACCESS_KEY` | Optional static AWS credentials (local/dev only; unset in ECS, which uses the Task Role) | None |
 | `AWS_REGION` | AWS region | None |
 
 ### HTTP Status Codes

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -293,12 +293,12 @@ aws secretsmanager list-secrets \
 **Secrets to review:**
 - `subscr-optinist/database/config` — Database credentials
 - `subscr-optinist/app/config` — Application secrets
-- `subscr-optinist-cloud-credentials` — AWS access keys for S3
+- `subscr-optinist-cloud-credentials` — AWS access keys for S3 (legacy; no longer read by containers, which authenticate via the ECS Task Role)
 - `subscr-optinist/firebase/private-key` — Firebase service account key
 - `subscr-optinist/firebase/config` — Firebase configuration
 - `subscr-optinist/stripe/config` — Stripe payment configuration
 
-**Procedure:** Update the secret value in Secrets Manager, then force a new ECS deployment so containers pick up the new credentials.
+**Procedure:** Update the secret value in Secrets Manager, then force a new ECS deployment so containers pick up the new credentials at startup. (Exception: `*-cloud-credentials` is no longer consumed by containers — they use the ECS Task Role — so rotating it does not require an ECS redeploy.)
 
 ### 2. Capacity Planning Review
 

--- a/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
+++ b/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
@@ -216,7 +216,9 @@ The Docker image is shared across environments (single ECR repository). Without 
 
 ### IAM Permissions
 
-The ECS containers use IAM user credentials (injected as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars), not the ECS task role. The IAM user policy grants:
+ECS containers authenticate to AWS using the **ECS Task Role**, delivered by the ECS agent via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` — not static IAM user keys. (Earlier task definitions injected `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from Secrets Manager; that injection has since been removed in favor of the Task Role.)
+
+A separate IAM user (`${var.environment}-optinist-cloud-user`) and its access key still exist in Terraform but are no longer injected into any container. Its policy is scoped, for example:
 
 ```hcl
 secretsmanager:GetSecretValue → ${var.environment}-optinist/*

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -857,10 +857,6 @@ class S3StorageController(BaseRemoteStorageController):
                     check=True,
                 )
 
-                assert (
-                    cmd_ret.returncode == 0
-                ), f"Fail aws_s3_sync_command. {cmd_ret.stderr}"
-
             except CalledProcessError as e:
                 logger.error(e)
                 logger.error(e.stderr)

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -847,20 +847,14 @@ class S3StorageController(BaseRemoteStorageController):
 
             # run aws cli command
             try:
+                # inherit the process env so the ECS Task Role container credentials
+                # reach the aws CLI
                 cmd_ret = subprocess.run(
                     aws_s3_sync_command,
                     shell=True,
                     capture_output=True,
                     text=True,
                     check=True,
-                    env={
-                        "PATH": os.environ.get("PATH"),
-                        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID"),
-                        "AWS_SECRET_ACCESS_KEY": os.environ.get(
-                            "AWS_SECRET_ACCESS_KEY"
-                        ),
-                        "AWS_DEFAULT_REGION": os.environ.get("AWS_DEFAULT_REGION"),
-                    },
                 )
 
                 assert (

--- a/studio/tests/app/common/core/storage/test_s3_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_s3_storage_controller.py
@@ -1154,3 +1154,43 @@ class TestDownloadS3RefreshesParentDir:
 
         assert result is True
         assert os.path.isfile(final_path)
+
+
+class TestDownloadAllExperimentsMetasViaAwsCli:
+    """The aws-cli sync path must let the AWS CLI inherit the process
+    environment so the ECS Task Role's container credentials are used, rather
+    than passing a curated env= that pins the (now-removed) static keys."""
+
+    def setup_method(self):
+        self.controller = S3StorageController("test-bucket")
+
+    @pytest.mark.asyncio
+    async def test_aws_cli_subprocess_inherits_process_env(self):
+        """subprocess.run is called without a curated env=, so the AWS CLI
+        resolves credentials via the default chain (Task Role on ECS)."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""  # no target files -> no downloads attempted
+
+        method = getattr(
+            self.controller,
+            "_S3StorageController__download_all_experiments_metas_via_aws_cli",
+        )
+        with patch.object(
+            self.controller,
+            "_S3StorageController__get_s3_client",
+            return_value=mock_client,
+        ), patch("subprocess.run", return_value=completed) as mock_run:
+            result = await method()
+
+        assert result is True
+        mock_run.assert_called_once()
+        # Regression guard: no curated env= is passed (the old one dropped
+        # AWS_CONTAINER_CREDENTIALS_RELATIVE_URI and injected None once the
+        # static keys were removed), so the child inherits os.environ.
+        assert "env" not in mock_run.call_args.kwargs
+        assert "aws s3 sync" in mock_run.call_args.args[0]


### PR DESCRIPTION
## Summary

Follow-ups to the Task-Role migration (#614, which removed the Secrets Manager
`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` injection so ECS containers authenticate
via the ECS Task Role):

1. The `aws s3 sync` subprocess still passed a curated `env=` that hard-coded
   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (now unset → `None`, which raises
   `TypeError` when building the child env) and dropped
   `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, so the CLI could reach neither static keys
   nor the Task Role. It now inherits the process environment, matching how the
   in-process boto3 clients resolve credentials.
2. Three infrastructure docs still described the removed IAM-user credential injection.

## Files changed

| File | Change |
|------|--------|
| `studio/app/common/core/storage/s3_storage_controller.py` | Drop the curated `env=` on the `aws s3 sync` subprocess so it inherits the process env (the ECS Task Role's container credentials reach the CLI). |
| `infrastructure/documentation/TERRAFORM_ARCHITECTURE.md` | IAM Permissions section now states containers authenticate via the ECS Task Role; clarifies the IAM user still exists but is no longer injected into containers. |
| `infrastructure/documentation/MAINTENANCE_PROCEDURES.md` | Note that `*-cloud-credentials` is no longer read by containers and that rotating it does not require an ECS redeploy. |
| `infrastructure/documentation/DATAVIEW_PUBLISHING_ARCHITECTURE.md` | Clarify the `AWS_*` env vars are local/dev only; ECS uses the Task Role. |

## Design Decisions

- **Inherit the environment rather than enumerate variables.** The credential chain needs
  `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` (and possibly `AWS_REGION`, a session token, etc.);
  whitelisting specific vars is brittle and was the source of this bug. Inheriting the process
  env makes the CLI resolve credentials exactly like the in-process boto3 clients, and removes
  the `None`-value `TypeError` from `os.environ.get` on the now-unset keys.
- **Scope is limited to docs + the one broken subprocess.** Terraform cleanup of the orphaned
  IAM user / static key / `cloud-credentials` secret, and the access-key rotation, are
  intentionally out of scope here and handled separately (sequenced with rotation).

## References

- PR #614 — removed the Secrets Manager credential injection (the reason these env vars are now unset).
- Affected function: `S3StorageController.__download_all_experiments_metas_via_aws_cli`.

## Manual Testcases

- `poetry run pytest studio/tests/app/common/core/storage/test_s3_storage_controller.py` → **43 passed**.
- `flake8` / `black --check` / `isort --check` clean on the changed file.
- (Runtime, ECS) Trigger an experiment-meta sync that hits the `aws s3 sync` dry-run path →
  no `Unable to locate credentials` and no `TypeError`; `aws` authenticates as the Task Role
  (same identity the boto3 S3 clients already use).

## Risk Assessment

- **Low.** The subprocess now uses the default credential chain like the rest of the
  application — the ECS Task Role on ECS (S3 permissions already verified), and the developer's
  profile/env locally (unchanged behavior for anyone who had `AWS_*` set). No signature or
  interface change. The documentation edits carry no runtime risk.
