### PR TITLE
Various fixes to reduce log noise

### DIFF
--- a/studio/app/common/core/auth/auth.py
+++ b/studio/app/common/core/auth/auth.py
@@ -25,10 +25,16 @@ logger = AppLogger.get_logger()
 def _extract_firebase_error(error: HTTPError) -> str:
     # The raw HTTPError string embeds the request URL with the Firebase API key,
     # so read the error code from the wrapped response body instead of logging it.
-    try:
-        return json.loads(error.args[1])["error"]["message"]
-    except (IndexError, KeyError, ValueError, TypeError):
-        return "authentication failed"
+    bodies = []
+    if len(error.args) > 1:
+        bodies.append(error.args[1])
+    bodies.append(getattr(error, "strerror", None))
+    for body in bodies:
+        try:
+            return json.loads(body)["error"]["message"]
+        except (KeyError, ValueError, TypeError):
+            continue
+    return "authentication failed"
 
 
 async def authenticate_user(db: Session, data: UserAuth) -> Tuple[Token, UserModel]:

--- a/studio/app/common/core/auth/auth.py
+++ b/studio/app/common/core/auth/auth.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse
 from firebase_admin import auth
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException
 from sqlmodel import Session
 
 from studio.app.common.core.auth import pyrebase_app
@@ -22,12 +22,15 @@ from studio.app.common.schemas.users import User
 logger = AppLogger.get_logger()
 
 
-def _extract_firebase_error(error: HTTPError) -> str:
-    # The raw HTTPError string embeds the request URL with the Firebase API key,
-    # so read the error code from the wrapped response body instead of logging it.
+def _extract_firebase_error(error: RequestException) -> str:
+    # The raw error string embeds the request URL with the Firebase API key,
+    # so read the error code from the response body instead of logging it.
     bodies = []
     if len(error.args) > 1:
         bodies.append(error.args[1])
+    response = getattr(error, "response", None)
+    if response is not None:
+        bodies.append(response.text)
     bodies.append(getattr(error, "strerror", None))
     for body in bodies:
         try:

--- a/studio/app/common/core/auth/auth.py
+++ b/studio/app/common/core/auth/auth.py
@@ -111,7 +111,8 @@ async def refresh_current_user_token(refresh_token: Optional[str]):
         user = pyrebase_app.auth().refresh(refresh_token=token["sub"])
         return AccessToken(access_token=user["idToken"])
     except Exception as e:
-        logger.warning(e)
+        message = _extract_firebase_error(e) if isinstance(e, HTTPError) else str(e)
+        logger.warning(f"Token refresh failed: {message}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
 
 

--- a/studio/app/common/core/auth/auth.py
+++ b/studio/app/common/core/auth/auth.py
@@ -22,6 +22,15 @@ from studio.app.common.schemas.users import User
 logger = AppLogger.get_logger()
 
 
+def _extract_firebase_error(error: HTTPError) -> str:
+    # The raw HTTPError string embeds the request URL with the Firebase API key,
+    # so read the error code from the wrapped response body instead of logging it.
+    try:
+        return json.loads(error.args[1])["error"]["message"]
+    except (IndexError, KeyError, ValueError, TypeError):
+        return "authentication failed"
+
+
 async def authenticate_user(db: Session, data: UserAuth) -> Tuple[Token, UserModel]:
     try:
         user = pyrebase_app.auth().sign_in_with_email_and_password(
@@ -70,11 +79,12 @@ async def authenticate_user(db: Session, data: UserAuth) -> Tuple[Token, UserMod
         raise
 
     except (HTTPError, AssertionError) as e:
-        logger.warning(e)
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        message = _extract_firebase_error(e) if isinstance(e, HTTPError) else str(e)
+        logger.warning(f"Authentication failed: {message}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
         )
@@ -101,14 +111,14 @@ async def send_reset_password_mail(db: Session, email: str):
         pyrebase_app.auth().send_password_reset_email(email)
         return JSONResponse(content=None, status_code=status.HTTP_200_OK)
     except HTTPError as e:
-        logger.warning(e)
-        err = json.loads(e.strerror)
+        message = _extract_firebase_error(e)
+        logger.warning(f"Password reset failed: {message}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=err.get("error").get("message"),
+            detail=message,
         )
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
@@ -136,11 +146,12 @@ async def login_with_uid(db: Session, uid: str, current_user: User) -> Token:
         return token
 
     except (HTTPError, AssertionError) as e:
-        logger.warning(e)
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        message = _extract_firebase_error(e) if isinstance(e, HTTPError) else str(e)
+        logger.warning(f"Authentication failed: {message}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
         )

--- a/studio/app/common/core/auth/auth_email_service.py
+++ b/studio/app/common/core/auth/auth_email_service.py
@@ -3,8 +3,10 @@ Email service for sending verification and authentication emails.
 """
 
 from firebase_admin import auth as firebase_auth
+from requests.exceptions import HTTPError
 
 from studio.app.common.core.auth import pyrebase_app
+from studio.app.common.core.auth.auth import _extract_firebase_error
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.config_handler import get_env_bool
 from studio.app.const import FRONTEND_URL
@@ -141,7 +143,6 @@ class AuthEmailService:
                 return True
 
         except Exception as e:
-            logger.error(
-                f"Failed to send password reset email to {email}: {e}", exc_info=True
-            )
+            message = _extract_firebase_error(e) if isinstance(e, HTTPError) else str(e)
+            logger.error(f"Failed to send password reset email to {email}: {message}")
             raise

--- a/studio/app/common/core/auth/auth_email_service.py
+++ b/studio/app/common/core/auth/auth_email_service.py
@@ -143,6 +143,15 @@ class AuthEmailService:
                 return True
 
         except Exception as e:
-            message = _extract_firebase_error(e) if isinstance(e, HTTPError) else str(e)
-            logger.error(f"Failed to send password reset email to {email}: {message}")
+            if isinstance(e, HTTPError):
+                # Traceback and str(e) embed the request URL with the API key.
+                message = _extract_firebase_error(e)
+                logger.error(
+                    f"Failed to send password reset email to {email}: {message}"
+                )
+            else:
+                logger.error(
+                    f"Failed to send password reset email to {email}: {e}",
+                    exc_info=True,
+                )
             raise

--- a/studio/app/common/core/auth/firebase_email_sender.py
+++ b/studio/app/common/core/auth/firebase_email_sender.py
@@ -10,6 +10,7 @@ import os
 import requests
 from firebase_admin import auth as firebase_auth
 
+from studio.app.common.core.auth.auth import _extract_firebase_error
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.file_reader import JsonReader
 from studio.app.dir_path import DIRPATH
@@ -104,44 +105,31 @@ def send_verification_email_via_firebase(email: str) -> bool:
         return True
 
     except requests.exceptions.RequestException as e:
-        logger.error(f"Firebase REST API error: {e}", exc_info=True)
-        error_message = str(e)
+        # str(e) and the chained traceback embed the request URL with the API
+        # key, so log the parsed body message and re-raise with "from None".
+        error_message = _extract_firebase_error(e)
+        logger.error(f"Firebase REST API error: {error_message}")
 
-        if hasattr(e, "response") and e.response is not None:
+        if e.response is not None:
             logger.error(f"Response status: {e.response.status_code}")
             logger.error(f"Response body: {e.response.text}")
 
-            try:
-                error_data = e.response.json()
-                logger.error(f"Response JSON: {error_data}")
-
-                if "error" in error_data:
-                    error_details = error_data["error"]
-                    error_message = error_details.get("message", str(e))
-                    logger.error(f"Firebase error message: {error_message}")
-
-                    # Check for specific error codes
-                    if (
-                        "TOO_MANY_ATTEMPTS_TRY_LATER" in error_message
-                        or "quota" in error_message.lower()
-                        or "rate" in error_message.lower()
-                    ):
-                        raise ValueError(
-                            "Too many verification emails sent. Please wait a few "
-                            "minutes before trying again."
-                        )
-                    elif "EMAIL_NOT_FOUND" in error_message:
-                        raise ValueError(
-                            f"User with email {email} not found in Firebase"
-                        )
-                    elif "INVALID_ID_TOKEN" in error_message:
-                        raise ValueError(f"Invalid or expired ID token for {email}")
-
-            except ValueError:
-                # Re-raise ValueError with user-friendly messages
-                raise
-            except Exception as json_err:
-                logger.error(f"Could not parse error response as JSON: {json_err}")
+            # Check for specific error codes
+            if (
+                "TOO_MANY_ATTEMPTS_TRY_LATER" in error_message
+                or "quota" in error_message.lower()
+                or "rate" in error_message.lower()
+            ):
+                raise ValueError(
+                    "Too many verification emails sent. Please wait a few "
+                    "minutes before trying again."
+                ) from None
+            elif "EMAIL_NOT_FOUND" in error_message:
+                raise ValueError(
+                    f"User with email {email} not found in Firebase"
+                ) from None
+            elif "INVALID_ID_TOKEN" in error_message:
+                raise ValueError(f"Invalid or expired ID token for {email}") from None
 
             # If it's a 400 error and we couldn't determine the specific cause,
             # it's likely rate limiting
@@ -149,11 +137,11 @@ def send_verification_email_via_firebase(email: str) -> bool:
                 raise ValueError(
                     "Unable to send verification email. This may be due to rate "
                     "limiting. Please wait a few minutes before trying again."
-                )
+                ) from None
 
         raise Exception(
             f"Failed to send verification email via Firebase: {error_message}"
-        )
+        ) from None
     except Exception as e:
         logger.error(f"Failed to send verification email: {e}", exc_info=True)
         raise
@@ -189,10 +177,15 @@ def send_password_reset_email_via_firebase(email: str) -> bool:
         return True
 
     except requests.exceptions.RequestException as e:
-        logger.error(f"Firebase REST API error: {e}", exc_info=True)
-        if hasattr(e, "response") and e.response:
+        # str(e) and the chained traceback embed the request URL with the API
+        # key, so log the parsed body message and re-raise with "from None".
+        error_message = _extract_firebase_error(e)
+        logger.error(f"Firebase REST API error: {error_message}")
+        if e.response is not None:
             logger.error(f"Response: {e.response.text}")
-        raise Exception(f"Failed to send password reset email via Firebase: {e}")
+        raise Exception(
+            f"Failed to send password reset email via Firebase: {error_message}"
+        ) from None
     except Exception as e:
         logger.error(f"Failed to send password reset email: {e}", exc_info=True)
         raise

--- a/studio/app/common/core/cloud/storage_tracking.py
+++ b/studio/app/common/core/cloud/storage_tracking.py
@@ -513,8 +513,10 @@ async def _calculate_live_storage_usage(
             return await _calculate_local_user_storage(user_id)
 
     except Exception as e:
+        # Use repr(e) so the exception type is visible even when str(e) is empty.
         logger.error(
-            f"Failed to calculate live storage usage for " f"user {user_id}: {e}"
+            f"Failed to calculate live storage usage for user {user_id}: {e!r}",
+            exc_info=True,
         )
         return 0
 

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -224,7 +224,11 @@ class ExptConfigReader:
             if config.success is None:
                 return None
             return WorkflowRunStatus(config.success)
-        except (ValueError, AssertionError, yaml.YAMLError) as e:
+        except AssertionError:
+            # An empty experiment.yaml means "no status yet", not corruption.
+            logger.debug(f"experiment.yaml is empty: [{workspace_id}/{unique_id}]")
+            return None
+        except (ValueError, yaml.YAMLError) as e:
             logger.warning(
                 f"experiment config read error: [{workspace_id}/{unique_id}] {e}"
             )

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -225,8 +225,11 @@ class ExptConfigReader:
                 return None
             return WorkflowRunStatus(config.success)
         except AssertionError:
-            # An empty experiment.yaml means "no status yet", not corruption.
-            logger.debug(f"experiment.yaml is empty: [{workspace_id}/{unique_id}]")
+            # A missing or empty experiment.yaml means "no status yet",
+            # not corruption.
+            logger.debug(
+                f"experiment.yaml is missing or empty: [{workspace_id}/{unique_id}]"
+            )
             return None
         except (ValueError, yaml.YAMLError) as e:
             logger.warning(

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -8,6 +8,7 @@ from dataclasses import asdict
 from typing import Dict
 
 import numpy as np
+import yaml
 from filelock import FileLock
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
@@ -71,9 +72,18 @@ class ExptConfigWriter:
             self.workspace_id, self.unique_id
         )
         if os.path.exists(expt_filepath):
-            expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
-            self.builder.set_config(expt_config)
-            self.add_run_info()
+            try:
+                expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
+                self.builder.set_config(expt_config)
+                self.add_run_info()
+            except (AssertionError, ValueError, KeyError, yaml.YAMLError):
+                # An existing but empty/corrupt experiment.yaml would otherwise
+                # abort the run; recreate it from scratch instead.
+                logger.warning(
+                    f"experiment.yaml for {self.workspace_id}/{self.unique_id} "
+                    f"is empty or invalid; recreating it"
+                )
+                self.create_config()
         else:
             self.create_config()
 

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -135,12 +135,13 @@ class WorkspaceDataCapacityService:
                 try:
                     cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
                 except AssertionError:
-                    # An empty experiment.yaml is recoverable - capacity is still
-                    # tracked in the DB - so it is logged at debug to avoid
-                    # re-warning on every recalculation.
+                    # A missing or empty experiment.yaml is recoverable - capacity
+                    # is still tracked in the DB - so it is logged at debug to
+                    # avoid re-warning on every recalculation.
                     logger.debug(
                         f"Skipping YAML update for experiment "
-                        f"{workspace_id}/{unique_id}: experiment.yaml is empty"
+                        f"{workspace_id}/{unique_id}: "
+                        f"experiment.yaml is missing or empty"
                     )
                 except (ValueError, yaml.YAMLError) as yaml_error:
                     logger.warning(

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import yaml
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, delete, update
 
@@ -133,13 +134,20 @@ class WorkspaceDataCapacityService:
                 # Update yaml file - skip if experiment.yaml is invalid/corrupted
                 try:
                     cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
-                except (AssertionError, ValueError) as yaml_error:
-                    # Log warning if experiment.yaml is invalid but continue processing
+                except AssertionError:
+                    # An empty experiment.yaml is recoverable - capacity is still
+                    # tracked in the DB - so it is logged at debug to avoid
+                    # re-warning on every recalculation.
+                    logger.debug(
+                        f"Skipping YAML update for experiment "
+                        f"{workspace_id}/{unique_id}: experiment.yaml is empty"
+                    )
+                except (ValueError, yaml.YAMLError) as yaml_error:
                     logger.warning(
                         f"Skipping YAML update for experiment "
                         f"{workspace_id}/{unique_id}: "
-                        f"Invalid or corrupted experiment.yaml file ({yaml_error}). "
-                        f"Data usage will still be tracked in database."
+                        f"malformed experiment.yaml ({yaml_error}). "
+                        f"Data usage will still be tracked in the database."
                     )
 
                 # Add experiment record even if YAML update failed

--- a/studio/app/common/routers/auth.py
+++ b/studio/app/common/routers/auth.py
@@ -59,9 +59,10 @@ async def login(user_data: UserAuth, db: Session = Depends(get_db)):
                 f"Failed to check limit warning for user " f"{user.id}: {warning_error}"
             )
 
-    except HTTPException as e:
-        logger.error(e, exc_info=True)
-        raise e
+    except HTTPException:
+        # The auth layer already logged the cause; a 4xx (e.g. a mistyped
+        # password) is routine, so re-raise without a second ERROR traceback.
+        raise
 
     except Exception as e:
         logger.error(e, exc_info=True)
@@ -89,9 +90,10 @@ async def login_with_uid(
 ):
     try:
         token = await auth.login_with_uid(db, uid, admin_user)
-    except HTTPException as e:
-        logger.error(e, exc_info=True)
-        raise e
+    except HTTPException:
+        # The auth layer already logged the cause; a 4xx (e.g. a mistyped
+        # password) is routine, so re-raise without a second ERROR traceback.
+        raise
 
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -109,7 +109,7 @@ async def fetch_last_experiment(
             logger.debug(f"No previous experiment in workspace {workspace_id}")
         else:
             logger.error(e, exc_info=True)
-        raise e
+        raise
     except RemoteStorageLockError as e:
         logger.error(e)
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -104,7 +104,11 @@ async def fetch_last_experiment(
             )
 
     except HTTPException as e:
-        logger.error(e, exc_info=True)
+        # A workspace with no previous run is an expected state, not an error.
+        if e.status_code == status.HTTP_404_NOT_FOUND:
+            logger.debug(f"No previous experiment in workspace {workspace_id}")
+        else:
+            logger.error(e, exc_info=True)
         raise e
     except RemoteStorageLockError as e:
         logger.error(e)

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -241,7 +241,10 @@ def caiman_cnmf(
         idx_good = []
         idx_bad = []
 
-    stop_server(dview=dview)
+    # In single-thread mode dview is None and there is no cluster to stop;
+    # stop_server() would shell out to a nonexistent `ipcluster` and log errors.
+    if dview is not None:
+        stop_server(dview=dview)
 
     # contours plot
     Cn = local_correlations(mmap_images.transpose(1, 2, 0))

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -111,7 +111,10 @@ def caiman_cnmf_multisession(
         del split_image_mmap
         gc.collect()
 
-    stop_server(dview=dview)
+    # In single-thread mode dview is None and there is no cluster to stop;
+    # stop_server() would shell out to a nonexistent `ipcluster` and log errors.
+    if dview is not None:
+        stop_server(dview=dview)
 
     spatial = [cnm.estimates.A for cnm in cnm_list]
     dims = templates[0].shape

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -62,7 +62,10 @@ def caiman_mc(
     mmap_file_new = save_memmap(
         mc.mmap_file, base_name=function_id, order="C", border_to_0=border_to_0
     )
-    stop_server(dview=dview)
+    # In single-thread mode dview is None and there is no cluster to stop;
+    # stop_server() would shell out to a nonexistent `ipcluster` and log errors.
+    if dview is not None:
+        stop_server(dview=dview)
 
     # now load the file
     Yr, dims, T = load_memmap(mmap_file_new)

--- a/studio/scripts/run_sync_data_capacity_cloud.py
+++ b/studio/scripts/run_sync_data_capacity_cloud.py
@@ -326,12 +326,13 @@ class CloudWorkspaceDataCapacityService:
                         workspace_id, unique_id, total_data_usage
                     )
                 except AssertionError:
-                    # An empty experiment.yaml is recoverable - capacity is still
-                    # tracked in the DB - so it is logged at debug to avoid
-                    # re-warning on every recalculation.
+                    # A missing or empty experiment.yaml is recoverable - capacity
+                    # is still tracked in the DB - so it is logged at debug to
+                    # avoid re-warning on every recalculation.
                     logger.debug(
                         f"Skipping YAML update for experiment "
-                        f"{workspace_id}/{unique_id}: experiment.yaml is empty"
+                        f"{workspace_id}/{unique_id}: "
+                        f"experiment.yaml is missing or empty"
                     )
                 except (ValueError, yaml.YAMLError) as yaml_error:
                     logger.warning(

--- a/studio/scripts/run_sync_data_capacity_cloud.py
+++ b/studio/scripts/run_sync_data_capacity_cloud.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import boto3
+import yaml
 
 from studio.app.common.core.storage.s3_storage_controller import S3StorageController
 
@@ -324,13 +325,20 @@ class CloudWorkspaceDataCapacityService:
                     WorkspaceDataCapacityService._update_exp_data_usage_yaml(
                         workspace_id, unique_id, total_data_usage
                     )
-                except (AssertionError, ValueError) as yaml_error:
-                    # Log warning if experiment.yaml is invalid but continue processing
+                except AssertionError:
+                    # An empty experiment.yaml is recoverable - capacity is still
+                    # tracked in the DB - so it is logged at debug to avoid
+                    # re-warning on every recalculation.
+                    logger.debug(
+                        f"Skipping YAML update for experiment "
+                        f"{workspace_id}/{unique_id}: experiment.yaml is empty"
+                    )
+                except (ValueError, yaml.YAMLError) as yaml_error:
                     logger.warning(
                         f"Skipping YAML update for experiment "
                         f"{workspace_id}/{unique_id}: "
-                        f"Invalid or corrupted experiment.yaml file ({yaml_error}). "
-                        f"Data usage will still be tracked in database."
+                        f"malformed experiment.yaml ({yaml_error}). "
+                        f"Data usage will still be tracked in the database."
                     )
 
                 # Add experiment record even if YAML update failed

--- a/studio/tests/app/common/core/auth/test_firebase_key_leak.py
+++ b/studio/tests/app/common/core/auth/test_firebase_key_leak.py
@@ -1,0 +1,162 @@
+import asyncio
+import io
+import json
+import logging
+import traceback
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+import studio.app.common.core.auth.auth as auth_module
+import studio.app.common.core.auth.firebase_email_sender as firebase_email_sender
+from studio.app.common.core.auth.auth import _extract_firebase_error
+
+FAKE_KEY = "AIzaFAKEKEY123"
+
+
+def make_response(status=400, body=b'{"error": {"message": "EMAIL_NOT_FOUND"}}'):
+    response = requests.models.Response()
+    response.status_code = status
+    response._content = body
+    response.url = (
+        "https://identitytoolkit.googleapis.com/v1/"
+        f"accounts:sendOobCode?key={FAKE_KEY}"
+    )
+    return response
+
+
+def pyrebase_http_error(message):
+    # pyrebase raises HTTPError(original_error, response_text); the key lives
+    # in the original error's URL, the clean message in the wrapped body.
+    original = requests.exceptions.HTTPError(
+        "400 Client Error: Bad Request for url: "
+        f"https://identitytoolkit.googleapis.com/v1/accounts:lookup?key={FAKE_KEY}"
+    )
+    return requests.exceptions.HTTPError(
+        original, json.dumps({"error": {"message": message}})
+    )
+
+
+@pytest.fixture
+def auth_log():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    auth_module.logger.addHandler(handler)
+    yield stream
+    auth_module.logger.removeHandler(handler)
+
+
+@pytest.fixture
+def sender_log():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    firebase_email_sender.logger.addHandler(handler)
+    with patch.object(firebase_email_sender, "FIREBASE_API_KEY", FAKE_KEY):
+        yield stream
+    firebase_email_sender.logger.removeHandler(handler)
+
+
+def assert_no_key_anywhere(exc, log_stream):
+    assert FAKE_KEY not in str(exc)
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert FAKE_KEY not in rendered
+    assert FAKE_KEY not in log_stream.getvalue()
+
+
+def test_extract_firebase_error_requests_shape():
+    # requests raise_for_status: key is in str(e), message is in response body
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        make_response().raise_for_status()
+    assert FAKE_KEY in str(exc_info.value)
+    assert _extract_firebase_error(exc_info.value) == "EMAIL_NOT_FOUND"
+
+
+def test_extract_firebase_error_pyrebase_shape():
+    # pyrebase raises HTTPError(original_error, response_text)
+    original = requests.exceptions.HTTPError(f"400 Client Error: url ?key={FAKE_KEY}")
+    error = requests.exceptions.HTTPError(
+        original, '{"error": {"message": "INVALID_LOGIN_CREDENTIALS"}}'
+    )
+    assert _extract_firebase_error(error) == "INVALID_LOGIN_CREDENTIALS"
+
+
+def test_extract_firebase_error_no_response():
+    error = requests.exceptions.ConnectionError(f"url?key={FAKE_KEY}")
+    assert _extract_firebase_error(error) == "authentication failed"
+
+
+def test_password_reset_sender_does_not_leak_key(sender_log):
+    with patch.object(
+        firebase_email_sender.requests, "post", return_value=make_response()
+    ):
+        with pytest.raises(Exception) as exc_info:
+            firebase_email_sender.send_password_reset_email_via_firebase(
+                "user@example.com"
+            )
+    assert "EMAIL_NOT_FOUND" in str(exc_info.value)
+    assert_no_key_anywhere(exc_info.value, sender_log)
+    assert "EMAIL_NOT_FOUND" in sender_log.getvalue()
+
+
+def test_verification_sender_does_not_leak_key(sender_log):
+    fake_user = type("FakeUser", (), {"email_verified": False, "uid": "uid1"})()
+    with patch.object(
+        firebase_email_sender.firebase_auth, "get_user_by_email", return_value=fake_user
+    ), patch.object(
+        firebase_email_sender.firebase_auth, "create_custom_token", return_value=b"tok"
+    ), patch.object(
+        firebase_email_sender.requests,
+        "post",
+        return_value=make_response(body=b'{"error": {"message": "UNKNOWN_CODE"}}'),
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            firebase_email_sender.send_verification_email_via_firebase(
+                "user@example.com"
+            )
+    assert "rate" in str(exc_info.value).lower()
+    assert_no_key_anywhere(exc_info.value, sender_log)
+
+
+def test_authenticate_user_does_not_leak_key(auth_log):
+    firebase = MagicMock()
+    firebase.auth.return_value.sign_in_with_email_and_password.side_effect = (
+        pyrebase_http_error("INVALID_LOGIN_CREDENTIALS")
+    )
+    data = MagicMock(email="user@example.com", password="wrong")
+    with patch.object(auth_module, "pyrebase_app", firebase):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(auth_module.authenticate_user(MagicMock(), data))
+    assert exc_info.value.detail == "INVALID_LOGIN_CREDENTIALS"
+    assert FAKE_KEY not in auth_log.getvalue()
+    assert "INVALID_LOGIN_CREDENTIALS" in auth_log.getvalue()
+
+
+def test_refresh_token_does_not_leak_key(auth_log):
+    firebase = MagicMock()
+    firebase.auth.return_value.refresh.side_effect = pyrebase_http_error(
+        "TOKEN_EXPIRED"
+    )
+    with patch.object(auth_module, "pyrebase_app", firebase), patch.object(
+        auth_module, "validate_refresh_token", return_value=({"sub": "rt"}, None)
+    ):
+        with pytest.raises(HTTPException):
+            asyncio.run(auth_module.refresh_current_user_token("refresh-token"))
+    assert FAKE_KEY not in auth_log.getvalue()
+    assert "TOKEN_EXPIRED" in auth_log.getvalue()
+
+
+def test_send_reset_password_mail_does_not_leak_key(auth_log):
+    firebase = MagicMock()
+    firebase.auth.return_value.send_password_reset_email.side_effect = (
+        pyrebase_http_error("EMAIL_NOT_FOUND")
+    )
+    with patch.object(auth_module, "pyrebase_app", firebase):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                auth_module.send_reset_password_mail(MagicMock(), "user@example.com")
+            )
+    assert exc_info.value.detail == "EMAIL_NOT_FOUND"
+    assert FAKE_KEY not in auth_log.getvalue()
+    assert "EMAIL_NOT_FOUND" in auth_log.getvalue()


### PR DESCRIPTION
### Content

#### Summary
- Routine client conditions (mistyped password, a workspace with no previous
  run, an empty `experiment.yaml`) were being logged at `ERROR` with full
  stack traces, drowning out genuine failures. They are now logged at
  `WARNING`/`DEBUG` or not re-logged at all, while true server errors keep
  their tracebacks.
- Firebase failures previously logged and returned raw exception strings,
  which embed the request URL **including the Firebase API key**. Every
  Firebase call path — login, token refresh, password reset, and the default
  REST email sender used for registration verification — now surfaces only
  the clean Firebase message, and regression tests lock this in.
- CaImAn nodes running single-threaded (`n_processes == 1`) no longer shell
  out to a nonexistent `ipcluster` binary and emit spurious `ERROR` lines.

#### Design Decisions
- **Extract the Firebase message from the response body, not the exception
  string.** The API key lives in the request URL embedded in `str(e)`, while
  the clean message lives in the response body. The new
  `_extract_firebase_error` helper handles both exception shapes — pyrebase's
  `HTTPError(original_error, response_text)` and a raw `requests`
  `HTTPError`/`RequestException` (via `response.text`) — and falls back to a
  generic string when the body can't be parsed. All Firebase call sites route
  through it: `authenticate_user`, `login_with_uid`, `send_reset_password_mail`,
  `refresh_current_user_token`, `AuthEmailService`, and the REST email sender.
- **Sanitize at the source and break the exception chain in
  `firebase_email_sender`.** The default (`USE_FIREBASE_EMAIL`) verification
  and password-reset senders call the Firebase REST API with `?key=` in the
  URL; they previously logged `str(e)` with `exc_info=True` and re-raised
  `Exception(f"...: {e}")`, leaking the key in the message, the traceback,
  and — via Python's implicit exception chaining — in any downstream
  `exc_info=True` logger (the resend-verification endpoint and user-creation
  path were live leak paths this way). Failure handlers now log the parsed
  body message, keep the safe response status/body logs, and re-raise with
  `from None` so no downstream traceback can render the original URL. The
  user-friendly rate-limit / `EMAIL_NOT_FOUND` / `INVALID_ID_TOKEN` mappings
  are preserved, now matched against the body-parsed message.
- **Keep tracebacks for unexpected email failures, drop them only for the
  key-bearing shape.** `AuthEmailService.send_password_reset_email` logs
  `HTTPError` (whose traceback embeds the key via the pyrebase fallback) as a
  sanitized message without `exc_info`, and everything else with the full
  traceback.
- **Keep `exc_info=True` for 5xx, drop it for 4xx.** Genuine server errors
  should keep a traceback, so all three auth-layer `except Exception` 500
  handlers now log with `exc_info=True`. Routine 4xx (bad credentials, no
  previous run) should not emit `ERROR`-level stack traces, so the router
  re-raises `HTTPException` without a second traceback and `fetch_last_experiment`
  logs a 404 at `DEBUG`.
- **Treat a missing or empty `experiment.yaml` as "no status yet", not
  corruption.**
  A missing/empty file (`AssertionError` from `ExptConfigReader.read`) is recoverable —
  capacity is still tracked in the DB and the writer recreates the file on the
  next run — so it is logged at `DEBUG` to avoid re-warning on every
  recalculation. A genuinely malformed file (`ValueError`/`yaml.YAMLError`)
  stays a `WARNING`. `yaml.YAMLError` was added to the caught set so a
  syntactically-broken file is handled instead of aborting the recalc loop.
- **`ExptConfigWriter.write` recreates a broken config instead of aborting.**
  An existing but empty/corrupt `experiment.yaml` used to crash the run start;
  it is now caught and the config is rebuilt from scratch.
- **Guard `stop_server` on `dview is not None`.** `setup_cluster(single_thread=True)`
  returns `dview=None`; `stop_server(dview=None)` falls through to
  `subprocess.Popen("ipcluster stop", ...)`, which logs errors when the binary
  is absent. There is no cluster to stop in single-thread mode, so the call is
  skipped.

### Evidence
- `flake8 --max-line-length=88` and `isort` (black profile) clean on all
  changed files.
- Backend pytest (run with fixtures staged into a writable `OPTINIST_DIR`):
  - `tests/app/common/routers/test_auth_api_contract.py` — 11 passed
  - `tests/app/common/core/auth/` — 27 passed (includes the 8 new key-leak
    regression tests)
  - experiment + workspace suites — 51 passed
- The new regression tests were validated against the pre-fix code: the
  sender tests fail against the pre-fix `firebase_email_sender.py`, and
  `test_refresh_token_does_not_leak_key` fails against the pre-fix
  `refresh_current_user_token` — i.e. each historical occurrence of the leak
  would have been caught.
- The `test_workflow.py` `TestClient`-based tests were not run locally — they
  hit a starlette/httpx `TestClient(app=...)` version mismatch in the local
  env and require the Docker test harness. This is unrelated to the change.

### References
- Builds on branch commit `bcff498a1` ("Various minor fixes to reduce log noise").
- `caiman.cluster.stop_server` / `setup_cluster` confirm the single-thread
  `dview=None` / `ipcluster` shell-out behavior.
- No linked issue.

#### Files changed
- `studio/app/common/core/auth/auth.py` -- add `_extract_firebase_error`
  (handles pyrebase and raw `requests` exception shapes); route all four auth
  handlers (including `refresh_current_user_token`) through it so the API key
  is no longer logged or returned; `exc_info=True` on the 500 handlers.
- `studio/app/common/core/auth/firebase_email_sender.py` -- both REST
  failure handlers log the body-parsed Firebase message instead of `str(e)`,
  drop `exc_info`, and re-raise `from None` so downstream loggers cannot
  render the key-bearing URL.
- `studio/app/common/core/auth/auth_email_service.py` -- password-reset
  handler logs `HTTPError` as a sanitized message and keeps `exc_info=True`
  tracebacks for all other exceptions.
- `studio/tests/app/common/core/auth/test_firebase_key_leak.py` -- new
  regression tests: `_extract_firebase_error` against all three exception
  shapes, and the auth handlers + email senders asserting the key never
  appears in exception messages, rendered tracebacks, or captured logs.
- `studio/app/common/routers/auth.py` -- re-raise `HTTPException` without a
  second `ERROR`+traceback for routine 4xx.
- `studio/app/common/routers/workflow.py` -- `fetch_last_experiment` logs a
  404 (no previous run) at `DEBUG`; other `HTTPException`s still `ERROR`+traceback.
- `studio/app/common/core/cloud/storage_tracking.py` --
  `_calculate_live_storage_usage` logs `repr(e)` + `exc_info=True` so the
  exception type is visible even when `str(e)` is empty.
- `studio/app/common/core/experiment/experiment_reader.py` --
  `read_experiment_status` splits missing/empty file (`AssertionError` →
  `DEBUG`/`None`) from malformed (`ValueError`/`YAMLError` → `WARNING`).
- `studio/app/common/core/experiment/experiment_writer.py` -- `write` recreates
  the config when the existing `experiment.yaml` is empty/corrupt instead of
  aborting the run.
- `studio/app/common/core/workspace/workspace_data_capacity_services.py` --
  recalc loop logs a missing/empty yaml at `DEBUG`, a malformed yaml
  (`ValueError`/`yaml.YAMLError`) at `WARNING`; adds `import yaml`.
- `studio/scripts/run_sync_data_capacity_cloud.py` -- same missing/empty vs
  malformed split as above; adds `import yaml`.
- `studio/app/optinist/wrappers/caiman/cnmf.py` -- guard `stop_server` with
  `if dview is not None`.
- `studio/app/optinist/wrappers/caiman/cnmf_multisession.py` -- same guard.
- `studio/app/optinist/wrappers/caiman/motion_correction.py` -- same guard.

### Manual Testcases
- **Bad password** — a user submits `POST /login` with a wrong password.
  Expected: 400 response whose `detail` is the Firebase message (e.g.
  `INVALID_LOGIN_CREDENTIALS`), not a URL; logs show a single `WARNING`
  "Authentication failed: ..." with no API key and no `ERROR` traceback.
- **Password reset — Firebase failure for a registered user** — request a reset
  for an email that exists as an *active* user in the DB but whose Firebase
  reset call fails (e.g. the account is absent in Firebase → `EMAIL_NOT_FOUND`).
  Expected: 400 with the clean Firebase message; a single `WARNING`
  "Password reset failed: ..." with no API key and no traceback.
  **Note:** an email *not* present in the DB is rejected by the preceding
  `.one()` lookup with `NoResultFound` → 500 (pre-existing behavior); it never
  reaches the Firebase branch this PR changed. The clean-message extraction
  itself is also exercised by the bad-password login test above (both paths
  share `_extract_firebase_error`).
- **Expired refresh token** — call the token-refresh endpoint with a refresh
  token Firebase rejects. Expected: 400; a single `WARNING`
  "Token refresh failed: ..." with the Firebase message and no API key.
- **Verification email failure (default Firebase REST path)** — with
  `USE_FIREBASE_EMAIL` enabled, trigger resend-verification for an account
  Firebase rejects (or a rate-limited account). Expected: the client gets the
  user-friendly message (e.g. rate-limit hint); logs show the Firebase error
  message plus response status/body, and no `key=` / `identitytoolkit` URL
  anywhere — including the traceback logged by the resend endpoint.
- **Real server error (5xx)** — force an unexpected exception in the auth path.
  Expected: the auth layer logs at `ERROR` with a full traceback (`exc_info`).
- **Fresh workspace** — an admin opens a workspace with no prior run, hitting
  `fetch_last_experiment`. Expected: 404 surfaced to the client; log shows
  `DEBUG` "No previous experiment in workspace ...", not `ERROR`+traceback.
- **Single-thread CNMF / motion correction** — run a CNMF or motion-correction
  node with `n_processes == 1`. Expected: the node completes and the logs
  contain no `ipcluster`-related `ERROR` lines.
- **Missing or empty experiment.yaml during capacity recalc** — leave an empty
  `experiment.yaml` (or delete it) and trigger a data-capacity recalculation.
  Expected: DB capacity is still updated; the YAML skip is logged at `DEBUG`,
  not `WARNING`.
- Automated: from `studio/`, with `OPTINIST_DIR` pointed at a writable copy of
  `test_data/output_test`:
  `IS_TEST=True IS_STANDALONE=True OPTINIST_DIR=<dir> python -m pytest tests/app/common/routers/test_auth_api_contract.py tests/app/common/core/auth/ tests/app/common/core/experiment/ tests/app/common/core/workspace/` -- 89 passed.

### Unit, Integration, Contract Test Coverage
- New: `tests/app/common/core/auth/test_firebase_key_leak.py` — regression
  tests for the API-key leak class. Covers `_extract_firebase_error` against
  all three exception shapes (pyrebase-wrapped, `requests` `raise_for_status`,
  no-response connection error) and exercises the auth handlers
  (`authenticate_user`, `refresh_current_user_token`,
  `send_reset_password_mail`) and both email senders with a key-bearing URL,
  asserting the key never appears in the exception message, the rendered
  traceback (this catches the implicit-chaining bypass that `from None`
  fixes), or captured logs — while the Firebase error message survives for
  diagnostics. Verified red against the pre-fix code.
- Log-level and wording changes remain covered by the existing auth
  API-contract suite (response shape unchanged) and the experiment/workspace
  core suites.

### Others

#### Out of scope (from issue #671 / review)
- 6.1 root cause — why tutorial provisioning writes an empty `experiment.yaml`
  (and regenerating already-broken files that are never re-run). The symptom
  is fixed here; the root cause is a separate change.
- 6.3 — the misleading "Failed to recover stale workflow counts: 0" wording in
  `workflow_count_recovery.py`. Unrelated file; separate trivial PR.
- 6.4 — treating a not-yet-created storage bucket as an expected state in
  `_calculate_live_storage_usage`. Behavior change needing its own
  expected-vs-error logic; this PR only improves the diagnostics (`repr(e)` +
  traceback).

#### Difficulties (if any)
- The backend test fixtures under `test_data/output_test` are consumed/deleted
  by some suites during a run, so repeated non-Docker runs against a shared
  `OPTINIST_DIR` show a spurious `test_expt_reader::test_read` failure. The
  Docker harness gives each run a clean copy; staging fixtures fresh reproduces
  a clean pass. The assertion that fails there lives in `ExptConfigReader.read`,
  which this branch does not modify.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Auth error responses | Medium | Failure `detail` now returns the clean Firebase message instead of the raw error string. Strictly less info leaked (drops the API key), but any frontend parsing the old verbatim string could see different text. Response field shape is unchanged (auth contract test passes). |
| Firebase email sender error handling | Medium | Failure-path only (success paths untouched): raised exception messages now carry the body-parsed Firebase message instead of `str(e)`, and `from None` suppresses chained-traceback rendering. The user-friendly rate-limit/`EMAIL_NOT_FOUND` mappings are preserved. Callers (resend-verification endpoint, user creation) already catch broad `Exception`, so control flow is unchanged. |
| Log levels (auth / workflow / capacity) | Low | Level/handler changes only; no control-flow change beyond which branch logs. Genuine errors still logged. |
| `ExptConfigWriter.write` recovery | Low | New `try/except` recreates a broken config instead of crashing the run; the builder is pristine when recovery runs (read raises before `set_config`). |
| CaImAn `dview` guard | Low | Skips a no-op cleanup in single-thread mode; multiprocessing path (`dview` is a Pool) is unchanged and still terminated. |
