### PR TITLE
Bum application version from 1.1.8 to 1.1.9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ from datetime import datetime
 project = "Araya-OptiNiSt Cloud"
 copyright = f"{datetime.now().year}, Araya Inc., OIST"
 author = "Araya Inc."
-release = "1.1.8"
+release = "1.1.9"
 
 # -- readthedocs -------------------------------------------------------------
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "araya-optinist",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "araya-optinist"
 description = "Cloud-based Calcium Imaging Pipeline Tool"
-version = "1.1.8"
+version = "1.1.9"
 license = "GPL-3.0"
 authors = ["ARAYA <optinist-support@araya.org>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump application version from **1.1.8** to **1.1.9**.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `version = "1.1.8"` → `"1.1.9"` |
| `frontend/package.json` | `"version": "1.1.8"` → `"1.1.9"` |
| `docs/conf.py` | `release = "1.1.8"` → `"1.1.9"` |

## Notes

- Version-only update; no functional changes.
- Keeps backend, frontend, and docs versions in sync.

Note: frontend/yarn.lock still has the package at 1.1.8 (line 6887) — if your build checks lock consistency, run yarn install in frontend/ and include the lockfile update.