### PR TITLE
Remove static IAM access key for the cloud user

### DIFF
--- a/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
@@ -408,7 +408,7 @@ terraform output alb_dns_name
 terraform output rds_endpoint
 
 # Sensitive output
-terraform output -raw optinist_cloud_user_secret_access_key
+terraform output -raw effective_ami_id
 ```
 
 ### Update a Single Resource

--- a/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
+++ b/infrastructure/documentation/MAINTENANCE_PROCEDURES.md
@@ -293,12 +293,11 @@ aws secretsmanager list-secrets \
 **Secrets to review:**
 - `subscr-optinist/database/config` — Database credentials
 - `subscr-optinist/app/config` — Application secrets
-- `subscr-optinist-cloud-credentials` — AWS access keys for S3 (legacy; no longer read by containers, which authenticate via the ECS Task Role)
 - `subscr-optinist/firebase/private-key` — Firebase service account key
 - `subscr-optinist/firebase/config` — Firebase configuration
 - `subscr-optinist/stripe/config` — Stripe payment configuration
 
-**Procedure:** Update the secret value in Secrets Manager, then force a new ECS deployment so containers pick up the new credentials at startup. (Exception: `*-cloud-credentials` is no longer consumed by containers — they use the ECS Task Role — so rotating it does not require an ECS redeploy.)
+**Procedure:** Update the secret value in Secrets Manager, then force a new ECS deployment so containers pick up the new credentials at startup.
 
 ### 2. Capacity Planning Review
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -496,18 +496,6 @@ output "ssh_command" {
   value       = "ssh -i ${local_file.private_key.filename} ec2-user@<INSTANCE_IP>"
 }
 
-# Output the access key credentials
-output "optinist_cloud_user_access_key_id" {
-  description = "Access Key ID for subscr-optinist-cloud-user"
-  value       = aws_iam_access_key.subscr_optinist_cloud_user_access_key.id
-}
-
-output "optinist_cloud_user_secret_access_key" {
-  description = "Secret Access Key for subscr-optinist-cloud-user"
-  value       = aws_iam_access_key.subscr_optinist_cloud_user_access_key.secret
-  sensitive   = true
-}
-
 output "alb_arn" {
   description = "ARN of the main ALB for premium instance routing"
   value       = aws_lb.autoscaling.arn

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -27,26 +27,6 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-resource "aws_iam_role_policy" "ecs_secrets_policy" {
-  name = "ecs-secrets-policy"
-  role = aws_iam_role.ecs_task_execution.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = [
-          aws_secretsmanager_secret.aws_credentials.arn
-        ]
-      }
-    ]
-  })
-}
-
 # ECS Task Role (for containers to call AWS services)
 # ------------------------------------------------------
 resource "aws_iam_role" "ecs_task" {
@@ -440,154 +420,6 @@ resource "aws_iam_role_policy" "ecs_instance_detailed_monitoring" {
   })
 }
 
-# IAM User for this OptiNiSt Cloud project (separate from other webapps)
-resource "aws_iam_user" "subscr_optinist_cloud_user" {
-  name = "${local.env_prefix}-cloud-user"
-  path = "/"
-}
-
-# IAM Policy for this OptiNiSt Cloud User
-resource "aws_iam_policy" "subscr_optinist_cloud_user_policy" {
-  name        = "${local.env_prefix}-cloud-user-policy"
-  description = "Policy for this OptiNiSt Cloud project"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "ec2:DescribeInstances",
-          "ecr:GetAuthorizationToken",
-          "ecr:DescribeRepositories",
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:BatchGetImage",
-          "ecr:DescribeImages",
-          "ecr:GetRepositoryPolicy",
-          "cloudwatch:ListMetrics",
-          "cloudwatch:GetMetricStatistics",
-          "cloudwatch:DescribeAlarms",
-          "cloudwatch:PutMetricData",
-          "autoscaling:DescribeAutoScalingGroups",
-          "ecs:ListClusters",
-          "ecs:ListContainerInstances"
-        ]
-        Resource = "*"
-      },
-      # S3: Allow CRUD only on this environment's buckets
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-          "s3:CreateBucket",
-          "s3:DeleteBucket"
-        ]
-        Resource = [
-          "arn:aws:s3:::${local.env_prefix}-*",
-          "arn:aws:s3:::${local.env_prefix}-*/*",
-          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*",
-          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*/*"
-        ]
-      },
-      # S3: Explicitly deny CRUD on other environments' buckets
-      # This ensures no other attached policy can grant cross-environment S3 access
-      {
-        Sid    = "DenyS3CrossEnvironment"
-        Effect = "Deny"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-          "s3:CreateBucket",
-          "s3:DeleteBucket"
-        ]
-        NotResource = [
-          "arn:aws:s3:::${local.env_prefix}-*",
-          "arn:aws:s3:::${local.env_prefix}-*/*",
-          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*",
-          "arn:aws:s3:::${var.s3_user_bucket_prefix}-*/*"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "ecs:DescribeTasks",
-          "ecs:DescribeContainerInstances",
-          "ecs:ListTasks",
-          "ecs:DescribeClusters",
-          "ecs:DescribeServices",
-          "ecs:UpdateService"
-        ]
-        Resource = [
-          "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/${local.env_prefix}-*",
-          "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${local.env_prefix}-*/*",
-          "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task/${local.env_prefix}-*/*",
-          "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:container-instance/${local.env_prefix}-*/*"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:GetLogEvents",
-          "logs:FilterLogEvents",
-          "logs:DescribeLogGroups",
-          "logs:DescribeLogStreams"
-        ]
-        Resource = [
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}-*",
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}-*:*",
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.environment}-*",
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.environment}-*:*"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "autoscaling:SetDesiredCapacity",
-          "autoscaling:SuspendProcesses",
-          "autoscaling:ResumeProcesses"
-        ]
-        Resource = "arn:aws:autoscaling:${var.aws_region}:${data.aws_caller_identity.current.account_id}:autoScalingGroup:*:autoScalingGroupName/${local.env_prefix}-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = "lambda:InvokeFunction"
-        Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${var.environment}-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = "iam:PassRole"
-        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.environment}-*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = [
-          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${var.environment}-optinist/*"
-        ]
-      }
-    ]
-  })
-}
-
-# Attach policy to user
-resource "aws_iam_user_policy_attachment" "subscr_optinist_cloud_user_policy_attachment" {
-  user       = aws_iam_user.subscr_optinist_cloud_user.name
-  policy_arn = aws_iam_policy.subscr_optinist_cloud_user_policy.arn
-}
-
-# Create access key for the user
-resource "aws_iam_access_key" "subscr_optinist_cloud_user_access_key" {
-  user = aws_iam_user.subscr_optinist_cloud_user.name
-}
-
 # S3 access for ECS tasks (scoped to app storage bucket)
 resource "aws_iam_role_policy" "ecs_task_s3_access" {
   name = "${var.environment}-ecs-task-s3-access"
@@ -955,20 +787,6 @@ resource "aws_security_group" "vpc_endpoints" {
 # ==============================
 # AWS Secrets Manager for storing
 # ==============================
-# Store AWS credentials in Secrets Manager
-resource "aws_secretsmanager_secret" "aws_credentials" {
-  name        = "${local.env_prefix}-cloud-credentials"
-  description = "AWS credentials for optinist cloud user"
-}
-
-resource "aws_secretsmanager_secret_version" "aws_credentials" {
-  secret_id = aws_secretsmanager_secret.aws_credentials.id
-  secret_string = jsonencode({
-    AWS_ACCESS_KEY_ID     = aws_iam_access_key.subscr_optinist_cloud_user_access_key.id
-    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.subscr_optinist_cloud_user_access_key.secret
-  })
-}
-
 # Store RDS credentials in Secrets Manager
 resource "aws_secretsmanager_secret" "rds_credentials" {
   name = "${var.environment}-rds-credentials"


### PR DESCRIPTION
### Content

#### Summary
- Deletes the long-lived **static IAM access key** for the OptiNiSt cloud IAM
  user, plus everything that kept it alive: the IAM user, its policy and
  attachment, the access key, the `*-cloud-credentials` Secrets Manager secret
  that stored the pair, the task-execution-role policy that read that secret,
  and the two Terraform outputs that exposed the key.
- PR #614 removed the *injection* of these credentials into ECS containers —
  containers now authenticate via the ECS **Task Role**
  (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`). It removed the *use* but not the
  *attack surface*: the user, key, and secret still existed and still
  authenticated. This change removes that orphaned surface.
- Infra docs are updated to drop the now-deleted secret/output from the
  rotation list and the example commands.

#### Design Decisions
- **Delete, don't rotate.** Nothing consumes this key at runtime post-#614 — no
  task definition injects `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or
  references the secret, and the backend builds every AWS client through the
  boto3/aioboto3 default provider chain (no explicit credentials), which on ECS
  resolves to the Task Role. A static key with no consumer is pure attack
  surface, so removal beats rotation.
- **Remove the whole chain, not just the key.** The IAM user, policy,
  attachment, access key, `*-cloud-credentials` secret + version, the
  `ecs-secrets-policy` execution-role grant, and both `optinist_cloud_user_*`
  outputs are deleted together. Leaving any one orphaned (e.g. the secret
  without the key, or the user without a key) keeps part of the surface and the
  dangling grant.
- **Dropping `ecs-secrets-policy` is safe.** That execution-role policy granted
  `secretsmanager:GetSecretValue` scoped *only* to the deleted secret. No task
  definition uses native ECS secret injection (no `secrets`/`valueFrom`
  blocks), so the execution role never needed broad `GetSecretValue` for task
  launch. The app reads the other secrets (rds/app/firebase/stripe) at runtime
  via the **Task Role**, which retains its own `GetSecretValue` grants
  (`ecs_task_secrets_access`, `ecs_task_routing_secret`) — those are untouched.
- **Scope is the Terraform-managed `${env}-cloud-user` only.** This does not
  touch the separate legacy `optinist-cloud-user` principal (the un-prefixed,
  pre-Terraform user whose key is baked into older images); that is handled
  separately by the `.dockerignore` work (PR #683) and an out-of-band key
  rotation. Reviewers should not conflate the two.
- **Per-environment resources.** These are created per environment via
  `local.env_prefix`, so the change must be planned and applied against each
  environment's own backend separately.

### Evidence
- Static verification that nothing still depends on the removed resources:
  - No `.tf` reference remains to `aws_iam_user.subscr_optinist_cloud_user`,
    `aws_iam_access_key.*`, `aws_iam_policy.subscr_optinist_cloud_user_policy`,
    `aws_secretsmanager_secret.aws_credentials`, the removed outputs, or
    `ecs_secrets_policy` (grep across `infrastructure/`).
  - No task definition injects `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or
    references the `*-cloud-credentials` secret (no `secrets`/`valueFrom`).
  - No application code (`studio/**`), CI workflow, shell script, or user-data
    reads the secret name or a static AWS key (repo-wide `git grep` clean).
  - The new doc example `terraform output -raw effective_ami_id` resolves to an
    existing output (`output "effective_ami_id"` in `image_builder.tf`, itself
    `sensitive = true`, so `-raw` is appropriate).
- `terraform plan` was **not** run from this session; the destroy-only plan
  should be reviewed per-environment before apply (see Testcases).

### References
- **PR #614** (merged 2026-05-22, commit `94a15f52f`) — removed the ECS
  credential injection; containers moved to the Task Role.
- Original design: commit `57ac98af1` (2025-07-11) — created the IAM user,
  static access key, and `*-cloud-credentials` secret.
- **PR #683** (open) — root `.dockerignore` to stop baking local secrets
  (`.env`, firebase keys) into images; separate from this Terraform cleanup.
- No linked issue (kept off the tracker while key values were in play).

#### Files changed
- `infrastructure/terraform/security.tf` -- remove the `ecs-secrets-policy`
  execution-role policy, the `${env}-cloud-user` IAM user + policy +
  attachment, its access key, and the `*-cloud-credentials` secret + version.
- `infrastructure/terraform/main.tf` -- remove the
  `optinist_cloud_user_access_key_id` and `optinist_cloud_user_secret_access_key`
  outputs.
- `infrastructure/documentation/MAINTENANCE_PROCEDURES.md` -- drop the
  `*-cloud-credentials` entry from the secrets-to-review list and remove the
  now-irrelevant rotation exception note.
- `infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md` -- replace the
  deleted `optinist_cloud_user_secret_access_key` output in the sensitive-output
  example with the existing `effective_ami_id` output.

### Manual Testcases
- **Plan is destroy-only, per environment** — an operator runs
  `terraform plan` against each environment's backend (verify the initialized
  backend matches the target `-var-file` first). Expected: only destroys of the
  IAM user/policy/attachment/access key, the `*-cloud-credentials`
  secret/version, the `ecs-secrets-policy`, and the two outputs; no other
  resource is added, changed, or replaced.
- **App still functions on the Task Role after apply** — after applying, an
  admin exercises an app path that calls AWS (e.g. S3 storage read/write,
  CloudWatch capacity metrics). Expected: success; container env shows
  `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and no `AWS_ACCESS_KEY_ID`, confirming
  the Task Role is the credential source.
- **No out-of-band consumer breaks** — before apply, confirm the key is not in
  use by anything outside the repo (`aws iam get-access-key-last-used` on the
  `${env}-cloud-user` key; CloudTrail for recent activity). Expected: no recent
  use; if a human/tool still authenticates with it, migrate that consumer to a
  role first — apply destroys the key.
- Automated (infra): `terraform validate` and `terraform fmt -check` pass on
  `infrastructure/terraform/`. There is no application test suite for this
  change (Terraform + docs only).

### Unit, Integration, Contract Test Coverage
- None added — this is an infrastructure deletion with no application code path.
  Correctness is established by the destroy-only plan plus the post-apply
  functional check that the app continues to operate on the Task Role.

### Others

#### Difficulties (if any)
- The naming is easy to conflate: the Terraform-managed `${env}-cloud-user`
  removed here is distinct from the legacy un-prefixed `optinist-cloud-user`
  whose key was baked into older images. This PR addresses only the former;
  the latter is rotated/scrubbed separately.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| ECS task launch | Low | The deleted `ecs-secrets-policy` was scoped only to the deleted secret; no task def uses native secret injection, so launch is unaffected. App-read secrets keep their Task-Role grants. |
| App AWS access at runtime | Low | App already authenticates via the Task Role (boto3 default chain, no injected keys); the deleted user/key were unreachable from containers, so removing them cannot regress runtime behavior. |
| Out-of-band key consumers | Medium | Apply destroys the access key. Any human/tool that configured this key manually (local `~/.aws`, CI variable, external integration) would break. Verify last-used / CloudTrail before apply; this is the intended security outcome. |
| Terraform apply (per env) | Medium | Touches IAM + Secrets Manager across each environment. Confirm the initialized backend matches the target `-var-file` before apply; review the destroy-only plan each time. |
