### PR TITLE
Background task permission and stale instance checker

### DIFF
--- a/infrastructure/scripts/check_ecs_image_drift.py
+++ b/infrastructure/scripts/check_ecs_image_drift.py
@@ -267,4 +267,13 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except FileNotFoundError:
+        print("ERROR: 'aws' CLI not found on PATH.", file=sys.stderr)
+        sys.exit(2)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/infrastructure/scripts/check_ecs_image_drift.py
+++ b/infrastructure/scripts/check_ecs_image_drift.py
@@ -26,7 +26,7 @@ import sys
 
 
 def aws(region, *args):
-    """Run an aws CLI command, return parsed JSON ([] / {} on empty)."""
+    """Run an aws CLI command, return parsed JSON (None on empty output)."""
     cmd = ["aws", "--region", region, "--output", "json", *args]
     p = subprocess.run(cmd, capture_output=True, text=True)
     if p.returncode != 0:
@@ -116,6 +116,13 @@ def main():
             name = s["serviceName"]
             desired, running = s["desiredCount"], s["runningCount"]
 
+            # Intentionally scaled to 0 -> not drift; report and skip.
+            if desired == 0:
+                rows.append(
+                    (name, desired, running, "—", "—", "IDLE", "scaled to 0")
+                )
+                continue
+
             # tag the task def points at (context only)
             td = aws(
                 region,
@@ -128,7 +135,8 @@ def main():
             )
             ref_tag = (td or "").rsplit(":", 1)[-1] if td else "?"
 
-            # Representative task: prefer RUNNING, else newest STOPPED.
+            # All RUNNING tasks (a row each); if none, the newest STOPPED
+            # task (one row) to surface a crash-loop image.
             run_arns = (
                 aws(
                     region,
@@ -256,7 +264,7 @@ def main():
                 print(f"  {ec2 or '?'}  ({arn.rsplit('/',1)[-1]})")
         return 1
 
-    print("OK: every service is running the target digest.")
+    print("OK: no drift (active services on the target digest).")
     return 0
 
 

--- a/infrastructure/scripts/check_ecs_image_drift.py
+++ b/infrastructure/scripts/check_ecs_image_drift.py
@@ -118,9 +118,7 @@ def main():
 
             # Intentionally scaled to 0 -> not drift; report and skip.
             if desired == 0:
-                rows.append(
-                    (name, desired, running, "—", "—", "IDLE", "scaled to 0")
-                )
+                rows.append((name, desired, running, "—", "—", "IDLE", "scaled to 0"))
                 continue
 
             # tag the task def points at (context only)

--- a/infrastructure/scripts/check_ecs_image_drift.py
+++ b/infrastructure/scripts/check_ecs_image_drift.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+check_ecs_image_drift.py — detect ECS services running a STALE image.
+
+Catches the recurring "stale cached :latest" problem: a task keeps running an
+old locally-cached image even though ECR :latest has moved on (because the ECS
+agent reuses the cached tag instead of re-pulling). The task definition only
+references the mutable tag (:latest), but ECS records the real digest each
+running container pulled — comparing that to the current ECR digest reveals drift.
+
+Read-only: only ECR/ECS/EC2 describe+list calls. Safe to run anytime.
+
+Usage:
+  python3 check_ecs_image_drift.py \
+      --cluster development-optinist-cloud-cluster \
+      --repo    development-optinist-for-cloud \
+      [--tag latest] [--region ap-northeast-1] [--services svcA svcB ...]
+
+Exit code 0 = every service runs the target digest. 1 = drift or a down service.
+Run it before AND after a deploy/test to confirm the fleet is on the real latest.
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+
+def aws(region, *args):
+    """Run an aws CLI command, return parsed JSON ([] / {} on empty)."""
+    cmd = ["aws", "--region", region, "--output", "json", *args]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"aws {' '.join(args[:3])}…: {p.stderr.strip()}")
+    out = p.stdout.strip()
+    return json.loads(out) if out else None
+
+
+def short(digest):
+    return (digest or "—").replace("sha256:", "")[:12]
+
+
+def chunks(seq, n):
+    for i in range(0, len(seq), n):
+        yield seq[i : i + n]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Detect stale ECS image digests vs ECR.")
+    ap.add_argument("--cluster", required=True)
+    ap.add_argument("--repo", required=True, help="ECR repository name")
+    ap.add_argument(
+        "--tag",
+        default="latest",
+        help="ECR tag treated as the target (default: latest)",
+    )
+    ap.add_argument("--region", default="ap-northeast-1")
+    ap.add_argument(
+        "--services", nargs="*", help="Service names (default: all in cluster)"
+    )
+    args = ap.parse_args()
+    region = args.region
+
+    # 1. Authoritative target digest = what REPO:TAG points to in ECR right now.
+    img = aws(
+        region,
+        "ecr",
+        "describe-images",
+        "--repository-name",
+        args.repo,
+        "--image-ids",
+        f"imageTag={args.tag}",
+        "--query",
+        "imageDetails[0]",
+    )
+    if not img:
+        print(f"ERROR: {args.repo}:{args.tag} not found in ECR ({region}).")
+        return 2
+    target = img["imageDigest"]
+    date_tags = [t for t in img.get("imageTags", []) if t != args.tag]
+    print(f"Target  {args.repo}:{args.tag}")
+    print(
+        f"  digest  {short(target)}   pushed {img.get('imagePushedAt','?')}"
+        f"   aka {', '.join(date_tags) or '—'}"
+    )
+    print()
+
+    # 2. Services to inspect.
+    if args.services:
+        services = args.services
+    else:
+        arns = (
+            aws(region, "ecs", "list-services", "--cluster", args.cluster) or {}
+        ).get("serviceArns", [])
+        services = [a.rsplit("/", 1)[-1] for a in arns]
+    if not services:
+        print("No services found.")
+        return 2
+
+    rows = []  # (service, desired, running, tag, digest, status, note)
+    ci_to_ec2 = {}  # container-instance ARN -> ec2 instance id (resolved lazily)
+
+    for batch in chunks(services, 10):
+        descs = (
+            aws(
+                region,
+                "ecs",
+                "describe-services",
+                "--cluster",
+                args.cluster,
+                "--services",
+                *batch,
+            )
+            or {}
+        ).get("services", [])
+        for s in descs:
+            name = s["serviceName"]
+            desired, running = s["desiredCount"], s["runningCount"]
+
+            # tag the task def points at (context only)
+            td = aws(
+                region,
+                "ecs",
+                "describe-task-definition",
+                "--task-definition",
+                s["taskDefinition"],
+                "--query",
+                "taskDefinition.containerDefinitions[0].image",
+            )
+            ref_tag = (td or "").rsplit(":", 1)[-1] if td else "?"
+
+            # Representative task: prefer RUNNING, else newest STOPPED.
+            run_arns = (
+                aws(
+                    region,
+                    "ecs",
+                    "list-tasks",
+                    "--cluster",
+                    args.cluster,
+                    "--service-name",
+                    name,
+                    "--desired-status",
+                    "RUNNING",
+                )
+                or {}
+            ).get("taskArns", [])
+            status_kind = "RUNNING"
+            task_arns = run_arns
+            if not task_arns:
+                stp = (
+                    aws(
+                        region,
+                        "ecs",
+                        "list-tasks",
+                        "--cluster",
+                        args.cluster,
+                        "--service-name",
+                        name,
+                        "--desired-status",
+                        "STOPPED",
+                    )
+                    or {}
+                ).get("taskArns", [])
+                task_arns = stp[:1]
+                status_kind = "STOPPED"
+
+            if not task_arns:
+                rows.append(
+                    (name, desired, running, ref_tag, "—", "DOWN", "no tasks at all")
+                )
+                continue
+
+            tasks = (
+                aws(
+                    region,
+                    "ecs",
+                    "describe-tasks",
+                    "--cluster",
+                    args.cluster,
+                    "--tasks",
+                    *task_arns,
+                )
+                or {}
+            ).get("tasks", [])
+            for t in tasks:
+                ci_to_ec2.setdefault(t.get("containerInstanceArn"), None)
+                for c in t.get("containers", []):
+                    digest = c.get("imageDigest")
+                    if status_kind == "STOPPED":
+                        status = "DOWN"
+                        note = (t.get("stoppedReason") or "")[:60]
+                    elif digest == target:
+                        status, note = "OK", ""
+                    elif digest is None:
+                        status, note = "UNKNOWN", "no imageDigest reported"
+                    else:
+                        status, note = "STALE", "running != target digest"
+                    rows.append(
+                        (
+                            name,
+                            desired,
+                            running,
+                            ref_tag,
+                            short(digest),
+                            status,
+                            f"[{status_kind} task] {note}".strip(),
+                        )
+                    )
+
+    # Resolve container-instance ARNs -> EC2 ids (location hint).
+    arns = [a for a in ci_to_ec2 if a]
+    for batch in chunks(arns, 100):
+        for ci in (
+            aws(
+                region,
+                "ecs",
+                "describe-container-instances",
+                "--cluster",
+                args.cluster,
+                "--container-instances",
+                *batch,
+            )
+            or {}
+        ).get("containerInstances", []):
+            ci_to_ec2[ci["containerInstanceArn"]] = ci.get("ec2InstanceId")
+
+    # 3. Report.
+    print(f"{'SERVICE':<46} {'DES':>3} {'RUN':>3} {'TAG':<26} {'DIGEST':<14} STATUS")
+    print("-" * 110)
+    for name, des, run, tag, digest, status, note in rows:
+        mark = {"OK": "  ", "STALE": "▲ ", "DOWN": "✖ ", "UNKNOWN": "? "}.get(
+            status, "  "
+        )
+        line = f"{name:<46} {des:>3} {run:>3} {tag:<26} {digest:<14} {mark}{status}"
+        print(line)
+        if note:
+            print(f"{'':<46} {'':>3} {'':>3} {'':<26} {'':<14}   ↳ {note}")
+    print()
+
+    stale = [r for r in rows if r[5] == "STALE"]
+    down = [r for r in rows if r[5] == "DOWN"]
+    if stale or down:
+        print("DRIFT DETECTED:")
+        for r in stale:
+            print(
+                f"  ▲ {r[0]} stale — recycle/repull its host to pull"
+                f" {short(target)}"
+            )
+        for r in down:
+            print(
+                f"  ✖ {r[0]} has no running task"
+                f" (desired={r[1]}, running={r[2]}) — see ↳ reason above"
+            )
+        print("\nHosts (container instances) in play:")
+        for arn, ec2 in ci_to_ec2.items():
+            if arn:
+                print(f"  {ec2 or '?'}  ({arn.rsplit('/',1)[-1]})")
+        return 1
+
+    print("OK: every service is running the target digest.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -88,13 +88,19 @@ resource "aws_iam_role_policy" "ecs_task_cloudwatch" {
         ]
         Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/*"
       },
-      # CloudWatch metrics (PutMetricData requires wildcard resource)
+      # CloudWatch metrics. PutMetricData requires Resource "*"; scope by
+      # namespace so the task can only publish its own OptiNiSt metrics.
       {
         Effect = "Allow"
         Action = [
           "cloudwatch:PutMetricData"
         ]
         Resource = "*"
+        Condition = {
+          StringLike = {
+            "cloudwatch:namespace" = "OptiNiSt/*/${var.environment}"
+          }
+        }
       }
     ]
   })

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -87,6 +87,14 @@ resource "aws_iam_role_policy" "ecs_task_cloudwatch" {
           "logs:DescribeLogStreams"
         ]
         Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/*"
+      },
+      # CloudWatch metrics (PutMetricData requires wildcard resource)
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
### Content

#### Summary
- The shared ECS task role (`<env>-cloud-task-role`) was missing `cloudwatch:PutMetricData`, so every background job that publishes metrics (`sync_job`, `cleanup_job`, `expiration_lifecycle_job`) silently failed to emit them. The jobs ran fine — only the metrics were lost — so `OptiNiSt/BackgroundJobs/<env>` (`ExperimentsSynced`, `SyncErrors`, `SyncErrorRate`) stayed empty and any dashboard/alarm built on them was blind.
- This is the real cause of the long-standing "ExperimentsSynced not incrementing" symptom (issue #355): the metric *code* is correct; the IAM grant was absent. Fix adds `PutMetricData` to the `ecs_task_cloudwatch` policy.
- The investigation that surfaced this also hit a separate **stale-image** failure (a background task crash-looping on an old cached `:latest`). That class of bug is invisible because the task definition only references the mutable `:latest` tag. This PR also adds `infrastructure/scripts/check_ecs_image_drift.py`, a read-only tool that compares the digest each ECS task is *actually running* against ECR's current `:latest` and flags drift.

#### Design Decisions
- **Grant `PutMetricData` on the task role, not the instance role.** The EC2 `ecs_instance_role` already has `PutMetricData` (enhanced/detailed monitoring), but the application runs under the `ecs_task` role, which is the principal CloudWatch denied. Fixed the role that actually emits.
- **`Resource = "*"` (no resource scoping).** `cloudwatch:PutMetricData` does not support resource-level permissions — wildcard is the only valid form. This matches the existing lambda policies (premium-manager, cost-tracker, free-manager all use the same pattern). Added only `PutMetricData` (publish), not `GetMetricData`, since the app only writes.
- **One shared task role, additive only.** `aws_iam_role.ecs_task` is shared by the free/premium/public/background tiers. The change is purely additive (no removals, no behavioral change beyond metrics now landing), so blast radius is limited to "metrics start working everywhere".
- **Drift script is read-only and digest-based.** It reads `describe-tasks → containers[].imageDigest` (the digest ECS recorded for the running container) and compares to the live ECR digest for the tag. That is the only reliable signal of the stale-`:latest` problem — the task def's tag string can't reveal it. Exits non-zero on drift so it can gate CI / pre- and post-deploy checks.
- **No code change to the jobs.** `_publish_metrics()` was already correct; the only fault was IAM.

### Evidence

**1. Symptom: background sync looked dead.** Service had a desired task but none running:
```
$ aws ecs describe-services --cluster development-optinist-cloud-cluster \
    --services development-background-optinist-cloud-service
{ "desired": 1, "running": 0, "status": "ACTIVE" }
```

**2. First finding (separate, ops-resolved): stale `:latest` crash-loop.** The task booted, failed Alembic, and the migration guard killed it — every ~40 s:
```
ERROR [alembic.util.messaging] Can't locate revision identified by 'i901i9230023'
FAILED: Can't locate revision identified by 'i901i9230023'
ERROR: Database migration failed!
Container will exit to prevent data loss and trigger deployment rollback.
```
The revision exists in `develop-main` (`studio/alembic/versions/i901i9230023_add_unique_user_provider_constraint.py`, merged 2026-06-24). ECR `:latest` (pushed 2026-06-29, digest `795dcb21…`, alias tag `20260629-140011-a2daf0aa`) contains it — but the background EC2 instance was running an older *cached* `:latest` that predated the migration, while the DB had already advanced to it. A `--force-new-deployment` eventually placed a task that re-pulled the correct image; it came up `HEALTHY` at 06:42:45 UTC. **This motivated the drift script** — nothing alerted on the stale image because the tag was still `:latest`.

**3. The actual bug in this PR: metrics never emitted.** Once the tier was healthy, the sync job ran successfully but its metric publish was denied:
```
2026-06-30 15:53:35 INFO [apscheduler.executors.default] Job
  "PublishedExperimentSyncJob.run (trigger: interval[0:05:00],
   next run at: 2026-06-30 15:58:35 JST)" executed successfully

botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling
  the PutMetricData operation: User: arn:aws:sts::637423646530:assumed-role/
  development-optinist-cloud-task-role/… is not authorized to perform:
  cloudwatch:PutMetricData because no identity-based policy allows the
  cloudwatch:PutMetricData action
```
And the metric itself was empty across the window:
```
$ aws cloudwatch get-metric-statistics \
    --namespace OptiNiSt/BackgroundJobs/development \
    --metric-name ExperimentsSynced --period 300 --statistics Sum …
Datapoints: []        # never any datapoints
```

**Effect this was having**
- `OptiNiSt/BackgroundJobs/<env>` metrics (`ExperimentsSynced`, `SyncErrors`, `SyncErrorRate`) never published — for `sync_job`, `cleanup_job`, and `expiration_lifecycle_job`.
- Any CloudWatch dashboard/alarm on those metrics was permanently blind: a degraded or failing background sync would raise no signal.
- It masked issue #355 as a code bug when it was an IAM gap — wasting investigation time and making "is sync healthy?" un-answerable from metrics.
- Dataview test cases that assert "ExperimentsSynced/SyncErrors incremented" (06-Dataview 726/727) were unverifiable in dev.
- **Not** affecting functional sync — the jobs completed; only observability was lost. Failure was silent except for the swallowed `AccessDenied` line.

**4. The drift script catches this class of bug (validated on dev and prod).** Run read-only against both clusters during this work. On dev (post-recovery) every tier reported OK on the current digest (exit 0). On **prod** it immediately flagged two tiers running an older cached `:latest` than ECR's current digest — the same drift class as the dev incident, sitting latent:
```
Target  optinist-for-cloud:latest   digest cd9e97eb8f8d   pushed 2026-06-15
subscr-background-optinist-cloud-service   1/1  4308487ecf78  ▲ STALE
subscr-premium-optinist-cloud-service      1/1  cd9e97eb8f8d    OK
subscr-public-optinist-cloud-service       2/2  4308487ecf78  ▲ STALE
subscr-optinist-cloud-service              1/1  cd9e97eb8f8d    OK
(exit code 1 — drift detected)
```
The prod stale tiers run fine until they restart, at which point they re-pull `:latest`; if that image's Alembic head and the prod DB disagree, it reproduces the dev crash-loop. Flagged for the prod owner — not actioned in this PR.

### References
- Issue #355 — "CloudWatch metric ExperimentsSynced incrementation not working" (root cause: this IAM gap, not the metric code).
- `studio/app/common/core/background/sync_job.py` (`_publish_metrics`) — correct metric code that was being denied.
- Lambdas already granting `PutMetricData` for comparison: `premium_manager_permissions`, `cost_tracker_permissions` (premium_manager.tf), `free_manager_lambda_policy` (free_manager.tf), `common_user_manager_lambda_policy` (common_user_manager.tf).
- 06-Dataview test sheet rows 726 / 727 (metric assertions, currently blocked on this fix).

### Files changed
- `infrastructure/terraform/security.tf` — add a `cloudwatch:PutMetricData` (Resource `*`) statement to the `ecs_task_cloudwatch` policy on `aws_iam_role.ecs_task`, so background-job metric emission is permitted for every ECS tier.
- `infrastructure/scripts/check_ecs_image_drift.py` — **new.** Read-only diagnostic that detects ECS services running a stale image vs ECR's current tag (default `:latest`). Resolves the live ECR digest, compares it to the digest each running container reports (`describe-tasks`), and flags `STALE` (running ≠ latest) or `DOWN` (no running task, with stop reason), prints the EC2 host to recycle, and exits non-zero on drift for CI/pre-post-deploy gating. Works for dev and prod (swap `--cluster`).

### Manual Testcases
- **IAM fix — before:** Tail the background task log → observe `AccessDenied … PutMetricData`. Query `OptiNiSt/BackgroundJobs/<env>` `ExperimentsSynced` → `Datapoints: []`.
- **IAM fix — after `terraform apply`:** No task redeploy needed (IAM is evaluated live). Wait one 5-min sync cycle, then: (a) background log no longer shows the `AccessDenied` line; (b) `aws cloudwatch get-metric-statistics --namespace OptiNiSt/BackgroundJobs/<env> --metric-name ExperimentsSynced --period 300 --statistics Sum SampleCount` returns datapoints.
- **Drift script:** `python3 infrastructure/scripts/check_ecs_image_drift.py --cluster development-optinist-cloud-cluster --repo development-optinist-for-cloud` → prints a per-service table; exits 0 when every running container matches the current `:latest` digest, 1 when any service is `STALE`/`DOWN`. Validated against **both** clusters: dev reported OK after recovery (exit 0); **prod** (`--cluster subscr-optinist-cloud-cluster --repo optinist-for-cloud`) flagged `subscr-background` and `subscr-public` as `STALE` (exit 1), catching real latent drift.
- Tests: `pytest studio/tests/app/common/core/background/test_sync_job.py` — existing background-job tests pass (the metric code was always correct; this PR only changes IAM + adds a script).

### Unit, Integration, Contract Test Coverage
- No new unit tests: the change is a Terraform IAM grant (no app logic) plus a read-only ops script. Existing `test_sync_job.py` already exercises the metric-emission code path that was being denied at runtime.
- The drift script is intentionally test-free per minimal-tooling convention (pure AWS read calls, no business logic); its correctness was demonstrated against the live cluster (see Manual Testcases).

### Others

#### Difficulties (if any)
- The two problems looked like one ("background sync is dead"). Separating the ops-level stale-image crash-loop from the IAM-level metric gap required getting the tier healthy first, then re-checking metrics — only then did the `AccessDenied` surface. The drift script exists so the stale-image half is detectable next time without a manual dig.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `ecs_task` IAM role (`security.tf`) | Low–Medium | Shared by all ECS tiers, but the change is additive (one `PutMetricData` action, wildcard resource required by the API). No removals, no app behavior change beyond metrics landing. Rollback = revert the statement. |
| Background-job observability | Low | Net improvement — metrics begin emitting; downstream dashboards/alarms that were silently empty start populating (verify alarm thresholds aren't stale). |
| `check_ecs_image_drift.py` | Low | New file, read-only (`describe`/`list` only), no infra mutation, no import into app code. |
