### PR TITLE
Fix false "temporarily unreachable" warning on the first premium assign at sign-in

### DIFF
--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -86,6 +86,21 @@ jest.mock("hooks/useSleepDetection", () => ({
   useSleepDetection: () => undefined,
 }))
 
+// Neutralize the dedicated warm-up grace here: these tests flip unreachable
+// immediately after a fresh dedicated assignment. The grace (which now covers
+// the initial undefined → dedicated case too) would otherwise suppress that
+// first 5xx. The grace itself is covered in
+// useInstanceUnreachableMachineLeader.test.tsx.
+// "mock" prefix required for Jest's out-of-scope factory guard.
+const mockUnreachableConstants = jest.requireActual(
+  "contexts/premium/unreachableConstants",
+) as typeof import("contexts/premium/unreachableConstants")
+jest.mock("contexts/premium/unreachableConstants", () => ({
+  __esModule: true,
+  ...mockUnreachableConstants,
+  DEDICATED_HANDOFF_GRACE_MS: 0,
+}))
+
 const mockTabSyncHandlers: Map<
   TabSyncMessageType,
   Set<(msg: TabSyncMessage) => void>

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -105,6 +105,21 @@ jest.mock("hooks/useSleepDetection", () => ({
   useSleepDetection: () => undefined,
 }))
 
+// Neutralize the dedicated warm-up grace here: these tests flip unreachable
+// immediately after a fresh dedicated assignment. The grace (which now covers
+// the initial undefined → dedicated case too) would otherwise suppress that
+// first 5xx. The grace itself is covered in
+// useInstanceUnreachableMachineLeader.test.tsx.
+// "mock" prefix required for Jest's out-of-scope factory guard.
+const mockUnreachableConstants = jest.requireActual(
+  "contexts/premium/unreachableConstants",
+) as typeof import("contexts/premium/unreachableConstants")
+jest.mock("contexts/premium/unreachableConstants", () => ({
+  __esModule: true,
+  ...mockUnreachableConstants,
+  DEDICATED_HANDOFF_GRACE_MS: 0,
+}))
+
 const mockTabSyncHandlers: Map<
   TabSyncMessageType,
   Set<(msg: TabSyncMessage) => void>

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -95,6 +95,21 @@ jest.mock("hooks/useSleepDetection", () => ({
   useSleepDetection: () => undefined,
 }))
 
+// Neutralize the dedicated warm-up grace here: these are raw machine-transition
+// integration tests that flip unreachable immediately after a fresh dedicated
+// assignment. The grace (which now covers the initial undefined → dedicated
+// case too) would otherwise suppress that first 5xx. The grace itself is
+// covered in useInstanceUnreachableMachineLeader.test.tsx.
+// "mock" prefix required for Jest's out-of-scope factory guard.
+const mockUnreachableConstants = jest.requireActual(
+  "contexts/premium/unreachableConstants",
+) as typeof import("contexts/premium/unreachableConstants")
+jest.mock("contexts/premium/unreachableConstants", () => ({
+  __esModule: true,
+  ...mockUnreachableConstants,
+  DEDICATED_HANDOFF_GRACE_MS: 0,
+}))
+
 // Mock tabSync so tests can invoke handlers directly. "mock" prefix required for Jest's out-of-scope guard.
 const mockTabSyncHandlers: Map<
   TabSyncMessageType,

--- a/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
+++ b/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
@@ -162,9 +162,12 @@ describe("useInstanceUnreachableMachine — leader-gated side effects", () => {
   test("non-leader tab does NOT write premium_unreachable_snapshot on unreachable", () => {
     // Drive the hook into unreachable state on a non-leader tab. The
     // leader-only write branch must skip — no snapshot key in localStorage.
+    jest.useFakeTimers()
     const { ref } = renderHook({ isTabLeader: false })
 
+    // Past the initial-dedicated warm-up grace so this is a genuine failure.
     act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS + 1)
       routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
     })
 
@@ -173,9 +176,12 @@ describe("useInstanceUnreachableMachine — leader-gated side effects", () => {
   })
 
   test("leader tab writes snapshot when unreachable, and clears it on recovery", () => {
+    jest.useFakeTimers()
     const { ref } = renderHook({ isTabLeader: true })
 
+    // Past the initial-dedicated warm-up grace so this is a genuine failure.
     act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS + 1)
       routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
     })
 
@@ -201,7 +207,9 @@ describe("useInstanceUnreachableMachine — leader-gated side effects", () => {
 
     const { ref } = renderHook({ isTabLeader: true })
 
+    // Past the initial-dedicated warm-up grace so this is a genuine failure.
     act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS + 1)
       routingService.emitPremiumUnreachable({ status: 503, sentAt: 1 })
     })
     expect(ref.current?.state.instanceUnreachable).toBe(true)
@@ -330,7 +338,7 @@ describe("useInstanceUnreachableMachine — dedicated handoff warm-up grace", ()
     )
   })
 
-  test("grace is single-shot: a second 5xx within the window is NOT suppressed", () => {
+  test("grace is a time-window: every 5xx within the window is suppressed", () => {
     jest.useFakeTimers()
 
     const { ref, rerender } = renderHook({ assignment: shared })
@@ -348,7 +356,8 @@ describe("useInstanceUnreachableMachine — dedicated handoff warm-up grace", ()
     })
     expect(ref.current?.state.instanceUnreachable).toBe(false)
 
-    // Second 5xx still within the original grace window — must flip.
+    // Second 5xx still within the original grace window — also suppressed
+    // (multiple warm-up flaps must all be absorbed, not just the first).
     act(() => {
       jest.advanceTimersByTime(1000)
       routingService.emitPremiumUnreachable({
@@ -357,14 +366,84 @@ describe("useInstanceUnreachableMachine — dedicated handoff warm-up grace", ()
       })
     })
 
-    expect(ref.current?.state.instanceUnreachable).toBe(true)
-    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
-      "instance_unreachable_warmup_suppressed",
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+    const suppressedCalls = mockLogPremiumUiEvent.mock.calls.filter(
+      ([event]) => event === "instance_unreachable_warmup_suppressed",
+    )
+    expect(suppressedCalls).toHaveLength(2)
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_unreachable",
       expect.anything(),
     )
+
+    // Once the window elapses, a 5xx flips to unreachable as normal.
+    act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
     expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
       "instance_unreachable",
       expect.anything(),
+    )
+  })
+
+  test("initial undefined → dedicated assignment (direct sign-in) arms the grace", () => {
+    // Regression for the false "temporarily unreachable" warning on the first
+    // premium /assign at sign-in: mounting directly on a dedicated instance
+    // (no prior shared/unassigned state) must still arm the warm-up grace, so a
+    // transient warm-up 5xx is suppressed rather than surfaced as a warning.
+    jest.useFakeTimers()
+
+    // Mount straight onto dedicated — no shared/unassigned assignment first.
+    const { ref } = renderHook({ assignment: dedicated })
+
+    act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS - 1)
+      routingService.emitPremiumUnreachable({
+        url: "/api/run",
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(false)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable_warmup_suppressed",
+      expect.objectContaining({
+        instance_id: "inst-A",
+        url: "/api/run",
+        status: 503,
+      }),
+    )
+    expect(mockLogPremiumUiEvent).not.toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.anything(),
+    )
+  })
+
+  test("initial dedicated: a genuine 5xx after the grace window still flips to unreachable", () => {
+    // The safety feature must survive: absorbing warm-up flaps must not mask a
+    // real, persistent unreachable condition once the grace has elapsed.
+    jest.useFakeTimers()
+
+    const { ref } = renderHook({ assignment: dedicated })
+
+    act(() => {
+      jest.advanceTimersByTime(DEDICATED_HANDOFF_GRACE_MS + 1)
+      routingService.emitPremiumUnreachable({
+        status: 503,
+        sentAt: Date.now(),
+      })
+    })
+
+    expect(ref.current?.state.instanceUnreachable).toBe(true)
+    expect(mockLogPremiumUiEvent).toHaveBeenCalledWith(
+      "instance_unreachable",
+      expect.objectContaining({ instance_id: "inst-A", status: 503 }),
     )
   })
 

--- a/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
+++ b/frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
@@ -493,4 +493,28 @@ describe("useInstanceUnreachableMachine — dedicated handoff warm-up grace", ()
       expect.objectContaining({ instance_id: "inst-B" }),
     )
   })
+
+  test("reload / new tab onto an existing instance co-arms the axios warm-up window", () => {
+    // Regression for the reload/new-tab stranding: the machine's grace arms on
+    // every fresh mount (prevDedicatedInstanceIdRef starts undefined), but the
+    // axios warm-up window (RoutingService) only arms on a CHANGED instance hash.
+    // On reload/new-tab the hash is unchanged (hydrated from localStorage), so
+    // without co-arming, a transient 5xx would tear routing down (axios not in
+    // warm-up) while the grace suppresses the unreachable event → stranded.
+
+    // Reproduce the post-reload RoutingService state: hash persisted, in-memory
+    // warm-up window lost, and the restore path re-confirms the SAME hash.
+    routingService.setPremiumInstanceId("inst-A") // arms window (null → inst-A)
+    routingService.clearPremiumWarmup() // reload drops the in-memory window
+    routingService.setPremiumInstanceId("inst-A") // restore re-confirms same hash
+    expect(routingService.isWithinPremiumWarmup()).toBe(false) // axios not armed on its own
+
+    // Mount the machine fresh (= reload) onto the same dedicated instance.
+    renderHook({ assignment: dedicated })
+
+    // Fix: the grace and the axios window are co-armed, so the teardown gate
+    // (tearDownPremiumRoutingUnlessWarmup → isWithinPremiumWarmup) suppresses a
+    // transient teardown instead of stranding premium routing.
+    expect(routingService.isWithinPremiumWarmup()).toBe(true)
+  })
 })

--- a/frontend/src/contexts/premium/unreachableConstants.ts
+++ b/frontend/src/contexts/premium/unreachableConstants.ts
@@ -4,8 +4,9 @@ export const MAX_PROBE_DELAY_MS = 300000
 export const PROBE_BACKOFF_MULTIPLIER = 2
 export const MAX_FAILED_PROBES = 5
 
-// Window to absorb a single transient 5xx after a dedicated handoff —
-// the dedicated ALB target group can flap once during warm-up.
+// Window to absorb transient 5xx after a dedicated handoff — the dedicated ALB
+// target group can flap while warming up. Every 5xx within the window is
+// suppressed (not just the first); the window expires naturally after this many ms.
 export const DEDICATED_HANDOFF_GRACE_MS = 15000
 
 // localStorage fallback because BroadcastChannel doesn't replay past messages to new tabs.

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -92,10 +92,9 @@ export function useInstanceUnreachableMachine({
   const lastReachableSentAtRef = useRef(0)
   // Last dedicated instance_id — lets the effect below detect a reassignment to a different instance.
   const prevDedicatedInstanceIdRef = useRef<string | undefined>(undefined)
-  // Distinguishes a true shared → dedicated migration from an initial mount
-  // already on dedicated (no warm-up to absorb in the latter).
-  const hasSeenNonDedicatedRef = useRef(false)
-  // Timestamp of the most recent shared → dedicated transition.
+  // Timestamp of the most recent transition onto a dedicated instance (initial
+  // assignment, shared → dedicated migration, or reassignment). Opens the
+  // warm-up grace window during which transient 5xx are suppressed.
   const dedicatedSinceRef = useRef<number | null>(null)
 
   // Consolidated state → refs mirror (one effect for three refs).
@@ -113,10 +112,6 @@ export function useInstanceUnreachableMachine({
     if (shouldClearUnreachableForAssignment(assignment)) {
       prevDedicatedInstanceIdRef.current = undefined
       dedicatedSinceRef.current = null
-      // Only a concrete assignment counts — null is "unknown", not shared.
-      if (assignment != null) {
-        hasSeenNonDedicatedRef.current = true
-      }
       if (unreachableRef.current || probingRef.current) {
         unreachableRef.current = false
         probingRef.current = false
@@ -140,10 +135,11 @@ export function useInstanceUnreachableMachine({
       dedicatedSinceRef.current = Date.now()
     } else if (
       isDedicated &&
-      prevDedicatedInstanceIdRef.current === undefined &&
-      hasSeenNonDedicatedRef.current
+      prevDedicatedInstanceIdRef.current === undefined
     ) {
-      // Shared → dedicated migration: arm the warm-up grace.
+      // First transition onto dedicated — initial sign-in assignment or a
+      // shared → dedicated migration. Either way the freshly-assigned instance
+      // may still be warming up, so arm the grace to absorb transient 5xx.
       dedicatedSinceRef.current = Date.now()
     }
     prevDedicatedInstanceIdRef.current = assignment?.instance_id
@@ -168,14 +164,16 @@ export function useInstanceUnreachableMachine({
         return
       }
 
-      // Single-shot warm-up grace — absorbs one transient 5xx within
+      // Warm-up grace window — absorbs every transient 5xx within
       // DEDICATED_HANDOFF_GRACE_MS of a handoff before flipping unreachable.
+      // Kept armed for the full window (not single-shot) so multiple warm-up
+      // flaps from a freshly-assigned instance are all suppressed; the window
+      // expires naturally once the timestamp ages out.
       if (
         !unreachableRef.current &&
         dedicatedSinceRef.current !== null &&
         Date.now() - dedicatedSinceRef.current < DEDICATED_HANDOFF_GRACE_MS
       ) {
-        dedicatedSinceRef.current = null
         logPremiumUiEvent("instance_unreachable_warmup_suppressed", {
           instance_id: a.instance_id ?? null,
           url: detail.url ?? null,
@@ -403,7 +401,6 @@ export function useInstanceUnreachableMachine({
     hasEverBeenUnreachableRef.current = false
     lastReachableSentAtRef.current = 0
     prevDedicatedInstanceIdRef.current = undefined
-    hasSeenNonDedicatedRef.current = false
     dedicatedSinceRef.current = null
     dispatch({ type: "CLEAR" })
     lsWriteUnreachableSnapshot(null)

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -131,16 +131,22 @@ export function useInstanceUnreachableMachine({
       failedProbesRef.current = 0
       dispatch({ type: "CLEAR" })
       routingService.setPremiumAssigned(true)
-      // Reassignment onto a different dedicated instance — start a fresh grace.
+      // Reassignment onto a different dedicated instance — fresh grace.
       dedicatedSinceRef.current = Date.now()
+      routingService.startPremiumWarmup()
     } else if (
       isDedicated &&
       prevDedicatedInstanceIdRef.current === undefined
     ) {
-      // First transition onto dedicated — initial sign-in assignment or a
-      // shared → dedicated migration. Either way the freshly-assigned instance
-      // may still be warming up, so arm the grace to absorb transient 5xx.
+      // First dedicated transition: initial sign-in, shared→dedicated migration,
+      // or reload/new-tab onto an existing instance.
+      // Co-arm the axios warm-up window with this grace (lock-step): on
+      // reload/new-tab the hash is unchanged (hydrated from localStorage), so
+      // setPremiumInstanceId does not arm axios by itself. Without co-arming, a
+      // transient 5xx tears routing down while this grace suppresses the
+      // unreachable event — stranding routing with no probe to recover it.
       dedicatedSinceRef.current = Date.now()
+      routingService.startPremiumWarmup()
     }
     prevDedicatedInstanceIdRef.current = assignment?.instance_id
   }, [assignment])

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -43,6 +43,7 @@ const mockEmitPremiumReachable = jest.fn<
 const mockGetPremiumInstanceId = jest.fn<string | null, []>(() => null)
 const mockIsPremiumAssigned = jest.fn<boolean, []>(() => false)
 const mockGetRoutingToken = jest.fn<string | null, []>(() => null)
+const mockIsWithinPremiumWarmup = jest.fn<boolean, []>(() => false)
 
 const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
   () => false,
@@ -70,6 +71,7 @@ jest.mock("utils/routing/RoutingService", () => ({
     getPremiumInstanceId: mockGetPremiumInstanceId,
     isPremiumAssigned: mockIsPremiumAssigned,
     getRoutingToken: mockGetRoutingToken,
+    isWithinPremiumWarmup: mockIsWithinPremiumWarmup,
   },
 }))
 
@@ -547,6 +549,36 @@ describe("axios premium-routing interceptors", () => {
     expect(mockSetPremiumAssigned).toHaveBeenCalledWith(false)
 
     // Must NOT emit reachable — instance mismatch.
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
+  it("does NOT clear premiumAssigned on instance mismatch during the warm-up grace", async () => {
+    // Right after a fresh dedicated assignment the instance may still be
+    // registering in the ALB target group, so a 200 from a different (shared)
+    // instance is expected — not a fallback. Tearing down premium routing here
+    // would disable it before warm-up completes and, since the unreachable
+    // state is grace-suppressed downstream, leave no path to re-enable it.
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+    mockIsWithinPremiumWarmup.mockReturnValue(true)
+
+    responses.set("/warmup-mismatch", {
+      status: 200,
+      data: { ok: true },
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "warming-shared-instance-hash",
+      },
+    })
+    const res = await axiosInstance.get("/warmup-mismatch")
+
+    expect(res.status).toBe(200)
+    // Suppressed during warm-up: neither teardown nor unreachable fires.
+    expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
     expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -582,6 +582,40 @@ describe("axios premium-routing interceptors", () => {
     expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
   })
 
+  it("does NOT clear premiumAssigned on a 502/503 during the warm-up grace", async () => {
+    // A transient 5xx from a freshly-assigned dedicated instance is expected
+    // during warm-up. Tearing down premiumAssigned here would strand premium
+    // routing (the machine's grace suppresses the unreachable event, so the
+    // recovery probe never re-enables it). The request still falls back to free
+    // tier so it resolves, but premium routing stays armed to converge.
+    mockRequiresPremiumRouting.mockReturnValue(true)
+    mockIsWithinPremiumWarmup.mockReturnValue(true)
+
+    let callCount = 0
+    responses.set("/warmup-5xx", () => {
+      callCount += 1
+      if (callCount === 1) {
+        return { status: 503, data: { detail: "warming up" } }
+      }
+      return { status: 200, data: { ok: true }, headers: {} }
+    })
+    // Premium headers on the first request, absent on the free-tier retry.
+    mockGetRoutingHeaders
+      .mockReturnValueOnce({
+        "X-Routing-ID": "rid-outgoing",
+        "X-User-Tier": "premium",
+      })
+      .mockReturnValue({})
+
+    const res = await axiosInstance.get("/warmup-5xx")
+
+    // Falls back so the request still resolves...
+    expect(res.status).toBe(200)
+    // ...but premium routing is NOT torn down during warm-up.
+    expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+  })
+
   it("does NOT emit unreachable on instance mismatch when _outgoingInstanceId is unset (startup race)", async () => {
     // Before the assignment API returns, getPremiumInstanceId() returns null.
     // Without a known instance ID, we cannot distinguish a legitimate

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -14,7 +14,7 @@ import {
 } from "utils/DataviewUtils"
 import {
   routingService,
-  PremiumUnreachableDetail,
+  type PremiumUnreachableDetail,
 } from "utils/routing/RoutingService"
 
 // Extend AxiosRequestConfig to include custom retry property

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -378,10 +378,15 @@ axios.interceptors.response.use(
         status: res.status,
         sentAt: cfg!._premiumSentAt,
       })
-    } else if (isInstanceMismatch(res, cfg)) {
+    } else if (
+      isInstanceMismatch(res, cfg) &&
+      !routingService.isWithinPremiumWarmup()
+    ) {
       // Active detection: 200 OK from wrong instance (ALB fallback after
       // EventBridge cleanup). Stop sending premium headers to prevent
       // further misrouted requests and trigger the recovery flow.
+      // Skipped during warm-up: a fresh dedicated instance may still be
+      // registering in the ALB target group, so a mismatch is expected there.
       routingService.setPremiumAssigned(false)
       routingService.emitPremiumUnreachable({
         url: cfg!.url,

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -12,7 +12,10 @@ import {
   isDataviewPublicOutputsRequest,
   DATAVIEW_PUBLIC_REQUEST_KEY,
 } from "utils/DataviewUtils"
-import { routingService } from "utils/routing/RoutingService"
+import {
+  routingService,
+  PremiumUnreachableDetail,
+} from "utils/routing/RoutingService"
 
 // Extend AxiosRequestConfig to include custom retry property
 interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
@@ -213,6 +216,24 @@ const handleUnauthorizedError = async (
 }
 
 /**
+ * Single guarded choke-point for tearing down premium routing after a transient
+ * premium-routing failure (wrong-instance 200 or 502/503).
+ *   within warm-up → no-op: a freshly-assigned instance is expected to flap;
+ *                    tearing down would strand routing (the machine grace-
+ *                    suppresses the unreachable event, so recovery never fires).
+ *   after warm-up  → tear down + emit so the recovery flow runs.
+ * Routing every failure site through here prevents a new site from forgetting
+ * the warm-up check.
+ */
+const tearDownPremiumRoutingUnlessWarmup = (
+  detail: PremiumUnreachableDetail,
+): void => {
+  if (routingService.isWithinPremiumWarmup()) return
+  routingService.setPremiumAssigned(false)
+  routingService.emitPremiumUnreachable(detail)
+}
+
+/**
  * Handle 503 Service Unavailable errors for premium routing by falling back to free tier
  */
 const handlePremiumRoutingError = async (
@@ -230,11 +251,9 @@ const handlePremiumRoutingError = async (
     return Promise.reject(error)
   }
 
-  // Premium instance not ready, falling back to free tier.
-  // Clear premiumAssigned so subsequent requests don't keep sending
-  // stale routing headers that cause repeated 503s.
-  routingService.setPremiumAssigned(false)
-  routingService.emitPremiumUnreachable({
+  // Premium instance not ready — fall back to free tier for this request.
+  // Teardown is warm-up-gated (see tearDownPremiumRoutingUnlessWarmup).
+  tearDownPremiumRoutingUnlessWarmup({
     url: originalRequest.url,
     status: error.response?.status,
     sentAt: originalRequest._premiumSentAt,
@@ -378,17 +397,11 @@ axios.interceptors.response.use(
         status: res.status,
         sentAt: cfg!._premiumSentAt,
       })
-    } else if (
-      isInstanceMismatch(res, cfg) &&
-      !routingService.isWithinPremiumWarmup()
-    ) {
+    } else if (isInstanceMismatch(res, cfg)) {
       // Active detection: 200 OK from wrong instance (ALB fallback after
-      // EventBridge cleanup). Stop sending premium headers to prevent
-      // further misrouted requests and trigger the recovery flow.
-      // Skipped during warm-up: a fresh dedicated instance may still be
-      // registering in the ALB target group, so a mismatch is expected there.
-      routingService.setPremiumAssigned(false)
-      routingService.emitPremiumUnreachable({
+      // EventBridge cleanup). Tear down to trigger the recovery flow — gated so
+      // a warm-up mismatch (fresh instance still registering) is left alone.
+      tearDownPremiumRoutingUnlessWarmup({
         url: cfg!.url,
         status: res.status,
         sentAt: cfg!._premiumSentAt,

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -682,7 +682,9 @@ describe("RoutingService", () => {
   })
 
   describe("premium warm-up window", () => {
-    const GRACE_MS = 15000
+    // Intentionally longer than DEDICATED_HANDOFF_GRACE_MS (15000) so the axios
+    // window contains the machine's grace window — see PREMIUM_WARMUP_GRACE_MS.
+    const GRACE_MS = 16000
     const T0 = 1_000_000
 
     beforeEach(() => {

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -1,4 +1,11 @@
-import { describe, test, expect, beforeEach, jest } from "@jest/globals"
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals"
 
 import { UserDTO } from "api/users/UsersApiDTO"
 import {
@@ -671,6 +678,77 @@ describe("RoutingService", () => {
 
       expect(routingService.getPremiumInstanceId()).toBeNull()
       expect(localStorageMock.getItem("premium_instance_id")).toBeNull()
+    })
+  })
+
+  describe("premium warm-up window", () => {
+    const GRACE_MS = 15000
+    const T0 = 1_000_000
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(T0)
+      // Rebuild after fake timers are active so no stale state leaks in.
+      routingService = new RoutingService()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    test("no window is open initially", () => {
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
+    })
+
+    test("startPremiumWarmup opens a window that expires after the grace", () => {
+      routingService.startPremiumWarmup()
+      expect(routingService.isWithinPremiumWarmup()).toBe(true)
+
+      jest.setSystemTime(T0 + GRACE_MS - 1)
+      expect(routingService.isWithinPremiumWarmup()).toBe(true)
+
+      jest.setSystemTime(T0 + GRACE_MS)
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
+    })
+
+    test("setPremiumInstanceId arms the window on a new/changed instance", () => {
+      routingService.setPremiumInstanceId("hash-A")
+      expect(routingService.isWithinPremiumWarmup()).toBe(true)
+    })
+
+    test("re-confirming the same instance does not extend the window", () => {
+      routingService.setPremiumInstanceId("hash-A")
+
+      // Advance near the end of the original window, then re-confirm the SAME
+      // instance — must not re-arm (a genuine late fallback still needs to
+      // surface once the original window expires).
+      jest.setSystemTime(T0 + GRACE_MS - 1)
+      routingService.setPremiumInstanceId("hash-A")
+
+      jest.setSystemTime(T0 + GRACE_MS)
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
+    })
+
+    test("changing to a different instance re-arms the window", () => {
+      routingService.setPremiumInstanceId("hash-A")
+
+      jest.setSystemTime(T0 + GRACE_MS)
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
+
+      routingService.setPremiumInstanceId("hash-B")
+      expect(routingService.isWithinPremiumWarmup()).toBe(true)
+    })
+
+    test("setPremiumInstanceId(null) clears the window", () => {
+      routingService.setPremiumInstanceId("hash-A")
+      routingService.setPremiumInstanceId(null)
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
+    })
+
+    test("clearRoutingInfo clears the window", () => {
+      routingService.setPremiumInstanceId("hash-A")
+      routingService.clearRoutingInfo()
+      expect(routingService.isWithinPremiumWarmup()).toBe(false)
     })
   })
 })

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -63,8 +63,13 @@ export class RoutingService {
   private storedTier: UserTier | null = null
   private premiumAssigned: boolean = false
   private premiumInstanceId: string | null = null
+  // Warm-up grace window (epoch ms) after a fresh dedicated assignment.
+  private premiumWarmupUntil: number | null = null
   private lastFetch: number = 0
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+  // Warm-up grace duration. Mirrors DEDICATED_HANDOFF_GRACE_MS in
+  // contexts/premium/unreachableConstants (kept in sync intentionally).
+  private readonly PREMIUM_WARMUP_GRACE_MS = 15000
   private readonly STORAGE_KEY = "routing_id"
   private readonly TIER_STORAGE_KEY = "routing_tier"
   private readonly PREMIUM_ASSIGNED_KEY = "premium_assigned"
@@ -168,6 +173,7 @@ export class RoutingService {
     this.storedTier = null
     this.premiumAssigned = false
     this.premiumInstanceId = null
+    this.premiumWarmupUntil = null
     this.lastFetch = 0
     this.clearTokenFromStorage()
     this.clearTierFromStorage()
@@ -217,10 +223,18 @@ export class RoutingService {
    * Used by the axios interceptor to detect ALB fallback responses.
    */
   setPremiumInstanceId(id: string | null): void {
+    // Arm the warm-up grace only when moving onto a new/changed dedicated
+    // instance — re-confirming the same instance must not keep extending the
+    // window, or a genuine late fallback would never surface.
+    const changedToNewInstance = !!id && id !== this.premiumInstanceId
     this.premiumInstanceId = id
     if (id) {
+      if (changedToNewInstance) {
+        this.startPremiumWarmup()
+      }
       this.savePremiumInstanceIdToStorage(id)
     } else {
+      this.clearPremiumWarmup()
       this.clearPremiumInstanceIdFromStorage()
     }
   }
@@ -230,6 +244,31 @@ export class RoutingService {
    */
   getPremiumInstanceId(): string | null {
     return this.premiumInstanceId
+  }
+
+  /**
+   * Arm the warm-up grace window (transition onto a new dedicated instance).
+   */
+  startPremiumWarmup(): void {
+    this.premiumWarmupUntil = Date.now() + this.PREMIUM_WARMUP_GRACE_MS
+  }
+
+  /**
+   * Whether we are still within the dedicated-instance warm-up grace window.
+   * axios uses this to suppress the isInstanceMismatch teardown while a
+   * freshly-assigned instance is still registering in the ALB target group.
+   */
+  isWithinPremiumWarmup(): boolean {
+    return (
+      this.premiumWarmupUntil != null && Date.now() < this.premiumWarmupUntil
+    )
+  }
+
+  /**
+   * Clear the warm-up grace window (release/logout/downgrade).
+   */
+  clearPremiumWarmup(): void {
+    this.premiumWarmupUntil = null
   }
 
   // Pure notifier — telemetry lives in listeners so tests can emit without side effects.

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -67,9 +67,15 @@ export class RoutingService {
   private premiumWarmupUntil: number | null = null
   private lastFetch: number = 0
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
-  // Warm-up grace duration. Mirrors DEDICATED_HANDOFF_GRACE_MS in
-  // contexts/premium/unreachableConstants (kept in sync intentionally).
-  private readonly PREMIUM_WARMUP_GRACE_MS = 15000
+  // Warm-up grace duration. Intentionally longer than DEDICATED_HANDOFF_GRACE_MS
+  // (15000 ms, contexts/premium/unreachableConstants) so this window CONTAINS the
+  // machine's grace:
+  //   - this window opens synchronously in setPremiumInstanceId (T0)
+  //   - the machine's dedicatedSinceRef opens later in a useEffect (T0+Δ)
+  // Equal durations would leave a tail [T0+15000, T0+Δ+15000] where teardown is no
+  // longer suppressed here but the machine still suppresses the unreachable event —
+  // stranding premium routing. Do NOT shrink this back to equality.
+  private readonly PREMIUM_WARMUP_GRACE_MS = 16000
   private readonly STORAGE_KEY = "routing_id"
   private readonly TIER_STORAGE_KEY = "routing_tier"
   private readonly PREMIUM_ASSIGNED_KEY = "premium_assigned"

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -69,9 +69,10 @@ export class RoutingService {
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
   // Warm-up grace duration. Intentionally longer than DEDICATED_HANDOFF_GRACE_MS
   // (15000 ms, contexts/premium/unreachableConstants) so this window CONTAINS the
-  // machine's grace:
-  //   - this window opens synchronously in setPremiumInstanceId (T0)
-  //   - the machine's dedicatedSinceRef opens later in a useEffect (T0+Δ)
+  // machine's grace. Arming sources:
+  //   - fresh/changed instance: setPremiumInstanceId arms synchronously (T0)
+  //   - every first dedicated transition (incl. reload/new-tab same instance):
+  //     the machine co-arms via startPremiumWarmup in its useEffect (T0+Δ)
   // Equal durations would leave a tail [T0+15000, T0+Δ+15000] where teardown is no
   // longer suppressed here but the machine still suppresses the unreachable event —
   // stranding premium routing. Do NOT shrink this back to equality.


### PR DESCRIPTION
### Content

#### Summary

- Premium users signing in and receiving a dedicated instance on the **first**
  `/assign` no longer see the false warning *"Your dedicated premium instance is
  temporarily unreachable. Retrying…"* immediately followed by the success
  snackbar. The warning was a false positive raised while the freshly-created
  dedicated instance was still warming up (transient ALB 502/503).
- The existing warm-up grace (`DEDICATED_HANDOFF_GRACE_MS`, 15 s) was only armed
  for shared → dedicated migration and reassignment. It is now also armed for the
  **initial `undefined → dedicated`** transition, closing the exact gap.
- The grace is changed from **single-shot** (absorb one 5xx, then re-arm needed)
  to a **time-window** (absorb every 5xx within the 15 s window). Multiple
  warm-up flaps are now all suppressed.
- Background assignment/routing behavior is unchanged — this is a purely
  UX/state-transition fix. A genuine unreachable condition (5xx persisting past
  the grace) still raises the warning and the recovery flow.
- **Also keeps premium routing alive during warm-up.** Beyond suppressing the
  warning, the axios interceptor no longer tears down `premiumAssigned` on a
  transient warm-up failure (a `200` from the wrong instance *or* a `502`/`503`).
  Both teardown sites are gated by a warm-up window on `RoutingService` and routed
  through one choke-point, so a warm-up flap no longer strands premium routing
  (previously: `x-routing-id` dropped until a reload). A genuine failure past the
  window still tears down and recovers as before.

#### Design Decisions

- **Why arm on the initial transition (option A)?** The root cause is that on a
  fresh sign-in with a direct dedicated assignment, neither the reassignment
  branch nor the migration branch fired: `prevDedicatedInstanceIdRef` is
  `undefined` and no prior non-dedicated state was ever observed. The assumption
  baked into the old code — *"initial → dedicated ⇒ no warm-up to absorb"* — is
  false, because the `/assign` that returns the dedicated instance is exactly when
  it was just created and the ALB target group can still be registering. Dropping
  the `hasSeenNonDedicatedRef` gate is the smallest, most direct fix.
- **Why a time-window instead of single-shot (option B)?** The old grace nulled
  `dedicatedSinceRef` on first use, so a second warm-up 5xx within the same window
  still flipped to unreachable. A freshly-assigned instance can flap more than
  once during registration, so absorbing only the first flap left the warning
  reachable. Keeping the timestamp for the full window (comparing timestamps
  rather than nulling the ref) absorbs all flaps and expires naturally.
- **Removed `hasSeenNonDedicatedRef` entirely.** With option A it is no longer
  read anywhere, so it is deleted along with its write in the clear branch and its
  reset in `reset()` — no dead state left behind.
- **The initial grace is armed unconditionally, not gated on `assignment_source`.**
  Arming on *every* first `undefined → dedicated` transition means a page reload
  that reconnects to an already-healthy instance also arms the 15 s grace, so a
  genuine early outage in that window is masked for up to 15 s (before this PR a
  fresh mount didn't arm the grace and flipped immediately). A narrower gate — arm
  only when `assignment_source ∈ {"new", "restarted_instance"}` — was considered
  and rejected: `assignment_source` is an opaque pass-through of the Lambda response
  with no central enum, and its string values are inconsistent across the stack
  (frontend uses `"new"`, the backend contract test uses `"new_assignment"`; other
  observed values include `"restored_from_pending_release"`, `"autoscaling_temp"`,
  `"standby"`). Gating on an unverified string set risks **silently reintroducing
  #742** on the common first-sign-in path if production emits a value not in the
  allow-list. Unconditional arming is also consistent with the pre-existing
  migration/reassignment branches, which already arm without consulting
  `assignment_source`. The trade-off (≤ 15 s masked warning on healthy-reconnect
  reloads, self-recovering, no functional loss) is accepted here; see the follow-up
  below to enable safe gating later.
- **Backend option (C) intentionally not included.** Extending the readiness gate
  (`check_instance_readiness_with_retry`) or waiting on ALB target health would
  reduce the underlying 5xx window, but the issue scopes it as a separate, larger
  change that is not required once A + B land. Out of scope here.
- **Test isolation for the raw machine-transition suites.** Three provider-level
  integration suites flip unreachable immediately after a fresh dedicated
  assignment to exercise the state machine. The newly-armed initial grace would
  otherwise suppress that first 5xx. They now neutralize the grace via a scoped
  `DEDICATED_HANDOFF_GRACE_MS: 0` mock (`jest.requireActual` spread + one
  override), keeping those tests focused on the transitions they own. The grace
  itself is fully covered by the unit suite.
- **Keep routing alive during warm-up (not just suppress the warning).** The
  warning suppression (initial-arm + time-window) lives in the state machine, but
  the machine also grace-suppresses the `unreachable` event — which disables the
  recovery probe, the only path that re-arms `premiumAssigned`. So any teardown
  during warm-up becomes permanent (stranded until reload). The axios interceptor
  therefore skips teardown while `RoutingService.isWithinPremiumWarmup()`; the
  request still falls back to free tier so it resolves, and routing converges as
  the instance warms. Both failure sites (200 mismatch / 5xx) go through one
  guarded choke-point (`tearDownPremiumRoutingUnlessWarmup`) so a new site cannot
  skip the check.
- **Grace-window containment (`PREMIUM_WARMUP_GRACE_MS` = 16000).** The axios
  window opens synchronously (T0, in `setPremiumInstanceId`); the machine's grace
  (`dedicatedSinceRef`) opens later in a `useEffect` (T0+Δ). Equal 15000 durations
  leave a tail `[T0+15000, T0+Δ+15000]` where axios stops suppressing but the
  machine still does → stranded. Making the axios window 1000 ms longer contains
  the machine window (for Δ ≤ 1000 ms). Do not shrink back to equality.

### Evidence

```
PASS  src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx
PASS  src/contexts/premium/__tests__/unreachableMachine.test.ts
PASS  src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
PASS  src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
PASS  src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
PASS  src/components/Premium/__tests__/PremiumNotificationManager.test.tsx
PASS  src/utils/__tests__/axiosPremiumInterceptor.test.ts
PASS  src/utils/routing/RoutingService.test.ts

Test Suites: 13 passed, 13 total   (--testPathPattern "premium|Premium|routing|Routing")
Tests:       250 passed, 250 total
```

- `tsc --noEmit` — no new type errors introduced by this change.
- `eslint` — clean on all changed files.

### References

- Issue: [#742](https://github.com/arayabrain/araya-optinist/issues/742) — False
  "temporarily unreachable" warning on the first premium `/assign` at sign-in
- Parent: [#730](https://github.com/arayabrain/araya-optinist/issues/730)
- Introduced by: [PR #563](https://github.com/arayabrain/araya-optinist/pull/563)
  (snackbar surfaced), [PR #590](https://github.com/arayabrain/araya-optinist/pull/590)
  (grace added, initial-assign gap left)
- Retrospective: [#667 (comment)](https://github.com/arayabrain/araya-optinist/issues/667#issuecomment-4828783333)

### Files changed

#### Frontend — source

- `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts`
  - Arm the warm-up grace on the initial `undefined → dedicated` transition
    (drop the `hasSeenNonDedicatedRef` gate); remove the now-unused ref.
  - Make the grace a time-window: stop nulling `dedicatedSinceRef` on first use
    so every 5xx within `DEDICATED_HANDOFF_GRACE_MS` is suppressed.
- `frontend/src/contexts/premium/unreachableConstants.ts`
  - Update the `DEDICATED_HANDOFF_GRACE_MS` doc comment to describe the multi-flap
    time-window semantics (was "absorb a single … flap once"). Comment-only.
- `frontend/src/utils/axios.ts`
  - Gate both premium-routing teardown sites (200 wrong-instance and 502/503) on
    `isWithinPremiumWarmup()`, via a single `tearDownPremiumRoutingUnlessWarmup`
    choke-point.
- `frontend/src/utils/routing/RoutingService.ts`
  - Warm-up window (`premiumWarmupUntil`, armed in `setPremiumInstanceId`);
    `PREMIUM_WARMUP_GRACE_MS = 16000` to contain the machine's grace window.

**Follow-up fix (reviewer comment — reload/new-tab stranding):**

- `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts`
  - Co-arm the axios warm-up window (`routingService.startPremiumWarmup()`) on every
    first dedicated transition and on reassignment. On reload/new-tab the instance
    hash is unchanged (hydrated from localStorage), so `setPremiumInstanceId` did
    not arm the axios window while the machine grace did — a transient 5xx then tore
    routing down while the grace suppressed the unreachable event, stranding premium
    routing (free tier) until the next reload. Co-arming keeps the two windows in
    lock-step.

#### Frontend — tests

- `frontend/src/contexts/premium/__tests__/useInstanceUnreachableMachineLeader.test.tsx`
  - New: initial `undefined → dedicated` (direct sign-in) arms the grace.
  - New: initial dedicated — a genuine 5xx after the grace window still flips.
  - Replace the single-shot test with a time-window test (all flaps suppressed,
    then flips after the window elapses).
  - Advance past the grace in the three pre-existing leader tests that intend a
    genuine failure on the default dedicated assignment.
  - **Follow-up**: reload/new-tab onto an existing instance co-arms the axios
    warm-up window (asserts `isWithinPremiumWarmup()` after a same-hash re-confirm +
    fresh mount — the teardown gate that prevents stranding).
- `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx`
- `frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx`
- `frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx`
  - Each: scoped `DEDICATED_HANDOFF_GRACE_MS: 0` mock so raw machine-transition
    tests are unaffected by the newly-armed initial grace.
- `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts`
  - Warm-up 5xx and 200-mismatch suppression (no teardown), plus non-warm-up
    teardown still fires.
- `frontend/src/utils/routing/RoutingService.test.ts`
  - Warm-up window arm / expire / re-arm / clear paths (16000 grace).

### Manual Testcases

#### Prerequisites

- A premium-subscribed user account with **no** currently-assigned dedicated
  instance (so sign-in triggers a fresh `/assign` that creates/registers one).
- Browser DevTools open — Network tab (filter `premium`, "Preserve log" on).
  Premium telemetry (`instance_unreachable_warmup_suppressed`,
  `instance_unreachable`, …) is sent as `POST /users/me/premium/ui-event`
  requests, so it is verified in the Network tab, **not** the Console tab.
- Optional: AWS Console (EC2 / ALB target groups) to observe warm-up timing.

---

#### Test 1: First sign-in with a fresh dedicated instance shows NO false warning (primary fix)

**Objective**: A premium user whose dedicated instance is created on the first
`/assign` must not see the "temporarily unreachable" warning for a transient
warm-up 5xx.

**Steps**

1. Ensure the user has no live dedicated assignment (release/expire any existing
   one, or use an account that has never been assigned).
2. Log in as the premium user. Watch the Network tab.
3. **Verify**: `POST /users/me/premium/assign` returns `200 OK` with
   `{ "assigned": true, "is_shared": false, "assignment_source": "dedicated", "instance_id": "i-…" }`.
4. Observe the first premium-routed requests immediately after assignment. Some
   may return `502`/`503` while the ALB target group is still registering.
5. **Verify (UI)**: The warning snackbar *"Your dedicated premium instance is
   temporarily unreachable. Retrying…"* does **NOT** appear.
6. **Verify (UI)**: The success snackbar *"Premium instance assigned successfully!
   You now have dedicated compute resources."* appears **exactly once**.
7. **Verify (Network — telemetry)**: A `POST /users/me/premium/ui-event` request
   is sent with `event_type: "instance_unreachable_warmup_suppressed"` (its
   `details` carry the suppressed request's `instance_id` / `url` / `status`);
   **no** ui-event `POST` with `event_type: "instance_unreachable"` is sent for
   the same 5xx. (These events are emitted as `ui-event` POSTs via
   `logPremiumUiEvent`, not written to the browser Console.)

**Expected**: No false warning; success snackbar shown once; background routing
correct (subsequent premium requests carry routing headers and succeed).

---

#### Test 2: A genuine, persistent unreachable still surfaces the warning (safety preserved)

**Objective**: Absorbing warm-up flaps must not mask a real outage.

**Steps**

1. Establish a healthy dedicated assignment (complete Test 1, or sign in with an
   already-healthy instance).
2. Wait **more than 15 seconds** (past `DEDICATED_HANDOFF_GRACE_MS`) after the
   assignment so the warm-up grace window has elapsed.
3. Make the instance unreachable, e.g. from a separate terminal:
   `aws ec2 stop-instances --instance-ids <instance_id>` (or otherwise force the
   per-user target group to have no healthy target).
4. Trigger any premium-routed API request (navigate to a workflow page, etc.).
5. **Verify (Network)**: The request fails with `502`/`503`, then a retry is sent
   without premium headers and succeeds on the free tier.
6. **Verify (UI)**: The *"temporarily unreachable. Retrying…"* warning **does**
   appear, and the recovery/probe flow runs.
7. **Verify (Network — telemetry)**: A `POST /users/me/premium/ui-event` request
   is sent with `event_type: "instance_unreachable"`. (Emitted as a `ui-event`
   POST via `logPremiumUiEvent`, not written to the browser Console.)

**Expected**: Genuine unreachable is still reported; the safety feature is intact.

---

#### Test 3: Shared → dedicated migration is unchanged (regression guard)

**Objective**: The pre-existing grace behavior on the normal shared → dedicated
migration must be preserved.

**Steps**

1. Sign in as a premium user who is first placed on the **shared** pool
   (`is_shared: true`), then **automatically** migrated to a dedicated instance
   (`is_shared: false`) — the normal migration path, no manual intervention.
2. During the first ~15 s after the dedicated handoff, if a transient warm-up 5xx
   occurs, **verify** it is suppressed (no warning; success snackbar shows once),
   exactly as before this change.

**Expected**: Identical behavior to before this PR for the migration path.

**Note**: The migration arms the grace through the same first-transition branch as
Test 1, so this mainly confirms the shared-entry variant. The separate
**reassignment** case (a direct dedicated → *different* dedicated swap, e.g. after
an instance failure) is a low-frequency recovery path, is **unchanged** by this
PR, and is covered deterministically by the automated leader tests
(`useInstanceUnreachableMachineLeader.test.tsx`).

---

#### Test 4: Reload / new tab onto an existing instance does NOT strand premium routing (follow-up fix)

**Objective**: A page reload — or opening a second tab — onto an already-assigned
dedicated instance keeps premium routing alive if a transient warm-up 5xx lands in
the first ~15 s, instead of silently downgrading to free tier until the next reload.

**Background**: On reload/new-tab the machine's grace arms (fresh mount) but the
axios warm-up window did **not** — `setPremiumInstanceId` re-confirms the same
instance hash (hydrated from localStorage) and only armed on a *changed* hash. So a
transient 5xx tore routing down (axios not in warm-up) while the grace suppressed
the unreachable event, leaving no recovery probe. The follow-up co-arms the axios
window with the grace on every first dedicated transition.

**Injecting the transient failure (Method A — Chrome DevTools, no proxy)**

The warm-up window is only ~15 s and starts when the reload's `/premium/status`
restore completes — too tight to react to manually — so **pre-arm** the failure
before reloading. The axios premium path fires on `(502/503 || network error) &&
requiresPremiumRouting()` (`axios.ts`), so a DevTools-blocked request (a network
error) exercises the **same** teardown choke-point as a real 5xx.

Key constraint: fail a **premium data request** (one that carries the `X-Routing-ID`
request header), and **never** block `/users/me/premium/status` or `/assign` — the
reload restore needs those to re-establish `premiumAssigned` and arm the warm-up
window.

**Steps**

1. Establish a healthy dedicated assignment (complete Test 1) and confirm premium
   requests carry routing headers and succeed. Keep DevTools open (Network +
   Console).
2. **Identify a target request**: in the Network tab, pick an authenticated backend
   request whose Request Headers include `X-Routing-ID` and that you can re-fire on
   demand (e.g. an experiments/workspace list or a `/run/result` poll). Not
   `/premium/status` or `/assign`.
3. **Pre-arm the block**: `Cmd/Ctrl-Shift-P` → "Show Network request blocking" →
   enable → add a pattern matching the step-2 URL (e.g. `*/experiments*`).
4. **Reload the page** (or open the app in a **second tab**) so a fresh JS context
   restores the existing assignment via `POST /users/me/premium/status`
   (`{ assigned: true, is_shared: false, instance_id: "i-…" }`, same instance as
   step 1). The restore is not blocked, so `premiumAssigned` is set and the warm-up
   window arms.
5. **Within ~15 s**, trigger the blocked premium request (navigate to / act on the
   page that fires it). It fails with `net::ERR_BLOCKED_BY_CLIENT` → the premium
   path runs the warm-up-gated teardown choke-point.
6. **Verify (Network)**: the failing request falls back to free tier and succeeds,
   and **no** `event_type: "instance_unreachable"` ui-event is sent (grace
   suppresses it — same as Test 1). Console shows
   `Using free tier while premium instance provisions`.
7. **Verify (routing preserved)**: disable the block, then trigger another
   premium-routed request — it still carries `x-routing-id` / instance headers and
   is served by the dedicated instance — i.e. `premiumAssigned` stayed true; routing
   was **not** downgraded to free tier.
8. **Contrast (pre-fix)**: before the follow-up, step 7 failed — subsequent requests
   carried no premium headers and stayed on free tier until another reload.

> Alternative (Method B — most faithful, needs a proxy): use a local proxy
> (mitmproxy / Charles / Fiddler) to return a real `503` for the step-2 URL instead
> of blocking it; the rest of the flow is identical.

**Checkpoint**: reload/new-tab onto an existing instance is symmetric with the
first-assign case; a warm-up 5xx never strands routing.

---

#### Automated verification

```
cd frontend
CI=true yarn test --testPathPattern "premium|Premium|routing|Routing"
# → Test Suites: 13 passed, Tests: 241 passed
```

### Unit, Integration, Contract Test Coverage

- **Unit** (`useInstanceUnreachableMachineLeader.test.tsx`,
  `unreachableMachine.test.ts`): initial-dedicated arms grace; genuine post-window
  5xx flips; time-window absorbs all flaps; shared→dedicated and reassignment
  graces unchanged; leader-gated snapshot/probe behavior.
- **Integration** (`PremiumUnreachableIntegration`, `PremiumRetriggerAssign`,
  `PremiumPollingRoutingRestore`): provider-level machine transitions, polling and
  re-trigger flows — grace neutralized so these stay focused on their own logic.
- **Notification** (`PremiumNotificationManager.test.tsx`): success/warning
  snackbar rendering unaffected.

### Others

#### Difficulties (if any)

- The newly-armed initial grace legitimately changed the outcome of several
  pre-existing tests that emit a 5xx immediately after a fresh dedicated
  assignment. Distinguishing "these should now be suppressed (correct new
  behavior)" from "these test the raw transition and should bypass the grace"
  drove the split: unit tests advance past the window to assert genuine failures,
  while the three integration suites neutralize the grace with a scoped constant
  mock. The mock had to be written with a `mock`-prefixed `jest.requireActual`
  binding to satisfy the CRA Babel out-of-scope factory guard.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Initial dedicated assign UX (`useInstanceUnreachableMachine`) | Low | Isolated state-transition change; the false warning is suppressed only within the existing 15 s grace; genuine unreachable past the window still surfaces. Strong unit coverage. |
| Warm-up grace becoming a time-window | Low | Broadens suppression to all 5xx within the same 15 s window that already suppressed the first; window expires naturally, no new persistent state. |
| Migration / reassignment behavior | Low | Reassignment branch untouched; migration branch still arms the grace (now also for the initial case). Covered by unchanged tests. |
| Masking a real early outage (< 15 s after assign) | Low | Intentional trade-off already accepted by the grace design; a real outage persists past the window and then surfaces. |
| Masking a real early outage on a **healthy-reconnect reload** (< 15 s after reload) | Low | Unconditional initial arming also covers reload onto an already-healthy instance. A genuine outage in that window is delayed ≤ 15 s before the warning surfaces. Not gated on `assignment_source` because its string values are unverified/inconsistent across the stack and gating risks reintroducing #742 on the common first-assign path. See follow-up. |
| **Reload/new-tab stranding** (transient 5xx < 15 s after reload) | Closed by follow-up | Original PR armed only the machine grace on reload (axios window arms on a *changed* hash; reload re-confirms the same hash), so a teardown during that window became permanent (free tier until next reload) — the reviewer-reported bug. The follow-up co-arms the axios window with the grace on every first dedicated transition, keeping routing alive; guarded by a new leader test. |
| Warm-up teardown gating / grace-window containment (`axios`, `RoutingService`) | Low | Teardown is skipped only within the window; a genuine failure past it still tears down and recovers. The `16000` margin relies on the machine `useEffect` committing within Δ ≤ 1000 ms of assignment — comfortable in practice; documented in-code ("do not shrink to equality") so the constant is not reverted to 15000. Single choke-point prevents a future teardown site from skipping the guard. See follow-up. |

#### Follow-up

- **Enable safe `assignment_source` gating (to narrow the healthy-reconnect-reload
  trade-off above).** Centralize `assignment_source` as a validated enum shared by the
  Lambda, the backend pass-through, and the frontend, and confirm the exact value
  set emitted in production. Once the values are reliable, the initial warm-up
  grace can be scoped to genuinely-warming sources (e.g. `"new"` /
  `"restarted_instance"`) so a healthy-reconnect reload no longer masks an early
  outage — without the current risk of silently reintroducing #742. Tracked
  separately; not required for this PR.
- **Unify the warm-up window (single source of truth).** The machine's
  `dedicatedSinceRef` and `RoutingService`'s window represent the same thing but are
  armed at different times, which is why the `16000` containment margin exists. The
  follow-up co-arm closes the reload/new-tab stranding by making the machine also
  arm the axios window, but the two windows still coexist. Having the machine read
  `RoutingService.isWithinPremiumWarmup()` directly (or driving a single window)
  would remove the second window and the Δ ≤ 1000 ms timing assumption entirely.
  Larger change touching the state machine; deferred (not required for this PR).
