### PR TITLE
CaImAn model download poisoned by GitHub 429

### DIFF
--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -115,7 +115,9 @@ def util_download_model_files():
     download model files for component evaluation
     """
     # NOTE: We specify the version of the CaImAn to download.
-    base_url = "https://github.com/flatironinstitute/CaImAn/raw/v1.9.12/model"
+    base_url = (
+        "https://raw.githubusercontent.com/flatironinstitute/CaImAn/v1.9.12/model"
+    )
     model_files = [
         "cnn_model.h5",
         "cnn_model.h5.pb",
@@ -140,6 +142,7 @@ def util_download_model_files():
             if not os.path.exists(file_path):
                 logger.info(f"Downloading {model}")
                 response = requests.get(url)
+                response.raise_for_status()
                 with open(file_path, "wb") as f:
                     f.write(response.content)
 

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -3,6 +3,8 @@ import os
 
 import numpy as np
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
@@ -135,12 +137,16 @@ def util_download_model_files():
     if not os.path.exists(model_dir):
         create_directory(join_filepath(model_dir))
 
+    retry = Retry(total=5, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+
     for model in model_files:
         url = f"{base_url}/{model}"
         file_path = join_filepath([model_dir, model])
         if not os.path.exists(file_path):
             logger.info(f"Downloading {model}")
-            response = requests.get(url, timeout=30)
+            response = session.get(url, timeout=30)
             response.raise_for_status()
             with open(file_path, "wb") as f:
                 f.write(response.content)

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -135,16 +135,15 @@ def util_download_model_files():
     if not os.path.exists(model_dir):
         create_directory(join_filepath(model_dir))
 
-    if len(os.listdir(model_dir)) < len(model_files):
-        for model in model_files:
-            url = f"{base_url}/{model}"
-            file_path = join_filepath([model_dir, model])
-            if not os.path.exists(file_path):
-                logger.info(f"Downloading {model}")
-                response = requests.get(url)
-                response.raise_for_status()
-                with open(file_path, "wb") as f:
-                    f.write(response.content)
+    for model in model_files:
+        url = f"{base_url}/{model}"
+        file_path = join_filepath([model_dir, model])
+        if not os.path.exists(file_path):
+            logger.info(f"Downloading {model}")
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            with open(file_path, "wb") as f:
+                f.write(response.content)
 
 
 def caiman_cnmf(

--- a/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
+++ b/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #
 # This function is a port of
@@ -6,8 +7,8 @@
 #
 download_model_files() {
   # Base URL for downloading model files
-  BASE_URL="https://github.com/flatironinstitute/CaImAn/raw/v1.9.12/model"
-  
+  BASE_URL="https://raw.githubusercontent.com/flatironinstitute/CaImAn/v1.9.12/model"
+
   # List of model files to download
   MODEL_FILES=(
       "cnn_model.h5"
@@ -17,29 +18,29 @@ download_model_files() {
       "cnn_model_online.h5.pb"
       "cnn_model_online.json"
   )
-  
+
   # Create caiman_data directory in home directory
   CAIMAN_DATA_DIR="$HOME/caiman_data"
   if [ ! -d "$CAIMAN_DATA_DIR" ]; then
     mkdir -p "$CAIMAN_DATA_DIR"
   fi
-  
+
   # Create model directory
   MODEL_DIR="$CAIMAN_DATA_DIR/model"
   if [ ! -d "$MODEL_DIR" ]; then
     mkdir -p "$MODEL_DIR"
   fi
-  
+
   # Count existing files in model directory
   FILE_COUNT=$(ls -1 "$MODEL_DIR" | wc -l)
-  
+
   # Download files if needed
   if [ "$FILE_COUNT" -lt "${#MODEL_FILES[@]}" ]; then
       for MODEL in "${MODEL_FILES[@]}"; do
           FILE_PATH="$MODEL_DIR/$MODEL"
           if [ ! -f "$FILE_PATH" ]; then
               echo "Downloading $MODEL"
-              curl -L "$BASE_URL/$MODEL" -o "$FILE_PATH"
+              curl --fail --location --retry 5 --retry-delay 3 "$BASE_URL/$MODEL" -o "$FILE_PATH"
           fi
       done
   fi

--- a/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
+++ b/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
@@ -31,19 +31,14 @@ download_model_files() {
     mkdir -p "$MODEL_DIR"
   fi
 
-  # Count existing files in model directory
-  FILE_COUNT=$(ls -1 "$MODEL_DIR" | wc -l)
-
-  # Download files if needed
-  if [ "$FILE_COUNT" -lt "${#MODEL_FILES[@]}" ]; then
-      for MODEL in "${MODEL_FILES[@]}"; do
-          FILE_PATH="$MODEL_DIR/$MODEL"
-          if [ ! -f "$FILE_PATH" ]; then
-              echo "Downloading $MODEL"
-              curl --fail --location --retry 5 --retry-delay 3 "$BASE_URL/$MODEL" -o "$FILE_PATH"
-          fi
-      done
-  fi
+  # Download any model file that is missing
+  for MODEL in "${MODEL_FILES[@]}"; do
+      FILE_PATH="$MODEL_DIR/$MODEL"
+      if [ ! -f "$FILE_PATH" ]; then
+          echo "Downloading $MODEL"
+          curl --fail --location --connect-timeout 10 --retry 5 --retry-delay 3 "$BASE_URL/$MODEL" -o "$FILE_PATH"
+      fi
+  done
 }
 
 # call downloading func

--- a/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
+++ b/studio/app/optinist/wrappers/caiman/run_download_model_files.sh
@@ -36,7 +36,7 @@ download_model_files() {
       FILE_PATH="$MODEL_DIR/$MODEL"
       if [ ! -f "$FILE_PATH" ]; then
           echo "Downloading $MODEL"
-          curl --fail --location --connect-timeout 10 --retry 5 --retry-delay 3 "$BASE_URL/$MODEL" -o "$FILE_PATH"
+          curl --fail --location --remove-on-error --connect-timeout 10 --retry 5 --retry-delay 3 "$BASE_URL/$MODEL" -o "$FILE_PATH"
       fi
   done
 }


### PR DESCRIPTION
### Content

#### Summary
- CaImAn tutorials that reach CNN component evaluation (e.g. tutorial 2) crash with `JSONDecodeError: Extra data: line 1 column 4 (char 3)` when loading `cnn_model.json`.
- Root cause: the model files are fetched from `github.com/.../raw/...` with `curl -L` (build) and `requests.get` (runtime), **neither of which checks the HTTP status**. When GitHub returns `429: Too Many Requests`, the 199-byte error bodyis written into the model file, and the build/runtime "download only if missing" guards then freeze the corrupt file into the image.
- Fix: download from the `raw.githubusercontent.com` CDN instead of the rate-limited website host, fail loudly on any HTTP error (`--fail` / `raise_for_status()`), and abort the build (`set -e`) so a poisoned file can never be baked in silently.

#### Design Decisions
- **Fail loud, not silent (the core fix).** The bug is not "a download failed" — downloads fail transiently all the time. The bug is that a failure was written to disk as if it were data. `curl --fail` + `set -e` and `response.raise_for_status()` convert a bad HTTP response into a hard error (build abort / runtime exception) instead of a 199-byte poisoned file. A visibly failed build is strictly better than a silently broken image.
- **`raw.githubusercontent.com` over `github.com/.../raw`.** The `github.com/.../raw/<ref>/<path>` URL is served by theGitHub **website** tier: it responds with a `302` redirect to `raw.githubusercontent.com` and enforces anti-scraping rate limits (the `429: ... For more on scraping GitHub` body we captured). `raw.githubusercontent.com` is the raw-content CDN with far more generous anonymous limits. This **reduces** 429 probability; it does not eliminate it (the CDN also throttled under load during testing) — which is why the fail-loud + retry changes above are the real safety net, not the host swap alone.
- **Retry transient throttling.** `--fail --retry 5 --retry-delay 3` rides out a brief 429 (curl treats 429 as transient and honours `Retry-After`) before giving up and failing the build.
- **Rejected: "just rebuild" / clear the Docker cache.** Verified three times that a plain rebuild — cache hit *or* full `--no-cache` — reproduces the corruption, because the old code re-downloads from the throttled host with no error checking. Which files get poisoned is nondeterministic per build (observed 3-of-6 and 4-of-6 corrupt, different file sets each time). Editing the download script is also what invalidates only the model-download Docker layer, so the fixed rebuild re-runs that one ~28s step instead of a full image rebuild.

### Evidence

**1. The crash (deployed container, tutorial 2 CNMF):**
```
File ".../caiman/components_evaluation.py", line 299, in evaluate_components_CNN
    loaded_model = model_from_json(loaded_model_json)
...
File ".../json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 4 (char 3)
```
The `char 3` offset is the tell: `json.loads("429: Too Many Requests...")` parses `429` as an integer (chars 0–2) then chokes on the trailing `: Too...`.

**2. The poisoned file's actual contents (`cnn_model.json`, 199 bytes):**
```
429: Too Many Requests
For more on scraping GitHub and how it may affect your ...
```

**3. Downstream cascade — the corrupt CNMF output invalidates later nodes:**
```
AssertionError: Invalid node input data content. [.../caiman_cnmf_*/caiman_cnmf.pkl]
AssertionError: Invalid node input data content. [.../pca_*/pca.pkl]
```

**4. Why the URL matters — `github.com/.../raw` is a redirect, not a file server:**
```
$ curl -sI https://github.com/flatironinstitute/CaImAn/raw/v1.9.12/model/cnn_model.json
HTTP/2 302
location: https://raw.githubusercontent.com/flatironinstitute/CaImAn/v1.9.12/model/cnn_model.json

$ curl -sI https://raw.githubusercontent.com/.../cnn_model.json
HTTP/2 429
via: 1.1 varnish
x-served-by: cache-itm1220048-ITM     # served by the raw-content CDN
```

**5. Proof a plain uncached rebuild does NOT fix it (original code, `docker build --no-cache`):**
```
=> [14/28] RUN bash run_download_model_files.sh && rm run_download_model_files.sh   27.9s   # ran fresh, not CACHED

$ docker run --rm optinist-for-cloud:latest sh -c 'wc -c /root/caiman_data/model/*'
     199 /root/caiman_data/model/cnn_model.h5
     199 /root/caiman_data/model/cnn_model.h5.pb
     199 /root/caiman_data/model/cnn_model.json
26793608 /root/caiman_data/model/cnn_model_online.h5
13378807 /root/caiman_data/model/cnn_model_online.h5.pb
     199 /root/caiman_data/model/cnn_model_online.json
```
4 of 6 files are the 199-byte 429 body — a different set than a previous build (which corrupted 3), confirming the corruption is random per build and cannot be dodged by rebuilding.

**6. Post-fix expectation.** With this change, an equivalent 429 during the build stops it (`curl --fail` → non-zero → `set -e` aborts) instead of pushing a poisoned image; a clean build yields all six files at their real sizes (`cnn_model.json` = 5573 bytes, parses as JSON with `{"class_name": "Sequential", ...}`).

### References
- Upstream model files: `flatironinstitute/CaImAn` at tag `v1.9.12`, `model/` directory.
- CaImAn loader that consumes the file: `evaluate_components_CNN` → `model_from_json` in `caiman/components_evaluation.py`.
- Closes #<open-a-bug-issue-and-fill-in>.

#### Files changed
- `studio/app/optinist/wrappers/caiman/run_download_model_files.sh` — build-time downloader: switch base URL to `raw.githubusercontent.com`, add `curl --fail --location --retry 5 --retry-delay 3`, and add `set -e` so a failed download aborts the image build instead of writing the 429 body.
- `studio/app/optinist/wrappers/caiman/cnmf.py` — runtime downloader `util_download_model_files()`: switch base URL to `raw.githubusercontent.com` and add `response.raise_for_status()` before writing, so a bad response raises instead of poisoning the file.

### Manual Testcases
- **Build integrity.** Build the image from this branch, then:
  `docker run --rm <image> sh -c 'wc -c /root/caiman_data/model/*'`
  Expected: all six files well above 199 bytes; none contain `429: Too Many Requests`.
- **JSON validity.** `docker run --rm <image> python3 -c "import json; json.load(open('/root/caiman_data/model/cnn_model.json'))"`
  Expected: exits 0 (valid JSON).
- **Fail-loud regression guard.** Point the base URL at a 404 path and rebuild.
  Expected: the build aborts non-zero at the `run_download_model_files.sh` step (previously it would succeed and bake in the error body).
- **End-to-end.** As a free-tier user, run CaImAn tutorial 2 to completion.
  Expected: CNN component evaluation completes; no `JSONDecodeError`; downstream `pca` / `post_process` nodes produce valid `.pkl` output.
- Automated: no unit test covers the external download; the deterministic check is the `wc -c` / `json.load` image inspection above. Existing wrapper suite: `pytest studio/app/optinist/wrappers/caiman/ -- all tests pass`.

### Unit, Integration, Contract Test Coverage
- None added — the failure is an external-network/HTTP-status condition not exercised by the current suite. Regression is guarded by the build-time `--fail`/`set -e` (a bad download now breaks CI at build) and the manual image-integrity checks above.

### Others

#### Difficulties (if any)
- The corruption is nondeterministic: the poisoned file set varies per build depending on which of the six requests hitGitHub's rate-limit window, which is why "it worked on my last build" is not evidence the bug is gone. Only per-file size/parse inspection is reliable.

#### Operational note
- The four currently-running `subscr` app containers (free / premium ×2 / public) were hot-fixed in place (valid model files dropped in via ECS Exec) so release testing could continue. Those are ephemeral — the existing ECR `:latest` is still poisoned and must be replaced by an image built from this branch before any deploy, or a task restart will reintroduce the crash.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Build-time download (`run_download_model_files.sh`) | Low–Medium | `set -e` + `--fail` now abort the build on a bad download. Safer (no silent poison) but a persistent CDN 429 could block a build until retried — desired trade-off. |
| Runtime download (`cnmf.py`) | Low | `raise_for_status()` makes a bad fetch raise instead of poisoning; `caiman_cnmf`would fail loudly rather than emit corrupt output. Same failure surface, louder and non-persistent. |
| Deployment | Medium | ECR `:latest` is currently poisoned; must be rebuilt from this branch and verified before deploy, else the manual hot-fix on live tasks is lost on next task replacement. |