### PR TITLE
Fix Silent Free-Tier Drop After EventBridge Cleanup

### DIFF
--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -511,6 +511,90 @@ describe("axios premium-routing interceptors", () => {
     expect(mockUpdateRoutingToken).toHaveBeenCalledWith("reseeded-token")
   })
 
+  // --- Instance mismatch active detection (issue #709) ---
+
+  it("emits unreachable and clears premiumAssigned when 200 OK comes from wrong instance (instance mismatch detection)", async () => {
+    // When EventBridge cleanup deletes the per-user ALB rule before the
+    // user's next request, ALB falls through to free-tier → 200 OK from a
+    // different instance. The interceptor must actively detect this and
+    // trigger the recovery flow.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+
+    responses.set("/wrong-instance-200", {
+      status: 200,
+      data: { ok: true },
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "free-tier-instance-hash",
+      },
+    })
+    const res = await axiosInstance.get("/wrong-instance-200")
+
+    // Response still resolves — no retry needed for 200.
+    expect(res.status).toBe(200)
+    expect(res.data).toEqual({ ok: true })
+
+    // Active detection: unreachable emitted, premiumAssigned cleared.
+    expect(mockEmitPremiumUnreachable).toHaveBeenCalledTimes(1)
+    expect(mockEmitPremiumUnreachable.mock.calls[0][0]).toMatchObject({
+      url: "/wrong-instance-200",
+      status: 200,
+    })
+    expect(mockSetPremiumAssigned).toHaveBeenCalledWith(false)
+
+    // Must NOT emit reachable — instance mismatch.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
+  it("does NOT emit unreachable on instance mismatch when _outgoingInstanceId is unset (startup race)", async () => {
+    // Before the assignment API returns, getPremiumInstanceId() returns null.
+    // Without a known instance ID, we cannot distinguish a legitimate
+    // fallback from a startup race — suppress unreachable.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue(null)
+
+    responses.set("/startup-mismatch", {
+      status: 200,
+      data: {},
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "some-instance-hash",
+      },
+    })
+    await axiosInstance.get("/startup-mismatch")
+
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
+  it("does NOT emit unreachable when x-served-by-instance header is absent", async () => {
+    // If the response lacks x-served-by-instance (e.g. edge case with
+    // middleware skip), we cannot determine instance identity — suppress.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+
+    responses.set("/no-served-by", {
+      status: 200,
+      data: {},
+      headers: { "x-routing-id": "rid-outgoing" },
+    })
+    await axiosInstance.get("/no-served-by")
+
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+    // Also no reachable — instance cannot be verified without the header.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
   it("does NOT update routing token when premiumAssigned is true and instance hash mismatches", async () => {
     // Premium headers were sent but the response came from a different
     // instance (ALB fallback to shared backend).

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -311,6 +311,35 @@ function shouldEmitPremiumReachable(
   return true
 }
 
+/**
+ * Detects when a successful response (200 OK) came from the wrong instance
+ * — indicating ALB fallback after EventBridge cleanup deleted the per-user
+ * rule and target group.
+ *
+ * Returns true only when ALL of:
+ *  1. The request carried premium routing headers
+ *  2. The expected instance ID was known at request time (not startup race)
+ *  3. The response carries an x-served-by-instance header
+ *  4. The serving instance differs from the expected dedicated instance
+ *
+ * When true, the caller should emit premiumUnreachable to trigger the
+ * recovery flow (polling /status + /assign). The warm-up grace period
+ * (DEDICATED_HANDOFF_GRACE_MS) is respected downstream by the
+ * useInstanceUnreachableMachine listener.
+ */
+function isInstanceMismatch(
+  res: AxiosResponse,
+  cfg: CustomAxiosRequestConfig | undefined,
+): boolean {
+  if (!cfg?._hadPremiumHeaders) return false
+  const outgoingInstanceId = cfg._outgoingInstanceId
+  if (!outgoingInstanceId) return false
+  const servedByHeader = RoutingHeaders.SERVED_BY_INSTANCE.toLowerCase()
+  const servedByInstance = res.headers[servedByHeader]
+  if (typeof servedByInstance !== "string") return false
+  return servedByInstance !== outgoingInstanceId
+}
+
 axios.interceptors.response.use(
   async (res) => {
     const cfg = res.config as CustomAxiosRequestConfig | undefined
@@ -345,6 +374,16 @@ axios.interceptors.response.use(
 
     if (shouldEmitPremiumReachable(res, cfg)) {
       routingService.emitPremiumReachable({
+        url: cfg!.url,
+        status: res.status,
+        sentAt: cfg!._premiumSentAt,
+      })
+    } else if (isInstanceMismatch(res, cfg)) {
+      // Active detection: 200 OK from wrong instance (ALB fallback after
+      // EventBridge cleanup). Stop sending premium headers to prevent
+      // further misrouted requests and trigger the recovery flow.
+      routingService.setPremiumAssigned(false)
+      routingService.emitPremiumUnreachable({
         url: cfg!.url,
         status: res.status,
         sentAt: cfg!._premiumSentAt,

--- a/studio/app/common/core/premium/premium_assignment_service.py
+++ b/studio/app/common/core/premium/premium_assignment_service.py
@@ -35,6 +35,8 @@ class PremiumStatusCheckError(Exception):
 LAMBDA_TIMEOUT_SECONDS = 60
 LAMBDA_MAX_RETRIES = 2
 LAMBDA_RETRY_BASE_DELAY_SECONDS = 2
+# instance_id the Lambda returns for non-pinned autoscaling-pool assignments.
+AUTOSCALING_POOL_INSTANCE_ID = "autoscaling-pool"
 # Short bound for latency-sensitive callers (e.g. the Stripe webhook path),
 # which must respond quickly. Cleanup that exceeds this is handled by the
 # periodic premium-expiration sweep, so failing open here is safe.

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -20,6 +20,7 @@ from studio.app.common.core.middleware.user_activity_middleware import (
     mark_user_logged_out,
 )
 from studio.app.common.core.premium.premium_assignment_service import (
+    AUTOSCALING_POOL_INSTANCE_ID,
     premium_assignment_service,
 )
 from studio.app.common.core.subscription.constants import (
@@ -121,7 +122,7 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
                 "instance_id": instance_id,
                 "instance_id_hash": (
                     get_instance_hash_cached(instance_id, ROUTING_SECRET_KEY)
-                    if instance_id
+                    if instance_id and instance_id != AUTOSCALING_POOL_INSTANCE_ID
                     else None
                 ),
                 "assigned": True,
@@ -351,7 +352,11 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
             status_info.get("instance_id") if status_info else None,
         )
 
-        if status_info and status_info.get("instance_id"):
+        if (
+            status_info
+            and status_info.get("instance_id")
+            and status_info.get("instance_id") != AUTOSCALING_POOL_INSTANCE_ID
+        ):
             status_info["instance_id_hash"] = get_instance_hash_cached(
                 status_info["instance_id"], ROUTING_SECRET_KEY
             )

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -76,10 +76,14 @@ PREMIUM_STATUS_OPTIONAL_FIELDS = {
 # PremiumAssignment (nested in PremiumStatusResult)
 PREMIUM_ASSIGNMENT_NESTED_FIELDS = {
     "instance_id": str,
-    "instance_id_hash": str,
     "assigned_at": str,
     "status": str,
     "is_shared": bool,
+}
+
+# instance_id_hash is omitted for non-instance-pinned (autoscaling-pool) assignments
+PREMIUM_ASSIGNMENT_NESTED_OPTIONAL_FIELDS = {
+    "instance_id_hash": str,
 }
 
 # PremiumHeartbeatResult interface
@@ -322,6 +326,43 @@ async def test_contract_premium_assign_shared_instance(mock_premium_user):
         # Semantic validation for shared instance
         assert result["assigned"] is True
         assert result["is_shared"] is True
+        # Real-shared is pinned to one instance, so it keeps a verifiable hash.
+        assert isinstance(result["instance_id_hash"], str)
+
+
+@pytest.mark.asyncio
+async def test_contract_premium_assign_autoscaling_pool(mock_premium_user):
+    """
+    Contract test: an autoscaling-pool assignment is load-balanced across the
+    pool, not pinned to one instance, so instance_id_hash must be None — the
+    marker is not a real instance and its hash could never match x-served-by.
+    """
+    with patch(
+        "studio.app.common.routers.users_me.premium_assignment_service"
+    ) as mock_service:
+        mock_service.assign_premium_user = AsyncMock(
+            return_value={
+                "success": True,
+                "message": "Assigned to autoscaling pool",
+                "instance_id": "autoscaling-pool",
+                "is_shared": True,
+                "assignment_source": "autoscaling_temp",
+            }
+        )
+
+        from studio.app.common.routers.users_me import assign_premium_instance
+
+        result = await assign_premium_instance(current_user=mock_premium_user)
+
+        validate_contract(
+            result,
+            PREMIUM_ASSIGNMENT_REQUIRED_FIELDS,
+            PREMIUM_ASSIGNMENT_OPTIONAL_FIELDS,
+            context="PremiumAssignmentResult (autoscaling pool)",
+        )
+
+        assert result["is_shared"] is True
+        assert result["instance_id_hash"] is None
 
 
 # ============================================================================
@@ -428,11 +469,45 @@ async def test_contract_premium_status_with_assignment(mock_premium_user):
         validate_contract(
             result["assignment"],
             PREMIUM_ASSIGNMENT_NESTED_FIELDS,
+            PREMIUM_ASSIGNMENT_NESTED_OPTIONAL_FIELDS,
             context="PremiumAssignment (nested)",
         )
 
         # Semantic validation
         assert result["is_premium"] is True
+
+
+@pytest.mark.asyncio
+async def test_contract_premium_status_autoscaling_pool(mock_premium_user):
+    """
+    Contract test: a status response for an autoscaling-pool assignment omits
+    instance_id_hash (the pool marker is not a real, verifiable instance).
+    """
+    with patch(
+        "studio.app.common.routers.users_me.premium_assignment_service"
+    ) as mock_service:
+        mock_service.get_premium_user_status = AsyncMock(
+            return_value={
+                "instance_id": "autoscaling-pool",
+                "assigned_at": "2024-01-15T10:30:00Z",
+                "status": "active",
+                "is_shared": True,
+            }
+        )
+
+        from studio.app.common.routers.users_me import get_premium_assignment_status
+
+        result = await get_premium_assignment_status(current_user=mock_premium_user)
+
+        validate_contract(
+            result,
+            PREMIUM_STATUS_REQUIRED_FIELDS,
+            PREMIUM_STATUS_OPTIONAL_FIELDS,
+            context="PremiumStatusResult (autoscaling pool)",
+        )
+
+        assert result["assignment"] is not None
+        assert result["assignment"].get("instance_id_hash") is None
 
 
 @pytest.mark.asyncio

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -475,6 +475,8 @@ async def test_contract_premium_status_with_assignment(mock_premium_user):
 
         # Semantic validation
         assert result["is_premium"] is True
+        # Pinned instance must always return a verifiable hash.
+        assert isinstance(result["assignment"]["instance_id_hash"], str)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When a premium user's dedicated EC2 instance is terminated externally, the EventBridge cleanup Lambda deletes the per-user ALB rule, target group, and `premium_user_assignments` row within ~2 seconds. If the user's next request arrives **after** this cleanup completes, ALB falls through to the free-tier target group and returns `200 OK` — no 502/503 error is generated. Since the frontend's unreachable detection relied exclusively on 502/503 errors, `emitPremiumUnreachable()` never fired, polling never started, and the user was silently stranded on free-tier compute with no UI signal and no automatic recovery.

This fix extends the axios success response interceptor to actively detect instance identity mismatch on 200 OK responses. When a request carrying premium routing headers receives a successful response from a different instance than expected, the interceptor now emits `premiumUnreachable` and clears `premiumAssigned`, triggering the existing recovery flow (polling `/status` + `/assign`).

---

## Root Cause

The `shouldEmitPremiumReachable()` function (introduced in PR #649, commit `ce4886aa`) already detected the instance hash mismatch — free-tier `x-served-by-instance` differs from the expected premium instance hash. However, this detection was **passive**: it only suppressed the `emitPremiumReachable()` signal. It did not actively trigger `emitPremiumUnreachable()` or any recovery flow.

The detection gap existed whenever:
1. The user's dedicated instance was externally terminated
2. EventBridge cleanup completed before the user's next request (~2s)
3. ALB had no per-user rule, so the request fell through to free-tier (priority 320)
4. Free-tier backend returned `200 OK` with a different `x-served-by-instance` hash
5. No 502/503 was ever generated → existing error-path detection never triggered

---

## Design Rationale

### Why Extend the Success Path (Not Add a Periodic Health Check)

An alternative approach would be a periodic health check that probes the dedicated instance. This was rejected because:

1. **Unnecessary complexity** — the existing response interceptor already processes every API request and has access to all required signals (`_hadPremiumHeaders`, `_outgoingInstanceId`, `x-served-by-instance`).
2. **Latency** — a periodic probe would have a detection delay equal to the probe interval. The interceptor detects the mismatch on the **first** user-initiated request after cleanup.
3. **No additional network traffic** — the fix piggybacks on existing API calls.

### Why `isInstanceMismatch` Is a Separate Function (Not Inlined)

Separating `isInstanceMismatch()` from `shouldEmitPremiumReachable()` maintains the single-responsibility principle:
- `shouldEmitPremiumReachable()` answers: "Can we confirm the premium instance is healthy?"
- `isInstanceMismatch()` answers: "Do we have evidence that the premium instance is NOT serving this response?"

The two functions share guard conditions (`_hadPremiumHeaders`, `_outgoingInstanceId`) but differ in their third check:
- `shouldEmitPremiumReachable` requires the served-by-instance to **match** → emit reachable
- `isInstanceMismatch` requires the served-by-instance to be **present AND different** → emit unreachable

The "present AND different" distinction in `isInstanceMismatch` is critical — if `x-served-by-instance` is absent (e.g., unauthenticated endpoint edge case), neither function fires, which is the safe default.

### Why `setPremiumAssigned(false)` in the Interceptor

The 502/503 path (`handlePremiumRoutingError`) also calls `setPremiumAssigned(false)` immediately before emitting unreachable. The same pattern is used here for consistency and to prevent subsequent requests from continuing to send stale premium routing headers to the wrong instance. The `useInstanceUnreachableMachine` listener processes the unreachable event downstream and manages the circuit-breaker state.

### Warm-Up Grace Period Compatibility

The `DEDICATED_HANDOFF_GRACE_MS` (15 seconds) is enforced in the `useInstanceUnreachableMachine` hook's unreachable listener (not in the interceptor). If `isInstanceMismatch` fires during a shared→dedicated handoff, the listener absorbs the event as a single-shot warm-up grace — the same behavior as a transient 5xx during handoff.

---

## Changed Files

### Frontend

| File | Change |
|------|--------|
| `frontend/src/utils/axios.ts` | Added `isInstanceMismatch()` helper function (lines 314-341). Modified success response interceptor to emit `premiumUnreachable` on instance mismatch (lines 381-391). |
| `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` | Added 3 new test cases for instance mismatch active detection (lines 514-596). |

---

## How It Works

### Before (detection gap)

```
User request (with premium headers)
  → ALB: no per-user rule (cleaned up) → free-tier TG → 200 OK
  → Response interceptor:
    → shouldEmitPremiumReachable(): false (instance hash mismatch)
    → [nothing else happens]
  → Result: premiumAssigned=true, no polling, no recovery
```

### After (active detection)

```
User request (with premium headers)
  → ALB: no per-user rule (cleaned up) → free-tier TG → 200 OK
  → Response interceptor:
    → shouldEmitPremiumReachable(): false (instance hash mismatch)
    → isInstanceMismatch(): true (served-by != expected)
    → setPremiumAssigned(false) — stop sending premium headers
    → emitPremiumUnreachable() — trigger recovery flow
  → Result: polling starts, /status + /assign called, user recovers
  → Response still returned to caller (200 OK — no retry needed)
```

### New Function: `isInstanceMismatch(res, cfg)`

Returns `true` when ALL of:
1. `cfg._hadPremiumHeaders === true` — request carried premium routing headers
2. `cfg._outgoingInstanceId` is truthy — instance ID was known at request time
3. `typeof res.headers["x-served-by-instance"] === "string"` — header is present
4. `res.headers["x-served-by-instance"] !== cfg._outgoingInstanceId` — different instance

### False-Positive Safety Matrix

| Scenario | `_hadPremiumHeaders` | `_outgoingInstanceId` | `x-served-by-instance` | `isInstanceMismatch` |
|----------|---------------------|-----------------------|------------------------|---------------------|
| Startup race (`premiumInstanceId=null`) | `true` | `undefined` | any | `false` — guard #2 |
| Correct instance serving | `true` | `"hash-A"` | `"hash-A"` | `false` — guard #4 |
| Free-tier request (no premium headers) | `false` | `undefined` | any | `false` — guard #1 |
| Header missing (unauthenticated path) | `true` | `"hash-A"` | `undefined` | `false` — guard #3 |
| **ALB fallback after cleanup** | **`true`** | **`"hash-A"`** | **`"hash-B"`** | **`true`** |
| Warm-up grace period | `true` | `"hash-A"` | `"hash-B"` | `true` — absorbed downstream by `DEDICATED_HANDOFF_GRACE_MS` in `useInstanceUnreachableMachine` |

---

## Automated Test Cases

### Frontend: Axios Interceptor Tests (3 new)

| # | Test | Scenario | Expected |
|---|------|----------|----------|
| 1 | `emits unreachable and clears premiumAssigned when 200 OK comes from wrong instance` | Premium headers sent with `_outgoingInstanceId="expected-instance-hash"`. Response 200 with `x-served-by-instance: "free-tier-instance-hash"`. | `emitPremiumUnreachable` called once (with `status: 200`). `setPremiumAssigned(false)` called. `emitPremiumReachable` NOT called. Response resolves normally (`res.status === 200`). |
| 2 | `does NOT emit unreachable on instance mismatch when _outgoingInstanceId is unset (startup race)` | Premium headers sent. `getPremiumInstanceId()` returns `null`. Response 200 with `x-served-by-instance: "some-instance-hash"`. | Neither `emitPremiumUnreachable` nor `emitPremiumReachable` called. |
| 3 | `does NOT emit unreachable when x-served-by-instance header is absent` | Premium headers sent with `_outgoingInstanceId="expected-instance-hash"`. Response 200 with no `x-served-by-instance` header. | Neither `emitPremiumUnreachable` nor `emitPremiumReachable` called. |

### Existing Tests (14 — all pass, no regressions)

All pre-existing tests continue to pass. The `else if` structure ensures the new `isInstanceMismatch` branch is only evaluated when `shouldEmitPremiumReachable` returns `false`, so existing reachable/unreachable behavior is unchanged.

### Test Results

```
Frontend axios interceptor: 17 passed (14 existing + 3 new)
TypeScript tsc --noEmit:     0 errors in axios.ts
```

---

## Manual Test Plan

### Prerequisites

- A premium-subscribed user account with a dedicated EC2 instance currently assigned and running
- Access to AWS Console (EC2 instances, EventBridge rules, CloudWatch Logs)
- Access to MySQL (RDS) via the RDS Proxy endpoint (`RDS_HOST` environment variable)
- Browser DevTools open (Network tab with "Preserve log" enabled, Console tab)
- Network tab filter set to exclude static assets (e.g., filter by `XHR` or `Fetch`)

### Test 1: Instance termination — cleanup BEFORE next request (core fix verification)

**Objective**: Verify that when EventBridge cleanup completes before the user's next request, the new instance mismatch detection triggers recovery. This is the primary scenario that issue #709 addresses.

**Scope**: This test targets the timing window where:
- The dedicated instance is externally terminated
- EventBridge cleanup deletes the per-user ALB rule/TG/DB row (~2s)
- The user's next request arrives AFTER cleanup — ALB falls through to free-tier → 200 OK

#### Step 1: Establish baseline (no false positive)

1. Log in as the premium user. Open DevTools Network tab.
2. Navigate to a workflow page or perform any action that triggers API requests.
3. Select any API request and inspect the **response headers**:
   - **Verify**: `x-served-by-instance` header is present (16-char hex value).
   - **Verify**: `x-routing-id` header is present.
4. **Verify**: No `POST /users/me/premium/ui-event` with `event_type: "instance_unreachable"` appears — confirming `emitPremiumUnreachable` was NOT called on a healthy instance.
5. In DevTools Console, run:
   ```javascript
   localStorage.getItem("premium_instance_id")
   ```
6. Note the returned value (e.g., `"a1b2c3d4e5f67890"`) — this is the expected instance hash.
7. **Verify**: The Console value matches the `x-served-by-instance` header value from step 3 — confirming baseline identity match.

#### Step 2: Terminate the dedicated instance (externally)

1. In the AWS EC2 Console, identify the user's dedicated instance:
   - Filter by Tag `Type` = `Premium-Instance`
   - Cross-reference with the `instance_id` from `GET /users/me/premium/status`
2. **Terminate** the instance (not Stop — termination triggers EventBridge immediately).
3. **Wait at least 30 seconds** — this ensures EventBridge cleanup Lambda has completed:
   - Deleted the `premium_user_assignments` row
   - Deleted the per-user ALB rule (priority 100-199)
   - Deleted the per-user target group (`premium-tg-{user_id}`)
4. **Do NOT interact with the browser during the wait** — the next request must arrive after cleanup.

#### Step 3: Verify cleanup completed (optional but recommended)

1. **MySQL (RDS)**: Confirm the assignment row is deleted:
   ```sql
   SELECT * FROM premium_user_assignments WHERE user_id = <user_id>;
   ```
   Must return 0 rows.
2. **AWS ALB Console**: Confirm the per-user rule is deleted:
   - Go to the ALB → Listeners → Rules
   - Search for the user's routing-id rule (priority 100-199)
   - Must be absent.

#### Step 4: Trigger a request and verify active detection (this PR fix target)

1. In the browser, trigger any API request — navigate to a different page, click a button, or refresh a data view. **Do NOT perform a full page reload** (that would clear the routing state).
2. In the Network tab, select the triggered request.
3. Inspect the **request headers**:
   - **Verify**: `X-Routing-ID` is present (the request was sent with premium routing headers).
   - **Verify**: `X-User-Tier: premium` is present.
4. Inspect the **response headers**:
   - **Verify**: HTTP status is `200` (NOT 502/503 — confirming ALB fell through to free-tier).
   - **Verify**: `x-served-by-instance` is present but its value **differs** from the baseline noted in Step 1.6.
5. **Verify (this PR fix)**: A `POST /users/me/premium/ui-event` with `event_type: "instance_unreachable"` appears in the Network tab.
   - Before the fix, this telemetry event was NOT generated for 200-from-wrong-instance.
   - The event payload should include `"status": 200` — confirming this is the new 200-mismatch path, not the existing 502/503 path.
6. **Verify**: Subsequent requests do NOT carry `X-Routing-ID` or `X-User-Tier` headers — confirming `setPremiumAssigned(false)` was called.
7. **Verify**: The "Premium instance unresponsive" snackbar appears (or the polling recovery flow starts — `GET /users/me/premium/status` calls appear in the Network tab).
8. **Verify**: The original response (200 OK) was still returned to the caller — the UI action completed successfully (no error displayed to the user for the data request itself).

**Expected**: The first request after cleanup is a 200 OK from the wrong instance. The interceptor detects the mismatch, emits unreachable, clears premiumAssigned, and the recovery flow begins.

#### Step 5: Verify recovery (end-to-end)

1. Wait for the polling mechanism to call `POST /users/me/premium/assign`.
2. **Verify**: A new dedicated instance is launched and assigned.
3. **Verify**: Once the new instance is healthy, `GET /users/me/premium/status` returns the new `instance_id` and `instance_id_hash`.
4. **Verify**: The probe mechanism re-arms `premiumAssigned=true` and the next request is routed to the new dedicated instance.
5. **Verify**: `x-served-by-instance` on the new responses matches the new `instance_id_hash`.

### Test 2: Startup race condition — no false unreachable on fresh login

**Objective**: Verify that the instance mismatch detection does not fire during the startup race when `premiumInstanceId` is not yet set (`isInstanceMismatch` guard #2).

1. Clear localStorage (DevTools Application → Local Storage → Clear All) or use an incognito window.
2. Log in as the premium user. Open DevTools Network tab immediately.
3. **Verify**: During the initial page load, before `/premium/assign` or `/premium/status` returns:
   - `localStorage.getItem("premium_instance_id")` may return `null` briefly.
   - No `POST /users/me/premium/ui-event` with `event_type: "instance_unreachable"` appears.
4. **Verify**: The "Premium instance unresponsive" snackbar does NOT appear.
5. **Verify**: After the assignment API returns, `localStorage.getItem("premium_instance_id")` returns a 16-char hex hash, and subsequent requests operate normally.

**Expected**: No false unreachable during the startup window. `isInstanceMismatch` returns `false` because `_outgoingInstanceId` is `null/undefined` when `premiumInstanceId` has not been set.

### Test 3 (Optional): Instance termination — cleanup AFTER next request (existing 502/503 path)

**Objective**: Regression check for the existing 502/503 detection path. This path was not modified by this PR (it is in the error interceptor, separate from the success interceptor change), so regression risk is minimal.

1. Log in as the premium user and confirm normal operation.
2. In the AWS EC2 Console, **terminate** the user's dedicated instance.
3. **Immediately** (within 2 seconds) trigger an API request in the browser.
4. **Verify**: The request gets a `502` or `503` error (ALB per-user rule still exists, but the target group is empty/unhealthy).
5. **Verify**: The axios interceptor retries the request without premium headers (`console.warn("Using free tier while premium instance provisions")` appears in Console).
6. **Verify**: A `POST /users/me/premium/ui-event` with `event_type: "instance_unreachable"` appears, with `"status": 502` or `"status": 503`.
7. **Verify**: Recovery polling starts.

**Expected**: Existing 502/503 path behavior is unchanged.

### Checklist

| # | Test | Focus | Required |
|---|------|-------|----------|
| 1 | Instance terminated, cleanup BEFORE request | **Core fix** — 200-from-wrong-instance triggers recovery | Yes |
| 2 | Startup race condition | No false unreachable during fresh login | Yes |
| 3 | Instance terminated, cleanup AFTER request | Existing 502/503 path regression check | Optional |

---

## Key Files

| File | Role |
|------|------|
| `frontend/src/utils/axios.ts` | Axios interceptors: request header stamping, success response handler (reachable/unreachable detection), 502/503 fallback |
| `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` | Unit tests for interceptor behavior |
| `frontend/src/utils/routing/RoutingService.ts` | Premium routing state management (`premiumAssigned`, `premiumInstanceId`, event emitters) |
| `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts` | Unreachable state machine (circuit breaker, probe backoff, cross-tab sync) |
| `frontend/src/contexts/premium/unreachableConstants.ts` | Constants: `DEDICATED_HANDOFF_GRACE_MS`, probe delays, max probes |
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | Assignment lifecycle, polling `/status` + `/assign`, recovery flow |

---

## Related

| Reference | Relevance |
|-----------|-----------|
| Issue #709 | This fix |
| PR #704 | Silent free-tier drop after stopped/terminated — fixes the 502/503 → re-trigger path (complementary fix) |
| PR #649 / Issue #566 | Introduced `shouldEmitPremiumReachable` and `x-served-by-instance` — the passive detection that this PR upgrades to active |
| PR #623 | Fix: Premium User Not Assigned to Dedicated Instance After Login — polling success path |
