### PR TITLE
Fix: Frontend does not re-trigger assign after assign API timeout

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -766,6 +766,35 @@ export const PremiumAssignmentProvider: React.FC<{
     }
   }, [state.assignmentResult?.is_shared])
 
+  // Shared helper for the polling effect: finalize a dedicated assignment
+  // by updating state, restoring routing, acquiring the beacon token, and
+  // resetting the polling cadence.  Used by both the "status found dedicated"
+  // path and the "re-trigger assign succeeded" path to avoid duplication.
+  const finalizeDedicatedAssignment = async (
+    result: PremiumAssignmentResult,
+    statusResult?: PremiumStatusResult | null,
+  ) => {
+    setState((prev) => ({
+      ...prev,
+      assignmentResult: result,
+      ...(statusResult !== undefined ? { statusResult } : {}),
+      error: null,
+      isRetryableError: false,
+    }))
+    routingService.setPremiumAssigned(true)
+    routingService.setPremiumInstanceId(result.instance_id_hash ?? null)
+    try {
+      const tokenRes = await getBeaconTokenApi()
+      beaconTokenRef.current = tokenRes.data.token
+    } catch {
+      // Non-critical; beacon will fail gracefully.
+      // If this was a 502/503, the axios interceptor already
+      // handled recovery (setPremiumAssigned(false) + retry).
+    }
+    setPollInterval(INITIAL_POLL_INTERVAL_MS)
+    setPollAttempts(0)
+  }
+
   // Poll runs while unreachable so a backend reassignment is caught; a poll result alone never clears unreachable (only a real response does).
   useEffect(() => {
     if (
@@ -834,31 +863,10 @@ export const PremiumAssignmentProvider: React.FC<{
             "Premium instance now available",
           )
           // The hook clears unreachable on an instance_id change; same-id is a no-op — reachability must come from a real response.
-          setState((prev) => ({
-            ...prev,
-            assignmentResult: result,
-            statusResult: status,
-            error: null,
-            isRetryableError: false,
-          }))
-          // Restore routing: an earlier 502/503 may have flipped premiumAssigned off.
-          routingService.setPremiumAssigned(true)
-          routingService.setPremiumInstanceId(result.instance_id_hash ?? null)
-          setPollInterval(INITIAL_POLL_INTERVAL_MS)
-          setPollAttempts(0)
-
-          // Acquire beacon token (matches autoAssignOnLogin behavior).
           // Also serves as a routing probe — if the dedicated instance is
           // unreachable, the 502/503 handler will flip premiumAssigned off
           // and emit unreachable, causing polling to resume automatically.
-          try {
-            const tokenRes = await getBeaconTokenApi()
-            beaconTokenRef.current = tokenRes.data.token
-          } catch {
-            // Non-critical; beacon will fail gracefully.
-            // If this was a 502/503, the axios interceptor already
-            // handled recovery (setPremiumAssigned(false) + retry).
-          }
+          await finalizeDedicatedAssignment(result, status)
         } else {
           if (assignment) {
             setState((prev) => {
@@ -887,6 +895,9 @@ export const PremiumAssignmentProvider: React.FC<{
             // actually created, status polling alone will never discover
             // one.  Periodically re-call assignPremiumInstance() so the
             // backend gets another chance to create the assignment.
+            // NOTE: state.assignmentResult is read from the closure and
+            // must remain in this effect's dependency array (see
+            // deps below) to stay fresh across re-renders.
             const originalWasRetryable =
               state.assignmentResult != null && !state.assignmentResult.assigned
 
@@ -907,24 +918,7 @@ export const PremiumAssignmentProvider: React.FC<{
                     "[premium-poll] Re-assign succeeded:",
                     reassignResult.instance_id,
                   )
-                  setState((prev) => ({
-                    ...prev,
-                    assignmentResult: reassignResult,
-                    error: null,
-                    isRetryableError: false,
-                  }))
-                  routingService.setPremiumAssigned(true)
-                  routingService.setPremiumInstanceId(
-                    reassignResult.instance_id_hash ?? null,
-                  )
-                  try {
-                    const tokenRes = await getBeaconTokenApi()
-                    beaconTokenRef.current = tokenRes.data.token
-                  } catch {
-                    // Non-critical; beacon will fail gracefully
-                  }
-                  setPollInterval(INITIAL_POLL_INTERVAL_MS)
-                  setPollAttempts(0)
+                  await finalizeDedicatedAssignment(reassignResult)
                   return
                 }
                 // Still retryable or non-retryable — fall through to

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -58,6 +58,11 @@ const MAX_POLL_INTERVAL_MS = 60000
 const MAX_POLL_ATTEMPTS = 40
 const BACKOFF_MULTIPLIER = 1.5
 const ERROR_BACKOFF_MULTIPLIER = 2
+// When polling returns assignment=null after a retryable assign response,
+// re-trigger assignPremiumInstance() every N polls instead of only polling
+// status. This handles the case where the assign API timed out without
+// actually creating an assignment (e.g., lock contention).
+const ASSIGN_RETRY_POLL_THRESHOLD = 3
 
 // sessionStorage keys — per-tab persistence across page refreshes.
 // Clears automatically when the tab closes.
@@ -782,13 +787,25 @@ export const PremiumAssignmentProvider: React.FC<{
       console.warn(
         `Max poll attempts (${MAX_POLL_ATTEMPTS}) reached. Stopping polling.`,
       )
+      // If the original assign was retryable and no assignment was ever
+      // found, reset the attempt guard so the user can retry via page
+      // refresh or user gesture without closing the tab entirely.
+      if (state.assignmentResult && !state.assignmentResult.assigned) {
+        hasAttemptedRef.current = false
+        ssRemove(SS_HAS_ATTEMPTED)
+        // Allow re-assignment on the next user gesture (click/keydown).
+        needsReassignAfterReleaseRef.current = true
+      }
       setState((prev) => ({
         ...prev,
+        assignmentResult: null,
         error:
           "No premium instance available after extended wait. " +
           "Please try again later or contact support.",
         isRetryableError: false,
       }))
+      setPollAttempts(0)
+      setPollInterval(INITIAL_POLL_INTERVAL_MS)
       return
     }
 
@@ -864,6 +881,63 @@ export const PremiumAssignmentProvider: React.FC<{
             })
           } else {
             setState((prev) => ({ ...prev, statusResult: status }))
+
+            // If the original assign API returned a retryable error
+            // (scaling_in_progress / retry_after) but no assignment was
+            // actually created, status polling alone will never discover
+            // one.  Periodically re-call assignPremiumInstance() so the
+            // backend gets another chance to create the assignment.
+            const originalWasRetryable =
+              state.assignmentResult != null && !state.assignmentResult.assigned
+
+            if (
+              originalWasRetryable &&
+              pollAttempts > 0 &&
+              (pollAttempts + 1) % ASSIGN_RETRY_POLL_THRESHOLD === 0
+            ) {
+              // eslint-disable-next-line no-console
+              console.log(
+                `[premium-poll] Re-triggering assign after ${pollAttempts + 1} null-status polls`,
+              )
+              try {
+                const reassignResult = await assignPremiumInstance()
+                if (reassignResult?.assigned) {
+                  // eslint-disable-next-line no-console
+                  console.log(
+                    "[premium-poll] Re-assign succeeded:",
+                    reassignResult.instance_id,
+                  )
+                  setState((prev) => ({
+                    ...prev,
+                    assignmentResult: reassignResult,
+                    error: null,
+                    isRetryableError: false,
+                  }))
+                  routingService.setPremiumAssigned(true)
+                  routingService.setPremiumInstanceId(
+                    reassignResult.instance_id_hash ?? null,
+                  )
+                  try {
+                    const tokenRes = await getBeaconTokenApi()
+                    beaconTokenRef.current = tokenRes.data.token
+                  } catch {
+                    // Non-critical; beacon will fail gracefully
+                  }
+                  setPollInterval(INITIAL_POLL_INTERVAL_MS)
+                  setPollAttempts(0)
+                  return
+                }
+                // Still retryable or non-retryable — fall through to
+                // continue polling with backoff.
+              } catch (retryError) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                  "[premium-poll] Re-assign attempt failed:",
+                  retryError,
+                )
+                // Fall through to continue polling
+              }
+            }
           }
           // eslint-disable-next-line no-console
           console.warn(

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -1,0 +1,429 @@
+/**
+ * Tests for the re-trigger assign logic during polling.
+ *
+ * Covers:
+ *  1. Re-trigger fires at correct interval (every ASSIGN_RETRY_POLL_THRESHOLD polls).
+ *  2. Re-trigger success transitions state correctly.
+ *  3. Re-trigger failure continues polling without crash.
+ *  4. Normal assign (assigned: true) does NOT fire re-trigger (regression test).
+ *  5. MAX_POLL_ATTEMPTS resets flags for retryable cases.
+ *  6. User gesture recovery after MAX_POLL_ATTEMPTS exhaustion.
+ */
+
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import type {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must precede provider import) ---
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: () => {},
+    broadcastPremiumReleased: () => {},
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type))
+        mockTabSyncHandlers.set(type, new Set())
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => 0,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+// require() not import — static imports hoist above the mock vars.
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+const { routingService } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+// --- Helpers ---
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const renderProvider = () => {
+  const ctxRef: { current: Ctx | null } = { current: null }
+  render(
+    <SnackbarProvider maxSnack={3}>
+      <PremiumAssignmentProvider>
+        <Harness ctxRef={ctxRef} />
+      </PremiumAssignmentProvider>
+    </SnackbarProvider>,
+  )
+  return ctxRef
+}
+
+/** A retryable assign response (assigned: false, scaling_in_progress: true). */
+const retryableAssignment: PremiumAssignmentResult = {
+  message: "scaling in progress",
+  instance_id: "",
+  assigned: false,
+  is_shared: false,
+  assignment_source: "pending",
+  scaling_in_progress: true,
+  retry_after: 30,
+}
+
+/** A successful dedicated assignment. */
+const dedicatedAssignment: PremiumAssignmentResult = {
+  message: "dedicated",
+  instance_id: "inst-A",
+  instance_id_hash: "hash-A",
+  assigned: true,
+  is_shared: false,
+  assignment_source: "existing",
+}
+
+/** Status endpoint returning null assignment (no assignment exists). */
+const nullAssignmentStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: null,
+}
+
+/** Status endpoint returning a dedicated assignment. */
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2026-06-22T00:00:00Z",
+    status: "active",
+  },
+}
+
+/** Simulate a pointerdown event on the window (as a user click). */
+const simulateClick = () => {
+  window.dispatchEvent(new Event("pointerdown"))
+}
+
+/**
+ * Advance timers and flush microtasks to simulate polling cycles.
+ * Each call advances 60s (enough for any backoff interval).
+ */
+const advanceOnePollCycle = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(60_000)
+    await Promise.resolve()
+  })
+}
+
+// --- Tests ---
+
+describe("PremiumAssignmentProvider — re-trigger assign during polling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockTabSyncHandlers.clear()
+    localStorage.clear()
+    sessionStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("re-trigger fires at correct interval (every 3 polls with null status)", async () => {
+    // autoAssignOnLogin: /status returns null → calls /assign → retryable
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    renderProvider()
+
+    // Wait for autoAssignOnLogin to complete with retryable response.
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Clear to track only polling-phase calls.
+    mockAssignPremiumInstance.mockClear()
+    // Keep returning null status so re-trigger fires.
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    // Poll 1: no re-trigger expected
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // Poll 2: no re-trigger expected
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // Poll 3: re-trigger expected (pollAttempts=2, (2+1)%3===0)
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+
+    mockAssignPremiumInstance.mockClear()
+
+    // Polls 4-5: no re-trigger
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // Poll 6: re-trigger again
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+  })
+
+  test("re-trigger success transitions state and stops polling", async () => {
+    // autoAssignOnLogin: retryable
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // After polls 1-2 return null, poll 3 re-triggers assign.
+    // This time, assign succeeds.
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    // Advance through 3 poll cycles.
+    await advanceOnePollCycle() // poll 1
+    await advanceOnePollCycle() // poll 2
+    await advanceOnePollCycle() // poll 3 → re-trigger → success
+
+    // State should reflect the dedicated assignment.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Routing should be configured.
+    expect(routingService.isPremiumAssigned()).toBe(true)
+
+    // Error should be cleared.
+    expect(ctxRef.current?.error).toBeNull()
+
+    // Beacon token should have been acquired.
+    expect(mockGetBeaconTokenApi).toHaveBeenCalled()
+  })
+
+  test("re-trigger failure continues polling without crash", async () => {
+    // autoAssignOnLogin: retryable
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Re-trigger will throw on poll 3.
+    mockAssignPremiumInstance.mockRejectedValue(new Error("Lock contention"))
+
+    // Advance through 3 polls → re-trigger fires and fails.
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+
+    // Polling should continue — no crash.
+    // assignmentResult should still be the retryable one (not cleared).
+    expect(ctxRef.current?.assignmentResult?.assigned).toBe(false)
+    // error is the original retryable message from autoAssignOnLogin — the
+    // re-trigger failure must NOT replace or escalate it.
+    expect(ctxRef.current?.error).toBe("scaling in progress")
+
+    // Advance one more cycle to confirm polling continues.
+    mockAssignPremiumInstance.mockClear()
+    await advanceOnePollCycle() // poll 4
+    // Still polling (getPremiumStatus called).
+    expect(mockGetPremiumStatus.mock.calls.length).toBeGreaterThan(3)
+  })
+
+  test("normal assign (assigned: true) does NOT fire re-trigger", async () => {
+    // autoAssignOnLogin: /status returns null → calls /assign → succeeds
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Polling should not be active (dedicated assignment found).
+    // assignPremiumInstance should have been called exactly once.
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+
+    mockAssignPremiumInstance.mockClear()
+    mockGetPremiumStatus.mockClear()
+
+    // Advance several cycles — no re-trigger or polling should fire.
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+  })
+
+  test("MAX_POLL_ATTEMPTS resets flags for retryable cases", async () => {
+    // Cannot pre-seed pollAttempts via sessionStorage because the reset
+    // effect clears it when assignmentResult.is_shared changes on mount.
+    // Instead, loop through all 40 poll cycles (fast with fake timers).
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Advance through all 40 poll cycles to reach MAX_POLL_ATTEMPTS.
+    for (let i = 0; i < 40; i++) {
+      await advanceOnePollCycle()
+    }
+
+    // State should show error and assignmentResult should be null (polling stopped).
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+      expect(ctxRef.current?.error).toContain(
+        "No premium instance available after extended wait",
+      )
+    })
+
+    // sessionStorage hasAttempted should be cleared (allowing fresh retry).
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBeNull()
+  })
+
+  test("user gesture recovery after MAX_POLL_ATTEMPTS exhaustion", async () => {
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Advance through all 40 poll cycles to reach MAX_POLL_ATTEMPTS.
+    for (let i = 0; i < 40; i++) {
+      await advanceOnePollCycle()
+    }
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+
+    // Now set up mocks for the recovery path: assign succeeds.
+    mockAssignPremiumInstance.mockClear()
+    mockGetPremiumStatus.mockClear()
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    // Simulate user gesture (click) — should trigger fresh autoAssignOnLogin.
+    act(() => {
+      simulateClick()
+    })
+
+    // autoAssignOnLogin should re-fire via autoAssignGeneration bump.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Error should be cleared.
+    expect(ctxRef.current?.error).toBeNull()
+  })
+})


### PR DESCRIPTION
## Issue

When the assign API (`POST /premium/assign`) returns a timeout/retryable response (`scaling_in_progress: true`, `assigned: false`), the frontend enters a status-only polling loop that calls `getPremiumStatus()` only. If the backend did not actually create an assignment (e.g., due to lock contention timeout), status returns `assignment: null` forever and the assign endpoint is never re-called. Recovery previously required closing the browser tab entirely.

## Root Cause

```
Service layer returns requires_retry: True, retry_after: 30
  -> API layer converts to scaling_in_progress: true (users_me.py:132-139)
    -> Frontend interprets as "poll status until assignment appears"
      -> But no backend process created the assignment (assign API timeout case)
        -> Status returns assignment: null forever
          -> assign is never re-called (hasAttemptedRef blocks)
```

Two gaps in the frontend:

1. **Polling effect calls `getPremiumStatus()` only**: It can discover assignments created by other processes (e.g., another tab) but cannot create new ones. When the assign API timed out without creating an assignment, polling finds nothing indefinitely.

2. **`hasAttemptedRef` + `SS_HAS_ATTEMPTED` block retry**: After `autoAssignOnLogin()` runs once, both the in-memory ref and sessionStorage guard prevent it from running again. The `MAX_POLL_ATTEMPTS` exhaustion path did not reset these flags, so even after polling gave up, no recovery was possible without closing the tab.

## This Fix

Two complementary mechanisms, both in `frontend/src/contexts/PremiumAssignmentContext.tsx`:

### 1. Re-trigger assign during polling (main fix)

When the polling loop detects all three conditions:
- Status returned `assignment: null` (no assignment exists on the backend)
- The original assign response was retryable (`assignmentResult.assigned === false`)
- Poll attempts have reached a multiple of `ASSIGN_RETRY_POLL_THRESHOLD` (3)

It calls `assignPremiumInstance()` directly from inside the polling effect instead of only calling `getPremiumStatus()`.

| Re-assign outcome | Behavior |
|-------------------|----------|
| `assigned: true` | State updated, routing configured, beacon token acquired, polling stops |
| Still retryable | Falls through to continue polling with backoff |
| Error thrown | Logged, falls through to continue polling with backoff |

### 2. Reset attempt guard at `MAX_POLL_ATTEMPTS` (safety net)

When polling exhausts `MAX_POLL_ATTEMPTS` (40) and the original assign was retryable (no assignment ever found):
- Resets `hasAttemptedRef.current = false`
- Clears `SS_HAS_ATTEMPTED` from sessionStorage
- Sets `needsReassignAfterReleaseRef.current = true` so the next user gesture (click/keydown) triggers a fresh auto-assign via the existing `autoAssignGeneration` mechanism (from PR #656)
- Resets `pollAttempts` and `pollInterval` for the next attempt cycle
- Sets `assignmentResult: null` to stop polling

This eliminates the requirement to close the browser tab for recovery.

## Changes

All changes are in `frontend/src/contexts/PremiumAssignmentContext.tsx`:

| # | Change | Location | Purpose |
|---|--------|----------|---------|
| 1 | Add `ASSIGN_RETRY_POLL_THRESHOLD = 3` constant | L61-65 | Controls how often the assign API is re-called during null-status polling (every 3 polls) |
| 2 | Add re-trigger assign logic in polling null-assignment branch | L868-924 | When status returns `assignment: null` and the original assign was retryable, periodically calls `assignPremiumInstance()` instead of only polling status |
| 3 | Reset flags at `MAX_POLL_ATTEMPTS` for retryable cases | L785-805 | Resets `hasAttemptedRef`, sessionStorage, and primes user-gesture re-assignment so recovery is possible without closing the tab |

## What is NOT changed (avoiding regressions)

- **`autoAssignOnLogin` function** — The `hasAttemptedRef` guard and catch-block behavior are unchanged. Failed assignments during initial login remain locked until page refresh (prevents the rapid-fire retry loop from the PR #603 regression).
- **`needsReassignAfterReleaseRef` semantics** — Only set at `MAX_POLL_ATTEMPTS` exhaustion (existing usage: inactivity release and cross-tab release). The one-shot DOM listener pattern is reused as-is.
- **Polling interval and backoff** — The existing exponential backoff (`BACKOFF_MULTIPLIER`, `ERROR_BACKOFF_MULTIPLIER`) is preserved. Re-assign attempts occur alongside the existing backoff cadence.
- **Shared assignment polling** — The `isOnShared` bypass at `MAX_POLL_ATTEMPTS` is preserved; shared assignments continue polling past the cap.

## Safety Properties

| Scenario | Behavior |
|----------|----------|
| **Initial login (normal)** | `autoAssignOnLogin` calls `/assign` once. If assigned, done. No re-trigger logic involved. |
| **Assign returns retryable, status finds dedicated** | Polling discovers the assignment (existing path). Re-trigger logic never fires (assignment is not null). |
| **Assign returns retryable, status finds null** | After 3 null-status polls (~90-135s), re-calls `/assign`. If succeeds, done. If fails, continues polling with backoff. |
| **Re-assign succeeds on retry** | State updated, routing configured, polling stops. Same as normal assignment success. |
| **Re-assign still retryable on retry** | Falls through, continues polling. Next re-trigger at poll 6, 9, etc. |
| **MAX_POLL_ATTEMPTS reached (no assignment found)** | Flags reset, error shown, next user gesture triggers fresh auto-assign. |
| **Concurrent tabs** | Only leader tab polls (existing `CrossTabLeaderElection`). Re-trigger is inside the polling effect, so only the leader tab re-assigns. |
| **Tab close during re-assign** | Same as existing behavior; `beforeunload` handler fires beacon if token exists. |

## Timeline of Events (Assign API Timeout Scenario)

```
T+0s    autoAssignOnLogin() -> assignPremiumInstance() (POST /assign)
T+186s  Assign API timeout -> retryable response (scaling_in_progress=true)
        -> assignmentResult = { assigned: false, scaling_in_progress: true }
        -> Polling starts

T+216s  Poll 1: getPremiumStatus() -> assignment: null
T+261s  Poll 2: getPremiumStatus() -> assignment: null  (backoff: 45s)
T+328s  Poll 3: getPremiumStatus() -> assignment: null  (backoff: 67s)
        -> [NEW] Re-trigger: assignPremiumInstance() (POST /assign)
        -> If assigned: done!
        -> If still retryable: continue polling

T+~429s Poll 6: null -> [NEW] Re-trigger again
...
T+~20m  Poll 40 (MAX_POLL_ATTEMPTS): [NEW] Reset flags, show error
        -> Next user gesture triggers fresh autoAssignOnLogin()
```

## Manual Test Cases

### Prerequisites

- A premium-subscribed user account
- Access to AWS console (EC2 instances)
- Access to RDS MySQL
- Browser DevTools (Console + Network tabs) open **before** login
- PR #658 merged (provides the per-user distributed lock `assign_user_{user_id}` used to reproduce the timeout scenario)

### How to Reproduce the Retryable Response

Manually acquire the DB lock to block the Lambda's per-user lock, producing a 409 → `requires_retry: True` → `scaling_in_progress: true` response. The lock timeout is 10 seconds, so the retryable response arrives ~15 seconds after login. While the lock is held, no assignment row is created, so the status endpoint returns `assignment: null`.

```
MySQL session: GET_LOCK('assign_user_<user_id>', 3600)
  → Browser login → POST /assign → Lambda lock wait 10s → 409
    → Service layer: requires_retry: True
      → Router: { assigned: false, scaling_in_progress: true }
        → Frontend: retryable polling starts
          → GET /status → { assignment: null }  (no assignment row created)
```

---

### Test 1: Normal assignment — no regression

**Goal:** Verify the re-trigger logic does not interfere with normal assignment flow.

1. Open DevTools Network tab and Console tab.
2. Log in as a premium user. The assign API (`POST /users/me/premium/assign`) fires automatically on login.
3. **Verify (Network):** `POST /users/me/premium/assign` returns `200 OK` with `assigned: true`.
4. **Verify (Console):** No `[premium-poll] Re-triggering assign` messages appear.
5. **Verify (UI):** Workspace loads and functions normally. No "scaling in progress" popup.

---

### Test 2: Assign timeout → re-trigger during polling → success (core test)

**Goal:** Verify that after the initial assign returns a retryable timeout, the polling effect re-calls `assignPremiumInstance()` and succeeds once the backend issue resolves.

#### Setup

1. Open DevTools Network tab and Console tab. **Do not log in yet.**
2. Connect to the RDS MySQL instance:
   ```
   mysql -h <RDS_HOST> -u <RDS_USER> -p <RDS_DATABASE>
   ```
3. Look up the test user's ID:
   ```sql
   SELECT id, uid FROM users WHERE email = '<test_user_email>';
   ```
4. Clear any existing assignment (test preparation):
   ```sql
   DELETE FROM premium_user_assignments WHERE user_id = <user_id>;
   ```
5. Acquire the per-user assign lock (hold with a long timeout):
   ```sql
   SELECT GET_LOCK('assign_user_<user_id>', 3600);
   -- Returns 1 if acquired
   ```

#### Execution

6. Log in as the premium user in the browser. The assign API fires automatically.
7. **Verify (Network):** `POST /users/me/premium/assign` returns within ~10-15 seconds (lock timeout 10s + overhead).
8. **Verify (Network):** Response body contains `assigned: false`, `scaling_in_progress: true`, `retry_after`.
9. **Verify (Console):** Polling starts — `"Still on temporary instance, will retry with backoff..."` appears at ~30-second intervals.
10. **Verify (Network):** `GET /users/me/premium/status` returns `assignment: null`.
11. Wait ~60 seconds after polling starts (approximately 2 poll cycles), then **release the lock** in MySQL:
    ```sql
    SELECT RELEASE_LOCK('assign_user_<user_id>');
    ```
12. **Verify (Console):** After the 3rd null-status poll, the following log appears:
    ```
    [premium-poll] Re-triggering assign after 3 null-status polls
    ```
13. **Verify (Network):** A new `POST /users/me/premium/assign` request appears (triggered from the polling loop, not from `autoAssignOnLogin`).
14. **Verify (Network):** The re-triggered assign returns `200 OK` with `assigned: true`.
15. **Verify (Console):**
    ```
    [premium-poll] Re-assign succeeded: <instance_id>
    ```
16. **Verify (Console):** Polling stops — no further `"Still on temporary instance"` messages.
17. **Verify (UI):** Workspace loads normally. No error notifications.

#### Expected Network request sequence

```
POST /users/me/premium/assign       → 200 { assigned: false, scaling_in_progress: true }
GET  /users/me/premium/status        → 200 { assignment: null }     (poll 1)
GET  /users/me/premium/status        → 200 { assignment: null }     (poll 2)
GET  /users/me/premium/status        → 200 { assignment: null }     (poll 3)
POST /users/me/premium/assign       → 200 { assigned: true }       ← RE-TRIGGER
```

---

### Test 3: MAX_POLL_ATTEMPTS exhaustion → user gesture recovery

**Goal:** Verify that after `MAX_POLL_ATTEMPTS` (40) is reached without an assignment, flags are reset and the user can recover via a mouse click or keypress — without closing the tab.

> **Note:** This test takes ~20-40 minutes at production intervals. To accelerate, temporarily change `MAX_POLL_ATTEMPTS` to `6` in the source code, rebuild the frontend, and revert after testing.

#### Setup

1. (If accelerating) Change `MAX_POLL_ATTEMPTS` to `6` in `PremiumAssignmentContext.tsx` and rebuild the frontend.
2. Follow Test 2 setup steps 1-5 (acquire lock, open DevTools).

#### Execution

3. Log in as the premium user.
4. **Keep the lock held** throughout all polling cycles.
5. **Verify (Console):** Re-trigger attempts are logged and fail (lock still held):
   ```
   [premium-poll] Re-triggering assign after 3 null-status polls
   [premium-poll] Re-assign attempt failed: <error>
   ```
6. **Verify (Console):** When `MAX_POLL_ATTEMPTS` is reached:
   ```
   Max poll attempts (6) reached. Stopping polling.
   ```
7. **Verify (UI):** Error notification: `"No premium instance available after extended wait. Please try again later or contact support."`
8. **Verify (Network):** Polling stops — no further `GET /users/me/premium/status` calls.
9. **Release the lock** in MySQL:
   ```sql
   SELECT RELEASE_LOCK('assign_user_<user_id>');
   ```
10. **Click anywhere on the page** (or press any key). The `pointerdown`/`keydown` listener detects `needsReassignAfterReleaseRef.current === true` and bumps `autoAssignGeneration`.
11. **Verify (Network):** A fresh `POST /users/me/premium/assign` request fires (from `autoAssignOnLogin` re-firing).
12. **Verify (Network):** The assign returns `200 OK` with `assigned: true`.
13. **Verify (UI):** Workspace loads normally. Error notification clears.

**Key difference from pre-fix behavior:** Before this fix, the user remained stuck until the tab was closed. Now, a single click/keypress after `MAX_POLL_ATTEMPTS` triggers recovery.

---

### Verification Checklist

| # | Test | Pass Criteria |
|---|------|---------------|
| 1 | Normal assignment | `assigned: true` on first attempt, no re-trigger logs |
| 2 | Re-trigger → success | `[premium-poll] Re-assign succeeded` appears in Console after lock release |
| 3 | MAX_POLL_ATTEMPTS → gesture | Error shown, then click/keypress triggers fresh assign that succeeds |

---

### Edge Cases (reference only — optional tests if time permits)

| Scenario | Expected Behavior | How to Verify |
|----------|-------------------|---------------|
| **Re-trigger also fails → continued polling** | If re-assign at poll 3 still returns retryable (lock held), polling continues with backoff. Next re-trigger fires at poll 6, 9, etc. | Hold lock throughout Test 2; observe re-trigger attempts at polls 3 and 6. |
| **Page refresh (F5) during polling** | `SS_HAS_ATTEMPTED` is `"true"` in sessionStorage (written at L576), so `autoAssignOnLogin` is blocked on refresh. Recovery proceeds via re-trigger during polling, or via MAX_POLL_ATTEMPTS gesture path. | Press F5 after retryable response; observe behavior. |
| **Concurrent tabs — leader-only re-trigger** | Only the elected leader tab runs polling and re-trigger. Non-leader tabs do not emit redundant `POST /assign` calls during polling. | Open Tab A and Tab B, log in; verify only one tab shows `[premium-poll] Re-triggering` logs. |
| **Free-tier user** | No `POST /assign` triggered. No `[premium-poll]` console messages. Workspace loads normally. | Log in as free-tier user; inspect Network and Console. |

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | +47 lines (constant, re-trigger logic in polling, flag reset at MAX_POLL_ATTEMPTS) |

## References

| PR/Issue | Title | Relevance |
|----------|-------|-----------|
| [#699](https://github.com/arayabrain/araya-optinist/issues/699) | Frontend does not re-trigger assign after assign API timeout | This issue |
| [#658](https://github.com/arayabrain/araya-optinist/pull/658) | Fix concurrent premium assign race condition (ALB corruption) | Source of the Known Issue |
| [#656](https://github.com/arayabrain/araya-optinist/pull/656) | Fix: Premium Instance Re-assignment After Inactivity Release | Introduced `needsReassignAfterReleaseRef` mechanism reused here |
| [#630](https://github.com/arayabrain/araya-optinist/issues/630) | Concurrent assign ALB corruption | Fixed by PR #658 |
