### PR TITLE
Fix/db id burn 2

### DIFF
--- a/studio/alembic/versions/o901o0716028_add_unique_subscription_users_user_id.py
+++ b/studio/alembic/versions/o901o0716028_add_unique_subscription_users_user_id.py
@@ -1,0 +1,35 @@
+"""add unique constraint on subscription_users(user_id)
+
+Revision ID: o901o0716028
+Revises: n901n0716027
+Create Date: 2026-07-16 12:00:00.000000
+
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "o901o0716028"
+down_revision = "n901n0716027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Keep the MAX(expiration) row per user (id as tiebreak): all read paths
+    # resolve duplicates by MAX(expiration), so this preserves read-visible state
+    op.execute(
+        text(
+            "DELETE s1 FROM subscription_users s1 "
+            "INNER JOIN subscription_users s2 "
+            "ON s1.user_id = s2.user_id "
+            "AND (s1.expiration < s2.expiration "
+            "OR (s1.expiration = s2.expiration AND s1.id < s2.id))"
+        )
+    )
+    op.create_unique_constraint("idx_user_id_unique", "subscription_users", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("idx_user_id_unique", "subscription_users", type_="unique")

--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from sqlalchemy import BIGINT, INTEGER, JSON, TIMESTAMP, Boolean, DateTime
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy import String, Text, UniqueConstraint
+from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint
 from sqlalchemy.sql import func
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import Column, Field, SQLModel
@@ -64,16 +64,32 @@ class SubscriptionPlans(SQLModel, table=True):
 class UserSubscription(SQLModel, table=True):
     __tablename__ = "subscription_users"
     __table_args__ = (
-        UniqueConstraint("id", name="idx_id"),
         UniqueConstraint("user_id", name="idx_user_id_unique"),
+        Index("idx_subscription_users_user_id", "user_id"),
+        Index("idx_subscription_users_plan_id", "plan_id"),
+        Index("idx_subscription_users_expiration", "expiration"),
+        Index("idx_subscription_users_user_plan", "user_id", "plan_id"),
+        Index("idx_subscription_users_user_expiration", "user_id", "expiration"),
     )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
     )
-    plan_id: int = Field(sa_column=Column(BIGINT, nullable=False))
-    user_id: int = Field(sa_column=Column(BIGINT, nullable=False))
+    plan_id: int = Field(
+        sa_column=Column(
+            BIGINT,
+            ForeignKey("subscription_plans.id", name="fk_subscription_users_plan"),
+            nullable=False,
+        )
+    )
+    user_id: int = Field(
+        sa_column=Column(
+            BIGINT,
+            ForeignKey("users.id", name="fk_subscription_users_user"),
+            nullable=False,
+        )
+    )
     expiration: datetime = Field(sa_column=Column(DateTime, nullable=False))
     scheduled_downgrade: bool = Field(
         sa_column=Column(Boolean, nullable=False, default=False),


### PR DESCRIPTION
# Pull Request: Add unique constraint on subscription_users.user_id

**Current Branch:** fix/db-id-burn-2
**Target Branch:** develop-main
 
Note this builds on https://github.com/arayabrain/araya-optinist/pull/743 and expects that 743 is merged and tested.

----------
### Content

#### Summary
- Materialises the unique constraint on `subscription_users.user_id` that the `UserSubscription` model already declares (`idx_user_id_unique`) but `af8c4144cd54_add_stripe_integration_tables` implemented as a plain index — the model/migration drift that let the 30-minute bootstrap re-runs leak thousands of phantom admin subscription rows (#615).
- The migration first dedups existing rows (keeping the MAX(expiration) row per user, id as tiebreak), then adds the constraint — same pattern as `i901i9230023_add_unique_user_provider_constraint`.
- Also starts #723 (model/migration drift): the `UserSubscription` model is aligned with the schema the migrations actually built — its two FKs and five `idx_*` indexes added, its phantom `idx_id` unique constraint removed — making `subscription_users` the first table with zero `alembic check` drift.
- **Merge gate: do not merge until the parent PR's fix is confirmed live** — `users` AUTO_INCREMENT flat and no new `subscription_users` rows across a 30-minute SSM cycle after the terraform apply, per environment. Migrations auto-apply at container start, so merging is deploying.

#### Design Decisions
- **Dedup keeps MAX(expiration), not MIN(id) or MAX(id).** Every read path resolves duplicates by expiration — `get_current_user` in `auth_dependencies.py` aggregates `func.max(UserSubscription.expiration)`, and `subscription_service.py`/`webhook_service.py` use `.order_by(expiration.desc())` — so keeping the max-expiration row preserves read-visible state by construction on every environment the migration runs, not just prod. MIN(id) (the `i901i9230023` template's choice, right for that table) would snap the admin's effective expiration back to the first-ever insert, already expired if the leak ran long enough. Known edge: `auth_dependencies.py` takes `max(expiration)` and `max(plan_id)` independently, so a cohort where those come from different rows reads as a combination no single row reproduces — the max-expiration row is the defensible keep.
- **Why a separate PR from the bootstrap fix:** the script fix reaches instances only via terraform apply + the SSM schedule, while migrations run at container start. In one deploy, the still-live old script could insert a duplicate between the dedup DELETE and the ALTER (DDL commits implicitly, so they're not atomic), failing the migration and crash-looping the backend at startup.
- **No writer breaks under the constraint.** Only two places construct `UserSubscription`: `create_user` in `crud_users.py` (brand-new user at registration) and `checkout_service.py` — which was already written assuming uniqueness (SELECT-then-update upsert with SAVEPOINT + `IntegrityError` fallback for the concurrent-webhook race). This closes a latent assumption rather than adding a new invariant.
- **The leftover plain index `idx_subscription_users_user_id` is left in place** — it coexists harmlessly with the unique constraint and dropping it is not needed for correctness.
- **Model alignment follows #723's direction: the DB is the source of truth.** The FKs (`fk_subscription_users_plan`, `fk_subscription_users_user`) and indexes added to `UserSubscription` use the exact migration-created names, so autogenerate sees no diff; the `UniqueConstraint("id", name="idx_id")` the model declared was never implemented by any migration (id is the primary key) and is removed rather than materialised. Model-metadata change only — no migration is generated from it and no deployed schema changes. Scope is deliberately just this PR's table; the remaining ~90 drift ops stay with #723's per-table-cluster plan.

### Evidence
- Fresh MySQL 8: migrated to the parent revision, planted duplicate cohorts, then `alembic upgrade head`:
  - user with expirations (2026, **2028**, 2027) across ids (1, **2**, 3) → row id 2 kept — proves the dedup keys on expiration, not id position.
  - user with two equal expirations → higher id kept (tiebreak).
  - single-row user untouched.
- Post-migration duplicate insert fails as intended: `ERROR 1062 (23000): Duplicate entry '1' for key 'subscription_users.idx_user_id_unique'`.
- `alembic downgrade -1` drops the constraint (verified via `SHOW INDEX`); re-upgrade reapplies cleanly.
- `alembic check` against a fully migrated DB: `subscription_users` mentions in the drift output drop from 8 operations to **zero** (removed indexes 50→45, removed FKs 8→6, add_constraint 2→1); no other table's ops changed.
- `pytest` on the four subscription-related test files — 80 passed.

### References
- Issue #615 (users.id burn / phantom subscription rows) — parent PR fixes the writer; this PR fixes the schema
- Parent PR: fix/db-id-burn (bootstrap `WHERE NOT EXISTS` guards + seed migration) — this branch chains off it
- #723 (model/migration drift, `alembic check` unusable) — this PR is the first table-cluster slice: `subscription_users` now has zero autogenerate drift (constraint materialised DB-side, FKs/indexes aligned model-side). Adding `alembic check` to CI stays with #723 — it can only land once every table is clean.
- #720 (admin GUI upsert for users without a subscription row) — compatible with, but not fixed by, this constraint

#### Files changed
- `studio/alembic/versions/o901o0716028_add_unique_subscription_users_user_id.py` -- new migration: dedup keeping MAX(expiration) per user, then `create_unique_constraint("idx_user_id_unique")`; chained off the seed migration `n901n0716027`
- `studio/app/common/models/subscription.py` -- align `UserSubscription` with the migration-built schema: add `fk_subscription_users_plan`/`fk_subscription_users_user` FKs and the five `idx_subscription_users_*` indexes; remove the never-implemented `idx_id` unique constraint (#723, first table-cluster)

### Manual Testcases
- Operator, **before merge**: confirm the parent PR's terraform apply is done per environment and one full 30-min SSM cycle shows `users` AUTO_INCREMENT flat and `subscription_users` count unchanged (set `information_schema_stats_expiry = 0` before reading — MySQL 8 otherwise serves cached stats).
- Operator, **before merge**: pre-flight on prod — `SELECT user_id, COUNT(*) FROM subscription_users GROUP BY user_id HAVING COUNT(*) > 1;` — expect the admin phantom cohort only; if any other cohort appears, stop and investigate before deploying.
- Operator: on a DB copy with seeded duplicates, `alembic upgrade head` -- one row per `user_id` remains, and for each user it is the max-expiration row.
- Operator: insert a second `subscription_users` row for an existing `user_id` -- rejected with duplicate-key error 1062 on `idx_user_id_unique`.
- Operator: `alembic downgrade -1` -- constraint dropped; `alembic upgrade head` -- reapplied.
- User (premium, id 10 on dev): log in after deploy -- subscription status, plan name, and expiration read the same as before the migration.
- Operator: on a migrated DB, `alembic check` -- output contains no `subscription_users` operations.
- `pytest studio/tests/app/common/routers/test_users_admin_subscription.py studio/tests/app/common/routers/test_webhook.py studio/tests/app/common/routers/test_subscriptions_api_contract.py studio/tests/app/common/schemas/test_user_subscription_tier.py` -- all 80 tests pass.

### Unit, Integration, Contract Test Coverage
- No application code changed. Existing checkout/webhook tests cover the two `UserSubscription` writers; the checkout upsert's `IntegrityError` fallback path now actually exercisable end-to-end.

### Others

#### Difficulties (if any)
- The dedup DELETE is a pairwise self-join — quadratic within a duplicate cohort. At the expected ~5.5k prod rows that is ~30M pair evaluations, tens of seconds at container start. If the pre-flight count is dramatically larger, rewrite the dedup as keep-one-id-per-user via a derived table before merging.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Data migration (dedup DELETE) | Medium | Deletes duplicate rows on every environment at deploy; keep-rule preserves what reads already return. No rollback re-creates deleted rows — downgrade only drops the constraint. Pre-flight dup check required before merge. |
| Constraint vs writers | Low | Both writers verified compatible; checkout upsert was written assuming this constraint exists. |
| Deploy ordering | Medium | Safe only after the parent PR's leak fix is confirmed live — enforced by the merge gate above, not by code. |
| Model metadata alignment | Low | Describes constraints/indexes every deployed DB already has; generates no migration and changes no runtime schema. Subscription test files pass (80/80). |
