### PR TITLE
Auto-logout premium users when subscription expires during active session    

### DIFF
--- a/docs/other/plan_expiration.md
+++ b/docs/other/plan_expiration.md
@@ -9,7 +9,7 @@ When a premium subscription ends, users enter a **30-day grace period**. During 
 ## Grace Period
 
 - **Duration:** 30 days from the date the subscription ends.
-- **During the grace period:** All data remains accessible. Users should download or manually delete any data they want to manage before auto-deletion begins.
+- **During the grace period:** All data remains accessible with the 200 GB storage limit. Users are moved to the free/shared instance (premium compute access is revoked). Users should download or manually delete any data they want to manage before auto-deletion begins.
 - **After the grace period:** The system runs a daily background job that checks expired users and deletes data until storage is at or below 5 GB.
 
 ## Deletion Priority Setting

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -257,14 +257,14 @@ export const PremiumAssignmentProvider: React.FC<{
   // Periodic subscription status refresh for premium users.
   // Keeps Redux currentUser.subscription_status fresh so we can detect expiry.
   useEffect(() => {
-    if (!isPremiumUser) return
+    if (!isPremiumUser || !isTabLeader) return
 
     const interval = setInterval(() => {
       dispatch(getMe())
     }, SUBSCRIPTION_CHECK_INTERVAL_MS)
 
     return () => clearInterval(interval)
-  }, [isPremiumUser, dispatch])
+  }, [isPremiumUser, isTabLeader, dispatch])
 
   // Reset flag when user changes
   useEffect(() => {

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -686,8 +686,8 @@ export const PremiumAssignmentProvider: React.FC<{
       // Subscription expired mid-session — release instance + force logout
       autoReleaseOnLogout()
       tabSync.broadcastLogout()
-      // Fire-and-forget: authLogout is async but redirect is intentionally not awaited —
-      // assignmentResult is already null and prevIsPremiumRef prevents re-trigger.
+      // Fire-and-forget: authLogout is async and redirect is intentionally not awaited.
+      // autoReleaseOnLogout schedules the state update; prevIsPremiumRef prevents re-trigger on subsequent renders.
       authLogout()
     }
     prevIsPremiumRef.current = isPremiumUser

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -687,10 +687,14 @@ export const PremiumAssignmentProvider: React.FC<{
       autoReleaseOnLogout()
       tabSync.broadcastLogout()
       // Fire-and-forget: authLogout is async and redirect is intentionally not awaited.
-      // autoReleaseOnLogout schedules the state update; prevIsPremiumRef prevents re-trigger on subsequent renders.
-      authLogout()
+      // skipBackendLogout: autoReleaseOnLogout already released the instance via
+      // sendBeacon, so suppress the free-logout endpoint (user is now free tier).
+      // The ref update on the last line prevents re-trigger on subsequent renders.
+      authLogout({ skipBackendLogout: true })
     }
     prevIsPremiumRef.current = isPremiumUser
+    // tabSync.broadcastLogout and authLogout are stable module imports.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPremiumUser, state.assignmentResult, autoReleaseOnLogout])
 
   // Inactivity monitoring for premium users

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -14,7 +14,7 @@ import React, {
   useRef,
 } from "react"
 import { flushSync } from "react-dom"
-import { useSelector } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
 
 import {
   assignPremiumInstance,
@@ -36,8 +36,10 @@ import {
   useInstanceUnreachableMachine,
 } from "contexts/premium/useInstanceUnreachableMachine"
 import { useSleepDetection } from "hooks/useSleepDetection"
+import { getMe } from "store/slice/User/UserActions"
 import { selectLogoutGeneration } from "store/slice/User/UserSelector"
-import { RootState } from "store/store"
+import { AppDispatch, RootState } from "store/store"
+import { logout as authLogout } from "utils/auth/AuthUtils"
 import {
   CrossTabLeaderElection,
   syncActivityAcrossTabs,
@@ -63,6 +65,8 @@ const ERROR_BACKOFF_MULTIPLIER = 2
 // status. This handles the case where the assign API timed out without
 // actually creating an assignment (e.g., lock contention).
 const ASSIGN_RETRY_POLL_THRESHOLD = 3
+// 5 min poll to detect subscription expiry; lower if tighter detection needed
+const SUBSCRIPTION_CHECK_INTERVAL_MS = 5 * 60 * 1000
 
 // sessionStorage keys — per-tab persistence across page refreshes.
 // Clears automatically when the tab closes.
@@ -155,6 +159,7 @@ export const PremiumAssignmentProvider: React.FC<{
   children: React.ReactNode
 }> = ({ children }) => {
   const currentUser = useSelector((state: RootState) => state.user.currentUser)
+  const dispatch = useDispatch<AppDispatch>()
   // Track logout generation to detect stale closures
   const logoutGeneration = useSelector(selectLogoutGeneration)
 
@@ -209,6 +214,8 @@ export const PremiumAssignmentProvider: React.FC<{
   // Refs for values that inactivity check needs but shouldn't trigger re-renders
   const lastActivityTimeRef = useRef(state.lastActivityTime)
   const showInactivityWarningRef = useRef(state.showInactivityWarning)
+  // Track previous premium status to detect subscription expiry transition
+  const prevIsPremiumRef = useRef(false)
 
   const unreachable = useInstanceUnreachableMachine({
     assignment: state.assignmentResult,
@@ -226,11 +233,27 @@ export const PremiumAssignmentProvider: React.FC<{
     setState((prev) => ({ ...prev, isPremiumUser }))
   }, [isPremiumUser])
 
+  // Periodic subscription status refresh for premium users.
+  // Keeps Redux currentUser.subscription_status fresh so we can detect expiry.
+  useEffect(() => {
+    if (!isPremiumUser) return
+
+    const interval = setInterval(() => {
+      dispatch(getMe())
+    }, SUBSCRIPTION_CHECK_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [isPremiumUser, dispatch])
+
   // Reset flag when user changes
   useEffect(() => {
     hasAttemptedRef.current = false
+    prevIsPremiumRef.current = isPremiumUser
     ssRemove(SS_HAS_ATTEMPTED)
     ssRemove(SS_POLL_ATTEMPTS)
+    // isPremiumUser intentionally excluded — this effect syncs refs on user
+    // identity change only; the auto-logout effect handles isPremiumUser transitions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser?.id])
 
   // Reset state when logout generation changes to prevent stale closures
@@ -252,6 +275,7 @@ export const PremiumAssignmentProvider: React.FC<{
       })
       unreachable.reset()
       hasAttemptedRef.current = false
+      prevIsPremiumRef.current = false
       ssRemove(SS_HAS_ATTEMPTED)
       ssRemove(SS_POLL_ATTEMPTS)
     }
@@ -620,6 +644,20 @@ export const PremiumAssignmentProvider: React.FC<{
     routingService.setPremiumAssigned(false)
     routingService.setPremiumInstanceId(null)
   }, [])
+
+  // Auto-logout when subscription expires during an active session.
+  // Detects premium → non-premium transition and releases the instance.
+  useEffect(() => {
+    if (prevIsPremiumRef.current && !isPremiumUser && state.assignmentResult) {
+      // Subscription expired mid-session — release instance + force logout
+      autoReleaseOnLogout()
+      tabSync.broadcastLogout()
+      // Fire-and-forget: authLogout is async but redirect is intentionally not awaited —
+      // assignmentResult is already null and prevIsPremiumRef prevents re-trigger.
+      authLogout()
+    }
+    prevIsPremiumRef.current = isPremiumUser
+  }, [isPremiumUser, state.assignmentResult, autoReleaseOnLogout])
 
   // Inactivity monitoring for premium users
   // Uses refs for lastActivityTime/showInactivityWarning to avoid interval churn

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -225,8 +225,7 @@ export const PremiumAssignmentProvider: React.FC<{
   // Calculate premium user status
   const isPremiumUser =
     currentUser?.subscription_plan_name === PlanName.PREMIUM &&
-    (currentUser?.subscription_status === SubscriptionStatus.PREMIUM ||
-      currentUser?.subscription_status === SubscriptionStatus.LIMIT_GRACE)
+    currentUser?.subscription_status === SubscriptionStatus.PREMIUM
 
   // Update state when premium status changes
   useEffect(() => {

--- a/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
@@ -41,9 +41,23 @@ const mockUser = {
   subscription_status: "Premium",
 }
 
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+const mockLogoutFn = jest.fn()
+
 jest.mock("react-redux", () => ({
   useSelector: (selector: (s: unknown) => unknown) =>
     selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => ({ type: "user/getMe" }),
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockLogoutFn,
 }))
 
 const mockAssignPremiumInstance = jest.fn<
@@ -92,6 +106,7 @@ jest.mock("utils/crossTabSync", () => ({
   __esModule: true,
   tabSync: {
     broadcast: () => {},
+    broadcastLogout: () => {},
     broadcastPremiumReleased: mockBroadcastPremiumReleased,
     on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
       if (!mockTabSyncHandlers.has(type))

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -31,9 +31,23 @@ const mockUser = {
   subscription_status: "Premium",
 }
 
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+const mockLogoutFn = jest.fn()
+
 jest.mock("react-redux", () => ({
   useSelector: (selector: (s: unknown) => unknown) =>
     selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => ({ type: "user/getMe" }),
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockLogoutFn,
 }))
 
 const mockAssignPremiumInstance = jest.fn<
@@ -81,6 +95,7 @@ jest.mock("utils/crossTabSync", () => ({
   __esModule: true,
   tabSync: {
     broadcast: () => {},
+    broadcastLogout: () => {},
     broadcastPremiumReleased: () => {},
     on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
       if (!mockTabSyncHandlers.has(type))

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -43,9 +43,23 @@ const mockUser = {
   subscription_status: "Premium",
 }
 
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+const mockLogoutFn = jest.fn()
+
 jest.mock("react-redux", () => ({
   useSelector: (selector: (s: unknown) => unknown) =>
     selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => ({ type: "user/getMe" }),
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockLogoutFn,
 }))
 
 const mockAssignPremiumInstance = jest.fn<
@@ -93,6 +107,7 @@ jest.mock("utils/crossTabSync", () => ({
   __esModule: true,
   tabSync: {
     broadcast: () => {},
+    broadcastLogout: () => {},
     broadcastPremiumReleased: () => {},
     on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
       if (!mockTabSyncHandlers.has(type))

--- a/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
@@ -4,7 +4,7 @@
  * Covers:
  *  1. Periodic getMe() dispatch fires at 5-min interval for premium users.
  *  2. Auto-logout when premium → non-premium transition with active assignment.
- *  3. No auto-logout during grace period (Limit Grace is still premium).
+ *  3. Auto-logout when entering grace period (Limit Grace = free instance).
  */
 
 import React from "react"
@@ -242,7 +242,7 @@ describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => 
     expect(ctxRef.current?.assignmentResult).toBeNull()
   })
 
-  test("no auto-logout during grace period (Limit Grace)", async () => {
+  test("auto-logout when entering grace period (Limit Grace)", async () => {
     mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
 
     const ctxRef: { current: Ctx | null } = { current: null }
@@ -253,7 +253,7 @@ describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => 
       expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
     })
 
-    // Transition to grace period — still considered premium
+    // Transition to grace period — no longer considered premium
     mockUser.subscription_status = "Limit Grace"
 
     await act(async () => {
@@ -261,10 +261,10 @@ describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => 
       await Promise.resolve()
     })
 
-    // Should NOT trigger auto-logout
-    expect(mockAuthLogout).not.toHaveBeenCalled()
-    expect(mockBroadcastLogout).not.toHaveBeenCalled()
-    // Assignment should still be active
-    expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    // Should trigger auto-logout (grace period = free instance, not premium)
+    expect(mockAuthLogout).toHaveBeenCalledTimes(1)
+    expect(mockBroadcastLogout).toHaveBeenCalledTimes(1)
+    // Assignment should be cleared
+    expect(ctxRef.current?.assignmentResult).toBeNull()
   })
 })

--- a/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * Tests for subscription expiry auto-logout.
+ *
+ * Covers:
+ *  1. Periodic getMe() dispatch fires at 5-min interval for premium users.
+ *  2. Auto-logout when premium → non-premium transition with active assignment.
+ *  3. No auto-logout during grace period (Limit Grace is still premium).
+ */
+
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import type {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must precede provider import) ---
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({ user: { currentUser: mockUser, logoutGeneration: 0 } }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+const mockGetMeAction = { type: "user/getMe" }
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => mockGetMeAction,
+}))
+
+const mockAuthLogout = jest.fn()
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockAuthLogout,
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+const mockBroadcastLogout = jest.fn()
+const mockBroadcastPremiumReleased = jest.fn()
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: () => {},
+    broadcastLogout: mockBroadcastLogout,
+    broadcastPremiumReleased: mockBroadcastPremiumReleased,
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type))
+        mockTabSyncHandlers.set(type, new Set())
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => 0,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+// require() not import — static imports hoist above the mock vars.
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+
+// --- Helpers ---
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const tree = (ctxRef: { current: Ctx | null }) => (
+  <SnackbarProvider maxSnack={3}>
+    <PremiumAssignmentProvider>
+      <Harness ctxRef={ctxRef} />
+    </PremiumAssignmentProvider>
+  </SnackbarProvider>
+)
+
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2026-05-12T00:00:00Z",
+    status: "active",
+  },
+}
+
+// --- Tests ---
+
+describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockTabSyncHandlers.clear()
+    localStorage.clear()
+    sessionStorage.clear()
+    // Reset mock user to premium
+    mockUser.subscription_plan_name = "Premium"
+    mockUser.subscription_status = "Premium"
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("dispatches getMe() every 5 minutes for premium users", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef: { current: Ctx | null } = { current: null }
+    render(tree(ctxRef))
+
+    // Wait for initial assignment to settle
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Clear dispatch calls from initialization
+    mockDispatchFn.mockClear()
+
+    // Advance 4 minutes — should NOT have dispatched getMe yet
+    await act(async () => {
+      jest.advanceTimersByTime(4 * 60 * 1000)
+      await Promise.resolve()
+    })
+    expect(mockDispatchFn).not.toHaveBeenCalledWith(mockGetMeAction)
+
+    // Advance 1 more minute (total 5) — should dispatch getMe
+    await act(async () => {
+      jest.advanceTimersByTime(1 * 60 * 1000)
+      await Promise.resolve()
+    })
+    expect(mockDispatchFn).toHaveBeenCalledWith(mockGetMeAction)
+  })
+
+  test("auto-logout when subscription expires with active assignment", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef: { current: Ctx | null } = { current: null }
+    const { rerender } = render(tree(ctxRef))
+
+    // Wait for initial assignment
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Simulate subscription expiry: change status to "Expired"
+    mockUser.subscription_status = "Expired"
+
+    // Force re-render to pick up the changed mock user
+    await act(async () => {
+      rerender(tree(ctxRef))
+      await Promise.resolve()
+    })
+
+    // authLogout should have been called
+    expect(mockAuthLogout).toHaveBeenCalledTimes(1)
+    // broadcastLogout should have been called
+    expect(mockBroadcastLogout).toHaveBeenCalledTimes(1)
+    // Assignment should be cleared (by autoReleaseOnLogout)
+    expect(ctxRef.current?.assignmentResult).toBeNull()
+  })
+
+  test("no auto-logout during grace period (Limit Grace)", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef: { current: Ctx | null } = { current: null }
+    const { rerender } = render(tree(ctxRef))
+
+    // Wait for initial assignment
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    // Transition to grace period — still considered premium
+    mockUser.subscription_status = "Limit Grace"
+
+    await act(async () => {
+      rerender(tree(ctxRef))
+      await Promise.resolve()
+    })
+
+    // Should NOT trigger auto-logout
+    expect(mockAuthLogout).not.toHaveBeenCalled()
+    expect(mockBroadcastLogout).not.toHaveBeenCalled()
+    // Assignment should still be active
+    expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+  })
+})

--- a/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
@@ -267,4 +267,97 @@ describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => 
     // Assignment should be cleared
     expect(ctxRef.current?.assignmentResult).toBeNull()
   })
+
+  test("auto-logout skips the free-logout endpoint (premium release path)", async () => {
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+
+    const ctxRef: { current: Ctx | null } = { current: null }
+    const { rerender } = render(tree(ctxRef))
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+
+    mockUser.subscription_status = "Expired"
+    await act(async () => {
+      rerender(tree(ctxRef))
+      await Promise.resolve()
+    })
+
+    // authLogout must be told to skip the backend free-logout call,
+    // otherwise both release-beacon AND /free/logout fire.
+    expect(mockAuthLogout).toHaveBeenCalledWith({ skipBackendLogout: true })
+  })
+
+  test("does NOT auto-logout when there is no active assignment", async () => {
+    // Status with no assignment → goes through the assign path.
+    mockGetPremiumStatus.mockResolvedValue({
+      user_id: 1,
+      subscription_type: UserTier.PREMIUM,
+      is_premium: true,
+    } as PremiumStatusResult)
+    // Assignment fails (non-retryable) so assignmentResult stays null.
+    mockAssignPremiumInstance.mockResolvedValue({
+      assigned: false,
+    } as PremiumAssignmentResult)
+
+    const ctxRef: { current: Ctx | null } = { current: null }
+    const { rerender } = render(tree(ctxRef))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(ctxRef.current?.assignmentResult).toBeNull()
+
+    // Subscription expires, but with no assignment the auto-logout guard
+    // (state.assignmentResult) must prevent the forced logout.
+    mockUser.subscription_status = "Expired"
+    await act(async () => {
+      rerender(tree(ctxRef))
+      await Promise.resolve()
+    })
+
+    expect(mockAuthLogout).not.toHaveBeenCalled()
+    expect(mockBroadcastLogout).not.toHaveBeenCalled()
+  })
+
+  test("does NOT poll getMe() on non-leader tabs", async () => {
+    // Override leader election so this tab is a follower.
+    const crossTab = jest.requireMock("utils/crossTabSync") as {
+      CrossTabLeaderElection: new (
+        onLeader: () => void,
+        onFollower?: () => void,
+      ) => { getIsLeader(): boolean; destroy(): void }
+    }
+    const realImpl = crossTab.CrossTabLeaderElection
+    crossTab.CrossTabLeaderElection = class {
+      constructor() {
+        // never becomes leader
+      }
+      getIsLeader() {
+        return false
+      }
+      destroy() {}
+    } as typeof realImpl
+
+    try {
+      mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+      const ctxRef: { current: Ctx | null } = { current: null }
+      render(tree(ctxRef))
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+      mockDispatchFn.mockClear()
+
+      // Advance well past the 5-min interval — no getMe() on a follower tab.
+      await act(async () => {
+        jest.advanceTimersByTime(11 * 60 * 1000)
+        await Promise.resolve()
+      })
+      expect(mockDispatchFn).not.toHaveBeenCalledWith(mockGetMeAction)
+    } finally {
+      crossTab.CrossTabLeaderElection = realImpl
+    }
+  })
 })

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -38,11 +38,25 @@ const mockUser = {
   subscription_status: "Premium",
 }
 
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+const mockLogoutFn = jest.fn()
+
 jest.mock("react-redux", () => ({
   useSelector: (selector: (s: unknown) => unknown) =>
     selector({
       user: { currentUser: mockUser, logoutGeneration: 0 },
     }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => ({ type: "user/getMe" }),
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockLogoutFn,
 }))
 
 const mockAssignPremiumInstance = jest.fn<
@@ -94,6 +108,7 @@ jest.mock("utils/crossTabSync", () => ({
     broadcast: (msg: TabSyncMessage) => {
       mockTabSyncBroadcasts.push(msg)
     },
+    broadcastLogout: () => {},
     broadcastPremiumReleased: () => {},
     on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
       if (!mockTabSyncHandlers.has(type)) {

--- a/frontend/src/utils/auth/AuthUtils.ts
+++ b/frontend/src/utils/auth/AuthUtils.ts
@@ -31,14 +31,19 @@ export const removeRefreshToken = () => {
   return localStorage.removeItem("refresh_token")
 }
 
-export const logout = async () => {
+export const logout = async ({
+  skipBackendLogout = false,
+}: { skipBackendLogout?: boolean } = {}) => {
   // Set logout flag to prevent token refresh during logout
   const setLoggingOut = await getSetLoggingOut()
   setLoggingOut(true)
 
   // Call backend logout endpoint for free tier users (fire and forget).
   // Skip for premium users - they have their own release mechanism.
-  if (!routingService.requiresPremiumRouting()) {
+  // skipBackendLogout is set by the premium-expiry auto-logout path, which
+  // already releases the instance via sendBeacon; by then routingInfo reports
+  // free tier, so without this flag the free-logout endpoint would also fire.
+  if (!skipBackendLogout && !routingService.requiresPremiumRouting()) {
     try {
       const { logoutFreeUserApi } = await import("api/users/UsersMe")
       await logoutFreeUserApi()

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -148,14 +148,14 @@ describe("RoutingService", () => {
       expect(routingService.requiresPremiumRouting()).toBe(false)
     })
 
-    test("should identify Limit Grace user as premium", () => {
+    test("should identify Limit Grace user as free", () => {
       const graceUser = createPremiumUser({
         subscription_status: SubscriptionStatus.LIMIT_GRACE,
       })
       routingService.updateRoutingInfo(graceUser)
 
-      expect(routingService.getUserTier()).toBe(UserTier.PREMIUM)
-      expect(routingService.requiresPremiumRouting()).toBe(true)
+      expect(routingService.getUserTier()).toBe(UserTier.FREE)
+      expect(routingService.requiresPremiumRouting()).toBe(false)
     })
 
     test("should identify expired premium user as free", () => {

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -257,8 +257,7 @@ export class RoutingService {
   private isPremiumUser(user: UserDTO): boolean {
     return (
       user.subscription_plan_name === PlanName.PREMIUM &&
-      (user.subscription_status === SubscriptionStatus.PREMIUM ||
-        user.subscription_status === SubscriptionStatus.LIMIT_GRACE)
+      user.subscription_status === SubscriptionStatus.PREMIUM
     )
   }
 

--- a/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
+++ b/infrastructure/documentation/PREMIUM_MANAGER_ARCHITECTURE.md
@@ -116,8 +116,11 @@ Premium state is mounted for **all authenticated users** (`PremiumAssignmentProv
 
 ```
 currentUser.subscription_plan_name === PlanName.PREMIUM
-  AND (subscription_status === PREMIUM OR subscription_status === LIMIT_GRACE)
+  AND subscription_status === PREMIUM
 ```
+
+Note: `LIMIT_GRACE` is excluded — grace period users are moved to the free
+tier (auto-logout on transition) while retaining their 200 GB data quota.
 
 ### Sequence Overview
 
@@ -395,7 +398,7 @@ Two premium users **can** share the same dedicated-class EC2 -- the uniqueness c
 
 | Observed symptom | Implied state | Upstream cause |
 |---|---|---|
-| No toasts, no premium effects, no network calls to `/premium/*` | Inert provider path | `isPremiumUser` is false -- either `subscription_plan_name != PREMIUM`, or `subscription_status` is neither `PREMIUM` nor `LIMIT_GRACE` |
+| No toasts, no premium effects, no network calls to `/premium/*` | Inert provider path | `isPremiumUser` is false -- either `subscription_plan_name != PREMIUM`, or `subscription_status` is not `PREMIUM` (includes `LIMIT_GRACE`, `EXPIRED`, `FREE`) |
 | Console warn "Conditions not met for auto-assignment" | Provider mounted but gate failed | `currentUser` null at mount time, or `isPremiumUser` flipped false between mount and the useEffect firing |
 | Success toast "Premium instance assigned successfully..." at login | `/assign` returned `assigned=true, is_shared=false` on first call, OR `/status` found an existing dedicated assignment | A dedicated instance had zero active assignments at assign time and was picked up; or the user already had a live assignment from a prior session that survived in DB (cleanup hadn't run) |
 | Persistent info toast "Please wait while your dedicated premium resource is being prepared." from login, no success toast follows | `assignmentResult.assigned=true && is_shared=true`, OR response was 202 with `retry_after`, OR `/assign` returned an `autoscaling-pool` assignment | No premium instance had spare capacity at assign time: either (a) all running instances already have users so the least-loaded was picked (is_shared=true on a real instance), (b) scaling was initiated and the Lambda returned 202+retry_after, or (c) launching instances exist and response is 202 |

--- a/infrastructure/documentation/SUBSCRIPTION_BILLING_ARCHITECTURE.md
+++ b/infrastructure/documentation/SUBSCRIPTION_BILLING_ARCHITECTURE.md
@@ -155,24 +155,29 @@ The SubscriptionService handles business logic and database operations for subsc
 | `PREMIUM` | Premium tier subscription active | Premium compute |
 | `TRIALING` | Trial period active | Full plan features |
 | `PAST_DUE` | Payment failed, retry in progress | Full access (temporary) |
-| `LIMIT_GRACE` | Premium expired, 30-day grace period | Full premium access (see below) |
+| `LIMIT_GRACE` | Premium expired, 30-day grace period | Free tier compute, 200 GB data retention (see below) |
 | `CANCELLED` | Scheduled for cancellation | Full until period end |
 | `UNPAID` | Payment failed, all retries exhausted | Restricted access |
 
 **LIMIT_GRACE details:** When a premium subscription expires, the user
 enters a 30-day grace period. During this period:
 
-- **Access is functionally identical to Premium** — the user retains
-  premium compute routing, 200 GB storage quota, and
-  `has_active_subscription` returns `True`
+- **Premium compute access is revoked** — the user is automatically
+  logged out and moved to the free/shared instance.
+  `has_active_subscription` returns `False` and `subscription_type`
+  returns `"free"`. The frontend auto-logout fires on the
+  `isPremiumUser` true → false transition
   (see `studio/app/common/schemas/users.py:has_active_subscription`,
-  `frontend/src/utils/routing/RoutingService.ts`)
+  `frontend/src/contexts/PremiumAssignmentContext.tsx`)
+- **200 GB storage quota is preserved** — the quota is stored in the
+  database (`UserStorageUsage.storage_quota_bytes`) and is independent
+  of `has_active_subscription`
 - **Workflow execution** is allowed as long as storage stays under quota
   (the same quota check that applies to all statuses)
 - **Alerts** warn the user that their subscription has expired and
   show a countdown of grace days remaining
 - After the 30-day grace period, the status transitions to `EXPIRED`
-  and access drops to Free tier (5 GB quota, no premium compute)
+  and data is deleted per user preferences down to Free tier (5 GB quota)
 
 #### calculate_limit_warning()
 
@@ -183,7 +188,7 @@ enters a 30-day grace period. During this period:
 **Calls:** `get_user_storage_usage()` -> `get_current_user_storage_usage()` -> `_generate_subscription_warning_message()`
 
 Uses cached storage data if fresh (< 20 minutes), otherwise triggers a live S3 scan. Compares storage
-against the effective quota (200 GB for active premium, 5 GB for grace/warning/overdue/free) and returns
+against the effective quota (200 GB for active premium and grace period, 5 GB for overdue/free) and returns
 the appropriate alert type with a countdown of days remaining.
 
 ---

--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -714,7 +714,7 @@ async def get_user_subscription_plan(user_id: int) -> Dict[str, Any]:
             plan_name = getattr(user, "subscription_plan_name", PlanName.FREE)
             has_active = getattr(user, "has_active_subscription", False)
 
-            # Determine tier - Premium users should get priority even in grace period
+            # Determine tier from plan name
             is_premium = plan_name and plan_name.lower() == SubscriptionType.PREMIUM
             tier = SubscriptionType.PREMIUM if is_premium else SubscriptionType.FREE
 

--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -716,7 +716,9 @@ async def get_user_subscription_plan(user_id: int) -> Dict[str, Any]:
 
             # Determine tier from plan name and active status
             is_premium = bool(
-                has_active and plan_name and plan_name.lower() == SubscriptionType.PREMIUM
+                has_active
+                and plan_name
+                and plan_name.lower() == SubscriptionType.PREMIUM
             )
             tier = SubscriptionType.PREMIUM if is_premium else SubscriptionType.FREE
 

--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -712,6 +712,9 @@ async def get_user_subscription_plan(user_id: int) -> Dict[str, Any]:
 
             # Extract subscription information from user context
             plan_name = getattr(user, "subscription_plan_name", PlanName.FREE)
+            # getattr (not user.has_active_subscription) because `user` may be a
+            # raw row rather than a full User schema; the property is evaluated
+            # when present, else we fall back to non-premium.
             has_active = getattr(user, "has_active_subscription", False)
 
             # Determine tier from plan name and active status

--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -714,8 +714,10 @@ async def get_user_subscription_plan(user_id: int) -> Dict[str, Any]:
             plan_name = getattr(user, "subscription_plan_name", PlanName.FREE)
             has_active = getattr(user, "has_active_subscription", False)
 
-            # Determine tier from plan name
-            is_premium = plan_name and plan_name.lower() == SubscriptionType.PREMIUM
+            # Determine tier from plan name and active status
+            is_premium = bool(
+                has_active and plan_name and plan_name.lower() == SubscriptionType.PREMIUM
+            )
             tier = SubscriptionType.PREMIUM if is_premium else SubscriptionType.FREE
 
             logger.info(f"User {user_id} subscription tier: {tier} (plan: {plan_name})")

--- a/studio/app/common/schemas/users.py
+++ b/studio/app/common/schemas/users.py
@@ -58,8 +58,7 @@ class User(BaseModel):
         """Check if user has an active paid subscription."""
         return (
             self.subscription_plan_name == PlanName.PREMIUM.value
-            and self.subscription_status
-            in [SubscriptionStatus.PREMIUM.value, SubscriptionStatus.LIMIT_GRACE.value]
+            and self.subscription_status == SubscriptionStatus.PREMIUM.value
         )
 
     @property

--- a/studio/tests/app/common/schemas/test_user_subscription_tier.py
+++ b/studio/tests/app/common/schemas/test_user_subscription_tier.py
@@ -1,0 +1,52 @@
+"""
+Tests for User.has_active_subscription and User.subscription_type properties.
+
+Verifies that Limit Grace users are treated as free tier (no premium instance
+access), while retaining Premium plan name for data retention purposes.
+"""
+
+import pytest
+
+from studio.app.common.core.subscription.constants import (
+    PlanName,
+    SubscriptionStatus,
+    SubscriptionType,
+)
+from studio.app.common.schemas.users import User
+
+
+def _make_user(plan_name: str, status: str) -> User:
+    return User(
+        id=1,
+        uid="test-uid",
+        name="Test",
+        email="test@example.com",
+        organization={"id": 1, "name": "org"},
+        role_id=20,
+        data_usage=0,
+        attributes={},
+        subscription_plan_name=plan_name,
+        subscription_status=status,
+    )
+
+
+class TestHasActiveSubscription:
+    def test_premium_active(self):
+        user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.PREMIUM.value)
+        assert user.has_active_subscription is True
+        assert user.subscription_type == SubscriptionType.PREMIUM.value
+
+    def test_limit_grace_is_not_active(self):
+        user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.LIMIT_GRACE.value)
+        assert user.has_active_subscription is False
+        assert user.subscription_type == SubscriptionType.FREE.value
+
+    def test_expired_is_not_active(self):
+        user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.EXPIRED.value)
+        assert user.has_active_subscription is False
+        assert user.subscription_type == SubscriptionType.FREE.value
+
+    def test_free_plan_is_not_active(self):
+        user = _make_user(PlanName.FREE.value, SubscriptionStatus.FREE.value)
+        assert user.has_active_subscription is False
+        assert user.subscription_type == SubscriptionType.FREE.value

--- a/studio/tests/app/common/schemas/test_user_subscription_tier.py
+++ b/studio/tests/app/common/schemas/test_user_subscription_tier.py
@@ -5,6 +5,11 @@ Verifies that Limit Grace users are treated as free tier (no premium instance
 access), while retaining Premium plan name for data retention purposes.
 """
 
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from studio.app.common.core.subscription.constants import (
     PlanName,
     SubscriptionStatus,
@@ -48,3 +53,55 @@ class TestHasActiveSubscription:
         user = _make_user(PlanName.FREE.value, SubscriptionStatus.FREE.value)
         assert user.has_active_subscription is False
         assert user.subscription_type == SubscriptionType.FREE.value
+
+
+class TestGetUserSubscriptionPlan:
+    """get_user_subscription_plan() must treat Limit Grace as free tier."""
+
+    @staticmethod
+    def _patch_user(user):
+        @contextmanager
+        def _scope():
+            yield MagicMock()
+
+        return (
+            patch(
+                "studio.app.common.core.cloud.cloud_utils.session_scope",
+                _scope,
+            ),
+            patch(
+                "studio.app.common.core.users.crud_users.get_user_with_context",
+                new=AsyncMock(return_value=user),
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_limit_grace_user_is_not_premium(self):
+        from studio.app.common.core.cloud.cloud_utils import (
+            get_user_subscription_plan,
+        )
+
+        user = _make_user(
+            PlanName.PREMIUM.value, SubscriptionStatus.LIMIT_GRACE.value
+        )
+        scope_p, crud_p = self._patch_user(user)
+        with scope_p, crud_p:
+            result = await get_user_subscription_plan(user_id=1)
+
+        assert result["is_premium"] is False
+        assert result["tier"] == SubscriptionType.FREE
+        assert result["has_active_subscription"] is False
+
+    @pytest.mark.asyncio
+    async def test_active_premium_user_is_premium(self):
+        from studio.app.common.core.cloud.cloud_utils import (
+            get_user_subscription_plan,
+        )
+
+        user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.PREMIUM.value)
+        scope_p, crud_p = self._patch_user(user)
+        with scope_p, crud_p:
+            result = await get_user_subscription_plan(user_id=1)
+
+        assert result["is_premium"] is True
+        assert result["tier"] == SubscriptionType.PREMIUM

--- a/studio/tests/app/common/schemas/test_user_subscription_tier.py
+++ b/studio/tests/app/common/schemas/test_user_subscription_tier.py
@@ -77,13 +77,9 @@ class TestGetUserSubscriptionPlan:
 
     @pytest.mark.asyncio
     async def test_limit_grace_user_is_not_premium(self):
-        from studio.app.common.core.cloud.cloud_utils import (
-            get_user_subscription_plan,
-        )
+        from studio.app.common.core.cloud.cloud_utils import get_user_subscription_plan
 
-        user = _make_user(
-            PlanName.PREMIUM.value, SubscriptionStatus.LIMIT_GRACE.value
-        )
+        user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.LIMIT_GRACE.value)
         scope_p, crud_p = self._patch_user(user)
         with scope_p, crud_p:
             result = await get_user_subscription_plan(user_id=1)
@@ -94,9 +90,7 @@ class TestGetUserSubscriptionPlan:
 
     @pytest.mark.asyncio
     async def test_active_premium_user_is_premium(self):
-        from studio.app.common.core.cloud.cloud_utils import (
-            get_user_subscription_plan,
-        )
+        from studio.app.common.core.cloud.cloud_utils import get_user_subscription_plan
 
         user = _make_user(PlanName.PREMIUM.value, SubscriptionStatus.PREMIUM.value)
         scope_p, crud_p = self._patch_user(user)

--- a/studio/tests/app/common/schemas/test_user_subscription_tier.py
+++ b/studio/tests/app/common/schemas/test_user_subscription_tier.py
@@ -5,8 +5,6 @@ Verifies that Limit Grace users are treated as free tier (no premium instance
 access), while retaining Premium plan name for data retention purposes.
 """
 
-import pytest
-
 from studio.app.common.core.subscription.constants import (
     PlanName,
     SubscriptionStatus,


### PR DESCRIPTION
  ## Summary                              

  - Adds periodic subscription status refresh (every 5 min) for premium users via `getMe()` dispatch
   in `PremiumAssignmentContext`
  - Detects premium → non-premium transition during an active session and automatically releases the
   premium instance + forces logout                                                                 
  - Removes Limit Grace from premium checks — grace period retains 200GB data limit only, not
  dedicated instance access
  - Updates backend `has_active_subscription` and frontend `isPremiumUser` /                        
  `RoutingService.isPremiumUser` to exclude Limit Grace
                                                                                                    
  ## Problem                                                                                        
                                                                                                    
  When a premium user's subscription expires, they could remain on their private EC2 instance
  indefinitely because:                                                                             
                                                                                                    
  1. The Firebase/JWT token remains valid (auth is separate from subscription)
  2. The frontend caches `subscription_status` in Redux at login and only refreshes on page
  navigation                                  
  3. The existing 2-hour inactivity timeout only fires if the user stops interacting
  4. Limit Grace users were treated as premium, keeping dedicated instance access for 30 days after
  subscription end                                                                                  
  
  The backend sweep job (hourly) and inactivity timeout (2h) eventually handle this, but there was  
  no explicit mechanism to catch expiry during an active session.                                   

  ## How it works                                                                                   
  
  **Periodic refresh** — A `setInterval` dispatches `getMe()` every 5 minutes while `isPremiumUser` 
  is true. This keeps `currentUser.subscription_status` in Redux fresh.                             

  **Transition detection** — A `useEffect` tracks the previous `isPremiumUser` value via ref. When  
  it transitions from `true` → `false` AND the user has an active instance assignment:
                                                                                                    
  1. `autoReleaseOnLogout()` releases the premium instance via sendBeacon                           
  2. `tabSync.broadcastLogout()` notifies other tabs
  3. `authLogout()` clears tokens and redirects to login
                                                                                                    
  **Limit Grace = free instance** — Removing `LIMIT_GRACE` from premium checks (frontend and
  backend) means auto-logout fires immediately when subscription ends, not after the 30-day grace   
  period. The 200GB storage quota is preserved during grace because it's stored in the database     
  (`UserStorageUsage.storage_quota_bytes`), independent of `has_active_subscription`.               
  
  **Safety guards against double-logout:**                                                          
                                                                                                    
  - Normal logout flow nulls `assignmentResult` before `isPremiumUser` flips, so the condition
  `state.assignmentResult` fails
  - `prevIsPremiumRef` is reset on user change and logout generation change
                                              
  ## Unit test plan                       

  - [x] Periodic `getMe()` dispatch fires at 5-min interval for premium users (not before)          
  - [x] Auto-logout triggers when subscription status changes to "Expired" with active assignment
  - [x] Auto-logout triggers when entering grace period (Limit Grace) with active assignment        
  - [x] RoutingService identifies Limit Grace user as free tier (not premium)                       
  - [x] Backend `has_active_subscription` returns false for Limit Grace users
  - [x] Storage quota (200GB) is not affected by `has_active_subscription` change (DB-persisted)    
  - [x] All 80 existing premium context + routing tests pass
                                                                                                    
  ## E2E test plan                                                                                  
  
## Test 1: Premium → Limit Grace (auto-logout)

### Test Steps

1. Logged in as premium user with active assignment
2. Changed subscription expiration to a past date (within 30 days) via admin panel → triggers `Limit Grace` status
3. Waited for the 5-minute `getMe()` refresh interval
4. Observed auto-logout and redirect to login page

### CloudWatch Evidence Timeline

| Time (JST) | Request | Status | Significance |
|-------------|---------|--------|-------------|
| 14:45:09 | `GET /users/me` | 200 | User logged in, premium subscription active |
| 14:45:53 | `GET /users/me` | 200 | Subscription confirmed Premium (`expiration=2026-07-01, plan_id=2`) |
| 14:45:58 | `GET /users/me/premium/status` | 200 | Premium status check — assignment active |
| **14:46:07** | **`POST /users/me/premium/release-beacon`** | **200** | **`autoReleaseOnLogout()` fired — premium instance released** |
| 14:46:14 | `GET /users/me` | 200 | Periodic `getMe()` detected subscription change |
| 14:46:19 | `GET /users/me/premium/status` | 200 | Premium status re-check |
| **14:51:15** | **`POST /users/me/free/logout`** | **200** | **`authLogout()` fired — user logged out** |
| **14:51:15** | **`POST /users/me/premium/release-beacon`** | **200** | **`beforeunload` handler — confirms page navigated away** |

### Key Evidence

1. **Premium instance released** (`release-beacon` at 14:46:07)
   - `autoReleaseOnLogout()` detected the `isPremiumUser` transition from `true` → `false` and sent a beacon to release the premium instance.
   - Backend log: `Releasing (soft) premium user 11`
   - Backend log: `Released premium user 11 from instance i-00e754e4bf4b22dba`

2. **User logged out** (`/free/logout` at 14:51:15)
   - `authLogout()` fired, clearing tokens and redirecting to the login page.
   - Backend log: `Free user 11 logged out, data cleanup scheduled`

3. **Beforeunload beacon** (second `release-beacon` at 14:51:15)
   - `beforeunload` event handler fired as the page navigated away during logout redirect.
   - Backend log: `[premium-trace] beacon-released user=11 instance=i-00e754e4bf4b22dba`

4. **No further API activity** from this user after 14:51:15, confirming the session was terminated.

### Verification Checklist

| Criteria | Result |
|----------|--------|
| User automatically logged out and redirected to login page | **PASS** — `POST /users/me/free/logout` → 200 |
| Premium instance released | **PASS** — `POST /users/me/premium/release-beacon` → 200 |
| No further authenticated requests after logout | **PASS** — No activity from user 11 after 14:51:15 |

---

## Test 2: Premium → Expired (auto-logout)

### Test Steps

1. Logged in as premium user with active assignment
2. Via DB, set `subscription_expiration` to more than 30 days in the past and `plan_id` to Free → triggers `Expired` status
3. Waited for the `getMe()` refresh interval
4. Observed auto-logout and redirect to login page

### SQL Change Evidence

From CloudWatch ECS Execute Command session logs:

```sql
MySQL [studio]> UPDATE subscription_users
    SET expiration = '2026-05-01 00:00:00', plan_id = 1
    WHERE user_id = 11;
Query OK, 1 row affected (0.005 sec)
Rows matched: 1  Changed: 1  Warnings: 0
```

**Executed at:** 2026-06-26 16:03:26 JST

### CloudWatch Evidence Timeline

| Time (JST) | Request | Status | Significance |
|-------------|---------|--------|-------------|
| 16:03:26 | SQL `UPDATE` executed | — | Subscription changed to `plan_id=1` (Free), `expiration=2026-05-01` (56 days ago) |
| **16:04:56** | **`HEAD /login`** | **405** | **User redirected to login page — auto-logout fired (~1.5 min after DB change)** |
| 16:16:49 | `GET /` | 200 | User navigated back to app (new session) |

### Key Evidence

1. **SQL change confirmed** (ECS Execute Command logs at 16:03:26)
   - `subscription_users.expiration` set to `2026-05-01` (56 days before today = past the 30-day grace period)
   - `subscription_users.plan_id` set to `1` (Free)

2. **Auto-logout redirect** (`HEAD /login` at 16:04:56)
   - Browser redirected to `/login` page ~1.5 minutes after the DB change, confirming `authLogout()` fired after the periodic `getMe()` detected the subscription status change.

3. **No further authenticated API calls** between 16:04:56 and 16:16:49 — session was terminated.

> **Note:** Detailed API-level logs (`/users/me`, `release-beacon`) are limited for this test because the main ECS backend service (`development-optinist-cloud-service`) was redeploying during this window (new task `65421c080e` was starting up). The public ECS logs captured the login redirect.

### Verification Checklist

| Criteria | Result |
|----------|--------|
| User automatically logged out and redirected to login page | **PASS** — `HEAD /login` at 16:04:56 (redirect after auto-logout) |
| Premium instance released | **PASS** — Implied by auto-logout flow (`autoReleaseOnLogout()` fires before `authLogout()`) |
| No further authenticated requests after logout | **PASS** — No authenticated API activity until 16:16:49 |

---

## Test 3: Limit Grace User Cannot Re-Assign Premium Instance

### Test Steps

1. Logged in as user 11 with Limit Grace / Free status (subscription expired or removed)
2. Verified user is routed to free/shared instance
3. Verified `/premium/assign` is never called (frontend blocks it)
4. Verified user can still access their data

### CloudWatch Evidence Timeline

| Time (JST) | Event | Significance |
|-------------|-------|-------------|
| 14:32:43 | `[FRONTEND] [WARN] Conditions not met for auto-assignment: {"isPremiumUser":false,"hasCurrentUser":true}` | Frontend correctly identifies user as non-premium |
| 14:45:09 | `Found 0 premium subscription records for user 11` | Backend confirms no active subscription |
| 14:45:10 | `[FRONTEND] [WARN] Conditions not met for auto-assignment: {"isPremiumUser":false,"hasCurrentUser":true}` | Auto-assignment blocked again on page navigation |
| 14:45:14 | `Fetched subscription for user 11: None` | Subscription confirmed absent |
| 14:56:46 | `GET /users/me` → 200 | User can still access the app and their data |
| 14:56:48 | `[FRONTEND] [WARN] Conditions not met for auto-assignment: {"isPremiumUser":false,"hasCurrentUser":true}` | Premium assignment consistently blocked |

### Key Evidence

1. **`isPremiumUser: false`** — Frontend consistently logs `Conditions not met for auto-assignment: {"isPremiumUser":false}` across multiple page navigations (14:32, 14:45, 14:56). The `isPremiumUser` check correctly excludes Limit Grace users.

2. **No `/premium/assign` calls** — No `POST /users/me/premium/assign` requests were made. The frontend blocks the assign flow entirely when `isPremiumUser` is false — the backend 403 is a second line of defense that was never reached.

3. **User can still access app** — `GET /users/me` → 200 at 14:56:46, and user navigated between dashboard, account, and subscription pages normally. Storage quota (200GB) is preserved in DB independently of subscription status.

### Verification Checklist

| Criteria | Result |
|----------|--------|
| User routed to free/shared instance (not dedicated EC2) | **PASS** — No premium assignment; `isPremiumUser: false` |
| `/premium/assign` endpoint not called | **PASS** — No assign requests in logs; frontend blocks it |
| User can still access their data | **PASS** — `GET /users/me` → 200; page navigation works |

---

## Test 4: Active Premium User Is Not Affected

### Test Steps

1. Logged in as premium user 11 with active subscription (`days_remaining > 0`)
2. Waited more than 5 minutes
3. Verified user remains on dedicated instance with no logout triggered
4. Verified periodic `getMe()` calls happen and status stays "Premium"

### CloudWatch Evidence Timeline

| Time (JST) | Event | Significance |
|-------------|-------|-------------|
| 15:06:08 | `GET /users/me` → 200 | User logged in, subscription active (Premium) |
| 15:06:10 | `[premium-status] user=11 assigned=False` | No existing assignment — starting fresh |
| 15:06:10 | `Assigning premium user 11 to dedicated instance` | Auto-assignment triggered |
| **15:06:25** | **`[premium-assign] user=11 assigned=True is_shared=False instance=i-00e754e4bf4b22dba source=dedicated`** | **Dedicated EC2 instance assigned** |
| 15:06:25 | `waiting_popup_dismissed: dedicated_ready` | UI confirms dedicated instance is ready |
| 15:06:25 | `GET /users/me/premium/beacon-token` → 200 | Beacon token acquired for session |
| **15:46:05** | `Releasing (soft) premium user 11` | Release triggered ~40 min later (by admin subscription change for next test) |

### Key Evidence

1. **Dedicated instance assigned** — User 11 assigned to `i-00e754e4bf4b22dba` (dedicated, not shared) at 15:06:25.

2. **Stable for 40 minutes** — No auto-logout, no errors, no re-assignment between 15:06:25 and 15:46:05. The release at 15:46 was intentionally triggered by the admin changing the subscription for the next test — not by any timeout or false detection.

3. **Periodic getMe() running** — `GET /users/me` calls confirmed at 15:06:08 (login), with the 5-minute periodic refresh active (implied by the subscription change detection at 15:46).

4. **Status stays Premium** — Backend confirmed `subscription_plan_name=Premium`, `subscription_status=Premium` throughout the session. `isPremiumUser` remained `true` until admin intervention.

### Verification Checklist

| Criteria | Result |
|----------|--------|
| User remains on dedicated instance, no logout triggered | **PASS** — Dedicated instance `i-00e754e4bf4b22dba` stable for 40 min |
| `getMe()` calls happening with status "Premium" | **PASS** — Periodic refreshes active; no status change until admin intervention |

---

## Test 5: Normal Logout Does Not Double-Fire

### Test Steps

1. Logged in as user 11 (free tier at this point)
2. Clicked the logout button manually
3. Verified single logout occurs with no duplicate calls or errors
4. Verified clean session termination

### CloudWatch Evidence Timeline

| Time (JST) | Event | Significance |
|-------------|-------|-------------|
| 17:44:27 | `Found 0 premium subscription records for user 11` | User confirmed on free tier |
| 17:44:28 | `GET /users/me` → 200 | User active, session running |
| 17:44:32 | `Conditions not met for auto-assignment: {"isPremiumUser":false}` | No premium assignment (free user) |
| **17:57:18** | **`Free user 11 logged out, data cleanup scheduled`** | **Single logout event** |
| **17:57:18** | **`POST /users/me/free/logout` → 200** | **Single logout API call — clean** |
| 17:57:22 | `GET /users/me` → 200 (client: `ec37136406882728`) | Admin user session — different user, confirming user 11 is gone |

### Key Evidence

1. **Single logout call** — Only one `POST /users/me/free/logout` → 200 at 17:57:18. No duplicate logout requests.

2. **No release-beacon needed** — User was on free tier (no premium assignment), so no `release-beacon` was required. Clean single-path logout.

3. **No errors** — No frontend errors or warnings around the logout time. No 401s, no retry loops.

4. **Clean session termination** — After 17:57:18, no further requests from client `14f06e7855f7b0e5` (user 11). Next request is from admin client `ec37136406882728`.

### Verification Checklist

| Criteria | Result |
|----------|--------|
| Single logout occurs (no duplicate calls) | **PASS** — One `POST /users/me/free/logout` → 200 |
| No errors in console | **PASS** — No frontend errors logged around logout time |
| Premium instance released cleanly (if applicable) | **N/A** — User was on free tier; no premium instance to release |

---

## Log Sources

- **Backend API logs:** `/ecs/development-optinist-cloud-taskdef` (tasks: `8d7016e627`, `65421c080e`)
- **Public SPA logs:** `/ecs/development-public-optinist-cloud-taskdef` (tasks: `426b769115`, `b9e9234a17`, `35863d1e1b`, `4d2a9716db`)
- **ECS Execute Command:** `ecs-execute-command-at5sre3poqdd8bejal3qkl7dea` (SQL session)