### PR TITLE
Incident Report: Heavy Workflow OOM Takes the Entire Site Down WIP

### DIFF
--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -858,9 +858,10 @@ resource "aws_ecs_task_definition" "premium" {
       command           = ["./cloud-startup.sh"]
 
       linuxParameters = {
-        # ponytail: swap capped — see free-tier comment above.
-        maxSwap    = 4096
-        swappiness = 10
+        # Premium instances are dedicated per-user, so a heavy workflow
+        # can't take down other users. Keep full swap headroom.
+        maxSwap    = 32768
+        swappiness = 20
       }
 
       portMappings = [

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -598,12 +598,12 @@ resource "aws_ecs_task_definition" "autoscaling" {
       command           = ["./cloud-startup.sh"]
 
       linuxParameters = {
-        # ponytail: swap capped at 4 GB (was 32 GB). 32 GB swap on gp3 caused
-        # minutes of I/O thrash that starved /health → site down. 4 GB limits
-        # the thrash window to seconds; oom_score_adj=1000 on the workflow child
-        # ensures it (not the API) is killed when the budget is exhausted.
-        # Total memory budget: 6656 MiB RAM + 4096 MiB swap ≈ 10.5 GB.
-        maxSwap    = 4096
+        # ponytail: swap capped at 16 GB (was 32 GB). 32 GB swap on gp3 caused
+        # minutes of I/O thrash that starved /health → site down. 16 GB is
+        # enough for suite2p on ~1 GB datasets while halving the thrash window.
+        # Once the Docker image is rebuilt with oom_score_adj=1000 on the
+        # workflow child (snakemake_executor.py), this can be lowered further.
+        maxSwap    = 16384
         swappiness = 10
       }
 

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -80,7 +80,7 @@ resource "aws_lb_target_group" "autoscaling" {
   health_check {
     enabled             = true
     healthy_threshold   = 2
-    unhealthy_threshold = 5
+    unhealthy_threshold = 6 # 6 × 60s = 360s grace; tolerates brief OOM-kill recovery
     interval            = 60
     matcher             = "200"
     path                = "/health"
@@ -598,8 +598,13 @@ resource "aws_ecs_task_definition" "autoscaling" {
       command           = ["./cloud-startup.sh"]
 
       linuxParameters = {
-        maxSwap    = 32768 # Max swap in MiB (matches 32GB host swap on EBS)
-        swappiness = 20    # Only swap under memory pressure (host also set to 20)
+        # ponytail: swap capped at 4 GB (was 32 GB). 32 GB swap on gp3 caused
+        # minutes of I/O thrash that starved /health → site down. 4 GB limits
+        # the thrash window to seconds; oom_score_adj=1000 on the workflow child
+        # ensures it (not the API) is killed when the budget is exhausted.
+        # Total memory budget: 6656 MiB RAM + 4096 MiB swap ≈ 10.5 GB.
+        maxSwap    = 4096
+        swappiness = 10
       }
 
       portMappings = [
@@ -853,8 +858,9 @@ resource "aws_ecs_task_definition" "premium" {
       command           = ["./cloud-startup.sh"]
 
       linuxParameters = {
-        maxSwap    = 32768 # Max swap in MiB (matches 32GB host swap on EBS)
-        swappiness = 20    # Only swap under memory pressure (host also set to 20)
+        # ponytail: swap capped — see free-tier comment above.
+        maxSwap    = 4096
+        swappiness = 10
       }
 
       portMappings = [

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import platform
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -45,6 +46,67 @@ from studio.app.dir_path import DIRPATH
 logger = AppLogger.get_logger()
 
 
+def _workflow_child_init():
+    """Configure the workflow child process for safe OOM behavior.
+
+    Sets oom_score_adj=1000 so the kernel OOM-killer targets this process
+    (not the API server) when the container hits its memory limit.
+    Also lowers scheduling priority so health-check responses aren't starved.
+    """
+    if platform.system() != "Linux":
+        return
+    try:
+        with open("/proc/self/oom_score_adj", "w") as f:
+            f.write("1000")
+    except OSError:
+        pass
+    try:
+        os.nice(19)
+    except OSError:
+        pass
+
+
+def _recover_from_child_death(workspace_id: str, unique_id: str):
+    """Run post-process error handling after the child process was killed.
+
+    When the child is OOM-killed, _snakemake_execute_process's post-process
+    block never runs.  This replicates the critical parts: release locks,
+    update experiment status, and mark remote-sync as error.
+    """
+    try:
+        if RemoteStorageController.is_available():
+            RemoteSyncLockFileUtil.delete_sync_lock_file(workspace_id, unique_id)
+    except Exception as e:
+        logger.error("Recovery: failed to delete sync lock: %s", e)
+
+    try:
+        asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+    except Exception as e:
+        logger.error("Recovery: observe_overall failed: %s", e)
+
+    try:
+        if ExperimentRecordService.is_available():
+            ExperimentRecordService.regist_record_on_workflow_completed(
+                workspace_id, unique_id
+            )
+    except Exception as e:
+        logger.error("Recovery: experiment record update failed: %s", e)
+
+    try:
+        if RemoteStorageController.is_available():
+            remote_bucket_name = RemoteSyncStatusFileUtil.get_remote_bucket_name(
+                workspace_id, unique_id
+            )
+            RemoteSyncStatusFileUtil.create_sync_status_file_for_error(
+                remote_bucket_name,
+                workspace_id,
+                unique_id,
+                RemoteSyncAction.UPLOAD,
+            )
+    except Exception as e:
+        logger.error("Recovery: sync status update failed: %s", e)
+
+
 def snakemake_execute(
     workspace_id: str, unique_id: str, params: SmkParam, user_id: int = None
 ):
@@ -61,7 +123,9 @@ def snakemake_execute(
 
     try:
         logger.info("Starting local execution mode")
-        with ProcessPoolExecutor(max_workers=1) as executor:
+        with ProcessPoolExecutor(
+            max_workers=1, initializer=_workflow_child_init
+        ) as executor:
             logger.info("start snakemake running process.")
 
             future = executor.submit(
@@ -71,7 +135,19 @@ def snakemake_execute(
                 params,
                 client_id=client_id,
             )
-            future_result = future.result()
+
+            try:
+                future_result = future.result()
+            except Exception as exc:
+                # Child was killed (OOM, SIGKILL, etc.) — post-process never ran.
+                # Run it here so the experiment doesn't stay stuck in "running".
+                logger.error(
+                    "Workflow child process died unexpectedly "
+                    "(likely OOM-killed): %s",
+                    exc,
+                )
+                future_result = False
+                _recover_from_child_death(workspace_id, unique_id)
 
         # Update user storage after workflow completion
         asyncio.run(update_user_storage_after_workflow(workspace_id))


### PR DESCRIPTION
# Incident Report: Heavy Workflow OOM Takes the Entire Site Down

**Date:** 2026-06-24
**Status:** Partially mitigated — full fix blocked on Docker image rebuild
**Related:** Issue #643, Phase A scope

---

## Executive Summary

A single user running `suite2p` on a 1 GB neurofinder dataset can take down the
entire site. Not "degrade performance." Not "slow down a little." **Take it
completely offline.** The API, the health checks, every other user's session —
all of it. Gone. Because we gave a scientific workflow process 32 GB of swap
on a gp3 EBS volume and said "good luck."

---

## The Problem

### What Happens

1. User kicks off a `suite2p` workflow via the UI.
2. `snakemake_executor.py` spawns the workflow as a child process using
   `ProcessPoolExecutor(max_workers=1)` — inside the same container as the API
   server.
3. The `suite2p_registration` step is memory-hungry. It blows past the
   container's 6,656 MiB hard RAM limit.
4. Instead of dying, the process **starts filling 32 GB of swap** on a gp3 EBS
   volume. Because we configured `maxSwap = 32768` and `swappiness = 20`.
5. gp3 baseline IOPS: 3,000. suite2p doing random-access mmap across 32 GB of
   swap: significantly more than 3,000. The disk is now **saturated**.
6. Every process in the container — including the uvicorn workers that serve
   `/health` — is now waiting on I/O. The API is effectively frozen.
7. ALB health checks fail. ECS marks the task unhealthy. **ECS kills the
   container.** Not just the workflow. The entire container. Every user on
   that instance loses their session.
8. ECS spins up a new task. Takes ~5 minutes. Site is down the whole time.

### Why It Happens

Three compounding mistakes, each of which alone would have been survivable:

**Mistake 1: No resource isolation between the API and the workflow.**

The workflow child process runs in the same container, same cgroup, same
memory pool as the API server. There is zero isolation. If the child eats all
the memory, the API starves. This is like running your database and your batch
jobs on the same server with no cgroups — it's 2016 ops practice.

**Mistake 2: 32 GB of swap on gp3.**

Someone (no blame, but I have thoughts) decided the container should have
access to `maxSwap = 32768` MiB of swap. On a gp3 volume. This means that
before the OOM killer even *considers* intervening, the process has to fill
**32 gigabytes** of swap through a disk that does 3,000 IOPS baseline.
That's not a safety net — that's a slow-motion death sentence for every
other process sharing that I/O path.

The swap was configured at three levels, all pointing the same direction:
- ECS task definition: `maxSwap = 32768`, `swappiness = 20`
- Host user-data script: 32 GB dedicated swap EBS volume (`/dev/xvds`)
- Host sysctl: `vm.swappiness = 20`

**Mistake 3: No OOM priority differentiation.**

When the kernel's OOM killer finally fires (after the 32 GB swap is full),
it picks a victim based on memory usage + `oom_score_adj`. Since nobody set
`oom_score_adj` on anything, the OOM killer doesn't know that the workflow
child is the expendable one and the API server is the one keeping the site
alive. It might kill the workflow. It might kill a uvicorn worker. Coin flip.
At 3 AM.

### The Kill Chain (in order)

```
suite2p_registration allocates aggressively
  → exceeds 6,656 MiB container RAM limit
    → kernel swaps pages to gp3 EBS volume (32 GB available)
      → gp3 IOPS saturated by random swap I/O
        → all container processes I/O-starved
          → uvicorn can't respond to /health within 30s timeout
            → ALB marks target unhealthy (5 consecutive failures × 60s interval)
              → ECS SIGKILLs the entire task
                → site down for ~5 minutes during replacement task startup
```

---

## What We Did

### Change 1: Python — OOM Score + Scheduling Priority (snakemake_executor.py)

**File:** `studio/app/common/core/snakemake/snakemake_executor.py`

Added a `ProcessPoolExecutor` initializer (`_workflow_child_init`) that runs
in the forked child process and does two things:

```python
# /proc/self/oom_score_adj = 1000
# → "I am the least important process. Kill me first."
#
# os.nice(19)
# → "I am the lowest CPU priority. Let everyone else run first."
```

**Why this matters:** When the container hits its memory ceiling, the kernel
OOM-killer now has clear instructions: kill the workflow child (score 1000),
not the API workers (default score). And `nice(19)` means that even during
swap pressure, the uvicorn workers get CPU time to respond to health checks.

Both settings are **inherited by child processes**, so snakemake's own
sub-processes (the actual `suite2p` Python scripts) also inherit them. This
is critical because snakemake spawns the heavy computation as a separate
`subprocess.Popen` call — without inheritance, only the snakemake orchestrator
would be deprioritized while the actual memory hog runs at default priority.

**Status:** ⚠️ **NOT YET DEPLOYED.** This is a Python code change. It requires
rebuilding the Docker image and pushing to ECR. `terraform apply` does not
deploy application code. This is the most important piece of the fix and it
is not live yet.

### Change 2: Python — Recovery from Child Process Death (snakemake_executor.py)

**File:** `studio/app/common/core/snakemake/snakemake_executor.py`

Added `_recover_from_child_death()` and a try/except around `future.result()`
in `snakemake_execute()`.

**The problem it solves:** When the workflow child is OOM-killed, the
`_snakemake_execute_process` function never reaches its post-processing code.
This means:
- The experiment stays stuck in "running" state forever in the UI
- Remote sync lock files are never cleaned up
- Remote sync status is never updated to "error"
- The experiment database record is never finalized

The recovery function replicates the critical error-path cleanup:
1. Deletes the remote sync lock file
2. Runs `WorkflowResult.observe_overall()` to update experiment status
3. Updates the experiment database record
4. Marks remote sync status as error

Without this, an OOM-killed workflow is a **silent failure** — the user sees
a perpetual spinner and has no idea their run died.

**Status:** ⚠️ **NOT YET DEPLOYED.** Same as above — needs Docker image rebuild.

### Change 3: Terraform — Swap Cap on Free Tier (compute.tf)

**File:** `infrastructure/terraform/compute.tf`
**Resource:** `aws_ecs_task_definition.autoscaling` (free/shared tier)

| Parameter   | Before  | After   |
|-------------|---------|---------|
| `maxSwap`   | 32768   | 16384   |
| `swappiness`| 20      | 10      |

**Rationale:** 32 GB of swap on gp3 is a death sentence. 16 GB cuts the
thrash window roughly in half while still providing enough headroom for
`suite2p_registration` on ~1 GB datasets (which needs roughly 10–15 GB total
memory). `swappiness = 10` (down from 20) makes the kernel more reluctant to
swap, keeping more pages in RAM longer.

This is a compromise. The proper fix (Change 1) lets us lower this further
because the OOM killer will target the workflow specifically. Without Change 1
deployed, we can't be too aggressive or workflows that legitimately need
swap headroom will be SIGKILL'd — which is exactly what happened during our
first attempt at `maxSwap = 4096` (see "Things That Went Wrong" below).

**Status:** ✅ Deployed via `terraform apply`. Requires `aws ecs update-service
--force-new-deployment` to take effect on running tasks.

### Change 4: Terraform — Premium Tier Swap Restored (compute.tf)

**File:** `infrastructure/terraform/compute.tf`
**Resource:** `aws_ecs_task_definition.premium`

| Parameter   | Intermediate | Final   |
|-------------|-------------|---------|
| `maxSwap`   | 0 → 4096    | 32768   |
| `swappiness`| 0 → 10      | 20      |

We initially set the premium tier to the same restricted swap as the free tier.
This was wrong. **Premium instances are dedicated per-user** — a heavy workflow
on a premium instance can't take down other users' sites. The swap-thrash
problem is a **shared-resource problem**, and premium instances aren't shared.

Restored to original values after confirming that workflow `f08d8300` was
SIGKILL'd on the premium tier with `maxSwap = 4096`.

**Status:** ✅ Deployed.

### Change 5: Terraform — ALB Health Check Hardening (compute.tf)

**File:** `infrastructure/terraform/compute.tf`
**Resource:** `aws_lb_target_group.autoscaling`

| Parameter           | Before | After |
|---------------------|--------|-------|
| `unhealthy_threshold` | 5      | 6     |

Changes the time-to-eviction from 300s (5 × 60s) to 360s (6 × 60s). This is
belt-and-suspenders — with the swap reduction and OOM priority changes, health
checks should stay responsive. But an extra 60 seconds of tolerance costs
nothing and prevents a false-positive eviction during brief memory spikes.

**Status:** ✅ Deployed.

---

## Things That Went Wrong During the Fix

### Attempt 1: maxSwap = 0 (too aggressive)

First instinct: disable swap entirely. `maxSwap = 0`, `swappiness = 0`.
Total memory budget: 6,656 MiB only.

**Problem:** Never deployed, but would have broken every workflow that needs
more than ~5.5 GB (container RAM minus API overhead). Corrected before
`terraform apply`.

### Attempt 2: maxSwap = 4096 (still too aggressive)

Second try: 4 GB swap. Total budget: ~10.5 GB.

**Problem:** `suite2p_registration` on the 1 GB neurofinder dataset needs
more than 10.5 GB. Workflow `f08d8300` (premium) and `2513e786` (free) both
died with `SIGKILL (signal 9)` at the `suite2p_registration` step. The site
stayed up (that part worked), but the workflow couldn't complete.

This is the fundamental tension: **the value of `maxSwap` that protects
the site is lower than the value that lets the workflow finish.** The only
way to resolve this is Change 1 (OOM priority) — which lets the workflow
use swap freely, with the guarantee that if things go south, only the
workflow dies.

### Attempt 3: maxSwap = 16384 (current)

Compromise: 16 GB swap. Total budget: ~22.5 GB. Enough for suite2p on
~1 GB datasets. Still cuts the worst-case thrash window in half vs. 32 GB.

**This is a band-aid.** The real fix is deploying the Docker image with
Changes 1 and 2.

---

## What's Not Done Yet

### Critical: Deploy the Docker Image

The two most important changes (OOM score adjustment and child death recovery)
are Python code changes sitting in `snakemake_executor.py`. They are **not
live**. `terraform apply` only updates infrastructure and task definitions —
it does not rebuild or push the Docker image.

**To deploy:**
1. Build the Docker image with the updated code
2. Push to ECR (`development-optinist` repository)
3. Force a new ECS deployment on both free and premium services

Once deployed, `maxSwap` on the free tier can be lowered further (to 8192 or
even 4096) because the OOM killer will cleanly target the workflow child
instead of randomly killing container processes.

### Not Addressed (Out of Scope per Issue)

- **Moving compute off the API instance.** The workflow runs in the same
  container as the API. This is the root architectural problem. Everything
  we did here is mitigation within that constraint.
- **Concurrent multi-user execution.** One workflow at a time, still.
- **Strict multi-tenant isolation.** Free tier users share a container.

---

## Verification Checklist

After the Docker image is deployed:

- [ ] Run the 1 GB neurofinder `suite2p` workflow on the free tier
- [ ] Confirm `/health` stays responsive throughout (0 failures)
- [ ] Confirm the API container is NOT killed by ECS during the run
- [ ] If the workflow exceeds the memory budget, confirm only the workflow
      process is OOM-killed (check `dmesg` or CloudWatch for
      `oom_score_adj=1000` in the kill log)
- [ ] Confirm the experiment status shows "error" (not stuck "running")
- [ ] Run the same workflow on the premium tier — confirm it completes
      successfully with full swap headroom

---

## Lessons Learned (for the next person who reads this at 3 AM)

1. **Swap on shared infrastructure is a force multiplier for failure.** 32 GB
   of swap on a gp3 volume doesn't prevent OOM — it converts a fast OOM kill
   into a slow I/O death spiral that takes everything else down with it.

2. **If two processes share a cgroup, set `oom_score_adj`.** The kernel's OOM
   killer is not psychic. It doesn't know which process is your API server and
   which is your batch job. Tell it. It's one write to `/proc/self/oom_score_adj`.

3. **`terraform apply` ≠ code deployment.** Infrastructure changes and
   application code changes have different deployment paths. Changing a task
   definition doesn't rebuild your Docker image. This seems obvious written
   down, but at 2 AM when you're iterating on a fix, it's easy to assume
   "I applied the changes" means all the changes.

4. **Premium instances are not free instances.** They have different isolation
   properties. A fix that makes sense for shared infrastructure (restrict
   swap) can break dedicated infrastructure (where the user owns the whole
   box). Don't apply the same constraints blindly to both.

5. **Test your memory limits with your actual workload.** We went from 32 GB
   → 0 → 4 GB → 16 GB because we didn't know how much memory
   `suite2p_registration` actually needs on a 1 GB dataset. The answer is
   "somewhere between 10.5 GB and 22.5 GB." We found out by watching it get
   killed. Twice.
