### PR TITLE
Silent free-tier drop after stopped/terminated

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -63,6 +63,11 @@ const ERROR_BACKOFF_MULTIPLIER = 2
 // status. This handles the case where the assign API timed out without
 // actually creating an assignment (e.g., lock contention).
 const ASSIGN_RETRY_POLL_THRESHOLD = 3
+// Maximum number of re-trigger assign attempts before stopping.
+// Independent of pollAttempts so that finalizeDedicatedAssignment (which
+// resets pollAttempts to 0) cannot remove the overall ceiling.
+// Only reset when confirmed reachable (instanceUnreachable → false).
+const MAX_RETRIGGER_ATTEMPTS = 5
 
 // sessionStorage keys — per-tab persistence across page refreshes.
 // Clears automatically when the tab closes.
@@ -206,6 +211,23 @@ export const PremiumAssignmentProvider: React.FC<{
   const leaderElectionRef = useRef<CrossTabLeaderElection | null>(null)
   const beaconTokenRef = useRef<string | null>(null)
 
+  // Monotonically increasing generation counter, incremented synchronously
+  // on every release path (autoReleaseOnLogout, cross-tab PREMIUM_RELEASED,
+  // explicit release, logout, MAX_POLL_ATTEMPTS).  The polling callback
+  // captures the value before its first await and re-checks after each
+  // subsequent await.  A mismatch means a release occurred during the
+  // in-flight call — the callback bails instead of resurrecting a released
+  // instance.
+  const releaseGenerationRef = useRef(0)
+  // Bounded counter for re-trigger assign attempts.  Independent of
+  // pollAttempts so that finalizeDedicatedAssignment (which resets
+  // pollAttempts) cannot remove the overall ceiling.  Only reset when
+  // confirmed reachable (instanceUnreachable → false).
+  const retriggerCountRef = useRef(0)
+  // In-flight guard to prevent overlapping re-trigger calls across
+  // concurrent polling callbacks.
+  const isRetriggeringRef = useRef(false)
+
   // Refs for values that inactivity check needs but shouldn't trigger re-renders
   const lastActivityTimeRef = useRef(state.lastActivityTime)
   const showInactivityWarningRef = useRef(state.showInactivityWarning)
@@ -237,6 +259,7 @@ export const PremiumAssignmentProvider: React.FC<{
   useEffect(() => {
     if (logoutGeneration > 0) {
       // Clear any cached assignment state on logout
+      releaseGenerationRef.current += 1
       setState({
         isAssigning: false,
         isReleasing: false,
@@ -267,6 +290,17 @@ export const PremiumAssignmentProvider: React.FC<{
   useEffect(() => {
     showInactivityWarningRef.current = state.showInactivityWarning
   }, [state.showInactivityWarning])
+
+  // Reset the re-trigger counter when the instance becomes reachable again.
+  // Only a confirmed-reachable response (emitPremiumReachable → state machine
+  // transition) flips instanceUnreachable to false — finalizeDedicatedAssignment
+  // alone does not reset it.
+  useEffect(() => {
+    if (!unreachable.state.instanceUnreachable) {
+      retriggerCountRef.current = 0
+      isRetriggeringRef.current = false
+    }
+  }, [unreachable.state.instanceUnreachable])
 
   // Initialize cross-tab leader election for premium users
   useEffect(() => {
@@ -431,6 +465,7 @@ export const PremiumAssignmentProvider: React.FC<{
       const result = await releasePremiumInstance()
       // Clear beacon token so beforeunload doesn't fire a duplicate release
       beaconTokenRef.current = null
+      releaseGenerationRef.current += 1
       setState((prev) => ({
         ...prev,
         isReleasing: false,
@@ -612,6 +647,7 @@ export const PremiumAssignmentProvider: React.FC<{
       navigator.sendBeacon(BEACON_RELEASE_URL, blob)
       beaconTokenRef.current = null
     }
+    releaseGenerationRef.current += 1
     setState((prev) => ({
       ...prev,
       assignmentResult: null,
@@ -712,6 +748,7 @@ export const PremiumAssignmentProvider: React.FC<{
       // Backend has already released this assignment; drop the local token
       // so a later logout/beforeunload doesn't beacon a now-invalid token.
       beaconTokenRef.current = null
+      releaseGenerationRef.current += 1
       setState((prev) => ({
         ...prev,
         assignmentResult: null,
@@ -820,6 +857,7 @@ export const PremiumAssignmentProvider: React.FC<{
       // or user gesture without closing the tab entirely.  Covers both
       // the retryable-assign case (assigned:false) and the instance-lost
       // case (assigned:true but status returned null).
+      releaseGenerationRef.current += 1
       if (state.assignmentResult) {
         hasAttemptedRef.current = false
         ssRemove(SS_HAS_ATTEMPTED)
@@ -840,9 +878,19 @@ export const PremiumAssignmentProvider: React.FC<{
     }
 
     const timeoutId = setTimeout(async () => {
+      // Capture release generation before async work. If any release path
+      // fires during an await, the generation will have advanced and we
+      // bail out instead of resurrecting a released instance.
+      const gen = releaseGenerationRef.current
+
       try {
         // /status reads the canonical assignment row; /assign could return shared even after migration completed.
         const status = await getPremiumStatus()
+
+        // Post-await liveness check: if a release occurred during the
+        // status call (autoReleaseOnLogout, cross-tab PREMIUM_RELEASED,
+        // explicit release), bail to avoid resurrecting the instance.
+        if (releaseGenerationRef.current !== gen) return
 
         if (status?.error) {
           // eslint-disable-next-line no-console
@@ -910,30 +958,54 @@ export const PremiumAssignmentProvider: React.FC<{
               pollAttempts > 0 &&
               (pollAttempts + 1) % ASSIGN_RETRY_POLL_THRESHOLD === 0
             ) {
-              // eslint-disable-next-line no-console
-              console.log(
-                `[premium-poll] Re-triggering assign after ${pollAttempts + 1} null-status polls`,
-              )
-              try {
-                const reassignResult = await assignPremiumInstance()
-                if (reassignResult?.assigned) {
-                  // eslint-disable-next-line no-console
-                  console.log(
-                    "[premium-poll] Re-assign succeeded:",
-                    reassignResult.instance_id,
-                  )
-                  await finalizeDedicatedAssignment(reassignResult)
-                  return
-                }
-                // Still retryable or non-retryable — fall through to
-                // continue polling with backoff.
-              } catch (retryError) {
+              if (retriggerCountRef.current >= MAX_RETRIGGER_ATTEMPTS) {
                 // eslint-disable-next-line no-console
                 console.warn(
-                  "[premium-poll] Re-assign attempt failed:",
-                  retryError,
+                  `[premium-poll] Re-trigger limit (${MAX_RETRIGGER_ATTEMPTS}) reached, ` +
+                    "continuing status-only polling",
                 )
-                // Fall through to continue polling
+              } else if (isRetriggeringRef.current) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                  "[premium-poll] Re-trigger already in-flight, skipping",
+                )
+              } else {
+                isRetriggeringRef.current = true
+                retriggerCountRef.current += 1
+                // eslint-disable-next-line no-console
+                console.log(
+                  `[premium-poll] Re-triggering assign after ${pollAttempts + 1} null-status polls ` +
+                    `(attempt ${retriggerCountRef.current}/${MAX_RETRIGGER_ATTEMPTS})`,
+                )
+                try {
+                  // Pre-assign liveness re-check
+                  if (releaseGenerationRef.current !== gen) return
+                  const reassignResult = await assignPremiumInstance()
+                  // Post-assign liveness re-check: a release during the
+                  // await means the instance was intentionally freed — do
+                  // not finalize.
+                  if (releaseGenerationRef.current !== gen) return
+                  if (reassignResult?.assigned) {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                      "[premium-poll] Re-assign succeeded:",
+                      reassignResult.instance_id,
+                    )
+                    await finalizeDedicatedAssignment(reassignResult)
+                    return
+                  }
+                  // Still retryable or non-retryable — fall through to
+                  // continue polling with backoff.
+                } catch (retryError) {
+                  // eslint-disable-next-line no-console
+                  console.warn(
+                    "[premium-poll] Re-assign attempt failed:",
+                    retryError,
+                  )
+                  // Fall through to continue polling
+                } finally {
+                  isRetriggeringRef.current = false
+                }
               }
             }
           }

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -816,10 +816,11 @@ export const PremiumAssignmentProvider: React.FC<{
       console.warn(
         `Max poll attempts (${MAX_POLL_ATTEMPTS}) reached. Stopping polling.`,
       )
-      // If the original assign was retryable and no assignment was ever
-      // found, reset the attempt guard so the user can retry via page
-      // refresh or user gesture without closing the tab entirely.
-      if (state.assignmentResult && !state.assignmentResult.assigned) {
+      // Reset the attempt guard so the user can retry via page refresh
+      // or user gesture without closing the tab entirely.  Covers both
+      // the retryable-assign case (assigned:false) and the instance-lost
+      // case (assigned:true but status returned null).
+      if (state.assignmentResult) {
         hasAttemptedRef.current = false
         ssRemove(SS_HAS_ATTEMPTED)
         // Allow re-assignment on the next user gesture (click/keydown).
@@ -890,19 +891,22 @@ export const PremiumAssignmentProvider: React.FC<{
           } else {
             setState((prev) => ({ ...prev, statusResult: status }))
 
-            // If the original assign API returned a retryable error
-            // (scaling_in_progress / retry_after) but no assignment was
-            // actually created, status polling alone will never discover
-            // one.  Periodically re-call assignPremiumInstance() so the
-            // backend gets another chance to create the assignment.
+            // Re-trigger assignPremiumInstance() when status returns null
+            // and we have a stale assignmentResult. Two scenarios:
+            //  1. Original assign returned retryable error (assigned:false,
+            //     scaling_in_progress) — polling alone can't create one.
+            //  2. Instance was successfully assigned but later stopped/
+            //     terminated externally (assigned:true, but status now null)
+            //     — the tab silently fell back to free tier.
+            // In both cases, periodically re-call assign so the backend
+            // gets another chance to place the user on a live instance.
             // NOTE: state.assignmentResult is read from the closure and
             // must remain in this effect's dependency array (see
             // deps below) to stay fresh across re-renders.
-            const originalWasRetryable =
-              state.assignmentResult != null && !state.assignmentResult.assigned
+            const shouldRetriggerAssign = state.assignmentResult != null
 
             if (
-              originalWasRetryable &&
+              shouldRetriggerAssign &&
               pollAttempts > 0 &&
               (pollAttempts + 1) % ASSIGN_RETRY_POLL_THRESHOLD === 0
             ) {

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -12,6 +12,9 @@
  *     stopped/terminated externally.
  *  8. Instance-lost MAX_POLL_ATTEMPTS: flag reset enables user-gesture
  *     recovery after stop/terminate exhausts polling.
+ *  9. Re-trigger stops after MAX_RETRIGGER_ATTEMPTS (bounded counter).
+ * 10. Release during poll prevents re-trigger (stale closure prevention).
+ * 11. Same-id restart: unreachable persists until confirmed reachable.
  */
 
 import React from "react"
@@ -565,5 +568,161 @@ describe("PremiumAssignmentProvider — re-trigger assign during polling", () =>
     })
 
     expect(ctxRef.current?.error).toBeNull()
+  })
+
+  test("re-trigger stops after MAX_RETRIGGER_ATTEMPTS (bounded counter)", async () => {
+    // autoAssignOnLogin: retryable
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Clear to track only re-trigger calls.
+    mockAssignPremiumInstance.mockClear()
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    // Re-trigger fires every 3 polls. With MAX_RETRIGGER_ATTEMPTS=5,
+    // re-triggers fire at polls 3, 6, 9, 12, 15 (retriggerCount 1-5)
+    // then stop. Advance 18 polls to exceed the limit.
+    for (let i = 0; i < 18; i++) {
+      await advanceOnePollCycle()
+    }
+
+    // Exactly 5 re-trigger calls should have fired.
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(5)
+
+    // Advance 3 more polls (poll 19-21) — no further re-triggers.
+    mockAssignPremiumInstance.mockClear()
+    for (let i = 0; i < 3; i++) {
+      await advanceOnePollCycle()
+    }
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+  })
+
+  test("release during poll prevents re-trigger (stale closure prevention)", async () => {
+    // Start with dedicated assignment (autoAssignOnLogin takes already-assigned path).
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Trigger unreachable → polling starts.
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/api/test",
+        status: 502,
+        sentAt: Date.now(),
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Configure getPremiumStatus:
+    //  - Polls 1-2: return null normally (pollAttempts climbs to 2)
+    //  - Poll 3: fire cross-tab PREMIUM_RELEASED before returning null
+    // Poll 3 is where re-trigger would fire (pollAttempts=2, (2+1)%3=0).
+    // The release increments releaseGenerationRef synchronously, so the
+    // post-await liveness check detects the mismatch and bails before
+    // reaching the re-trigger section.
+    let statusCallCount = 0
+    mockGetPremiumStatus.mockImplementation(async () => {
+      statusCallCount++
+      if (statusCallCount === 3) {
+        const handlers = mockTabSyncHandlers.get("PREMIUM_RELEASED")
+        handlers?.forEach((h) => h({} as TabSyncMessage))
+      }
+      return nullAssignmentStatus
+    })
+
+    // Clear assign mock — no re-trigger calls expected.
+    mockAssignPremiumInstance.mockClear()
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    // Advance 3 polls.
+    await advanceOnePollCycle() // poll 1 (normal)
+    await advanceOnePollCycle() // poll 2 (normal)
+    await advanceOnePollCycle() // poll 3 (release during status → bail)
+
+    // Without the liveness check, the stale closure would have read
+    // state.assignmentResult as non-null and fired assignPremiumInstance,
+    // resurrecting the released instance.
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // assignmentResult cleared by the PREMIUM_RELEASED handler.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+    })
+  })
+
+  test("same-id restart: unreachable persists until confirmed reachable", async () => {
+    // autoAssignOnLogin: dedicated inst-A (already-assigned path).
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Instance goes unreachable (stopped/crashed).
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockClear()
+
+    // Same instance restarted — same instance_id, different source.
+    const restartedSameInstance: PremiumAssignmentResult = {
+      message: "dedicated",
+      instance_id: "inst-A",
+      instance_id_hash: "hash-A",
+      assigned: true,
+      is_shared: false,
+      assignment_source: "restarted_instance",
+    }
+    mockAssignPremiumInstance.mockResolvedValue(restartedSameInstance)
+
+    // Trigger unreachable.
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/api/test",
+        status: 502,
+        sentAt: Date.now(),
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Advance 3 polls → re-trigger fires → returns same inst-A.
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+
+    // Assignment updates to the restarted instance.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+      expect(ctxRef.current?.assignmentResult?.assignment_source).toBe(
+        "restarted_instance",
+      )
+    })
+
+    // Unreachable persists — same instance_id means the CLEAR branch
+    // in useInstanceUnreachableMachine is a no-op. The "unresponsive"
+    // snackbar stays visible until a real premium 200 fires
+    // emitPremiumReachable.
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
   })
 })

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -8,6 +8,10 @@
  *  4. Normal assign (assigned: true) does NOT fire re-trigger (regression test).
  *  5. MAX_POLL_ATTEMPTS resets flags for retryable cases.
  *  6. User gesture recovery after MAX_POLL_ATTEMPTS exhaustion.
+ *  7. Instance-lost recovery: re-trigger fires when assigned instance is
+ *     stopped/terminated externally.
+ *  8. Instance-lost MAX_POLL_ATTEMPTS: flag reset enables user-gesture
+ *     recovery after stop/terminate exhausts polling.
  */
 
 import React from "react"
@@ -424,6 +428,142 @@ describe("PremiumAssignmentProvider — re-trigger assign during polling", () =>
     })
 
     // Error should be cleared.
+    expect(ctxRef.current?.error).toBeNull()
+  })
+
+  test("instance-lost: re-trigger fires when assigned instance is stopped/terminated", async () => {
+    // autoAssignOnLogin: /status returns dedicated → state has assigned:true
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Simulate instance stopped/terminated: status now returns null assignment.
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockClear()
+
+    // The new dedicated instance after re-assign.
+    const newDedicated: PremiumAssignmentResult = {
+      message: "dedicated",
+      instance_id: "inst-B",
+      instance_id_hash: "hash-B",
+      assigned: true,
+      is_shared: false,
+      assignment_source: "new",
+    }
+    mockAssignPremiumInstance.mockResolvedValue(newDedicated)
+
+    // Trigger the unreachable state so shouldPoll returns true even though
+    // we have a dedicated assignment. This simulates the 502/503 handler
+    // calling emitPremiumUnreachable() when the dead instance is hit.
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/api/test",
+        status: 502,
+        sentAt: Date.now(),
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Poll 1: no re-trigger (pollAttempts=0)
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // Poll 2: no re-trigger (pollAttempts=1)
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).not.toHaveBeenCalled()
+
+    // Poll 3: re-trigger fires (pollAttempts=2, (2+1)%3===0)
+    await advanceOnePollCycle()
+    expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+
+    // State should reflect the new dedicated assignment.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-B")
+    })
+
+    // Routing should be configured.
+    expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+
+  test("instance-lost: MAX_POLL_ATTEMPTS resets flags for user-gesture recovery", async () => {
+    // autoAssignOnLogin: /status returns dedicated → state has assigned:true
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+    mockAssignPremiumInstance.mockResolvedValue(dedicatedAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Simulate instance lost: status returns null.
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    // Re-trigger assign also fails (keeps returning retryable).
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    // Trigger unreachable to enable polling for the dedicated assignment.
+    act(() => {
+      routingService.emitPremiumUnreachable({
+        url: "/api/test",
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Advance through all 40 poll cycles to reach MAX_POLL_ATTEMPTS.
+    for (let i = 0; i < 40; i++) {
+      await advanceOnePollCycle()
+    }
+
+    // State should show error and assignmentResult should be null.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+      expect(ctxRef.current?.error).toContain(
+        "No premium instance available after extended wait",
+      )
+    })
+
+    // hasAttempted should be cleared — user gesture can trigger recovery.
+    expect(sessionStorage.getItem("premium_hasAttempted")).toBeNull()
+
+    // Set up mocks for recovery: status returns a new dedicated instance.
+    const newDedicatedStatus: PremiumStatusResult = {
+      user_id: 1,
+      subscription_type: UserTier.PREMIUM,
+      is_premium: true,
+      assignment: {
+        instance_id: "inst-C",
+        is_shared: false,
+        assigned_at: "2026-06-23T00:00:00Z",
+        status: "active",
+      },
+    }
+    mockGetPremiumStatus.mockResolvedValue(newDedicatedStatus)
+
+    // Simulate user gesture (click) — should trigger fresh autoAssignOnLogin.
+    act(() => {
+      simulateClick()
+    })
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-C")
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
     expect(ctxRef.current?.error).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

When a premium user's assigned EC2 instance is stopped or terminated externally, the backend correctly cleans up the `premium_user_assignments` row, but the still-open browser tab silently falls back to the free-tier ECS service with no UI signal and no automatic recovery. The user must manually log out and log back in before a fresh `POST /premium/assign` cascade runs.

This PR broadens the existing polling-loop re-trigger logic (introduced by PR #701 for the assign-timeout case) to also cover the "instance was successfully assigned but later lost" scenario, enabling automatic recovery without user intervention.

---

## v1 → v2 Summary

v1 broadened the re-trigger condition and `MAX_POLL_ATTEMPTS` flag reset. v2 addresses review feedback by adding safety mechanisms around the re-trigger path.

| Aspect | v1 (initial) | v2 (post-review) |
|--------|-------------|-----------------|
| Re-trigger condition | Broadened to `state.assignmentResult != null` | No change |
| `MAX_POLL_ATTEMPTS` flag reset | Removed `assigned` guard | No change |
| Re-trigger call cap | None — `finalizeDedicatedAssignment` resets `pollAttempts`, bypassing `MAX_POLL_ATTEMPTS` and allowing unbounded loops | `MAX_RETRIGGER_ATTEMPTS = 5` counter independent of `pollAttempts`; resets only on confirmed reachable |
| Stale closure after mid-flight release | None — release during `await getPremiumStatus()` leaves stale `state.assignmentResult`, causing `/assign` to resurrect a freed instance | `releaseGenerationRef` incremented in all release paths; poll callback bails on generation mismatch |
| Concurrent re-trigger guard | None — overlapping poll intervals with slow responses could fire duplicate `/assign` | `isRetriggeringRef` in-flight guard |
| Test count | 8 (6 existing + 2 new) | 11 (6 existing + 5 new) |

---

## Root Cause

The polling loop in `PremiumAssignmentContext.tsx` handles three cases when checking `/premium/status`:

| Case | Condition | Action |
|------|-----------|--------|
| Dedicated found | `assignment && !is_shared` | Finalize assignment, stop polling |
| Shared found | `assignment && is_shared` | Update state, keep polling |
| **No assignment** | `!assignment` | Update `statusResult`, conditionally re-trigger assign |

The third case has re-trigger logic (PR #701), but it was gated by:

```typescript
const originalWasRetryable =
    state.assignmentResult != null && !state.assignmentResult.assigned
```

In the stop/terminate scenario, `state.assignmentResult.assigned` is `true` (from the original successful assignment), so `originalWasRetryable` is `false` and the re-trigger never fires. The loop polls status indefinitely, logging "Still on temporary instance", and eventually gives up at `MAX_POLL_ATTEMPTS` (40).

The `MAX_POLL_ATTEMPTS` safety net also failed to enable recovery because its flag-reset condition had the same guard:

```typescript
if (state.assignmentResult && !state.assignmentResult.assigned) {
    hasAttemptedRef.current = false
    // ...
}
```

This condition is `false` for the stop/terminate case, so `hasAttemptedRef` was never reset, permanently blocking `autoAssignOnLogin()` from re-firing.

---

## End-to-end failure flow (before fix)

```
EC2 stopped / terminated externally
  |
  v
User triggers a premium-routed API call (workspace nav, log poll, etc.)
  |
  v
ALB per-user rule points at a dead/deleted target group --> 502/503
  |
  v
axios interceptor catches it
  |-- routingService.setPremiumAssigned(false)
  |-- emitPremiumUnreachable()
  |-- retry request stripped of premium headers (free-tier fallback)
  v
useInstanceUnreachableMachine transitions to UNREACHABLE
  |
  v
shouldPoll() returns true --> polling starts
  |
  v
GET /premium/status --> Backend detects stopped/terminated instance
  --> remove_user_assignment(user_id)
  --> returns 404 --> frontend receives { assignment: null }
  |
  v
*** GAP ***
Polling loop: assignment is null
  --> re-trigger logic does NOT fire (originalWasRetryable = false)
  --> increments pollAttempts
  --> stops after MAX_POLL_ATTEMPTS (40) without resetting flags
  --> user stranded on free tier indefinitely
```

---

## Changes

**File**: `frontend/src/contexts/PremiumAssignmentContext.tsx`

### Change 1: Broaden re-trigger condition in polling null-assignment branch

```typescript
// Before:
const originalWasRetryable =
    state.assignmentResult != null && !state.assignmentResult.assigned

// After:
const shouldRetriggerAssign = state.assignmentResult != null
```

When status returns `assignment: null` and we have any stale `assignmentResult` (whether from a retryable assign or a previously successful assignment), periodically re-call `assignPremiumInstance()` so the backend gets another chance to place the user on a live instance.

### Change 2: Broaden MAX_POLL_ATTEMPTS flag reset

```typescript
// Before:
if (state.assignmentResult && !state.assignmentResult.assigned) {
    hasAttemptedRef.current = false
    ssRemove(SS_HAS_ATTEMPTED)
    needsReassignAfterReleaseRef.current = true
}

// After:
if (state.assignmentResult) {
    hasAttemptedRef.current = false
    ssRemove(SS_HAS_ATTEMPTED)
    needsReassignAfterReleaseRef.current = true
}
```

When `MAX_POLL_ATTEMPTS` is reached, always reset the attempt guard regardless of the original assignment state. This enables the user to recover via a page refresh or user gesture (click/keydown) without closing the tab.

### Change 3: Cap re-trigger assign calls to prevent unbounded loop

`finalizeDedicatedAssignment` resets `pollAttempts` to 0. If a re-trigger returns a "successful" but non-recovering assignment (e.g., same dead instance restarted but not yet reachable), the `MAX_POLL_ATTEMPTS` ceiling is bypassed and the loop continues indefinitely. A bounded counter (`MAX_RETRIGGER_ATTEMPTS = 5`) independent of `pollAttempts` caps the total number of re-trigger calls. The counter resets only when the instance is confirmed reachable (`instanceUnreachable → false`).

### Change 4: Detect mid-flight release to avoid resurrecting a freed instance

The poll callback captures `state.assignmentResult` at render time. If a release event (logout, cross-tab `PREMIUM_RELEASED`, explicit release) fires during `await getPremiumStatus()`, the callback still sees a stale non-null value and calls `/assign`, resurrecting a released instance. A monotonically increasing generation counter (`releaseGenerationRef`) is incremented synchronously in all release paths. The poll callback captures the value before its first `await` and bails on mismatch after each subsequent `await`.

### Change 5: Guard against overlapping concurrent re-trigger calls

An in-flight guard (`isRetriggeringRef`) prevents a second re-trigger from firing while a previous one is still awaiting `/assign`. This avoids duplicate assign calls when polling intervals overlap with slow network responses.

### Recovery behavior after fix

```
EC2 stopped / terminated externally
  |
  v
502/503 --> unreachable --> polling starts
  |
  v
GET /premium/status --> { assignment: null }
  |
  v
shouldRetriggerAssign = true (state.assignmentResult != null)
  |
  v
Every 3 polls: POST /premium/assign (up to MAX_RETRIGGER_ATTEMPTS=5)
  |-- stopped instance: restart-if-stopped cascade --> new assignment
  |-- terminated instance: new instance placement --> new assignment
  |
  |  (v2) Before each await: check releaseGenerationRef for mid-flight release
  |  (v2) Before firing: check isRetriggeringRef to prevent duplicate calls
  v
finalizeDedicatedAssignment() --> state update, routing, beacon token
  --> user back on premium instance
```

Recovery latency: ~90-135s (3 polls x 30-45s) for the re-trigger path, or ~20min (`MAX_POLL_ATTEMPTS`) + 1 click for the safety-net path. If all 5 re-trigger attempts fail, the system continues status-only polling until `MAX_POLL_ATTEMPTS`.

---

## Changed Files

| # | File | Change |
|---|------|--------|
| 1 | `frontend/src/contexts/PremiumAssignmentContext.tsx` | Broaden re-trigger condition and `MAX_POLL_ATTEMPTS` flag reset (v1); add bounded counter, release liveness check, in-flight guard (v2) |
| 2 | `frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx` | Add 5 new test cases: instance-lost recovery (v1), bounded counter, stale closure prevention, same-id restart (v2) |

---

## Automated Test Cases

### Existing tests (6 — all pass, no changes)

| # | Test | Verification |
|---|------|--------------|
| 1 | `re-trigger fires at correct interval (every 3 polls with null status)` | Re-trigger fires at `pollAttempts` 2, 5, 8, ... (every `ASSIGN_RETRY_POLL_THRESHOLD` polls) |
| 2 | `re-trigger success transitions state and stops polling` | After re-trigger returns a dedicated assignment, state updates correctly and polling stops |
| 3 | `re-trigger failure continues polling without crash` | Re-trigger failure does not crash polling or escalate error state |
| 4 | `normal assign (assigned: true) does NOT fire re-trigger` | When a dedicated assignment is healthy (polling not active), no re-trigger fires |
| 5 | `MAX_POLL_ATTEMPTS resets flags for retryable cases` | After 40 polls with retryable assignment, `hasAttempted` is cleared |
| 6 | `user gesture recovery after MAX_POLL_ATTEMPTS exhaustion` | User click after MAX_POLL_ATTEMPTS triggers fresh `autoAssignOnLogin` |

### New tests (5 — added by this PR)

| # | Test | Verification | Version |
|---|------|--------------|---------|
| 7 | `instance-lost: re-trigger fires when assigned instance is stopped/terminated` | After a dedicated assignment, instance goes unreachable and status returns null. Re-trigger fires on poll 3 and recovers with a new instance. | v1 |
| 8 | `instance-lost: MAX_POLL_ATTEMPTS resets flags for user-gesture recovery` | After a dedicated assignment, instance goes unreachable and status returns null. After 40 polls exhaust, `hasAttempted` is cleared and user click triggers recovery. | v1 |
| 9 | `re-trigger stops after MAX_RETRIGGER_ATTEMPTS (bounded counter)` | Exactly 5 re-triggers fire across 18 polls; subsequent polls produce no further re-triggers. | v2 |
| 10 | `release during poll prevents re-trigger (stale closure prevention)` | Cross-tab `PREMIUM_RELEASED` fires during `await getPremiumStatus()` on the 3rd poll (where re-trigger would fire). The liveness check detects the generation mismatch and bails — `assignPremiumInstance` is not called. | v2 |
| 11 | `same-id restart: unreachable persists until confirmed reachable` | Re-trigger returns the same `instance_id` (restarted instance). Assignment updates, but `instanceUnreachable` remains `true` until a real premium 200 fires `emitPremiumReachable`. | v2 |

### Test results

```
PremiumRetriggerAssign:            11 passed (6 existing + 5 new)
PremiumInactivityReassign:         10 passed (all existing)
PremiumUnreachableIntegration:     16 passed (all existing)
PremiumPollingBackoff:              5 passed (all existing)
PremiumPollingRoutingRestore:       5 passed (all existing)
```

All existing tests continue to pass. No regressions.

---

## Manual Test Plan

### Prerequisites

- A premium-subscribed user account
- Access to AWS Console (EC2, CloudWatch Logs) and MySQL (RDS) via the RDS Proxy endpoint (`RDS_HOST` environment variable)
- Browser DevTools open (Network tab, Console tab)
- Network tab "Preserve log" enabled

### Test 1: Auto-recovery when assigned instance is stopped externally (test case 600-13)

**Objective**: Verify that when a premium user's dedicated EC2 instance is stopped externally, the frontend automatically detects the loss and re-fires `POST /premium/assign` to recover without user intervention.

#### Step 1: Establish a dedicated premium assignment

1. Open browser DevTools Network tab. Set the filter to `premium`.
2. Log in as a premium user.
3. Wait for assignment to complete.
4. **Verify**: `POST /users/me/premium/assign` returns `200 OK` with:
   ```json
   {
     "assigned": true,
     "instance_id": "i-xxxxxxxxxxxx",
     "is_shared": false,
     "assignment_source": "..."
   }
   ```
5. **Verify**: `GET /users/me/premium/beacon-token` returns `200 OK`.
6. Record the `instance_id` value (e.g., `i-02604332ec60dfcd1`).

**Checkpoint**: The user has a healthy dedicated assignment. The UI shows the premium-assigned state. No "unresponsive" snackbar is visible.

#### Step 2: Stop the instance externally

1. From a **separate terminal** (not the browser):
   ```bash
   aws ec2 stop-instances --instance-ids <instance_id>
   ```
2. Confirm the instance enters `stopping` → `stopped` state:
   ```bash
   aws ec2 describe-instances --instance-ids <instance_id> \
     --query 'Reservations[0].Instances[0].State.Name'
   ```

#### Step 3: Trigger the detection flow

1. In the browser, trigger any API request that uses premium routing (e.g., navigate to a workflow page, or click any UI element that calls an API endpoint).
2. **Verify (Network tab)**: The first request to the premium endpoint fails with `502` or `503` (ALB returns this because the per-user target group has no healthy targets).
3. **Verify (Network tab)**: A retry request is sent immediately **without** premium routing headers (`X-Routing-ID` and `X-User-Tier` absent). This retry succeeds with `200 OK` (routed to free-tier ECS).
4. **Verify (Network tab)**: `POST /users/me/premium/ui-event` is sent with `event_type: "instance_unreachable"` in the request body. (Note: `logPremiumUiEvent` is a backend API call, not a `console.log` — it does not appear in the Console tab.)
5. **Verify (UI)**: The "Premium instance unresponsive" snackbar appears.

**Checkpoint**: The tab has detected the dead instance and is now in the unreachable state. Polling has started.

#### Step 4: Wait for automatic recovery

1. **Verify (Network tab)**: `GET /users/me/premium/status` requests appear at polling intervals (~30-60s).
   - Early polls return `{ "assignment": null }` (backend detected the stopped instance and removed the assignment row).
2. **Verify (Network tab)**: After ~3 status polls, `POST /users/me/premium/assign` is called automatically (not by user action). This confirms the re-trigger logic fired.
   - **Optional (Console tab)**: If the "Info" log level is enabled in DevTools Console, a `console.log` message `[premium-poll] Re-triggering assign after 3 null-status polls (attempt 1/5)` appears at the same time. Note: this uses `console.log` (Info level), not `console.warn` — it is hidden when the Console is filtered to Warnings only.
4. **Verify**: The assign response returns a new assignment:
   ```json
   {
     "assigned": true,
     "instance_id": "i-xxxxxxxxxxxx",
     "is_shared": false,
     "assignment_source": "restarted_instance"
   }
   ```
   - Note: `assignment_source` may be `"restarted_instance"` (if the same instance was restarted) or another source depending on the tier cascade.
5. **Verify (Network tab)**: `GET /users/me/premium/beacon-token` is called after the successful assign.
6. **Verify (UI)**: The "Premium instance unresponsive" snackbar is dismissed.

**Checkpoint**: The user is back on a premium instance without having manually logged out or refreshed the page.

#### Step 5: Confirm end-to-end routing restoration

1. **Without reloading the browser**, perform API actions (navigate, load data, etc.).
2. **Verify (Network tab — response headers)**: Responses include `x-served-by-instance` header matching the new assignment's `instance_id_hash`.
3. **Verify (Network tab — response headers)**: Responses include `x-routing-id` header.
4. **Verify**: No `502`/`503` errors appear on subsequent requests.

### Test 2: Auto-recovery when assigned instance is terminated externally (test case 600-14)

**Objective**: Verify that when a premium user's dedicated EC2 instance is terminated externally, the same automatic recovery occurs.

#### Step 1: Establish a dedicated premium assignment

Same as Test 1 Step 1.

#### Step 2: Terminate the instance externally

1. From a **separate terminal**:
   ```bash
   aws ec2 terminate-instances --instance-ids <instance_id>
   ```
2. Within ~2 seconds, EventBridge fires `{env}-premium-ec2-state-change`, invoking `reconcile_instance` on the cleanup Lambda. This deletes:
   - The `premium_user_assignments` row
   - The per-user ALB rule
   - The per-user target group
3. **Optional verification (CloudWatch Logs)**: Check `/aws/lambda/{env}-premium-cleanup`:
   ```
   Found 1 assignments to clean up for terminated instance i-xxxxxxxxxxxx
   Deleted ALB rule for user XX: ...
   Deleted target group for user XX: ...
   ```

#### Step 3: Trigger the detection flow

Same as Test 1 Step 3.

**Note**: Because the per-user ALB rule and target group are already deleted by EventBridge, the 502/503 occurs because the default listener action routes to the free-tier target group (no matching premium rule exists anymore).

#### Step 4: Wait for automatic recovery

1. Same verification as Test 1 Step 4, except:
   - The assign response will have a different `assignment_source` (e.g., `"existing"`, `"new"`, `"standby"`, or `"autoscaling_temp"`) depending on available instances.
   - A completely new EC2 instance ID will appear (the terminated instance cannot be restarted).
2. **Verify**: If Tier 5 (autoscaling-pool) is used, the initial assign response has `is_shared: true`. Continue waiting for polling to detect the dedicated migration:
   - `GET /users/me/premium/status` will eventually return `is_shared: false` with a real `instance_id`.

#### Step 5: Confirm end-to-end routing restoration

Same as Test 1 Step 5.

### Checklist

- [x] **Test 1**: Auto-recovery when instance is stopped externally
- [x] **Test 2**: Auto-recovery when instance is terminated externally

### Removed Tests (reference)

The following tests were removed from the manual test plan because they became redundant after PR #702, #703, and #705 were merged into the test environment.

| Removed test | Reason | Remaining coverage |
|--------------|--------|--------------------|
| Test 3: No regression on normal login | Equivalent premium-login regression checks already executed in PR #702 Test 2 and PR #703 Test 2 | Automated test #4 `normal assign (assigned: true) does NOT fire re-trigger` |
| Test 4: Assign-timeout recovery (PR #701) | Not reproducible manually (requires all instances exhausted) | Automated test #1 `re-trigger fires at correct interval` |
| Test 5: 2h inactivity release recovery | Covered in detail by PR #703 Test 1 (release->reassign->routing recovery) and PR #705 Tests 1/5 (2h inactivity simulation). PR #704's code path is not exercised here (`autoReleaseOnLogout()` sets `assignmentResult: null`, so the re-trigger condition `state.assignmentResult != null` evaluates to `false`) | Automated: `PremiumInactivityReassign` suite (10 tests) |
| Test 6: MAX_POLL_ATTEMPTS user-gesture recovery | Not reproducible manually (requires all 40 polls to fail) | Automated test #8 `instance-lost: MAX_POLL_ATTEMPTS resets flags for user-gesture recovery` |

---

## Key Files

| File | Role |
|------|------|
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | Core: autoAssignOnLogin, polling, re-trigger, beacon handling |
| `frontend/src/contexts/premium/unreachableMachine.ts` | Unreachable state machine, `shouldPoll` logic |
| `frontend/src/utils/axios.ts` | Axios interceptors: 502/503 detection, free-tier fallback, `emitPremiumUnreachable` |
| `infrastructure/terraform/premium_manager_package/premium_manager.py` | Lambda: `get_premium_user_status()` (detects stopped/terminated, removes assignment), `assign_premium_user()` (restart-if-stopped cascade) |
| `studio/app/common/core/premium/premium_assignment_service.py` | Translates Lambda 404 to `None` for the frontend |
| `studio/app/common/routers/users_me.py` | Returns `{ assignment: null }` to frontend when service returns `None` |
