### PR TITLE
Fix users.id auto_increment burn

### DIFF
--- a/.github/scripts/e2e-bootstrap.sh
+++ b/.github/scripts/e2e-bootstrap.sh
@@ -11,13 +11,6 @@ $COMPOSE exec -T -e SUBSCRIPTION_PLANS_CONFIG -e DB_HOST=db -e DB_PORT=3306 \
   studio-dev-be \
   poetry run python infrastructure/scripts/seed_subscription_plans.py
 
-# No migration seeds organization/roles; registration FK-fails without them
-$COMPOSE exec -T db sh -c \
-  'exec mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -N "$MYSQL_DATABASE"' <<SQL
-INSERT IGNORE INTO organization (id, name) VALUES (1, 'E2E CI');
-INSERT IGNORE INTO roles (id, role) VALUES (1, 'admin'), (20, 'operator');
-SQL
-
 # Dev Firebase persists between runs while the CI DB starts empty; a
 # leftover Firebase user makes registration 400 without creating the DB
 # row, so remove the CI users first and register them fresh each run

--- a/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
@@ -102,10 +102,16 @@ OptiNiSt uses **AWS Secrets Manager** for credential storage. This enables team 
 
 2. **Ongoing deployments (no Terraform needed):**
    - Build and push Docker images using `ecr_build_push.sh`
-   - The `app_setup.sh` script inside the container automatically:
+
+3. **Host provisioning (`app_setup.sh`, runs on a 30-minute schedule):**
+   - Runs independently of image deploys. `aws_ssm_association "app_setup"` (`deployment.tf`, `schedule_expression = "rate(30 minutes)"`) downloads the script from S3 and executes it on each EC2 host via SSM — **not inside the container, and not one-shot**. It re-runs every 30 minutes for the life of the instance. On each cycle it:
      - Reads secrets from AWS Secrets Manager
      - Discovers infrastructure (RDS endpoint, S3 buckets) via AWS CLI
      - Configures the application with correct settings
+     - Applies the DB bootstrap SQL (idempotent — guarded so re-runs allocate
+       no new rows)
+
+   > **Design note / future consideration:** this script mixes two concerns on one 30-minute loop — periodic desired-state (env/config files, secret refresh, which *should* re-run) and one-shot bootstrap (package installs, DB seeding, Firebase admin verification, which need only run once). The seed migration now owns the DB reference rows, so the DB block could be removed from here entirely. A cleaner design would split bootstrap (launch-time / one-shot) from periodic config enforcement. Not required for correctness — the bootstrap steps are idempotent — but it would stop re-running one-shot work every 30 minutes for the life of each instance.
 
 ---
 

--- a/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
+++ b/infrastructure/documentation/TERRAFORM_ARCHITECTURE.md
@@ -22,7 +22,7 @@ infrastructure/terraform/
 ├── compute_domain.tf            # Route53, ACM certificate (conditional — production only)
 ├── security.tf                  # IAM roles/policies, security groups, key pairs, Secrets Manager
 ├── monitoring.tf                # CloudWatch log groups, alarms, dashboard
-├── deployment.tf                # SSM document for app_setup.sh deployment
+├── deployment.tf                # SSM document + association running app_setup.sh on each host every 30 min
 ├── background_service.tf        # Background job ECS service and task definition
 ├── premium_manager.tf           # Premium tier Lambda functions and scheduling
 ├── free_manager.tf              # Free tier Lambda functions and scheduling

--- a/infrastructure/scripts/app_setup.sh
+++ b/infrastructure/scripts/app_setup.sh
@@ -44,16 +44,6 @@ ECS_AGENT_RETRY_DELAY=30
 DEFAULT_ORG_ID=1
 ADMIN_ROLE_ID=1
 
-# Role Definitions
-ROLE_ADMIN_ID=1
-ROLE_ADMIN_NAME="admin"
-ROLE_DATA_MANAGER_ID=10
-ROLE_DATA_MANAGER_NAME="data manager"
-ROLE_OPERATOR_ID=20
-ROLE_OPERATOR_NAME="operator"
-ROLE_GUEST_OPERATOR_ID=30
-ROLE_GUEST_OPERATOR_NAME="guest operator"
-
 # Tax Configuration
 TAX_TYPE="sales_tax"
 TAX_NAME="Sales Tax"
@@ -284,26 +274,31 @@ FLUSH PRIVILEGES;
 CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE};
 USE ${MYSQL_DATABASE};
 
--- Insert initial data
-INSERT IGNORE INTO organization (name) VALUES ('${OPTINIST_ORG_NAME}');
-INSERT IGNORE INTO roles (id, role) VALUES
-  (${ROLE_ADMIN_ID}, '${ROLE_ADMIN_NAME}'),
-  (${ROLE_DATA_MANAGER_ID}, '${ROLE_DATA_MANAGER_NAME}'),
-  (${ROLE_OPERATOR_ID}, '${ROLE_OPERATOR_NAME}'),
-  (${ROLE_GUEST_OPERATOR_ID}, '${ROLE_GUEST_OPERATOR_NAME}');
+-- Organization/roles rows are seeded by migration; only the env-specific org name is applied here
+UPDATE organization SET name = '${OPTINIST_ORG_NAME}' WHERE id = ${DEFAULT_ORG_ID};
+
+-- NOT EXISTS guards below: this file re-runs every 30 min, and a bare INSERT IGNORE
+-- burns an auto_increment id (or leaks a row on tables with no unique key) per re-run
 
 -- Default admin user with S3 bucket info
 INSERT IGNORE INTO users (uid, organization_id, name, email, active, attributes)
-VALUES ('${OPTINIST_ADMIN_UID}', ${DEFAULT_ORG_ID}, '${OPTINIST_ADMIN_NAME}', '${OPTINIST_ADMIN_EMAIL}', true, '{"remote_bucket_name": "${S3_BUCKET}"}');
+SELECT '${OPTINIST_ADMIN_UID}', ${DEFAULT_ORG_ID}, '${OPTINIST_ADMIN_NAME}', '${OPTINIST_ADMIN_EMAIL}', true, '{"remote_bucket_name": "${S3_BUCKET}"}'
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE uid = '${OPTINIST_ADMIN_UID}');
 
 INSERT IGNORE INTO user_roles (user_id, role_id)
-SELECT id, ${ADMIN_ROLE_ID} FROM users WHERE uid = '${OPTINIST_ADMIN_UID}';
+SELECT u.id, ${ADMIN_ROLE_ID} FROM users u
+WHERE u.uid = '${OPTINIST_ADMIN_UID}'
+  AND NOT EXISTS (SELECT 1 FROM user_roles r WHERE r.user_id = u.id AND r.role_id = ${ADMIN_ROLE_ID});
 
 UPDATE users SET attributes = JSON_MERGE_PATCH(IFNULL(attributes,'{}'), '{"remote_bucket_name": "${S3_BUCKET}"}') WHERE uid = '${OPTINIST_ADMIN_UID}';
 
--- Tax rates initialization
+-- Tax rates initialization; keyed on (tax_type, tax_rate) so a rate change inserts
+-- a new row with a fresh effective_date instead of being silently skipped
 INSERT IGNORE INTO taxes (tax_type, tax_name, tax_rate, is_active, effective_date)
-VALUES ('${TAX_TYPE}', '${TAX_NAME}', ${TAX_RATE}, ${TAX_IS_ACTIVE}, CURDATE());
+SELECT '${TAX_TYPE}', '${TAX_NAME}', ${TAX_RATE}, ${TAX_IS_ACTIVE}, CURDATE()
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM taxes WHERE tax_type = '${TAX_TYPE}' AND tax_rate = ${TAX_RATE});
 
 -- Admin user storage quota initialization
 INSERT IGNORE INTO user_storage_usage (user_id, storage_usage_bytes, storage_quota_bytes)
@@ -312,7 +307,10 @@ ON DUPLICATE KEY UPDATE storage_quota_bytes = ${ADMIN_STORAGE_QUOTA_BYTES};
 
 -- Admin user free subscription
 INSERT IGNORE INTO subscription_users (plan_id, user_id, expiration)
-SELECT ${FREE_PLAN_ID}, id, DATE_ADD(NOW(), INTERVAL ${ADMIN_SUBSCRIPTION_DAYS} DAY) FROM users WHERE uid = '${OPTINIST_ADMIN_UID}';
+SELECT ${FREE_PLAN_ID}, u.id, DATE_ADD(NOW(), INTERVAL ${ADMIN_SUBSCRIPTION_DAYS} DAY)
+FROM users u
+WHERE u.uid = '${OPTINIST_ADMIN_UID}'
+  AND NOT EXISTS (SELECT 1 FROM subscription_users s WHERE s.user_id = u.id);
 
 INIT_SQL
 
@@ -322,8 +320,6 @@ INIT_SQL
 export MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE
 export OPTINIST_ORG_NAME OPTINIST_ADMIN_UID OPTINIST_ADMIN_NAME OPTINIST_ADMIN_EMAIL
 export S3_BUCKET DB_INIT_SQL_FILE
-export ROLE_ADMIN_ID ROLE_ADMIN_NAME ROLE_DATA_MANAGER_ID ROLE_DATA_MANAGER_NAME
-export ROLE_OPERATOR_ID ROLE_OPERATOR_NAME ROLE_GUEST_OPERATOR_ID ROLE_GUEST_OPERATOR_NAME
 export DEFAULT_ORG_ID ADMIN_ROLE_ID
 export TAX_TYPE TAX_NAME TAX_RATE TAX_IS_ACTIVE
 export ADMIN_STORAGE_USAGE_BYTES ADMIN_STORAGE_QUOTA_BYTES
@@ -352,14 +348,6 @@ var_names = [
     'OPTINIST_ADMIN_NAME',
     'OPTINIST_ADMIN_EMAIL',
     'S3_BUCKET',
-    'ROLE_ADMIN_ID',
-    'ROLE_ADMIN_NAME',
-    'ROLE_DATA_MANAGER_ID',
-    'ROLE_DATA_MANAGER_NAME',
-    'ROLE_OPERATOR_ID',
-    'ROLE_OPERATOR_NAME',
-    'ROLE_GUEST_OPERATOR_ID',
-    'ROLE_GUEST_OPERATOR_NAME',
     'DEFAULT_ORG_ID',
     'ADMIN_ROLE_ID',
     'TAX_TYPE',

--- a/studio/alembic/versions/n901n0716027_seed_reference_data.py
+++ b/studio/alembic/versions/n901n0716027_seed_reference_data.py
@@ -1,0 +1,36 @@
+"""seed reference data required for user registration
+
+Revision ID: n901n0716027
+Revises: i901i9230023
+Create Date: 2026-07-16 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "n901n0716027"
+down_revision = "i901i9230023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Registration FK-requires these rows; env-specific overrides (org name,
+    # plan prices/Stripe ids) are applied later by their existing seeders
+    op.execute(
+        "INSERT IGNORE INTO organization (id, name) VALUES (1, 'Default Organization')"
+    )
+    op.execute(
+        "INSERT IGNORE INTO roles (id, role) VALUES "
+        "(1, 'admin'), (10, 'data manager'), (20, 'operator'), (30, 'guest operator')"
+    )
+    op.execute(
+        "INSERT IGNORE INTO subscription_plans "
+        "(id, name, price, billing_cycle, features, currency, status) "
+        "VALUES (1, 'Free', 0, 1, '{}', 1, 1)"
+    )
+
+
+def downgrade() -> None:
+    pass  # seed data; nothing to unwind


### PR DESCRIPTION
### Content

#### Summary
- `users.id` on the subscription environment was being burned ~90/day with only ~31 real users (#615): the SSM association re-runs `app_setup.sh` every 30 minutes, and each run's `INSERT IGNORE INTO users` allocates an auto_increment id before the duplicate-`uid` check discards it.
- **Why every 30 minutes (root-cause mechanism):** `app_setup.sh` is *not* a one-shot init script. `aws_ssm_association "app_setup"` (`infrastructure/terraform/deployment.tf:117-130`) sets `schedule_expression = "rate(30 minutes)"`, so the association downloads the script from S3 and runs it on every EC2 instance in the ASG on a 30-minute cycle for the life of the instance — effectively a cron. `max_errors = "0"` / `compliance_severity = "HIGH"` on that same association is why this PR keeps `IGNORE` (one failing statement marks the association non-compliant).
- **Origin:** the burn became active once the unguarded `INSERT IGNORE INTO users` landed on that periodic path in commit `4e7d9f93` ("Other misc", 2026-01-14). The 30-minute association itself predates it (present since the infra move); the two coexisting is what started the burn, which later surfaced as #615.
- The same re-run also leaked phantom rows every 30 minutes into `subscription_users`, `organization`, and `taxes` (no unique key to hit), and burned ids on `user_roles`.
- All bootstrap inserts are now `INSERT IGNORE ... SELECT ... WHERE NOT EXISTS` — when the row exists, the SELECT yields zero rows and allocates nothing.
- A new seed migration (`n901n0716027_seed_reference_data`) owns the `organization`/`roles`/Free-plan rows that registration FK-requires, so a fresh `alembic upgrade head` can register users without any shell-script bootstrap; `app_setup.sh` and `e2e-bootstrap.sh` drop their now-redundant seed SQL.

#### Design Decisions
- **`WHERE NOT EXISTS` + keep `IGNORE`, rather than plain guarded INSERT:** `IGNORE` costs nothing and keeps the statement error-immune if it races a concurrent write or runs before migrations on a fresh instance — the association has `max_errors = "0"`, so a single failing statement would mark it non-compliant. Rejected splitting the DB bootstrap into a one-shot Run Command: it touches Terraform + ASG wiring for no extra benefit once the inserts allocate nothing.
- **Seed migration is NOT fed from tfvars.** Alembic runs where Terraform doesn't exist (local dev, CI compose, container start with only a DB URL). The migration seeds only fixed structural constants the code already hardcodes (org id 1, role ids 1/10/20/30, plan id 1); env-specific values keep their existing overlay paths — `UPDATE organization SET name` in `app_setup.sh`, and `seed_subscription_plans.py` for plan prices/Stripe ids.
- **Free plan only in the migration, no Premium row.** Registration FK-requires only `FREE_PLAN_ID = 1`; seeding Premium would hardcode live pricing in a migration, and every environment that sells Premium already runs `seed_subscription_plans.py` (which upserts by id, so migration default and env config coexist).
- **`taxes` guard keys on `(tax_type, tax_rate)`, not `tax_type` alone.** A type-only guard would silently swallow future `TAX_RATE` tfvars changes; the pair-key lets a rate change insert one new row with a fresh `effective_date`, matching the table's design.
- **`user_storage_usage` left as-is.** Its `ON DUPLICATE KEY UPDATE` is an intentional quota refresh; it burns one unreferenced id per run, accepted.
- **The `subscription_users` unique constraint is deliberately NOT in this PR.** Migrations auto-apply at container start (`cloud-startup.sh` runs `alembic upgrade head`), while this script fix only reaches instances after a terraform apply and an SSM fire. Shipping dedup+constraint in the same deploy races the still-live 30-min writer: a duplicate inserted between the dedup DELETE and the ALTER would fail the migration and crash-loop the backend. The constraint ships as a follow-up PR once the leak is confirmed stopped.

### Evidence
- Fresh MySQL 8 container, full `alembic upgrade head`, then the substituted `app_setup.sh` SQL block executed 8 times (`information_schema_stats_expiry = 0` before each reading):

  ```
  run,users_ai,user_roles_ai,sub_users_ai,org_cnt,tax_cnt,sub_cnt,role_link_cnt,users_cnt
  1,2,2,2,1,1,1,1,1
  5,2,2,2,1,1,1,1,1
  PASS: all counters flat across repeated runs
  ```

  Before this change, every run advanced `users`/`user_roles`/`subscription_users` AUTO_INCREMENT and added one `subscription_users`, `organization`, and `taxes` row.
- Changing `TAX_RATE` 0.10 → 0.12 inserted exactly one new tax row (fresh `effective_date`), then stayed flat on repeats.
- Fresh-DB seed check: after `alembic upgrade head` on an empty database, `organization` (id 1), all four `roles`, and the Free plan row are present; `alembic heads` shows the single head `n901n0716027`.

### References
- Issue #615 (users.id burn on subscription env)
- #720 (admin GUI upsert for users without a `subscription_users` row) — related but not addressed; the follow-up unique-constraint PR is compatible with it
- Model/migration drift context: `UserSubscription` declares `idx_user_id_unique`, but `af8c4144cd54_add_stripe_integration_tables` created only a plain index — the follow-up PR materialises the constraint

#### Files changed
- `infrastructure/scripts/app_setup.sh` -- guard `users`/`user_roles`/`taxes`/`subscription_users` inserts with `WHERE NOT EXISTS`; drop migration-owned `organization`/`roles` seeds (env org name now applied via `UPDATE`); remove dead `ROLE_*` variables from definitions/exports/`var_names`
- `studio/alembic/versions/n901n0716027_seed_reference_data.py` -- new seed migration for org 1, role ids 1/10/20/30, and the Free plan, chained off `i901i9230023`
- `.github/scripts/e2e-bootstrap.sh` -- drop inline `organization`/`roles` INSERTs now owned by the migration (CI org name becomes 'Default Organization'; nothing references the old 'E2E CI' string)
- `infrastructure/documentation/DEPLOYMENT_PROCEDURE.md` -- correct the `app_setup.sh` execution model: it runs on each EC2 host via the SSM association every 30 minutes, not "inside the container" one-shot per deploy (the misreading that made this burn invisible)
- `infrastructure/documentation/TERRAFORM_ARCHITECTURE.md` -- file-tree comment for `deployment.tf` now notes the 30-min periodic association

### Manual Testcases
- Operator: start a fresh MySQL 8, run `alembic upgrade head` -- chain applies cleanly; `organization`, `roles`, and Free-plan rows exist with no manual SQL.
- Operator: run the `app_setup.sh` DB-init SQL block 5+ times against that DB -- `SHOW TABLE STATUS` AUTO_INCREMENT for `users`/`user_roles`/`subscription_users` and all row counts stay flat (set `information_schema_stats_expiry = 0` first; MySQL 8 otherwise serves cached stats).
- Operator: change `TAX_RATE` and re-run the block -- exactly one new `taxes` row appears, then counts stay flat again.
- Post-deploy (per environment, dev first): terraform apply (the script ships via the `aws_s3_object.app_setup_script` object — merging alone changes nothing on instances), wait one 30-min SSM cycle, confirm `users` AUTO_INCREMENT flat and no new `subscription_users`/`user_roles`/`organization`/`taxes` rows.
- e2e CI (`e2e-bootstrap.sh` + registration specs) passes -- with the inline seed SQL removed, CI itself now regression-tests that the migration seeds everything registration needs.

### Unit, Integration, Contract Test Coverage
- No backend code paths changed (script + migration only). Fresh-DB registration coverage comes from the e2e workflow, which now depends on the seed migration instead of hand-inserted rows.

### Others

#### Difficulties (if any)
- On a brand-new environment, `app_setup.sh` can fire before the app has run migrations; the mysql client aborts the SQL file at the first missing-table error, and the association reports non-compliant for that window. Same behavior as today — it self-heals on the next cycle after the app migrates.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `app_setup.sh` bootstrap SQL | Low | Guards only skip work that already happened; `max_concurrency = "1"` and a single admin row mean no contention. Verified zero-burn over repeated runs on MySQL 8. |
| Seed migration | Low | `INSERT IGNORE` with explicit ids; no-op on every existing environment (rows already present). Runs once at container start. |
| e2e bootstrap | Low | CI org name changes from 'E2E CI' to 'Default Organization'; nothing asserts on that string. |
| Prod leaked-row cleanup | Medium | Existing phantom `organization`/`taxes` rows are NOT removed by this PR — manual dedup after deploy (keep `organization` id 1; keep earliest `taxes` row per type). Follow-up unique-constraint migration handles `subscription_users` dedup. |
