### PR TITLE
Remove `conda upgrade -y --all` from all Dockerfiles

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -14,12 +14,15 @@ RUN apt-get install --no-install-recommends -y gcc g++ clang clang libgl1 libgl1
 # Specify compiler (use clang)
 ENV CC=clang CXX=clang++
 
+# NOTE: Do NOT add `conda upgrade -y --all` here.
+# It upgrades conda itself along with all packages, which can break the conda
+# installation (ModuleNotFoundError: No module named 'conda').
+# The latest Miniforge3 installer already provides up-to-date packages.
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \
     rm /opt/miniforge/Miniforge3.sh && \
     export PATH="$PATH:/opt/miniforge/bin" && \
-    conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
     conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -14,12 +14,15 @@ RUN apt-get install --no-install-recommends -y gcc g++ clang libgl1 libgl1-mesa-
 # Specify compiler (use clang)
 ENV CC=clang CXX=clang++
 
+# NOTE: Do NOT add `conda upgrade -y --all` here.
+# It upgrades conda itself along with all packages, which can break the conda
+# installation (ModuleNotFoundError: No module named 'conda').
+# The latest Miniforge3 installer already provides up-to-date packages.
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \
     rm /opt/miniforge/Miniforge3.sh && \
     export PATH="$PATH:/opt/miniforge/bin" && \
-    conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
     conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin

--- a/studio/config/docker/Dockerfile.test
+++ b/studio/config/docker/Dockerfile.test
@@ -13,12 +13,15 @@ RUN apt-get install --no-install-recommends -y gcc g++ clang libgl1 libgl1-mesa-
 # Specify compiler (use clang)
 ENV CC=clang CXX=clang++
 
+# NOTE: Do NOT add `conda upgrade -y --all` here.
+# It upgrades conda itself along with all packages, which can break the conda
+# installation (ModuleNotFoundError: No module named 'conda').
+# The latest Miniforge3 installer already provides up-to-date packages.
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \
     rm /opt/miniforge/Miniforge3.sh && \
     export PATH="$PATH:/opt/miniforge/bin" && \
-    conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
     conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin


### PR DESCRIPTION
## Summary

Remove `conda upgrade -y --all` from all three Dockerfiles to fix a CI build failure and prevent the same issue in production/dev builds.

**Files changed:**

| File | Change |
|------|--------|
| `studio/config/docker/Dockerfile.test` | Remove `conda upgrade -y --all`, add warning comment |
| `studio/config/docker/Dockerfile` | Remove `conda upgrade -y --all`, add warning comment |
| `studio/config/docker/Dockerfile.dev` | Remove `conda upgrade -y --all`, add warning comment |

## Problem

The `make test_backend` GitHub Actions workflow started failing at Docker image build time with the following error:

```
Traceback (most recent call last):
  File "/opt/miniforge/bin/conda", line 12, in <module>
    from conda.cli import main
ModuleNotFoundError: No module named 'conda'
```

All three Dockerfiles contained the same `conda upgrade -y --all` pattern and were equally vulnerable to this failure.

## Root Cause

The `conda upgrade -y --all` command performs a blanket upgrade of **all** packages in the Miniforge environment, **including conda itself**. When conda upgrades itself alongside its dependencies in a single transaction, it can leave the installation in an inconsistent state where the `conda` Python module is no longer importable.

The build log shows two `done` messages (indicating the upgrade transaction completed), followed immediately by the `ModuleNotFoundError` when the next `conda config` command attempts to import `conda.cli`. This confirms that the upgrade process overwrote or relocated conda's own modules mid-flight.

### Why it broke now

The Dockerfiles download the **latest** Miniforge3 release (`releases/latest/download/...`). A recent upstream Miniforge or conda-forge update introduced a package combination that, when upgraded via `conda upgrade -y --all`, causes conda to corrupt its own installation. This is a known class of failure with blanket conda upgrades.

## Fix

1. **Removed** the `conda upgrade -y --all` line from all three Dockerfiles — since they already fetch the latest Miniforge3 installer, all packages are already up-to-date at install time. The blanket upgrade is unnecessary.

2. **Added a warning comment** above each `RUN` block to prevent re-introduction of the problematic command during future maintenance:

```dockerfile
# NOTE: Do NOT add `conda upgrade -y --all` here.
# It upgrades conda itself along with all packages, which can break the conda
# installation (ModuleNotFoundError: No module named 'conda').
# The latest Miniforge3 installer already provides up-to-date packages.
```

## Diff

The same change is applied to all three files:

```diff
+# NOTE: Do NOT add `conda upgrade -y --all` here.
+# It upgrades conda itself along with all packages, which can break the conda
+# installation (ModuleNotFoundError: No module named 'conda').
+# The latest Miniforge3 installer already provides up-to-date packages.
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \
     rm /opt/miniforge/Miniforge3.sh && \
     export PATH="$PATH:/opt/miniforge/bin" && \
-    conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
     conda clean -y --all
```

## Risk Assessment

- **Low risk** — The removed command was purely an optimization step (upgrade already-current packages). The Miniforge3 `latest` installer provides the same package versions that `conda upgrade --all` would resolve to.
- **No functional change** — The conda environment still has `channel_priority: flexible` configured and caches cleaned. All downstream `pip install` / `poetry install` steps are unaffected.
- **Consistent across environments** — Applying the fix to all three Dockerfiles ensures test, dev, and production builds behave identically.

## Verification

- Re-run `make test_backend` in CI and confirm the Docker image builds successfully past the Miniforge installation step.
- Verify `Dockerfile` and `Dockerfile.dev` builds remain functional (these can be validated by existing deployment/dev workflows).
