### PR TITLE
Fix Stale Routing Token After Premium Auto-Reassign

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -617,9 +617,7 @@ export const PremiumAssignmentProvider: React.FC<{
       assignmentResult: null,
       statusResult: null,
     }))
-    routingService.setPremiumAssigned(false)
-    routingService.setPremiumInstanceId(null)
-    routingService.clearRoutingToken()
+    routingService.resetForRelease()
   }, [])
 
   // Inactivity monitoring for premium users
@@ -718,7 +716,12 @@ export const PremiumAssignmentProvider: React.FC<{
         assignmentResult: null,
         statusResult: null,
       }))
-      routingService.clearRoutingToken()
+      // Mirror the same-tab release path: clear assigned flag, instance ID,
+      // and token together. Without setPremiumAssigned(false), this tab's
+      // in-memory RoutingService stays premiumAssigned=true with token=null
+      // — an unrecoverable state where the interceptor guard blocks
+      // re-seeding and getRoutingHeaders() returns {}.
+      routingService.resetForRelease()
       // Allow this tab to reassign on next user gesture.
       hasAttemptedRef.current = false
       ssRemove(SS_HAS_ATTEMPTED)

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -619,6 +619,7 @@ export const PremiumAssignmentProvider: React.FC<{
     }))
     routingService.setPremiumAssigned(false)
     routingService.setPremiumInstanceId(null)
+    routingService.clearRoutingToken()
   }, [])
 
   // Inactivity monitoring for premium users
@@ -717,6 +718,7 @@ export const PremiumAssignmentProvider: React.FC<{
         assignmentResult: null,
         statusResult: null,
       }))
+      routingService.clearRoutingToken()
       // Allow this tab to reassign on next user gesture.
       hasAttemptedRef.current = false
       ssRemove(SS_HAS_ATTEMPTED)

--- a/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
@@ -369,8 +369,10 @@ describe("PremiumAssignmentProvider — inactivity re-assignment", () => {
       expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
     })
 
-    // Pre-seed routing token.
+    // Pre-seed routing state as it would be in production after assignment.
     localStorage.setItem("routing_id", "d0250e94fae8595c")
+    localStorage.setItem("premium_assigned", "true")
+    localStorage.setItem("premium_instance_id", "inst-hash-A")
 
     // Simulate receiving a PREMIUM_RELEASED broadcast from another tab.
     act(() => {
@@ -378,7 +380,11 @@ describe("PremiumAssignmentProvider — inactivity re-assignment", () => {
     })
 
     expect(ctxRef.current?.assignmentResult).toBeNull()
-    // Routing token must be cleared by the cross-tab handler.
+    // resetForRelease() must clear all three: token, assigned flag, and instance ID.
+    // Without this, the receiving tab enters (premiumAssigned=true, token=null)
+    // — an unrecoverable deadlock where the interceptor guard blocks re-seeding.
     expect(localStorage.getItem("routing_id")).toBeNull()
+    expect(localStorage.getItem("premium_assigned")).toBe("false")
+    expect(localStorage.getItem("premium_instance_id")).toBeNull()
   })
 })

--- a/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
@@ -331,4 +331,54 @@ describe("PremiumAssignmentProvider — inactivity re-assignment", () => {
     // The DOM clicks must NOT have caused additional /assign calls.
     expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
   })
+
+  test("auto-release clears the routing token from localStorage (issue #605)", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Pre-seed routing token (the mocked APIs don't go through the real
+    // axios interceptor, so we simulate the token being set as it would
+    // be in production after the first premium-routed response).
+    localStorage.setItem("routing_id", "d0250e94fae8595c")
+
+    // Fast-forward 2h to trigger auto-release.
+    await act(async () => {
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000 + 5000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+
+    // Routing token must be cleared on release to prevent stale reuse.
+    expect(localStorage.getItem("routing_id")).toBeNull()
+  })
+
+  test("cross-tab PREMIUM_RELEASED clears routing token from localStorage (issue #605)", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Pre-seed routing token.
+    localStorage.setItem("routing_id", "d0250e94fae8595c")
+
+    // Simulate receiving a PREMIUM_RELEASED broadcast from another tab.
+    act(() => {
+      firePremiumReleased()
+    })
+
+    expect(ctxRef.current?.assignmentResult).toBeNull()
+    // Routing token must be cleared by the cross-tab handler.
+    expect(localStorage.getItem("routing_id")).toBeNull()
+  })
 })

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -41,6 +41,7 @@ const mockEmitPremiumReachable = jest.fn<
   [{ url?: string; status?: number; sentAt?: number }]
 >()
 const mockGetPremiumInstanceId = jest.fn<string | null, []>(() => null)
+const mockIsPremiumAssigned = jest.fn<boolean, []>(() => false)
 
 const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
   () => false,
@@ -66,6 +67,7 @@ jest.mock("utils/routing/RoutingService", () => ({
     emitPremiumUnreachable: mockEmitPremiumUnreachable,
     emitPremiumReachable: mockEmitPremiumReachable,
     getPremiumInstanceId: mockGetPremiumInstanceId,
+    isPremiumAssigned: mockIsPremiumAssigned,
   },
 }))
 
@@ -432,5 +434,82 @@ describe("axios premium-routing interceptors", () => {
     expect(recorded).toHaveLength(2)
     const retryConfig = recorded[1].config as Record<string, unknown>
     expect(retryConfig._outgoingInstanceId).toBeUndefined()
+  })
+
+  // --- Routing token update guard tests (Issue #605) ---
+
+  it("updates routing token when premiumAssigned is false (initial token seeding)", async () => {
+    mockIsPremiumAssigned.mockReturnValue(false)
+    mockGetRoutingHeaders.mockReturnValue({})
+
+    responses.set("/seed", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "new-token-from-public" },
+    })
+    await axiosInstance.get("/seed")
+
+    expect(mockUpdateRoutingToken).toHaveBeenCalledWith("new-token-from-public")
+  })
+
+  it("does NOT update routing token when premiumAssigned is true and instance is unverified", async () => {
+    // Simulates the stale-token overwrite scenario: premiumAssigned=true
+    // but the response came from the free/public tier (no premium headers
+    // sent, or instance mismatch).
+    mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingHeaders.mockReturnValue({})
+
+    responses.set("/free-tier", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "token-from-free-tier" },
+    })
+    await axiosInstance.get("/free-tier")
+
+    expect(mockUpdateRoutingToken).not.toHaveBeenCalled()
+  })
+
+  it("updates routing token when premiumAssigned is true and instance is verified", async () => {
+    mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+
+    responses.set("/premium-ok", {
+      status: 200,
+      data: {},
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "expected-instance-hash",
+      },
+    })
+    await axiosInstance.get("/premium-ok")
+
+    expect(mockUpdateRoutingToken).toHaveBeenCalledWith("rid-outgoing")
+  })
+
+  it("does NOT update routing token when premiumAssigned is true and instance hash mismatches", async () => {
+    // Premium headers were sent but the response came from a different
+    // instance (ALB fallback to shared backend).
+    mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+
+    responses.set("/wrong-instance", {
+      status: 200,
+      data: {},
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "different-instance-hash",
+      },
+    })
+    await axiosInstance.get("/wrong-instance")
+
+    expect(mockUpdateRoutingToken).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -42,6 +42,7 @@ const mockEmitPremiumReachable = jest.fn<
 >()
 const mockGetPremiumInstanceId = jest.fn<string | null, []>(() => null)
 const mockIsPremiumAssigned = jest.fn<boolean, []>(() => false)
+const mockGetRoutingToken = jest.fn<string | null, []>(() => null)
 
 const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
   () => false,
@@ -68,6 +69,7 @@ jest.mock("utils/routing/RoutingService", () => ({
     emitPremiumReachable: mockEmitPremiumReachable,
     getPremiumInstanceId: mockGetPremiumInstanceId,
     isPremiumAssigned: mockIsPremiumAssigned,
+    getRoutingToken: mockGetRoutingToken,
   },
 }))
 
@@ -452,11 +454,12 @@ describe("axios premium-routing interceptors", () => {
     expect(mockUpdateRoutingToken).toHaveBeenCalledWith("new-token-from-public")
   })
 
-  it("does NOT update routing token when premiumAssigned is true and instance is unverified", async () => {
+  it("does NOT update routing token when premiumAssigned is true, token is present, and instance is unverified", async () => {
     // Simulates the stale-token overwrite scenario: premiumAssigned=true
     // but the response came from the free/public tier (no premium headers
-    // sent, or instance mismatch).
+    // sent, or instance mismatch). Token is already set, so no null-recovery.
     mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingToken.mockReturnValue("existing-token")
     mockGetRoutingHeaders.mockReturnValue({})
 
     responses.set("/free-tier", {
@@ -490,10 +493,29 @@ describe("axios premium-routing interceptors", () => {
     expect(mockUpdateRoutingToken).toHaveBeenCalledWith("rid-outgoing")
   })
 
+  it("updates routing token when premiumAssigned is true but token is null (recovery from cleared state)", async () => {
+    // After resetForRelease(), premiumAssigned may briefly be true with
+    // token=null (e.g. cross-tab race). The null-token escape hatch ensures
+    // re-seeding is always possible, preventing a permanent deadlock.
+    mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingToken.mockReturnValue(null)
+    mockGetRoutingHeaders.mockReturnValue({})
+
+    responses.set("/reseed", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "reseeded-token" },
+    })
+    await axiosInstance.get("/reseed")
+
+    expect(mockUpdateRoutingToken).toHaveBeenCalledWith("reseeded-token")
+  })
+
   it("does NOT update routing token when premiumAssigned is true and instance hash mismatches", async () => {
     // Premium headers were sent but the response came from a different
     // instance (ALB fallback to shared backend).
     mockIsPremiumAssigned.mockReturnValue(true)
+    mockGetRoutingToken.mockReturnValue("existing-token")
     mockGetRoutingHeaders.mockReturnValue({
       "X-Routing-ID": "rid-outgoing",
       "X-User-Tier": "premium",

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -322,17 +322,23 @@ axios.interceptors.response.use(
     if (routingId) {
       // Only update the routing token when:
       //  (a) the user is NOT in premium-assigned mode (initial token seeding), or
-      //  (b) the response came from the verified premium instance.
+      //  (b) the response came from the verified premium instance, or
+      //  (c) the current token is null (recovery from cleared state).
       // This prevents non-premium responses (free/public tier 200s after
       // 502/503 fallback) from overwriting the token while premiumAssigned
       // is true — breaking the feedback loop described in issue #605.
+      // Condition (c) ensures that (premiumAssigned=true, token=null) is
+      // never a permanent trap — any response carrying X-Routing-ID can
+      // re-seed a missing token. This is safe because the token value is
+      // deterministic (HMAC of UID) and identical across all backends.
       const isPremiumMode = routingService.isPremiumAssigned()
+      const tokenIsNull = routingService.getRoutingToken() == null
       const instanceVerified =
         cfg?._hadPremiumHeaders &&
         cfg._outgoingInstanceId &&
         res.headers[RoutingHeaders.SERVED_BY_INSTANCE.toLowerCase()] ===
           cfg._outgoingInstanceId
-      if (!isPremiumMode || instanceVerified) {
+      if (!isPremiumMode || tokenIsNull || instanceVerified) {
         routingService.updateRoutingToken(routingId)
       }
     }

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -313,15 +313,30 @@ function shouldEmitPremiumReachable(
 
 axios.interceptors.response.use(
   async (res) => {
+    const cfg = res.config as CustomAxiosRequestConfig | undefined
+
     // Extract routing headers from backend response
     // Note: axios normalizes response header names to lowercase
     const routingIdHeader = RoutingHeaders.ROUTING_ID.toLowerCase()
     const routingId = res.headers[routingIdHeader]
     if (routingId) {
-      routingService.updateRoutingToken(routingId)
+      // Only update the routing token when:
+      //  (a) the user is NOT in premium-assigned mode (initial token seeding), or
+      //  (b) the response came from the verified premium instance.
+      // This prevents non-premium responses (free/public tier 200s after
+      // 502/503 fallback) from overwriting the token while premiumAssigned
+      // is true — breaking the feedback loop described in issue #605.
+      const isPremiumMode = routingService.isPremiumAssigned()
+      const instanceVerified =
+        cfg?._hadPremiumHeaders &&
+        cfg._outgoingInstanceId &&
+        res.headers[RoutingHeaders.SERVED_BY_INSTANCE.toLowerCase()] ===
+          cfg._outgoingInstanceId
+      if (!isPremiumMode || instanceVerified) {
+        routingService.updateRoutingToken(routingId)
+      }
     }
 
-    const cfg = res.config as CustomAxiosRequestConfig | undefined
     if (shouldEmitPremiumReachable(res, cfg)) {
       routingService.emitPremiumReachable({
         url: cfg!.url,

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -243,6 +243,54 @@ describe("RoutingService", () => {
     })
   })
 
+  describe("resetForRelease", () => {
+    test("should clear premiumAssigned, instanceId, and token together", () => {
+      const premiumUser = createPremiumUser()
+      routingService.updateRoutingToken("test-token")
+      routingService.updateRoutingInfo(premiumUser)
+      routingService.setPremiumAssigned(true)
+      routingService.setPremiumInstanceId("inst-hash")
+
+      routingService.resetForRelease()
+
+      expect(routingService.isPremiumAssigned()).toBe(false)
+      expect(routingService.getPremiumInstanceId()).toBeNull()
+      expect(routingService.getRoutingToken()).toBeNull()
+      expect(localStorageMock.getItem("routing_id")).toBeNull()
+      expect(localStorageMock.getItem("premium_assigned")).toBe("false")
+      expect(localStorageMock.getItem("premium_instance_id")).toBeNull()
+      // Tier and routingInfo are preserved (user is still premium-subscribed)
+      expect(routingService.getUserTier()).toBe(UserTier.PREMIUM)
+    })
+
+    test("should make getRoutingHeaders return empty after release", () => {
+      routingService.updateRoutingToken("test-token")
+      routingService.updateRoutingInfo(createPremiumUser())
+      routingService.setPremiumAssigned(true)
+
+      routingService.resetForRelease()
+
+      expect(routingService.getRoutingHeaders()).toEqual({})
+    })
+
+    test("should allow re-seeding after release (premiumAssigned=false path)", () => {
+      routingService.updateRoutingToken("test-token")
+      routingService.setPremiumAssigned(true)
+
+      routingService.resetForRelease()
+
+      // After release, premiumAssigned=false so interceptor can re-seed
+      expect(routingService.isPremiumAssigned()).toBe(false)
+      // Simulate re-seeding
+      routingService.updateRoutingToken("new-token")
+      routingService.setPremiumAssigned(true)
+      routingService.setPremiumInstanceId("new-hash")
+
+      expect(routingService.getRoutingToken()).toBe("new-token")
+      expect(routingService.isPremiumAssigned()).toBe(true)
+    })
+  })
+
   describe("clearRoutingInfo", () => {
     test("should clear all routing state including premiumAssigned", () => {
       const premiumUser = createPremiumUser()

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -211,6 +211,38 @@ describe("RoutingService", () => {
     })
   })
 
+  describe("clearRoutingToken", () => {
+    test("should clear token and localStorage but preserve tier and premiumAssigned", () => {
+      const premiumUser = createPremiumUser()
+      routingService.updateRoutingToken("test-token")
+      routingService.updateRoutingInfo(premiumUser)
+      routingService.setPremiumAssigned(true)
+      routingService.setPremiumInstanceId("inst-hash")
+
+      routingService.clearRoutingToken()
+
+      expect(routingService.getRoutingToken()).toBeNull()
+      expect(localStorageMock.getItem("routing_id")).toBeNull()
+      // Tier, premiumAssigned, and instanceId must be preserved
+      expect(routingService.getUserTier()).toBe(UserTier.PREMIUM)
+      expect(routingService.isPremiumAssigned()).toBe(true)
+      expect(routingService.getPremiumInstanceId()).toBe("inst-hash")
+      expect(localStorageMock.getItem("routing_tier")).toBe("premium")
+      expect(localStorageMock.getItem("premium_assigned")).toBe("true")
+    })
+
+    test("should cause getRoutingHeaders to return empty (token is null)", () => {
+      routingService.updateRoutingToken("test-token")
+      routingService.updateRoutingInfo(createPremiumUser())
+      routingService.setPremiumAssigned(true)
+
+      routingService.clearRoutingToken()
+
+      // Even though premiumAssigned is true, token is null → empty headers
+      expect(routingService.getRoutingHeaders()).toEqual({})
+    })
+  })
+
   describe("clearRoutingInfo", () => {
     test("should clear all routing state including premiumAssigned", () => {
       const premiumUser = createPremiumUser()

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -150,6 +150,15 @@ export class RoutingService {
   }
 
   /**
+   * Clear only the routing token (not tier, routing info, or premium flags).
+   * Used on premium release to prevent stale token reuse on reassignment.
+   */
+  clearRoutingToken(): void {
+    this.routingToken = null
+    this.clearTokenFromStorage()
+  }
+
+  /**
    * Set whether premium assignment has been confirmed
    * Controls whether routing headers are actually sent
    */

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -159,6 +159,18 @@ export class RoutingService {
   }
 
   /**
+   * Reset routing state for a premium release.
+   * Clears premiumAssigned, premiumInstanceId, and routingToken together.
+   * Use this in both same-tab and cross-tab release paths to keep them
+   * in sync and prevent (premiumAssigned=true, token=null) deadlocks.
+   */
+  resetForRelease(): void {
+    this.setPremiumAssigned(false)
+    this.setPremiumInstanceId(null)
+    this.clearRoutingToken()
+  }
+
+  /**
    * Set whether premium assignment has been confirmed
    * Controls whether routing headers are actually sent
    */


### PR DESCRIPTION
## Summary

After a premium user is auto-released following 2 hours of inactivity and then auto-reassigned (via PR #656), the backend confirms the user is assigned again, but frontend app traffic keeps routing to the shared control-plane service instead of the user's dedicated premium instance. A hard refresh recovers correct routing.

This PR fixes the stale-token feedback loop with three changes:

1. **New `clearRoutingToken()` method + `resetForRelease()` helper** — `clearRoutingToken()` clears only the routing token (not tier, routing info, or premium flags), appropriate for the inactivity-release path where the user is still signed in and still premium. `resetForRelease()` bundles the three release-cleanup operations (`setPremiumAssigned(false)`, `setPremiumInstanceId(null)`, `clearRoutingToken()`) into a single method, ensuring same-tab and cross-tab release paths stay in sync.
2. **Clear routing state on premium release** — calls `resetForRelease()` in both `autoReleaseOnLogout()` and the cross-tab `PREMIUM_RELEASED` handler, clearing `premiumAssigned`, `premiumInstanceId`, and `routingToken` together. This prevents the `(premiumAssigned=true, token=null)` deadlock in cross-tab scenarios.
3. **Guard response interceptor token update** — only updates the routing token when: (a) the user is NOT in premium-assigned mode (initial token seeding), (b) the response came from the verified premium instance, or (c) the current token is null (recovery from cleared state). Condition (c) ensures that `(premiumAssigned=true, token=null)` is never a permanent trap state.

#### v1 → v2 Change Summary

| # | Issue (from review) | v1 behavior | v2 fix |
|---|---------------------|-------------|--------|
| 1 | Cross-tab `PREMIUM_RELEASED` handler missing `setPremiumAssigned(false)` and `setPremiumInstanceId(null)` — receiving tab enters `(premiumAssigned=true, token=null)` deadlock | `clearRoutingToken()` only | `resetForRelease()` — clears all three: premiumAssigned, instanceId, token |
| 2 | Interceptor guard creates unrecoverable trap state `(premiumAssigned=true, token=null)` | Guard: `!isPremiumMode \|\| instanceVerified` — no path to re-seed null token | Guard: `!isPremiumMode \|\| tokenIsNull \|\| instanceVerified` — null token always re-seeded |
| 3 | Three release-cleanup operations duplicated across same-tab and cross-tab paths — prone to drift | `autoReleaseOnLogout`: 3 separate calls; cross-tab: 1 call (incomplete) | Both paths use `resetForRelease()` — single method, no drift |

---

## Root Cause

Two independent defects combine to create a feedback loop that prevents routing recovery after inactivity release and reassignment:

| # | Layer | Defect |
|---|-------|--------|
| 1 | `PremiumAssignmentContext.tsx` | `autoReleaseOnLogout()` does not clear the routing token from localStorage — stale token persists across release/reassign boundary |
| 2 | `axios.ts` | Response interceptor unconditionally overwrites the routing token from any backend response carrying `X-Routing-ID`, including non-premium responses during fallback |

**Failure sequence:**

1. Premium user assigned to dedicated instance — `premiumAssigned=true`, `routingToken=HMAC`, `premiumInstanceId=HASH`
2. 2h inactivity — `autoReleaseOnLogout()` fires: `premiumAssigned=false`, `instanceId=null`, but `routingToken=HMAC` (NOT cleared)
3. Background requests (heartbeat, polls) continue — `premiumAssigned=false` so `getRoutingHeaders()` returns `{}` — requests hit free/public tier — response includes `X-Routing-ID` — interceptor overwrites token unconditionally
4. User clicks — DOM listener fires — `autoAssignOnLogin()` re-runs — assignment succeeds — `premiumAssigned=true`
5. Next app request sends premium headers — if ALB premium target group is still propagating → 502/503 → `handlePremiumRoutingError`: `premiumAssigned=false`, retry on free tier → free-tier 200 response overwrites token → cycle repeats
6. Polling restores `premiumAssigned=true` → step 5 repeats until TG is healthy — user stuck in degraded routing

**Key insight:** The token VALUE (HMAC) is identical across all backends (same `HMAC-SHA256(SECRET_KEY, uid)`). The problem is the state management cycle: the combination of never clearing the token and unconditionally re-seeding it creates a feedback loop where `premiumAssigned` keeps flipping between true and false without recovery.

---

## Changed Files

### Change 1 — New `clearRoutingToken()` method + `resetForRelease()` helper

**File:** `frontend/src/utils/routing/RoutingService.ts`

```typescript
/**
 * Clear only the routing token (not tier, routing info, or premium flags).
 * Used on premium release to prevent stale token reuse on reassignment.
 */
clearRoutingToken(): void {
    this.routingToken = null
    this.clearTokenFromStorage()
}

/**
 * Reset routing state for a premium release.
 * Clears premiumAssigned, premiumInstanceId, and routingToken together.
 * Use this in both same-tab and cross-tab release paths to keep them
 * in sync and prevent (premiumAssigned=true, token=null) deadlocks.
 */
resetForRelease(): void {
    this.setPremiumAssigned(false)
    this.setPremiumInstanceId(null)
    this.clearRoutingToken()
}
```

**Rationale:** `clearRoutingInfo()` clears everything (tier, routing info, premium flags) — too aggressive for the inactivity-release path where the user is still signed in and still premium. `clearRoutingToken()` preserves `storedTier`, `routingInfo`, and `premiumAssigned`. `resetForRelease()` bundles the three release-cleanup operations into a single method so that same-tab and cross-tab paths cannot drift out of sync.

### Change 2 — Clear routing state on premium release

**File:** `frontend/src/contexts/PremiumAssignmentContext.tsx`

**(a) `autoReleaseOnLogout()` — inactivity auto-release:**

```typescript
routingService.resetForRelease()
```

**(b) `PREMIUM_RELEASED` cross-tab handler:**

```typescript
const unsubscribe = tabSync.on("PREMIUM_RELEASED", () => {
    beaconTokenRef.current = null
    setState((prev) => ({
      ...prev,
      assignmentResult: null,
      statusResult: null,
    }))
    // Mirror the same-tab release path: clear assigned flag, instance ID,
    // and token together. Without setPremiumAssigned(false), this tab's
    // in-memory RoutingService stays premiumAssigned=true with token=null
    // — an unrecoverable state where the interceptor guard blocks
    // re-seeding and getRoutingHeaders() returns {}.
    routingService.resetForRelease()
    hasAttemptedRef.current = false
    ssRemove(SS_HAS_ATTEMPTED)
    needsReassignAfterReleaseRef.current = true
})
```

**Rationale:** After release, `localStorage["routing_id"]` is cleared. `getRoutingHeaders()` returns `{}` (both `routingToken` and `premiumAssigned` are null/false). On reassignment, the token will be freshly seeded from the first pre-assign API call (which runs before `setPremiumAssigned(true)` is called) rather than carrying a stale value.

Each browser tab has its own in-memory `RoutingService` instance (localStorage is shared, JS fields are not). The cross-tab handler must call `resetForRelease()` (not just `clearRoutingToken()`) to also clear `premiumAssigned` and `premiumInstanceId` in the receiving tab's memory. Without this, the receiving tab enters `(premiumAssigned=true, token=null)` — an unrecoverable state where:

- `getRoutingHeaders()` returns `{}` (token is null)
- The interceptor guard blocks re-seeding: `!isPremiumMode` is false, `instanceVerified` needs premium headers (which need a token) — both paths unreachable
- All traffic permanently hits the shared backend; only logout/refresh recovers

### Change 3 — Guard response interceptor token update

**File:** `frontend/src/utils/axios.ts`

```typescript
const routingId = res.headers[routingIdHeader]
if (routingId) {
  // Only update the routing token when:
  //  (a) the user is NOT in premium-assigned mode (initial token seeding), or
  //  (b) the response came from the verified premium instance, or
  //  (c) the current token is null (recovery from cleared state).
  const isPremiumMode = routingService.isPremiumAssigned()
  const tokenIsNull = routingService.getRoutingToken() == null
  const instanceVerified =
    cfg?._hadPremiumHeaders &&
    cfg._outgoingInstanceId &&
    res.headers[RoutingHeaders.SERVED_BY_INSTANCE.toLowerCase()] ===
      cfg._outgoingInstanceId
  if (!isPremiumMode || tokenIsNull || instanceVerified) {
    routingService.updateRoutingToken(routingId)
  }
}
```

**Rationale:** This breaks the feedback loop. When `premiumAssigned=true` but the response came from the free/public tier (502 fallback path), the routing token is NOT overwritten. This extends the same instance-verification pattern already used by `shouldEmitPremiumReachable()` (PR #649) to the token-update path.

Condition (c) (`tokenIsNull`) prevents `(premiumAssigned=true, token=null)` from becoming an unrecoverable trap. Without it, seeding requires either `isPremiumMode=false` (unreachable) or `instanceVerified=true` (requires premium headers, which require a non-null token — circular). Adding `tokenIsNull` allows any response carrying `X-Routing-ID` to re-seed a missing token. This is safe because the token value is deterministic (`HMAC-SHA256(SECRET_KEY, uid)`) and identical across all backends.

**Edge case — first request after reassignment:** After Change 2 clears the token and Change 3 guards updates, the `getPremiumStatus()` call inside `autoAssignOnLogin()` seeds the token while `isPremiumMode=false` (before `setPremiumAssigned(true)` is called). By the time `setPremiumAssigned(true)` is called, the token is already set.

---

## Interaction with the Token Seeding Flow

To verify that Changes 1-3 don't break initial login, trace the first-login path:

```
1. User logs in → autoAssignOnLogin() fires
   premiumAssigned=false, routingToken=null

2. getPremiumStatus() → ALB rule 306 → public tier
   Response: X-Routing-ID=HMAC
   Interceptor: isPremiumMode=false → updateRoutingToken(HMAC) ✓

3. setPremiumAssigned(true), setPremiumInstanceId(hash)

4. Next app request → getRoutingHeaders() returns X-Routing-ID + X-User-Tier
   ALB premium rule matches → premium TG → 200
   Interceptor: isPremiumMode=true, instanceVerified=true → updateRoutingToken ✓

5. Steady-state: token stays fresh from verified premium responses
```

No regression.

### Token-null recovery path

```
1. Cross-tab PREMIUM_RELEASED fires → resetForRelease()
   premiumAssigned=false, routingToken=null, instanceId=null

2. User clicks → autoAssignOnLogin() fires
   premiumAssigned=false, routingToken=null

3. getPremiumStatus() → ALB rule 306 → public tier
   Response: X-Routing-ID=HMAC
   Interceptor: isPremiumMode=false → updateRoutingToken(HMAC) ✓

4. setPremiumAssigned(true), setPremiumInstanceId(hash)
   Normal flow resumes — no deadlock.
```

If a race condition leaves `premiumAssigned=true` with `token=null` (e.g. cross-tab timing), the `tokenIsNull` escape hatch (condition c) allows re-seeding from any response:

```
Race scenario: premiumAssigned=true, routingToken=null
   (e.g. setPremiumAssigned(true) fires before resetForRelease completes on another tab)

1. Next API request → getRoutingHeaders() returns {} (token is null)
   Request hits free/public tier → Response: X-Routing-ID=HMAC
   Interceptor: isPremiumMode=true, tokenIsNull=true → updateRoutingToken(HMAC) ✓
   Token recovered without logout/refresh.
```

---

## Automated Test Cases

### RoutingService: `clearRoutingToken` (2 tests)

| # | Test | Description | Covers |
|---|------|-------------|--------|
| 1 | `should clear token and localStorage but preserve tier and premiumAssigned` | Sets token, tier, premiumAssigned, and instanceId. After `clearRoutingToken()`, token and `localStorage["routing_id"]` are null, but tier/premiumAssigned/instanceId remain unchanged. | Change 1 |
| 2 | `should cause getRoutingHeaders to return empty (token is null)` | Sets token, tier, and premiumAssigned=true. After `clearRoutingToken()`, `getRoutingHeaders()` returns `{}` even though premiumAssigned is still true (token is null). | Change 1 |

### RoutingService: `resetForRelease` (3 tests)

| # | Test | Description | Covers |
|---|------|-------------|--------|
| 3 | `should clear premiumAssigned, instanceId, and token together` | Sets token, tier, premiumAssigned, and instanceId. After `resetForRelease()`, premiumAssigned=false, instanceId=null, token=null, localStorage keys cleared. Tier and routingInfo are preserved. | Change 1 |
| 4 | `should make getRoutingHeaders return empty after release` | Sets token, tier, premiumAssigned=true. After `resetForRelease()`, `getRoutingHeaders()` returns `{}`. | Change 1 |
| 5 | `should allow re-seeding after release (premiumAssigned=false path)` | Sets token, premiumAssigned=true. After `resetForRelease()`, verifies premiumAssigned=false. Then simulates re-seeding (updateRoutingToken + setPremiumAssigned(true)) and verifies recovery. | Change 1 |

### PremiumInactivityReassign (2 tests)

| # | Test | Description | Covers |
|---|------|-------------|--------|
| 6 | `auto-release clears the routing token from localStorage (issue #605)` | Renders provider, waits for assignment, pre-seeds `routing_id` in localStorage, fast-forwards 2h to trigger auto-release. Verifies `localStorage["routing_id"]` is cleared. | Change 2a |
| 7 | `cross-tab PREMIUM_RELEASED clears routing token from localStorage (issue #605)` | Renders provider, waits for assignment, pre-seeds `routing_id`, `premium_assigned`, and `premium_instance_id` in localStorage, fires `PREMIUM_RELEASED` broadcast. Verifies all three are cleared: `routing_id`=null, `premium_assigned`=`"false"`, `premium_instance_id`=null. | Change 2b |

### Axios Interceptor: Routing token update guard (5 tests)

| # | Test | Description | Covers |
|---|------|-------------|--------|
| 8 | `updates routing token when premiumAssigned is false (initial token seeding)` | `isPremiumAssigned` returns false. Response carries `x-routing-id`. Verifies `updateRoutingToken` IS called. | Change 3 (seeding) |
| 9 | `does NOT update routing token when premiumAssigned is true, token is present, and instance is unverified` | `isPremiumAssigned` returns true. `getRoutingToken` returns `"existing-token"`. No premium headers sent. Response carries `x-routing-id`. Verifies `updateRoutingToken` is NOT called. | Change 3 (guard) |
| 10 | `updates routing token when premiumAssigned is true and instance is verified` | `isPremiumAssigned` returns true. Premium headers sent. Response `x-served-by-instance` matches `_outgoingInstanceId`. Verifies `updateRoutingToken` IS called. | Change 3 (verified) |
| 11 | `updates routing token when premiumAssigned is true but token is null (recovery from cleared state)` | `isPremiumAssigned` returns true. `getRoutingToken` returns null. Response carries `x-routing-id`. Verifies `updateRoutingToken` IS called — the token-null escape hatch works. | Change 3 (null-recovery) |
| 12 | `does NOT update routing token when premiumAssigned is true and instance hash mismatches` | `isPremiumAssigned` returns true. `getRoutingToken` returns `"existing-token"`. Premium headers sent. Response `x-served-by-instance` differs from `_outgoingInstanceId`. Verifies `updateRoutingToken` is NOT called. | Change 3 (mismatch) |

---

## Test Results

```
Frontend RoutingService:            48 passed (43 existing + 5 new)
Frontend axios interceptor:         14 passed ( 9 existing + 5 new)
Frontend PremiumInactivityReassign:  6 passed ( 4 existing + 2 new)
```

All existing tests continue to pass. No regressions.

---

## Manual Test Plan

### Prerequisites

- A premium-subscribed user account
- Browser DevTools open (Network tab, Console tab, Application tab)
- Network tab "Preserve log" enabled
- Access to CloudWatch Logs for the backend ECS tasks (log group `/ecs/{env}-public-optinist-cloud-taskdef` and `/ecs/{env}-premium-optinist-cloud-taskdef`)

### Test 1: Primary repro — release → reassign → routing recovery (core fix)

**Objective:** Verify the main #605 fix — stale token no longer causes mis-routing after inactivity release and auto-reassignment.

**Scope:** This test covers Change 2 (clear on release) and Change 3 (interceptor guard) simultaneously.

#### Step 1: Establish premium assignment

1. Open a fresh browser tab (or clear localStorage for the application origin).
2. Open DevTools **Application** tab > **Local Storage** > select the application origin.
3. Log in as the **premium** user.
4. Wait for the premium assignment flow to complete (Network tab shows `POST /users/me/premium/assign` returning 200).
5. **Verify** in the Application tab:
   - `routing_id` exists and contains a 16-character hex string
   - `premium_assigned` is `"true"`
   - `routing_tier` is `"premium"`
   - `premium_instance_id` exists and contains a 16-character hex string
6. Navigate to a workflow page and trigger an API request (e.g., open the logs modal).
7. In the Network tab, select any API request and inspect the **Response Headers**:
   - **Verify:** `x-user-tier` header is `premium`.
   - **Verify:** `x-routing-id` header is present (16-char hex).
   - **Verify:** `x-served-by-instance` header is present (16-char hex).

#### Step 2: Simulate 2-hour inactivity auto-release

1. In the Console tab, suppress sleep-detection and override `Date.now`:
   ```js
   localStorage.removeItem('premium_last_activity');
   const _origNow = Date.now;
   Date.now = () => _origNow() + 2 * 60 * 60 * 1000 + 5000;
   ```
2. Wait up to 30 seconds for the inactivity check to fire (the check runs every 30s).
   **Note:** Do NOT click or type in the application page until Step 4 verification is complete. Any `pointerdown`/`keydown` on the page triggers auto-reassignment and re-populates the values.
3. **Verify** in the Console tab: A warning message appears:
   ```
   2 hours of inactivity detected - auto-releasing premium instance
   ```
4. **Verify** in the Application tab:
   - `routing_id` is **cleared** (key removed or value is empty)
   - `premium_assigned` is `"false"`
   - `premium_instance_id` is **cleared** (key removed or value is empty)

**Pass criteria (Step 2):** `routing_id` is cleared on release. This is the primary assertion for Change 2. Before this fix, `routing_id` would persist with the stale value.

#### Step 3: Trigger auto-reassignment via user gesture

1. Restore `Date.now` in the Console:
   ```js
   Date.now = _origNow;
   ```
2. Click anywhere in the application (or press any key) to trigger the DOM listener.
3. **Verify** in the Console tab: A message appears indicating reassignment:
   ```
   Premium instance assigned successfully
   ```
4. In the Network tab, locate `POST /users/me/premium/assign`:
   - **Verify:** Status is `200 OK`.
5. **Verify** in the Application tab:
   - `routing_id` is **re-populated** with a 16-character hex string
   - `premium_assigned` is `"true"`
   - `premium_instance_id` is re-populated

#### Step 4: Verify premium routing is restored

1. Navigate to a workflow page or trigger an API request.
2. In the Network tab, select any API request and inspect the **Response Headers**:
   - **Verify:** `x-user-tier` header is `premium`.
   - **Verify:** `x-routing-id` header is present.
   - **Verify:** `x-served-by-instance` header matches `localStorage["premium_instance_id"]`.
3. In CloudWatch Logs, search the **premium** log group for the user's recent requests:
   - **Verify:** Requests are landing on the premium task (not the shared control-plane task).
4. **Verify:** No full page refresh was needed for routing to recover.
5. **Verify:** The "Premium instance unresponsive" snackbar does NOT appear.

**Pass criteria:** Steps 2-4 all pass. Routing recovers after release→reassign without page refresh.

---

### Test 2: Initial login regression (CRITICAL)

**Objective:** Verify that Change 3 (interceptor guard) does not break initial token seeding on first login. This is the highest-risk regression because Change 3 affects every API response across the entire application.

**Scope:** Change 3 (interceptor guard)

#### Step 1: Clean state

1. If currently signed in, log out completely (click the Logout button).
2. In the Console tab, verify localStorage is clean:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   ```
   - **Expected:** `routing_id` is `null`, `premium_assigned` is `null` or `"false"`.

#### Step 2: Sign in as a premium user

1. Open DevTools Network tab with "Preserve log" enabled.
2. Log in as the **premium** user.

#### Step 3: Verify token is seeded correctly

1. In the Network tab:
   - **Verify:** `POST /auth/login` returns `200 OK`.
   - **Verify:** `GET /users/me` returns `200 OK`.
   - **Verify:** `GET /users/me/premium/status` or `POST /users/me/premium/assign` returns `200 OK`.
2. In the Console tab, run:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   console.log("routing_tier:", localStorage.getItem("routing_tier"))
   ```
3. **Verify:**
   - `routing_id` contains a 16-character hex string (freshly seeded from the pre-assign API call)
   - `premium_assigned` is `"true"`
   - `routing_tier` is `"premium"`

**Failure mode if regression:** `routingToken` stays null after login because Change 3 blocks the initial seeding. `getRoutingHeaders()` returns `{}`, all requests fall through to the free tier. Symptom: premium user is assigned but all traffic goes to the shared backend.

**Risk mitigation:** The `tokenIsNull` escape hatch (condition c) provides a secondary seeding path — even if condition (a) fails due to a race, condition (c) re-seeds a null token from any response.

#### Step 4: Verify premium routing is functional

1. Navigate to any workflow page or trigger an API request.
2. In the Network tab, select any API request and inspect the **Response Headers**:
   - **Verify:** `x-user-tier` header is `premium`.
   - **Verify:** `x-routing-id` header is present.
   - **Verify:** `x-served-by-instance` header is present.
3. Perform normal operations (file upload, workflow run) for a few minutes.
4. **Verify:** No 403 errors or routing failures in DevTools Network tab.
5. **Verify:** The "Premium instance unresponsive" snackbar does NOT appear.

**Pass criteria:** Token seeded on login (step 3), premium routing works (step 4), no errors during normal operation.

---

### Test 3: Page refresh regression

**Objective:** After a hard refresh, the routing state (persisted in localStorage) is correctly restored and premium routing continues working. Verifies that `clearRoutingToken` / `resetForRelease` only fires on release, not on page load.

**Scope:** Change 1 (`clearRoutingToken` / `resetForRelease` interacts with localStorage), Change 3 (interceptor guard on rehydrated state)

#### Step 1: Establish premium routing

1. Sign in as a premium user and confirm premium routing is working (Test 2 steps).
2. In the Console tab, note the current `localStorage["routing_id"]` value:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   ```

#### Step 2: Perform a hard refresh

1. Hard refresh the page (Cmd+Shift+R / Ctrl+Shift+R).
2. Wait for the page to fully load.

#### Step 3: Verify routing state is preserved

1. In the Console tab, run:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   ```
2. **Verify:** `routing_id` retains the same value as before refresh (not cleared).
3. **Verify:** `premium_assigned` is still `"true"`.
4. In the Network tab, select any API request and inspect the **Response Headers**:
   - **Verify:** `x-user-tier` header is `premium`.
   - **Verify:** `x-routing-id` header is present.
5. **Verify:** The "Premium instance unresponsive" snackbar does NOT appear.

**Pass criteria:** Routing survives refresh without re-seeding.

---

### Test 4: Cross-tab release and reassign

**Objective:** When one tab triggers an inactivity release, another tab correctly clears its routing state and can independently reassign. Verifies Change 2b (cross-tab handler calls `resetForRelease()`).

**Scope:** Change 2b (cross-tab `PREMIUM_RELEASED` handler)

#### Step 1: Establish premium routing in two tabs

1. Open **Tab A** and log in as the premium user. Confirm premium assignment completes.
2. Open **Tab B** (same browser, same origin). It should also show the premium-assigned state.
3. In both tabs, verify `localStorage["routing_id"]` is populated:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   ```

#### Step 2: Trigger auto-release from Tab A

1. In **Tab A**'s Console, suppress sleep-detection and override `Date.now`:
   ```js
   localStorage.removeItem('premium_last_activity');
   const _origNow = Date.now;
   Date.now = () => _origNow() + 2 * 60 * 60 * 1000 + 5000;
   ```
2. Wait up to 30 seconds for the inactivity check to fire in Tab A.
   **Note:** Do NOT click or type in Tab A's application page until Step 3 verification is complete.
3. **Verify** in Tab A's Console: `2 hours of inactivity detected` warning appears.
4. Restore `Date.now` in **Tab A**'s Console:
   ```js
   Date.now = _origNow;
   ```

#### Step 3: Verify Tab B received the release broadcast

1. Switch to **Tab B**.
2. In Tab B's Console, run:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   console.log("premium_assigned:", localStorage.getItem("premium_assigned"))
   console.log("premium_instance_id:", localStorage.getItem("premium_instance_id"))
   ```
3. **Verify:**
   - `routing_id` is **cleared** (the cross-tab `PREMIUM_RELEASED` handler fired)
   - `premium_assigned` is `"false"`
   - `premium_instance_id` is **cleared**

#### Step 4: Reassign from Tab B

1. Click anywhere in **Tab B** to trigger the reassignment DOM listener.
2. **Verify** in Tab B's Network tab: `POST /users/me/premium/assign` returns `200 OK`.
3. **Verify** in Tab B's Console:
   ```js
   console.log("routing_id:", localStorage.getItem("routing_id"))
   ```
   - `routing_id` is re-populated with a 16-character hex string.
4. **Verify:** Tab B shows premium routing is working (API responses have `x-user-tier: premium`).

**Pass criteria:** Tab B clears all routing state on cross-tab release (step 3), reassigns independently (step 4), and routes correctly.

---

### Skipped manual tests

The following tests were originally planned but are omitted from manual testing. Coverage is provided by automated tests or other merged PRs.

| Test | Reason for skipping |
|------|---------------------|
| **Double release-reassign cycle** (multi-cycle stale state) | Repeats the same code path as Test 1. `resetForRelease()` is stateless — no cross-cycle accumulation. Already verified by `PremiumInactivityReassign.test.tsx` automated tests. |
| **Free-tier user regression** (interceptor guard does not affect free users) | Free users always have `isPremiumAssigned()=false`, so the interceptor guard takes the same `!isPremiumMode=true` path as Test 2 (initial seeding). Additionally, PR #702's backend fix (`SecureRoutingMiddleware` ignores `x-routing-id` for free-tier) provides defense-in-depth. |

---

## Checklist

- [ ] **Test 1**: Release → reassign → routing recovery (core fix)
- [ ] **Test 2**: Initial login regression (CRITICAL — token seeding)
- [ ] **Test 3**: Page refresh regression
- [ ] **Test 4**: Cross-tab release and reassign

---

## Risk Assessment

| Change | Blast radius | Risk | Mitigation |
|--------|-------------|------|------------|
| Change 1 (`clearRoutingToken` + `resetForRelease` methods) | Isolated — new methods, no existing callers affected | **Very low** — additive change | Unit tests verify token-only clearing preserves other state; `resetForRelease` tests verify complete cleanup |
| Change 2 (clear on release via `resetForRelease`) | `autoReleaseOnLogout` path + cross-tab handler | **Low** — only fires after 2h inactivity or on `PREMIUM_RELEASED` broadcast | Test 1 validates happy path; Test 4 validates cross-tab |
| Change 3 (interceptor guard with token-null escape hatch) | **Every API response** in the app | **Medium** — `tokenIsNull` escape hatch ensures `(premiumAssigned=true, token=null)` is never a permanent trap, reducing risk of initial seeding regression | **Test 2 (CRITICAL)** validates initial login; Test 3 validates page refresh |

**Priority recommendation:** If manual test time is limited, prioritize **Test 2 then Test 1**. Test 2 catches the highest-risk regression (Change 3 breaking all premium routing). Test 1 validates the primary fix.

---

## Key Files

| File | Role |
|------|------|
| `frontend/src/utils/routing/RoutingService.ts` | Routing token management, localStorage persistence, `resetForRelease()` |
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | Premium assignment lifecycle, inactivity release, cross-tab sync |
| `frontend/src/utils/axios.ts` | Axios response interceptor: routing token update guard, premium reachability detection |
| `frontend/src/utils/routing/RoutingService.test.ts` | Unit tests for `clearRoutingToken()` and `resetForRelease()` |
| `frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx` | Integration tests for release clearing routing state |
| `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` | Unit tests for interceptor token update guard (incl. token-null recovery) |
