### PR TITLE
Fix Stale Routing-ID in localStorage Gives 403

### DIFF
--- a/frontend/src/store/slice/User/UserSlice.ts
+++ b/frontend/src/store/slice/User/UserSlice.ts
@@ -86,6 +86,11 @@ export const userSlice = createSlice({
       .addMatcher(
         isAnyOf(login.fulfilled, proxyLogin.fulfilled),
         (_, action) => {
+          // Clear stale routing state BEFORE saving new tokens.
+          // Prevents a new session from inheriting routing-id/premium_assigned
+          // from a prior premium session that did not log out cleanly (#659).
+          routingService.clearRoutingInfo()
+
           saveToken(action.payload.access_token)
           saveRefreshToken(action.payload.refresh_token)
           saveExToken(action.payload.ex_token)

--- a/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
+++ b/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
@@ -247,6 +247,36 @@ describe("UserSlice", () => {
       expect(clearOrder).toBeLessThan(saveOrder)
     })
   })
+
+  describe("proxyLogin.fulfilled", () => {
+    // proxyLogin currently shares the same action type as login
+    // ("user/login"), so this test exercises the same isAnyOf matcher.
+    // An explicit test ensures coverage remains visible if the action
+    // types diverge in the future.
+    const proxyLoginFulfilledAction = {
+      type: "user/login/fulfilled",
+      payload: {
+        access_token: "proxy_access_token",
+        refresh_token: "proxy_refresh_token",
+        ex_token: "proxy_ex_token",
+      },
+    }
+
+    it("should clear routing info before saving new tokens", () => {
+      const state = userSlice.reducer(undefined, { type: "@@INIT" })
+
+      userSlice.reducer(state, proxyLoginFulfilledAction)
+
+      expect(mockClearRoutingInfo).toHaveBeenCalledTimes(1)
+      expect(mockSaveToken).toHaveBeenCalledWith("proxy_access_token")
+      expect(mockSaveRefreshToken).toHaveBeenCalledWith("proxy_refresh_token")
+      expect(mockSaveExToken).toHaveBeenCalledWith("proxy_ex_token")
+
+      const clearOrder = mockClearRoutingInfo.mock.invocationCallOrder[0]
+      const saveOrder = mockSaveToken.mock.invocationCallOrder[0]
+      expect(clearOrder).toBeLessThan(saveOrder)
+    })
+  })
 })
 
 describe("selectLogoutGeneration", () => {

--- a/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
+++ b/frontend/src/store/slice/User/__tests__/UserSlice.test.ts
@@ -218,6 +218,35 @@ describe("UserSlice", () => {
       expect(mockClearRoutingInfo).not.toHaveBeenCalled()
     })
   })
+
+  describe("login.fulfilled", () => {
+    const loginFulfilledAction = {
+      type: "user/login/fulfilled",
+      payload: {
+        access_token: "new_access_token",
+        refresh_token: "new_refresh_token",
+        ex_token: "new_ex_token",
+      },
+    }
+
+    it("should clear routing info before saving new tokens", () => {
+      const state = userSlice.reducer(undefined, { type: "@@INIT" })
+
+      userSlice.reducer(state, loginFulfilledAction)
+
+      // clearRoutingInfo must be called
+      expect(mockClearRoutingInfo).toHaveBeenCalledTimes(1)
+      // tokens must be saved
+      expect(mockSaveToken).toHaveBeenCalledWith("new_access_token")
+      expect(mockSaveRefreshToken).toHaveBeenCalledWith("new_refresh_token")
+      expect(mockSaveExToken).toHaveBeenCalledWith("new_ex_token")
+
+      // clearRoutingInfo must be called BEFORE saveToken
+      const clearOrder = mockClearRoutingInfo.mock.invocationCallOrder[0]
+      const saveOrder = mockSaveToken.mock.invocationCallOrder[0]
+      expect(clearOrder).toBeLessThan(saveOrder)
+    })
+  })
 })
 
 describe("selectLogoutGeneration", () => {

--- a/studio/app/common/core/middleware/secure_routing_middleware.py
+++ b/studio/app/common/core/middleware/secure_routing_middleware.py
@@ -262,12 +262,11 @@ class SecureRoutingMiddleware:
         tier = get_user_tier_cached(uid)
 
         # Validate routing ID if present in request (detect header spoofing).
-        # Only enforce for premium users — the server only emits x-routing-id
-        # for premium tier, so validation is symmetric.  A free user carrying
-        # a stale header from a prior premium session is harmlessly ignored;
-        # the header conveys no routing authority for the free tier.
+        # Unconditional for all tiers — prevents a free-tier caller from
+        # attaching a stolen premium routing_id and being routed to a
+        # premium-dedicated instance by the ALB.
         routing_id_header = headers.get(b"x-routing-id", b"").decode()
-        if routing_id_header and tier == TIER_PREMIUM:
+        if routing_id_header:
             expected_routing_id = generate_routing_id(uid, ROUTING_SECRET_KEY)
             if routing_id_header != expected_routing_id:
                 logger.warning(

--- a/studio/app/common/core/middleware/secure_routing_middleware.py
+++ b/studio/app/common/core/middleware/secure_routing_middleware.py
@@ -31,7 +31,11 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from studio.app.common.core.auth.auth_helper import extract_uid_from_firebase_jwt
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.middleware.constants import SKIP_AUTH_PATHS
-from studio.app.common.core.middleware.user_activity_middleware import _get_instance_id
+from studio.app.common.core.middleware.user_activity_middleware import (
+    TIER_FREE,
+    TIER_PREMIUM,
+    _get_instance_id,
+)
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.subscription.constants import SubscriptionPlanIds
 
@@ -170,15 +174,19 @@ def get_user_tier_cached(uid: str) -> str:
         try:
             user = db.query(User).filter(User.uid == uid).first()
             if not user:
-                return "free"
+                return TIER_FREE
 
             # Check if user has active subscription
             subscription_data = SubscriptionService.get_user_subscription(db, user.id)
             if subscription_data:
                 _, plan = subscription_data
-                tier = "premium" if plan.id == SubscriptionPlanIds.PREMIUM else "free"
+                tier = (
+                    TIER_PREMIUM
+                    if plan.id == SubscriptionPlanIds.PREMIUM
+                    else TIER_FREE
+                )
             else:
-                tier = "free"
+                tier = TIER_FREE
 
             # Update cache
             _tier_cache[uid] = (tier, current_time)
@@ -187,7 +195,7 @@ def get_user_tier_cached(uid: str) -> str:
             db.close()
     except Exception as e:
         logger.warning(f"Failed to query user tier for {uid}: {e}")
-        return "free"
+        return TIER_FREE
 
 
 class SecureRoutingMiddleware:
@@ -253,9 +261,13 @@ class SecureRoutingMiddleware:
         # Get tier with caching
         tier = get_user_tier_cached(uid)
 
-        # Validate routing ID if present in request (detect header spoofing)
+        # Validate routing ID if present in request (detect header spoofing).
+        # Only enforce for premium users — the server only emits x-routing-id
+        # for premium tier, so validation is symmetric.  A free user carrying
+        # a stale header from a prior premium session is harmlessly ignored;
+        # the header conveys no routing authority for the free tier.
         routing_id_header = headers.get(b"x-routing-id", b"").decode()
-        if routing_id_header:
+        if routing_id_header and tier == TIER_PREMIUM:
             expected_routing_id = generate_routing_id(uid, ROUTING_SECRET_KEY)
             if routing_id_header != expected_routing_id:
                 logger.warning(
@@ -284,7 +296,7 @@ class SecureRoutingMiddleware:
                 headers.append((b"x-user-tier", tier.encode()))
 
                 # Only add routing ID for premium users
-                if tier == "premium":
+                if tier == TIER_PREMIUM:
                     routing_id = generate_routing_id(uid, ROUTING_SECRET_KEY)
                     headers.append((b"x-routing-id", routing_id.encode()))
 

--- a/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
@@ -410,9 +410,10 @@ class TestRoutingIDValidation:
                     assert sent_messages[0]["status"] == 403
 
     @pytest.mark.asyncio
-    async def test_stale_routing_id_ignored_for_free_user(self):
-        """Test that a free-tier user carrying a stale x-routing-id is NOT
-        rejected — the header is harmlessly ignored (defense-in-depth for #659)."""
+    async def test_mismatched_routing_id_rejected_for_free_user(self):
+        """A free-tier user sending a mismatched x-routing-id (e.g. stolen
+        from a premium user) must be rejected with 403.  Unconditional
+        validation prevents tier-bypass via ALB header spoofing."""
         from studio.app.common.core.middleware.secure_routing_middleware import (
             SecureRoutingMiddleware,
         )
@@ -426,7 +427,7 @@ class TestRoutingIDValidation:
             "path": "/api/test",
             "headers": [
                 (b"authorization", b"Bearer " + TEST_JWT_TOKEN.encode()),
-                (b"x-routing-id", b"stale_premium_routing_id"),
+                (b"x-routing-id", b"stolen_premium_routing_id"),
             ],
         }
 
@@ -434,9 +435,6 @@ class TestRoutingIDValidation:
 
         async def mock_send(message):
             sent_messages.append(message)
-
-        async def mock_receive():
-            return {"type": "http.request"}
 
         with patch.object(MODE, "IS_STANDALONE", False):
             with patch(
@@ -450,22 +448,11 @@ class TestRoutingIDValidation:
                     "get_user_tier_cached",
                     return_value=TEST_TIER_FREE,
                 ):
-                    # Mock the app to send a 200 response
-                    async def mock_app_impl(scope, receive, send):
-                        await send(
-                            {
-                                "type": "http.response.start",
-                                "status": 200,
-                                "headers": [],
-                            }
-                        )
+                    await middleware(scope, AsyncMock(), mock_send)
 
-                    middleware.app = mock_app_impl
-                    await middleware(scope, mock_receive, mock_send)
-
-                    # Should pass through (200), NOT be rejected (403)
-                    assert len(sent_messages) == 1
-                    assert sent_messages[0]["status"] == 200
+                    # Must be rejected with 403 — unconditional validation
+                    assert len(sent_messages) == 2
+                    assert sent_messages[0]["status"] == 403
 
     @pytest.mark.asyncio
     async def test_mismatched_routing_id_still_rejected_for_premium(self):

--- a/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_secure_routing_middleware.py
@@ -409,6 +409,108 @@ class TestRoutingIDValidation:
                     assert len(sent_messages) == 2
                     assert sent_messages[0]["status"] == 403
 
+    @pytest.mark.asyncio
+    async def test_stale_routing_id_ignored_for_free_user(self):
+        """Test that a free-tier user carrying a stale x-routing-id is NOT
+        rejected — the header is harmlessly ignored (defense-in-depth for #659)."""
+        from studio.app.common.core.middleware.secure_routing_middleware import (
+            SecureRoutingMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = SecureRoutingMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/api/test",
+            "headers": [
+                (b"authorization", b"Bearer " + TEST_JWT_TOKEN.encode()),
+                (b"x-routing-id", b"stale_premium_routing_id"),
+            ],
+        }
+
+        sent_messages = []
+
+        async def mock_send(message):
+            sent_messages.append(message)
+
+        async def mock_receive():
+            return {"type": "http.request"}
+
+        with patch.object(MODE, "IS_STANDALONE", False):
+            with patch(
+                "studio.app.common.core.middleware.secure_routing_middleware."
+                "extract_uid_from_firebase_jwt"
+            ) as mock_extract:
+                mock_extract.return_value = (TEST_UID, None)
+
+                with patch(
+                    "studio.app.common.core.middleware.secure_routing_middleware."
+                    "get_user_tier_cached",
+                    return_value=TEST_TIER_FREE,
+                ):
+                    # Mock the app to send a 200 response
+                    async def mock_app_impl(scope, receive, send):
+                        await send(
+                            {
+                                "type": "http.response.start",
+                                "status": 200,
+                                "headers": [],
+                            }
+                        )
+
+                    middleware.app = mock_app_impl
+                    await middleware(scope, mock_receive, mock_send)
+
+                    # Should pass through (200), NOT be rejected (403)
+                    assert len(sent_messages) == 1
+                    assert sent_messages[0]["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_mismatched_routing_id_still_rejected_for_premium(self):
+        """Regression: premium users with mismatched routing IDs must still
+        be rejected with 403."""
+        from studio.app.common.core.middleware.secure_routing_middleware import (
+            SecureRoutingMiddleware,
+        )
+        from studio.app.common.core.mode import MODE
+
+        mock_app = AsyncMock()
+        middleware = SecureRoutingMiddleware(app=mock_app)
+
+        scope = {
+            "type": "http",
+            "path": "/api/test",
+            "headers": [
+                (b"authorization", b"Bearer " + TEST_JWT_TOKEN.encode()),
+                (b"x-routing-id", b"wrong_routing_id"),
+            ],
+        }
+
+        sent_messages = []
+
+        async def mock_send(message):
+            sent_messages.append(message)
+
+        with patch.object(MODE, "IS_STANDALONE", False):
+            with patch(
+                "studio.app.common.core.middleware.secure_routing_middleware."
+                "extract_uid_from_firebase_jwt"
+            ) as mock_extract:
+                mock_extract.return_value = (TEST_UID, None)
+
+                with patch(
+                    "studio.app.common.core.middleware.secure_routing_middleware."
+                    "get_user_tier_cached",
+                    return_value=TEST_TIER_PREMIUM,
+                ):
+                    await middleware(scope, AsyncMock(), mock_send)
+
+                    # Should be rejected with 403
+                    assert len(sent_messages) == 2
+                    assert sent_messages[0]["status"] == 403
+
 
 class TestCacheInvalidation:
     """Test cache invalidation on subscription changes"""


### PR DESCRIPTION
## Summary

Clear stale routing state (`routing_id`, `routing_tier`, `premium_assigned`, `premium_instance_id`) from localStorage on successful login, preventing a new session from inheriting a prior premium session's routing headers.

### Version History

| Version | Description |
|---------|-------------|
| v1 | Initial implementation: Fix 1 (frontend clear) + Fix 2 (backend tier-gated validation) |
| v2 | Address [reviewer feedback](https://github.com/arayabrain/araya-optinist/pull/702#issuecomment-4777815284): revert Fix 2, restore unconditional routing-ID validation |

## Root Cause

`login.fulfilled` does not clear stale routing state from `localStorage`. When a free user signs in on a browser that previously held a premium session (without a clean logout), stale routing headers cause a 403 loop:

1. User A (premium) signs in — `routing_id` + `premium_assigned=true` stored in localStorage
2. Tab closed without logout — localStorage retains stale state
3. User B (free) signs in on same browser
4. `login.fulfilled` fires — tokens saved, routing state NOT cleared
5. `RoutingService` constructor loaded stale `routing_id` + `premium_assigned=true` from localStorage
6. `getRoutingHeaders()` attaches stale `x-routing-id` to every request
7. `SecureRoutingMiddleware` computes `expected = HMAC(SECRET, user_B_uid)`, got stale `HMAC(SECRET, user_A_uid)` — mismatch — 403
8. `/users/me` 403 — bootstrap stalls — UI stuck on login screen

---

## Changed Files

### Frontend: Clear routing state on successful login

**File:** `frontend/src/store/slice/User/UserSlice.ts`

Added `routingService.clearRoutingInfo()` call in the `isAnyOf(login.fulfilled, proxyLogin.fulfilled)` matcher, **before** saving new tokens:

```typescript
.addMatcher(
  isAnyOf(login.fulfilled, proxyLogin.fulfilled),
  (_, action) => {
    // Clear stale routing state BEFORE saving new tokens.
    // Prevents a new session from inheriting routing-id/premium_assigned
    // from a prior premium session that did not log out cleanly (#659).
    routingService.clearRoutingInfo()

    saveToken(action.payload.access_token)
    saveRefreshToken(action.payload.refresh_token)
    saveExToken(action.payload.ex_token)
  },
)
```

**Rationale:** `clearRoutingInfo()` removes `routing_id`, `routing_tier`, `premium_assigned`, and `premium_instance_id` from localStorage and resets in-memory state. This is the same method already called on logout (line 54). Calling it before saving new tokens guarantees a clean session boundary regardless of how the previous session ended.

The `getMe.fulfilled` handler (line 67) immediately follows login and calls `routingService.updateRoutingInfo(user)`, which correctly repopulates the tier for the new user. Premium users will get fresh routing state from the `PremiumAssignmentContext` assignment flow.

### Backend: Routing-ID validation (unconditional)

**File:** `studio/app/common/core/middleware/secure_routing_middleware.py`

The existing unconditional routing-ID validation is retained:

```python
# Validate routing ID if present in request (detect header spoofing).
# Unconditional for all tiers — prevents a free-tier caller from
# attaching a stolen premium routing_id and being routed to a
# premium-dedicated instance by the ALB.
routing_id_header = headers.get(b"x-routing-id", b"").decode()
if routing_id_header:
    expected_routing_id = generate_routing_id(uid, ROUTING_SECRET_KEY)
    if routing_id_header != expected_routing_id:
        # ... 403 response ...
```

> **v1→v2 note:** v1 changed this to `if routing_id_header and tier == TIER_PREMIUM:` (tier-gated, intended as defense-in-depth). Reviewer [identified this as a security regression](https://github.com/arayabrain/araya-optinist/pull/702#issuecomment-4777815284) — skipping validation for free-tier callers opens a tier-bypass exploit path where a free user with a stolen premium `routing_id` can reach a premium-dedicated instance via ALB header spoofing. Reverted in v2. The frontend fix alone resolves the UX bug; unconditional validation preserves the anti-spoofing control.

### Additional cleanup (both versions)

- Replaced string literals `"free"` / `"premium"` with `TIER_FREE` / `TIER_PREMIUM` constants in `get_user_tier_cached` and `send_wrapper`

---

## Automated Test Cases

### Backend: `TestRoutingIDValidation` (2 new tests)

| # | Test | Description | Expected |
|---|------|-------------|----------|
| 1 | `test_mismatched_routing_id_rejected_for_free_user` | Free-tier user sending a mismatched `x-routing-id` | 403 |
| 2 | `test_mismatched_routing_id_still_rejected_for_premium` | Premium user with mismatched `x-routing-id` | 403 |

> **v1→v2 note:** v1 had `test_stale_routing_id_ignored_for_free_user` (expected 200). Replaced in v2 with `test_mismatched_routing_id_rejected_for_free_user` (expected 403) to match restored unconditional validation.

Existing tests serving as regression coverage:

| # | Test | Description |
|---|------|-------------|
| 3 | `test_valid_routing_id_accepted` | Premium user with valid `x-routing-id` passes through |
| 4 | `test_invalid_routing_id_logged` | Premium user with invalid `x-routing-id` is rejected with 403 and warning logged |

### Frontend: `UserSlice.test.ts` (2 new tests)

| # | Test | Description |
|---|------|-------------|
| 1 | `login.fulfilled > should clear routing info before saving new tokens` | Verifies `clearRoutingInfo()` is called exactly once, tokens are saved, and `clearRoutingInfo()` is called BEFORE `saveToken()` (call order assertion) |
| 2 | `proxyLogin.fulfilled > should clear routing info before saving new tokens` | Same verification for `proxyLogin` path |

---

## Test Results

```
Backend middleware:     30 passed
Frontend UserSlice:    15 passed
```

All tests pass. No regressions.

---

## Manual Test Plan

### Prerequisites

- Two test user accounts: one with an active premium subscription, one free-tier
- Browser DevTools open (Network tab, Console tab, Application tab)
- Network tab "Preserve log" enabled
- Access to CloudWatch Logs for the backend ECS tasks. The routing-ID validation runs in `SecureRoutingMiddleware` on whichever ECS task receives the request, and the ALB routes different paths to different target groups:
  - `/ecs/{env}-optinist-cloud-taskdef` (free tier) — endpoints that match the ALB Bearer catch-all rule (p320), e.g., `GET /is_standalone`
  - `/ecs/{env}-public-optinist-cloud-taskdef` (public tier) — endpoints with explicit ALB path rules, e.g., `GET /users/me` (p306), `POST /auth/login` (p305)

### Test 1: Primary repro — premium session closed without logout, then free user login (core fix)

**Objective:** Verify the exact scenario from issue #659 — a free user signing in after a premium user (on the same browser, without logout) no longer gets 403 on every request.

**Scope:** The frontend fix prevents the stale header from being sent, so the backend's unconditional validation is never triggered.

**Note on session persistence:** Closing a tab without logging out leaves both routing state and auth tokens in localStorage. If you navigate back to the app, the existing session is still valid and the login page will not be displayed. Step 2 below manually removes auth tokens (simulating token expiry) while preserving the stale routing state, so that the login page is accessible for signing in as a different user.

#### Step 1: Establish stale routing state from a premium session

1. Open a fresh browser tab (or clear localStorage for the application origin).
2. Open DevTools **Application** tab > **Local Storage** > select the application origin.
3. Log in as the **premium** user.
4. Wait for the premium assignment flow to complete (Network tab shows `POST /users/me/premium/assign` returning 200).
5. **Verify** in the Application tab:
   - `routing_id` exists and contains a 16-character hex string
   - `premium_assigned` is `"true"`
   - `routing_tier` is `"premium"`
6. **Close the tab** (or quit the browser) **without** clicking Logout.
   - Do NOT use the Logout button. The purpose of this step is to leave stale routing state in localStorage.

#### Step 2: Clear auth tokens while preserving stale routing state

Closing the tab without logout leaves the premium user's session (auth tokens) intact. Navigating back to the app would auto-authenticate as the premium user instead of showing the login page. This step simulates a scenario where the auth session has expired but stale routing state remains — which is the actual trigger condition for issue #659.

1. Open a new tab and navigate to the application's top page (`https://.../`). The page content does not matter — this step only needs the browser to be on the correct origin so that DevTools can access its localStorage.
2. Open DevTools **Console** tab.
3. Remove auth tokens only (leave routing state untouched):
   ```js
   localStorage.removeItem("access_token")
   localStorage.removeItem("refresh_token")
   localStorage.removeItem("ExToken")
   ```
4. **Verify** that stale routing state is still present:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   console.log("routing_tier:", localStorage.getItem("routing_tier"))
   ```
   - **Expected:** `routing_id` contains the premium user's hex value, `premium_assigned` is `"true"`, `routing_tier` is `"premium"`.
5. Refresh the page (F5 or Ctrl+R).
   - **Verify:** The application redirects to the login page (session invalidated).

#### Step 3: Sign in as a free user on the same browser

1. Open DevTools **Network** tab with "Preserve log" enabled.
2. Open DevTools **Console** tab in a separate panel (or side-by-side).
3. Log in as the **free** user.

#### Step 4: Verify login succeeds

1. In the Network tab, locate `POST /auth/login`.
   - **Verify:** Status is `200 OK`.
2. Locate `GET /users/me` immediately following the login.
   - **Verify:** Status is `200 OK` (NOT 403).
   - **Before this fix:** This request returned 403, and the UI would hang on the login screen.
3. **Verify:** The application navigates to the dashboard/home page normally.

#### Step 5: Verify stale routing state was cleared

1. In the Console tab, run:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   console.log("routing_tier:", localStorage.getItem("routing_tier"))
   console.log("premium_instance_id:", localStorage.getItem("premium_instance_id"))
   ```
2. **Verify:**
   - `routing_id` is `null`
   - `premium_assigned` is `null` or `"false"`
   - `routing_tier` is `"free"` (repopulated by `getMe.fulfilled` > `updateRoutingInfo`)
   - `premium_instance_id` is `null`

#### Step 6: Verify no routing-ID mismatch in backend logs

1. In CloudWatch Logs, search for `"Routing ID mismatch"` entries within the time window of the test in **both** log groups (replace `{env}` with the environment name, e.g., `development`, `subscr`):
   - `/ecs/{env}-optinist-cloud-taskdef` (free tier)
   - `/ecs/{env}-public-optinist-cloud-taskdef` (public tier)
2. **Verify:** No mismatch warnings appear for the free user's requests in either log group.

**Pass criteria:** All of Steps 4-6 pass. Free user can sign in normally after a premium session ended without logout.

---

### Test 2: Premium user login still works after the fix (regression check)

**Objective:** Verify that the `clearRoutingInfo()` call on `login.fulfilled` does not break the premium login flow. After clearing, the premium assignment context must repopulate all routing state.

#### Step 1: Clean state

1. If currently signed in, log out completely (click the Logout button).
2. In the Console tab, verify localStorage is clean:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   ```
   - **Expected:** `null`

#### Step 2: Sign in as a premium user

1. Open DevTools Network tab with "Preserve log" enabled.
2. Log in as the **premium** user.

#### Step 3: Verify the login and assignment flow

1. In the Network tab:
   - **Verify:** `POST /auth/login` returns `200 OK`.
   - **Verify:** `GET /users/me` returns `200 OK`.
   - **Verify:** `POST /users/me/premium/assign` returns `200 OK`.
2. In the Console tab, run:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   console.log("routing_tier:", localStorage.getItem("routing_tier"))
   ```
3. **Verify:**
   - `routing_id` contains a 16-character hex string (freshly generated for this user)
   - `premium_assigned` is `"true"`
   - `routing_tier` is `"premium"`

#### Step 4: Verify premium routing is functional

1. Navigate to any workflow page or trigger an API request.
2. In the Network tab, select any API request and inspect the **Response Headers**:
   - **Verify:** `x-user-tier` header is `premium`.
   - **Verify:** `x-routing-id` header is present (16-char hex).
   - **Verify:** `x-served-by-instance` header is present (16-char hex).
3. **Verify:** The "Premium instance unresponsive" snackbar does NOT appear.

**Pass criteria:** All steps pass. The `clearRoutingInfo()` on login is transparent to the premium assignment flow.

---

### Test 3: Anti-spoofing — free user with manually injected routing-ID is rejected

**Objective:** Verify that the backend rejects a spoofed `x-routing-id` regardless of the caller's tier, preventing tier-bypass via ALB header spoofing.

**Note:** Under normal operation, the frontend will never send a stale header (cleared by Fix 1). This scenario simulates an attacker or a polluted localStorage state.

> **v1→v2 note:** In v1, this test expected 200 (free users skipped validation). In v2, the expected result is 403 (unconditional validation restored).

#### Step 1: Sign in as a free user

1. Log in as the **free** user.
2. **Verify:** `GET /users/me` returns `200 OK`.
3. **Verify:** In the Console tab:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   ```
   - **Expected:** `routing_id` is `null`, `premium_assigned` is `null` or `"false"`.

#### Step 2: Manually inject stale routing state

1. In the Console tab, inject stale values:
   ```js
   localStorage.setItem("routing_id", "aaaa1111bbbb2222")
   localStorage.setItem("premium_assigned", "true")
   ```
2. **Refresh the page** (F5 or Ctrl+R).
   - This forces `RoutingService` to load the polluted values from localStorage in its constructor.

#### Step 3: Verify API calls are rejected

1. In the Network tab, observe the requests made during page load.
2. Select any authenticated API request (e.g., `GET /users/me`) and inspect the **Request Headers**:
   - **Verify:** `x-routing-id` header is present with value `aaaa1111bbbb2222` (the injected stale value).
3. **Verify:** The response status is `403 Forbidden`.
   - The middleware validates `x-routing-id` unconditionally for all tiers. `HMAC(free_user_uid) != "aaaa1111bbbb2222"` → mismatch → 403.
4. **Verify:** In CloudWatch Logs, a `"Routing ID mismatch"` warning appears for this request. The log group depends on which endpoint returned 403 (ALB routes each path to a different target group):
   - `GET /users/me` → `/ecs/{env}-public-optinist-cloud-taskdef` (public tier, ALB path rule p306)
   - Other endpoints (e.g., `GET /is_standalone`) → `/ecs/{env}-optinist-cloud-taskdef` (free tier, ALB Bearer catch-all p320)

#### Step 4: Cleanup

1. In the Console tab, clear the injected values:
   ```js
   localStorage.removeItem("routing_id")
   localStorage.removeItem("premium_assigned")
   ```
2. Refresh the page. Verify normal free-tier operation resumes (the login page may appear due to the 403 clearing the session — log in again if needed).

**Pass criteria:** Step 3 passes. The backend rejects the injected stale header with 403 for free-tier users.

---

## Checklist

- [ ] **Test 1**: Free user login after premium session without logout — no 403, stale state cleared
- [ ] **Test 2**: Premium user login still works (regression)
- [ ] **Test 3**: Anti-spoofing — free user with injected stale header gets 403

---

## Risk Assessment

| Fix | Blast radius | Risk | Mitigation |
|-----|-------------|------|------------|
| Frontend clear on login | Login path only | **Low** — `clearRoutingInfo()` is already called on logout with no issues; calling it on login is the symmetric operation | Test 2 validates premium login is unaffected |
| Backend unconditional validation | All authenticated requests with `x-routing-id` | **Low** — behaviour is unchanged from pre-PR baseline; frontend fix prevents stale headers from being sent | Existing tests + `test_mismatched_routing_id_rejected_for_free_user` cover regression paths |

**Combined risk:** Low. The frontend fix resolves the user-facing bug. The backend validation is unchanged from the pre-PR baseline, preserving the existing anti-spoofing control.

---

## Key Files

| File | Role |
|------|------|
| `frontend/src/store/slice/User/UserSlice.ts` | Redux slice: login/logout reducers, token management |
| `frontend/src/utils/routing/RoutingService.ts` | Premium routing header management, localStorage persistence |
| `frontend/src/utils/auth/AuthUtils.ts` | Token save/remove utilities, logout cleanup |
| `studio/app/common/core/middleware/secure_routing_middleware.py` | ASGI middleware: routing header injection/validation |
| `frontend/src/store/slice/User/__tests__/UserSlice.test.ts` | Frontend unit tests |
| `studio/tests/app/common/core/middleware/test_secure_routing_middleware.py` | Backend unit tests |
