### PR TITLE
Remove redundant firebase key and use only secrets manager

### DIFF
--- a/infrastructure/scripts/ecs-user-data.sh
+++ b/infrastructure/scripts/ecs-user-data.sh
@@ -207,23 +207,6 @@ if [ ! -d "optinist-for-cloud" ]; then
 fi
 cd optinist-for-cloud
 
-# Create Firebase configuration files on the host
-echo "$(date): Creating Firebase configuration files"
-mkdir -p /opt/optinist-for-cloud/studio/config/auth
-
-# Create firebase_config.json
-cat > /opt/optinist-for-cloud/studio/config/auth/firebase_config.json << 'FIREBASE_CONFIG'
-${firebase_config_json}
-FIREBASE_CONFIG
-
-# Create firebase_private.json
-cat > /opt/optinist-for-cloud/studio/config/auth/firebase_private.json << 'FIREBASE_PRIVATE'
-${firebase_private_json}
-FIREBASE_PRIVATE
-
-# Set proper permissions
-chmod 644 /opt/optinist-for-cloud/studio/config/auth/firebase_*.json
-
 # Add AWS Batch plugins to Dockerfile
 echo "$(date): Adding AWS Batch plugins to Dockerfile"
 # Build the Docker image

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -46,6 +46,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.0"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
+    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
+    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
+    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
+    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
+    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
+    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
+    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
+    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
+    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
+    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
+    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
   constraints = "~> 2.5"

--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -39,18 +39,16 @@ resource "aws_launch_template" "background" {
   }
 
   user_data = base64encode(templatefile("${path.module}/../scripts/ecs-user-data.sh", {
-    tier                  = "background"
-    cluster_name          = aws_ecs_cluster.main.name
-    git_branch            = var.git_branch
-    git_repo              = var.git_repo
-    firebase_config_json  = var.firebase_config_json
-    firebase_private_json = var.firebase_private_json
-    ecr_registry          = split("/", local.ecr_repository_url)[0]
-    ecr_repository_url    = local.ecr_repository_url
-    efs_id                = aws_efs_file_system.snmk.id
-    db_host               = replace(aws_db_instance.main.endpoint, ":3306", "")
-    swap_size_mb          = 1536 # 2x task memory (768MB) for stable background job operation
-    swap_device_name      = ""   # File-based swap (1.5GB dd is fast, no dedicated volume needed)
+    tier               = "background"
+    cluster_name       = aws_ecs_cluster.main.name
+    git_branch         = var.git_branch
+    git_repo           = var.git_repo
+    ecr_registry       = split("/", local.ecr_repository_url)[0]
+    ecr_repository_url = local.ecr_repository_url
+    efs_id             = aws_efs_file_system.snmk.id
+    db_host            = replace(aws_db_instance.main.endpoint, ":3306", "")
+    swap_size_mb       = 1536 # 2x task memory (768MB) for stable background job operation
+    swap_device_name   = ""   # File-based swap (1.5GB dd is fast, no dedicated volume needed)
   }))
 
   tag_specifications {

--- a/infrastructure/terraform/compute.tf
+++ b/infrastructure/terraform/compute.tf
@@ -179,18 +179,16 @@ resource "aws_launch_template" "ecs" {
   }
 
   user_data = base64encode(templatefile("${path.module}/../scripts/ecs-user-data.sh", {
-    tier                  = "free"
-    cluster_name          = aws_ecs_cluster.main.name
-    git_branch            = var.git_branch
-    git_repo              = var.git_repo
-    firebase_config_json  = var.firebase_config_json
-    firebase_private_json = var.firebase_private_json
-    ecr_registry          = split("/", local.ecr_repository_url)[0]
-    ecr_repository_url    = local.ecr_repository_url
-    efs_id                = aws_efs_file_system.snmk.id
-    db_host               = replace(aws_db_instance.main.endpoint, ":3306", "")
-    swap_size_mb          = 32768 # 32GB swap for workflow memory spikes
-    swap_device_name      = "/dev/xvds"
+    tier               = "free"
+    cluster_name       = aws_ecs_cluster.main.name
+    git_branch         = var.git_branch
+    git_repo           = var.git_repo
+    ecr_registry       = split("/", local.ecr_repository_url)[0]
+    ecr_repository_url = local.ecr_repository_url
+    efs_id             = aws_efs_file_system.snmk.id
+    db_host            = replace(aws_db_instance.main.endpoint, ":3306", "")
+    swap_size_mb       = 32768 # 32GB swap for workflow memory spikes
+    swap_device_name   = "/dev/xvds"
   }))
   tag_specifications {
     resource_type = "instance"
@@ -412,18 +410,16 @@ resource "aws_launch_template" "premium" {
   }
 
   user_data = base64encode(templatefile("${path.module}/../scripts/ecs-user-data.sh", {
-    tier                  = "premium"
-    cluster_name          = aws_ecs_cluster.main.name
-    git_branch            = var.git_branch
-    git_repo              = var.git_repo
-    firebase_config_json  = var.firebase_config_json
-    firebase_private_json = var.firebase_private_json
-    ecr_registry          = split("/", local.ecr_repository_url)[0]
-    ecr_repository_url    = local.ecr_repository_url
-    efs_id                = aws_efs_file_system.snmk.id
-    db_host               = replace(aws_db_instance.main.endpoint, ":3306", "")
-    swap_size_mb          = 32768 # 32GB swap for workflow memory spikes
-    swap_device_name      = "/dev/xvds"
+    tier               = "premium"
+    cluster_name       = aws_ecs_cluster.main.name
+    git_branch         = var.git_branch
+    git_repo           = var.git_repo
+    ecr_registry       = split("/", local.ecr_repository_url)[0]
+    ecr_repository_url = local.ecr_repository_url
+    efs_id             = aws_efs_file_system.snmk.id
+    db_host            = replace(aws_db_instance.main.endpoint, ":3306", "")
+    swap_size_mb       = 32768 # 32GB swap for workflow memory spikes
+    swap_device_name   = "/dev/xvds"
   }))
 
   tag_specifications {

--- a/infrastructure/terraform/public_service.tf
+++ b/infrastructure/terraform/public_service.tf
@@ -62,18 +62,16 @@ resource "aws_launch_template" "public" {
   }
 
   user_data = base64encode(templatefile("${path.module}/../scripts/ecs-user-data.sh", {
-    tier                  = "public"
-    cluster_name          = aws_ecs_cluster.main.name
-    git_branch            = var.git_branch
-    git_repo              = var.git_repo
-    firebase_config_json  = var.firebase_config_json
-    firebase_private_json = var.firebase_private_json
-    ecr_registry          = split("/", local.ecr_repository_url)[0]
-    ecr_repository_url    = local.ecr_repository_url
-    efs_id                = ""
-    db_host               = replace(aws_db_instance.main.endpoint, ":3306", "")
-    swap_size_mb          = 0
-    swap_device_name      = ""
+    tier               = "public"
+    cluster_name       = aws_ecs_cluster.main.name
+    git_branch         = var.git_branch
+    git_repo           = var.git_repo
+    ecr_registry       = split("/", local.ecr_repository_url)[0]
+    ecr_repository_url = local.ecr_repository_url
+    efs_id             = ""
+    db_host            = replace(aws_db_instance.main.endpoint, ":3306", "")
+    swap_size_mb       = 0
+    swap_device_name   = ""
   }))
 
   tag_specifications {


### PR DESCRIPTION
### Content

#### Summary
- The Firebase service-account private key (and web config) were interpolated into EC2 `user_data` via `templatefile()` on all four launch templates. Because the AWS provider does not mark `user_data` sensitive, the value can render in cleartext in `terraform plan`/`apply` diffs (observed as a `-> null` removal on `aws_instance.premium[0]`), and it also lives in cleartext in state-at-rest, via IMDS, and in the EC2 console.
- This removes the secret from `user_data` entirely. The container already writes `firebase_config.json` / `firebase_private.json` at startup from Secrets Manager (`cloud-startup.sh`), so the `user_data` copy was redundant and unused by the app.
- Terraform variables and the `aws_secretsmanager_secret_version` resources are unchanged — Secrets Manager remains the single source of truth.

#### Design Decisions
- **Delete, don't mask.** Display masking (relying on Terraform propagating the `sensitive` mark through `templatefile()`/`base64encode()`) only hides the value in logs; it does nothing for the copies in state-at-rest, IMDS, and the EC2 console. Removing the secret from `user_data` is the root fix and is version-independent.
- **Reuse the existing runtime path.** `cloud-startup.sh` already fetches `${ENV_PREFIX}-optinist/firebase/config` and `.../firebase/private-key` from Secrets Manager and writes both files into `/app/studio/config/auth/` inside the container, for every tier. The ECS instance/task roles already hold `GetSecretValue` for those ARNs. No new mechanism was added.
- **Fix all four launch templates, not just the one observed leaking.** `ecs`, `premium`, `background`, and `public` all embedded the key; fixing only the observed `premium`/`ecs` pair would leave the same exposure in the other two.
- **Key rotation deferred.** The observed leak is confined to local `terraform plan` output; rotation of the exposed key is tracked as a separate follow-up rather than blocking this change.

### Evidence
- `terraform plan` (per env) — the four `user_data` attributes change and render `(sensitive value)`; grep of the plan output for `BEGIN PRIVATE KEY` returns 0. _(attach plan excerpt)_
- Post-apply container exec — `firebase_private.json` / `firebase_config.json` present under `/app/studio/config/auth/`. _(attach `ls`/auth-check output)_

### References
- Runtime provisioning: `cloud-startup.sh` (Secrets Manager fetch → `studio/config/auth/`).
- Secrets: `aws_secretsmanager_secret.firebase_config`, `aws_secretsmanager_secret.firebase_private_key` (`security.tf`).
- Context: 2026-06-04 prod-recovery re-import is the most likely source of the unmarked `user_data` value seen in state.

#### Files changed
- `infrastructure/scripts/ecs-user-data.sh` — remove the host-side Firebase block (mkdir + `firebase_config.json` / `firebase_private.json` heredocs + chmod); no secret is written to the host anymore.
- `infrastructure/terraform/compute.tf` — drop `firebase_config_json` / `firebase_private_json` template inputs from the `ecs` and `premium` launch templates (fmt realigned the surrounding map).
- `infrastructure/terraform/background_service.tf` — drop the same two inputs from the `background` launch template.
- `infrastructure/terraform/public_service.tf` — drop the same two inputs from the `public` launch template.

### Manual Testcases

Run per environment, **development first**. Verify the initialized backend matches the `-var-file` before any terraform command.

1. **Plan is clean.** Run `terraform plan -var-file=environments/<env>.tfvars`. Expect: the four launch templates show `~ user_data = (sensitive value)`; `terraform plan ... | grep -c 'BEGIN PRIVATE KEY'` returns `0`.
2. **Apply + refresh.** `terraform apply` the plan, then trigger an ASG instance refresh on each tier. Expect: new launch-template versions; instances replaced without health-check failures.
3. **Container still gets the key.** Exec into a running task on each tier and run `ls -l /app/studio/config/auth/`. Expect: `firebase_config.json` and `firebase_private.json` both present and non-empty (written by `cloud-startup.sh` from Secrets Manager).
4. **Auth works end-to-end.** Log in through the deployed app (free + premium tiers) and load an authenticated page. Expect: login succeeds, no Firebase-auth errors in backend logs — proving the container copy is sufficient without the `user_data` copy.
5. **Background jobs unaffected.** Check the `background` service logs after refresh. Expect: scheduled jobs run; no "firebase file missing" errors.
6. **No secret in instance metadata.** On a newly launched instance, `curl http://169.254.169.254/latest/user-data | grep -c 'BEGIN PRIVATE KEY'`. Expect: `0`. Confirm the host file `/opt/optinist-for-cloud/studio/config/auth/firebase_private.json` is absent and the app is unaffected.


### Unit, Integration, Contract Test Coverage
- No new automated coverage added; this is a removal of embedded config. Existing infra tests (task-definition / safe-env-var suites) guard against regressions in the task definitions that remain the app's config source.

### Others

#### Difficulties (if any)

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| EC2 launch templates (all 4 tiers) | Medium | `user_data` changes create new LT versions → instance replacement on ASG refresh. Verify testcase 3 before scaling down old instances. |
| Firebase auth at runtime | Low | Files are still provisioned by `cloud-startup.sh` from Secrets Manager, which already ran in production; behavior is unchanged for the container. |
| Rollback | Low | Revert the commit and re-apply; no state/data migration involved. |
| Residual exposure | Medium | One intended plaintext copy remains in state via `secret_string`; already-exposed key is not rotated here (tracked separately). |
