### PR TITLE
Record terraform apply provenance as ECS cluster tags

### DIFF
--- a/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
@@ -150,11 +150,16 @@ terraform apply -var-file=environments/<ENV>.tfvars
 - Lambda function code and layers
 - Copies `infrastructure/aws_constants.py` to all Lambda packages via provisioners
 
+> **Traceability:** Each apply stamps the applied `infrastructure/` git revision onto the
+> ECS cluster as tags (`TfGitCommit` / `TfGitBranch`), so you can later confirm which
+> infrastructure version is running. See [INFRA_DEPLOYMENT_PROCEDURE.md](INFRA_DEPLOYMENT_PROCEDURE.md) →
+> "Check Which Git Revision Was Applied".
+
 > **Note:** The commands above are a quick reference for production deployment. For the authoritative guide — including environment switching, development setup, destroying environments, and Terraform troubleshooting — see [INFRA_DEPLOYMENT_PROCEDURE.md](INFRA_DEPLOYMENT_PROCEDURE.md).
 
 ### Step 2: Build and Push Docker Image (if application code changed)
 
-Skip this step if only Lambda or infrastructure code changed.
+Skip this step if only Lambda or infrastructure code changed — see [Determine What Needs to Be Deployed](#determine-what-needs-to-be-deployed) for the exact paths each category maps to.
 
 #### 2a. Initialize Terraform for the target environment
 
@@ -192,7 +197,7 @@ The script automatically:
 
 ### Step 3: Force ECS Redeployment (after Docker image push)
 
-Skip this step if only Lambda or infrastructure code changed.
+Skip this step if only Lambda or infrastructure code changed — see [Determine What Needs to Be Deployed](#determine-what-needs-to-be-deployed) for the exact paths each category maps to.
 
 **Option A: AWS Console**
 

--- a/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
@@ -446,19 +446,24 @@ commit changes, so no-op applies produce no diff.
 > compute plane the app runs on — so only that one resource changes on a real deploy.
 
 ```bash
-# <ENV> = production (subscr) | development
-aws ecs describe-clusters \
-  --clusters <ENV>-optinist-cloud-cluster \
+# Get the cluster name for the active environment from Terraform state
+# (unambiguous — returns exactly one name, even when dev and prod share an account)
+CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
+
+# Note: ECS tags use lowercase `key` (unlike EC2's `Key`)
+aws ecs describe-clusters --clusters "$CLUSTER_NAME" \
   --include TAGS --region ap-northeast-1 \
-  --query 'clusters[0].tags[?starts_with(Key, `Tf`)]' --output table
+  --query 'clusters[0].tags[?starts_with(key, `Tf`)]' --output table
 ```
 
 > To see *when* the last change-bearing apply ran, check the state file's `LastModified`
 > in the environment's state bucket (a no-op apply does not rewrite state, so it reflects
-> the last apply that actually changed something):
+> the last apply that actually changed something). The bucket name matches the active
+> environment: `subscr-optinist-for-cloud-tfstate` (production) or
+> `development-optinist-for-cloud-tfstate` (development).
 >
 > ```bash
-> aws s3api head-object --bucket <ENV>-optinist-for-cloud-tfstate \
+> aws s3api head-object --bucket <STATE_BUCKET> \
 >   --key terraform.tfstate --region ap-northeast-1 --query 'LastModified' --output text
 > ```
 

--- a/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/INFRA_DEPLOYMENT_PROCEDURE.md
@@ -432,6 +432,36 @@ terraform import -var-file=environments/development.tfvars aws_s3_bucket.app_sto
 cat .terraform/terraform.tfstate | python3 -c "import sys,json; print(json.load(sys.stdin)['backend']['config']['bucket'])"
 ```
 
+### Check Which Git Revision Was Applied
+
+Every `terraform apply` stamps the applied `infrastructure/` git revision onto the ECS
+cluster as tags (`TfGitCommit` / `TfGitBranch`), so you can confirm which infrastructure
+version is actually running and detect deploy mistakes. The tag only changes when the git
+commit changes, so no-op applies produce no diff.
+
+> **Why only the ECS cluster is tagged:** the commit is deliberately *not* added to
+> `provider.default_tags`. A default tag would apply the value to every taggable resource,
+> so each new-commit apply would churn dozens of resources' tags at once. Instead it is
+> stamped onto a single long-lived, representative resource — the ECS cluster, which is the
+> compute plane the app runs on — so only that one resource changes on a real deploy.
+
+```bash
+# <ENV> = production (subscr) | development
+aws ecs describe-clusters \
+  --clusters <ENV>-optinist-cloud-cluster \
+  --include TAGS --region ap-northeast-1 \
+  --query 'clusters[0].tags[?starts_with(Key, `Tf`)]' --output table
+```
+
+> To see *when* the last change-bearing apply ran, check the state file's `LastModified`
+> in the environment's state bucket (a no-op apply does not rewrite state, so it reflects
+> the last apply that actually changed something):
+>
+> ```bash
+> aws s3api head-object --bucket <ENV>-optinist-for-cloud-tfstate \
+>   --key terraform.tfstate --region ap-northeast-1 --query 'LastModified' --output text
+> ```
+
 ---
 
 ## Troubleshooting

--- a/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
+++ b/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
@@ -111,8 +111,8 @@ locals {
 }
 
 # Examples:
-# Production: subscr-optinist-app-storage, subscr-optinist-cloud-ecs-cluster
-# Development: development-optinist-app-storage, development-optinist-cloud-ecs-cluster
+# Production: subscr-optinist-app-storage, subscr-optinist-cloud-cluster
+# Development: development-optinist-app-storage, development-optinist-cloud-cluster
 ```
 
 ---

--- a/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
+++ b/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
@@ -28,6 +28,7 @@ infrastructure/terraform/
 ├── free_manager.tf              # Free tier Lambda functions and scheduling
 ├── common_user_manager.tf       # Shared user lifecycle Lambda function
 ├── lambda_layers.tf             # Shared Lambda layer (aws_constants)
+├── deploy_info.tf               # Apply-time git provenance → ECS cluster tags (see "Deployment Provenance")
 │
 ├── backends/
 │   ├── production.hcl           # S3 backend config → subscr-optinist-for-cloud-tfstate
@@ -113,6 +114,34 @@ locals {
 # Production: subscr-optinist-app-storage, subscr-optinist-cloud-ecs-cluster
 # Development: development-optinist-app-storage, development-optinist-cloud-ecs-cluster
 ```
+
+---
+
+## Deployment Provenance (Apply Traceability)
+
+To make the *actually-applied* infrastructure version verifiable from the running
+environment, each `terraform apply` records which `infrastructure/` git revision it was
+applied from. This mirrors the Docker `/app/BUILD_INFO` concept (image provenance) at the
+infrastructure layer.
+
+| File | Role |
+| --- | --- |
+| `scripts/terraform_build_info.sh` | Emits the apply-time git commit/branch/dirty as JSON (no `jq` dependency) |
+| `deploy_info.tf` | `data.external.tf_build_info` runs the script at apply time |
+| `compute.tf` (`aws_ecs_cluster.main`) | Stamps `TfGitCommit` / `TfGitBranch` tags from that data |
+
+Design notes:
+
+- The commit is stamped onto a **single** long-lived resource (the ECS cluster), not via
+  `provider.default_tags`, so only that one resource changes on a real deploy instead of
+  every taggable resource.
+- The tag value changes **only when the git commit changes**, so no-op applies produce no
+  diff.
+- No timestamp is stored in the tag — "when was the last change-bearing apply" is already
+  answered by the state file's `LastModified` in the S3 backend bucket.
+
+See [INFRA_DEPLOYMENT_PROCEDURE.md](INFRA_DEPLOYMENT_PROCEDURE.md) → "Check Which Git
+Revision Was Applied" for how to read it back.
 
 ---
 

--- a/infrastructure/scripts/terraform_build_info.sh
+++ b/infrastructure/scripts/terraform_build_info.sh
@@ -21,7 +21,9 @@ cd "$(dirname "$0")/.."
 
 git_commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+# `|| true` keeps the dirty check non-fatal under `set -e`
+git_status=$(git status --porcelain 2>/dev/null || true)
+if [ -n "$git_status" ]; then
   git_dirty="true"
 else
   git_dirty="false"

--- a/infrastructure/scripts/terraform_build_info.sh
+++ b/infrastructure/scripts/terraform_build_info.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# terraform_build_info.sh
+# ============================================================================
+# Emits terraform-apply provenance as JSON on stdout, for consumption by the
+# Terraform `external` data source (data.external.tf_build_info).
+#
+# This records "which git revision of infrastructure/ was applied", mirroring
+# the Docker /app/BUILD_INFO concept (which records image provenance) at the
+# infrastructure layer. The values are stamped onto the ECS cluster as tags so
+# a deployment can be traced back to its source revision from the running env.
+#
+# `external` requires a flat JSON object of string values on stdout.
+# ============================================================================
+
+# Resolve to the infrastructure/ directory so git info reflects the IaC repo,
+# regardless of the caller's working directory.
+cd "$(dirname "$0")/.."
+
+git_commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  git_dirty="true"
+else
+  git_dirty="false"
+fi
+
+# Encode as JSON via python3 (available in the toolchain; avoids a jq dependency).
+python3 -c "import json,sys; json.dump({'git_commit':sys.argv[1],'git_branch':sys.argv[2],'git_dirty':sys.argv[3]}, sys.stdout)" \
+  "$git_commit" "$git_branch" "$git_dirty"

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -467,6 +467,10 @@ resource "aws_ecs_cluster" "main" {
 
   tags = {
     Name = "${local.env_prefix}-cloud-cluster"
+    # Terraform apply provenance (see deploy_info.tf). Traces the running
+    # deployment back to the infrastructure/ git revision it was applied from.
+    TfGitCommit = data.external.tf_build_info.result.git_commit
+    TfGitBranch = data.external.tf_build_info.result.git_branch
   }
 }
 

--- a/infrastructure/terraform/deploy_info.tf
+++ b/infrastructure/terraform/deploy_info.tf
@@ -1,0 +1,20 @@
+# ============================================================================
+# Terraform apply provenance
+# ============================================================================
+# Records which git revision of infrastructure/ was applied, so a running
+# deployment can be traced back to its source revision. This mirrors the Docker
+# /app/BUILD_INFO concept (image provenance) at the infrastructure layer.
+#
+# The values are gathered at apply time by scripts/terraform_build_info.sh and
+# stamped onto the ECS cluster as tags (see aws_ecs_cluster.main in compute.tf).
+# The tag only changes when the git commit changes, so no-op applies produce no
+# diff and only the single ECS cluster resource churns on a real deploy.
+#
+# Inspect from the running environment with:
+#   aws ecs describe-clusters --clusters <cluster-name> --include TAGS \
+#     --query 'clusters[0].tags' --output table
+# ============================================================================
+
+data "external" "tf_build_info" {
+  program = ["bash", "${path.module}/../scripts/terraform_build_info.sh"]
+}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -2,11 +2,12 @@ terraform {
   required_version = ">= 1.14.8"
 
   required_providers {
-    aws     = { source = "hashicorp/aws", version = "~> 6.0" }
-    archive = { source = "hashicorp/archive", version = "~> 2.7" }
-    local   = { source = "hashicorp/local", version = "~> 2.5" }
-    null    = { source = "hashicorp/null", version = "~> 3.2" }
-    random  = { source = "hashicorp/random", version = "~> 3.7" }
-    tls     = { source = "hashicorp/tls", version = "~> 4.1" }
+    aws      = { source = "hashicorp/aws", version = "~> 6.0" }
+    archive  = { source = "hashicorp/archive", version = "~> 2.7" }
+    external = { source = "hashicorp/external", version = "~> 2.3" }
+    local    = { source = "hashicorp/local", version = "~> 2.5" }
+    null     = { source = "hashicorp/null", version = "~> 3.2" }
+    random   = { source = "hashicorp/random", version = "~> 3.7" }
+    tls      = { source = "hashicorp/tls", version = "~> 4.1" }
   }
 }


### PR DESCRIPTION
## Summary

Make the **actually-applied infrastructure version verifiable from the running
environment**, so a deploy mistake (e.g. an old revision left running, or an apply from an
unexpected branch) can be detected after the fact.

Every `terraform apply` now stamps the `infrastructure/` git revision it was applied from
onto the ECS cluster as tags (`TfGitCommit` / `TfGitBranch`). This mirrors, at the
infrastructure layer, the existing Docker `/app/BUILD_INFO` mechanism that records **image**
provenance (git commit / branch / build timestamp baked into the image and read back by
`studio/app/version.py`).

- Related: #683 

### The gap this closes

Before this change, the following were already recoverable without any new code:

| Question | Where it was already recorded |
| --- | --- |
| When did the last change-bearing apply run? | S3 state object `LastModified` in the env's tfstate bucket |
| What Terraform version / state serial? | Inside the state file (`terraform_version`, `serial`) |
| Who applied, and what AWS API calls? | CloudTrail |
| **Which `infrastructure/` git revision was applied?** | **Nowhere** |

The missing piece was the **git revision of the infrastructure code**. That is exactly what
this PR records.

---

## What changed

| File | Change |
| --- | --- |
| `infrastructure/scripts/terraform_build_info.sh` (new) | Emits the apply-time `infrastructure/` git commit/branch/dirty as JSON on stdout. JSON is produced with `python3` (already in the toolchain) to avoid a `jq` dependency. |
| `infrastructure/terraform/deploy_info.tf` (new) | `data "external" "tf_build_info"` runs the script at apply time. |
| `infrastructure/terraform/compute.tf` | Adds `TfGitCommit` / `TfGitBranch` to `aws_ecs_cluster.main`'s `tags`. `default_tags` is left untouched. |
| `infrastructure/terraform/versions.tf` | Declares the `hashicorp/external` provider (required by `data.external`). |

Documentation (this PR's working-tree changes):

| File | Change |
| --- | --- |
| `TERRAFORM_ARCHITECTURE.md` | New "Deployment Provenance (Apply Traceability)" section (mechanism + design rationale); `deploy_info.tf` added to the directory listing. |
| `INFRA_DEPLOYMENT_PROCEDURE.md` | New "Check Which Git Revision Was Applied" task (how to read the tag + state `LastModified`), including the "why only the ECS cluster" rationale. |
| `DEPLOYMENT_PROCEDURE.md` | Short traceability pointer under "Apply Infrastructure Changes", linking to the infra guide (kept compact by design). |

---

## Design decisions

### Why only the ECS cluster is tagged (and not `default_tags`)

The provider already sets `default_tags` (`Environment` / `ManagedBy` / `Project`). It was
tempting to simply add `TfGitCommit` there — one line, and every resource would carry it.
**This was deliberately rejected:**

- `default_tags` applies its value to **every taggable resource**. Because the git commit
  changes on essentially every deploy, each new-commit apply would produce an in-place tag
  update across **dozens of resources** at once — harmless (metadata only, no replacement)
  but a large, noisy `plan` diff that can mask real changes.
- Putting frequently-changing, high-cardinality values in `default_tags` is generally
  discouraged; that block is conventionally reserved for **stable, low-cardinality**
  classification tags.

Instead, the commit is stamped onto **a single, long-lived, representative resource**: the
**ECS cluster**. It was chosen because:

- It is **the compute plane the application actually runs on**, so "this cluster was applied
  from commit X" reads naturally and matches the intent ("this service runs on ECS").
- It is **long-lived** — rarely replaced — so the tag persists across normal deploys.
- It is **easy to inspect** from the running environment via `aws ecs describe-clusters`.

Net effect: on a real deploy, **only one resource churns** instead of all of them, and the
value updates **only when the git commit changes** (no-op applies produce no diff).

### Why no timestamp is stored in the tag

"When was the last change-bearing apply?" is already answered by the state object's
`LastModified` in the S3 backend bucket, so duplicating a timestamp into the tag would only
add churn without adding information. The tag therefore carries commit/branch only.

### This would be simpler with CI/CD or HCP Terraform

This custom record exists **because applies are currently run manually from a developer's
machine** (local `terraform apply`, local `.pem` keys, local scripts). In that setup there
is no platform recording who/what/when, so the provenance has to be captured explicitly.

If applies were instead run through **CI/CD (GitHub Actions, Atlantis, Spacelift, …) or
HCP Terraform / Terraform Enterprise**, this requirement would largely be satisfied
**out of the box**:

- The pipeline / run history natively records the **triggering git commit, the actor, and
  the timestamp** for every apply.
- No custom `external` data source, script, or resource tag would be needed.

So this change is best understood as a **lightweight stand-in for a capability that a
CI/CD or Terraform-platform layer would otherwise provide for free**. When infrastructure
applies are eventually moved onto such a platform, this tagging can be simplified or
retired, and the same provenance can be surfaced further (e.g. an app `/version` endpoint
that shows image and infra revisions side by side) by writing the same data to an SSM
parameter once a consumer exists.

---

## How to verify (after apply)

```bash
# <ENV> = production (subscr) | development
aws ecs describe-clusters \
  --clusters <ENV>-optinist-cloud-cluster \
  --include TAGS --region ap-northeast-1 \
  --query 'clusters[0].tags[?starts_with(key, `Tf`)].[key, value]' \
  --output table
```

Expected: `TfGitCommit` and `TfGitBranch` reflecting the revision that was applied.

---

## Reviewer checklist / notes

- `terraform init` is required after pulling (new `hashicorp/external` provider).
- First `plan` after this change shows the ECS cluster with a `~ update in-place` adding the
  two tags — no replacement, no downtime.
- `default_tags` is intentionally **not** modified.
- `terraform fmt` clean; `plan`/`apply` were not run in the authoring environment (no AWS
  credentials there) — to be exercised by the reviewer / deployer.
