### PR TITLE
Fix/proactive download scheme dev

### DIFF
--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -267,6 +267,10 @@ resource "aws_ecs_task_definition" "background" {
           name  = "ALB_DNS_NAME"
           value = aws_lb.autoscaling.dns_name
         },
+        {
+          name  = "INTERNAL_API_BASE_URL"
+          value = var.enable_custom_domain ? "https://${aws_lb.autoscaling.dns_name}" : "http://${aws_lb.autoscaling.dns_name}:8080"
+        },
         # Background scheduler ENABLED - this service runs all background jobs
         {
           name  = "DISABLE_BACKGROUND_SCHEDULER"

--- a/infrastructure/terraform/background_service.tf
+++ b/infrastructure/terraform/background_service.tf
@@ -267,6 +267,11 @@ resource "aws_ecs_task_definition" "background" {
           name  = "ALB_DNS_NAME"
           value = aws_lb.autoscaling.dns_name
         },
+        # Base URL for the sync job's internal /system-internal call.
+        # Scheme/port mirror aws_lb_listener.autoscaling_https: HTTPS:443 in
+        # prod, HTTP:8080 in dev. enable_custom_domain gates both this and
+        # compute.tf, so the flag can't drift them apart; the ":8080" literal
+        # is kept to match compute.tf and must be changed there in lockstep.
         {
           name  = "INTERNAL_API_BASE_URL"
           value = var.enable_custom_domain ? "https://${aws_lb.autoscaling.dns_name}" : "http://${aws_lb.autoscaling.dns_name}:8080"

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -498,9 +498,7 @@ class PublishedExperimentSyncJob:
 
         base = os.environ.get("INTERNAL_API_BASE_URL") or f"https://{alb_dns}"
         url = (
-            f"{base}"
-            f"/system-internal/sync-experiment"
-            f"/{workspace_id}/{unique_id}"
+            f"{base}" f"/system-internal/sync-experiment" f"/{workspace_id}/{unique_id}"
         )
         headers = {
             "X-Internal-Secret": internal_secret,

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -496,8 +496,9 @@ class PublishedExperimentSyncJob:
         if not alb_dns or not internal_secret:
             return False
 
+        base = os.environ.get("INTERNAL_API_BASE_URL") or f"https://{alb_dns}"
         url = (
-            f"https://{alb_dns}"
+            f"{base}"
             f"/system-internal/sync-experiment"
             f"/{workspace_id}/{unique_id}"
         )

--- a/studio/app/common/core/background/sync_job.py
+++ b/studio/app/common/core/background/sync_job.py
@@ -512,8 +512,10 @@ class PublishedExperimentSyncJob:
         }
 
         try:
-            # Skip SSL verification for internal VPC traffic;
-            # ALB cert doesn't match AWS-generated hostname
+            # Skip SSL verification for internal VPC traffic on the prod
+            # HTTPS path; the ALB cert doesn't match the AWS-generated
+            # hostname. On dev the base URL is plain HTTP (:8080), where
+            # verify=False is a no-op.
             response = requests.post(
                 url,
                 headers=headers,

--- a/studio/tests/app/common/core/background/test_sync_job.py
+++ b/studio/tests/app/common/core/background/test_sync_job.py
@@ -140,6 +140,65 @@ class TestProactiveDownloadTrigger:
             assert result is False
 
     @pytest.mark.asyncio
+    async def test_trigger_uses_internal_base_url(self):
+        """INTERNAL_API_BASE_URL, when set, overrides the scheme/port.
+
+        Dev has no HTTPS:443 listener, so the base URL is injected as
+        http://{dns}:8080 (see issue #719). Verify the request targets it.
+        """
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret-123",
+            "INTERNAL_API_BASE_URL": "http://test-alb.example.com:8080",
+        }
+        with patch.dict(os.environ, env):
+            with patch("requests.post") as mock_post:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 200
+                mock_post.return_value = mock_resp
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is True
+                call_url = mock_post.call_args[0][0]
+                assert call_url == (
+                    "http://test-alb.example.com:8080"
+                    "/system-internal/sync-experiment/ws1/uid1"
+                )
+
+    @pytest.mark.asyncio
+    async def test_trigger_falls_back_to_https(self):
+        """Without INTERNAL_API_BASE_URL, fall back to https://{alb_dns}.
+
+        Preserves the pre-#719 prod behavior so the code change is safe to
+        roll out before the env var reaches every environment.
+        """
+        env = {
+            "ALB_DNS_NAME": "test-alb.example.com",
+            "INTERNAL_API_SECRET": "secret-123",
+        }
+        # clear=True guarantees INTERNAL_API_BASE_URL is absent even if the
+        # host environment happens to define it.
+        with patch.dict(os.environ, env, clear=True):
+            with patch("requests.post") as mock_post:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 200
+                mock_post.return_value = mock_resp
+
+                result = await PublishedExperimentSyncJob._trigger_proactive_download(
+                    "ws1", "uid1", "bucket1"
+                )
+
+                assert result is True
+                call_url = mock_post.call_args[0][0]
+                assert call_url == (
+                    "https://test-alb.example.com"
+                    "/system-internal/sync-experiment/ws1/uid1"
+                )
+
+    @pytest.mark.asyncio
     async def test_trigger_connection_error(self):
         """ConnectionError returns False"""
         import requests


### PR DESCRIPTION
## Summary

After the background sync job validates an experiment in S3 and flips it to
`synced`, it fires a fire-and-forget "proactive download" POST to the ALB
(`/system-internal/sync-experiment/...`) to pre-warm the file cache on the
public/API tier. In dev this POST **always fails with `[Errno 111] Connection
refused`**, because the code hardcodes `https://{alb_dns}` (implicit port 443)
while the dev ALB has no HTTPS:443 listener — only HTTP on :80 and :8080.

Net effect: the proactive-download optimization never runs outside prod. The
sync itself is unaffected (status still flips to `synced`), and files still
download on-demand at first view — so it degrades performance, not correctness.

This PR moves the scheme/port decision into terraform (which already owns the
listener config) and injects the internal base URL as an environment variable,
mirroring how `ALB_DNS_NAME` is already passed. Python reads the new env var and
falls back to the previous `https://{alb_dns}` behavior when it is unset.

---

## Root Cause

**Code** (`_do_proactive_download_sync`) hardcoded the scheme:

```python
url = f"https://{alb_dns}/system-internal/sync-experiment/{workspace_id}/{unique_id}"
```

→ implicit port 443. `alb_dns` comes from env `ALB_DNS_NAME`, which terraform
sets to `aws_lb.autoscaling.dns_name` (bare hostname, no scheme/port).

**Infra** (`compute.tf`) makes the listener scheme/port conditional on
`enable_custom_domain`, which is **false in dev**:

```hcl
# aws_lb_listener.autoscaling_https
port     = var.enable_custom_domain ? "443" : "8080"
protocol = var.enable_custom_domain ? "HTTPS" : "HTTP"
```

The live dev ALB `development-optinist-lb` has listeners on **HTTP :80 and :8080
only, no :443**. Every `/system-internal/sync-experiment` routing rule
(`public_alb_rules.tf`) is attached to `aws_lb_listener.autoscaling_https.arn`,
which in dev is the **:8080 HTTP** listener.

So the endpoint is reachable at `http://{dns}:8080/system-internal/...`, but the
job dialed `https://{dns}:443` → nothing listening → RST → `Errno 111`.

### Blame — designed for prod only

The `https://` hardcode was introduced in `a3fe478de` (2026-02-24). Its
`verify=False` comment — *"Skip SSL verification for internal VPC traffic; ALB
cert doesn't match AWS-generated hostname"* — shows the author designed for the
**prod** path (443 + HTTPS + cert-hostname mismatch) and never accounted for
non-custom-domain envs having no 443 listener. Hence it works in prod
(`enable_custom_domain=true`) and is dead in every dev-style deploy.

---

## Symptom (observed on dev, test 720)

Experiment 182 (`13/ee47c9b3`) published → `pending` → synced correctly, but the
proactive-download trigger failed in the same run:

```
14:21:02 INFO  _validate_experiment():436 - Successfully validated 13/ee47c9b3
14:21:02 DEBUG _mark_sync_complete():578 - Marked experiment 182 as synced
14:21:02 INFO  _run_validation_logic():236 - Validation job completed: 1 synced, 0 errors
14:21:02 WARNING _do_proactive_download_sync():537 - Proactive download trigger error for 13/ee47c9b3:
         HTTPSConnectionPool(host='development-optinist-lb-...elb.amazonaws.com', port=443):
         Max retries exceeded ... [Errno 111] Connection refused
```

`Errno 111` (RST, not a timeout) means something answered and refused 443 — i.e.
no listener on that port. Reproducible, not a flake: the identical failure hit
`13/f859b72e` earlier the same day.

---

## Changes

### Fix 1: Inject the internal base URL from terraform

**File:** `infrastructure/terraform/background_service.tf`

Added an `INTERNAL_API_BASE_URL` env var next to the existing `ALB_DNS_NAME`,
carrying the same `enable_custom_domain` scheme/port split terraform already uses
for the listener:

```hcl
{
  name  = "ALB_DNS_NAME"
  value = aws_lb.autoscaling.dns_name
},
{
  name  = "INTERNAL_API_BASE_URL"
  value = var.enable_custom_domain ? "https://${aws_lb.autoscaling.dns_name}" : "http://${aws_lb.autoscaling.dns_name}:8080"
},
```

**Rationale:** terraform owns the listener config, so the scheme/port decision
lives there rather than duplicating the `enable_custom_domain` conditional in
Python.
- prod (`enable_custom_domain=true`): `https://{dns}` (implicit 443, HTTPS)
- dev (`enable_custom_domain=false`): `http://{dns}:8080` (matches the actual
  dev listener the sync-experiment rules attach to)

The `:8080` literal intentionally repeats the value already used by the two
listener blocks in `compute.tf` and by `local.effective_frontend_port`, rather
than deriving it from the listener resource. `enable_custom_domain` gates both
this env var and `compute.tf`, so the flag can never drift them apart; the raw
`:8080` port stays shared with `compute.tf` and must be changed there in
lockstep. The rationale is recorded inline next to the env var in
`background_service.tf`.

### Fix 2: Read the injected base URL in the sync job

**File:** `studio/app/common/core/background/sync_job.py`

```python
# Before:
url = (
    f"https://{alb_dns}"
    f"/system-internal/sync-experiment"
    f"/{workspace_id}/{unique_id}"
)

# After:
base = os.environ.get("INTERNAL_API_BASE_URL") or f"https://{alb_dns}"
url = (
    f"{base}"
    f"/system-internal/sync-experiment"
    f"/{workspace_id}/{unique_id}"
)
```

- `verify=False` is **kept** — still needed for the prod HTTPS cert-hostname
  mismatch. Its comment is clarified to note that on the dev plaintext HTTP path
  `verify=False` is a no-op.
- The `or f"https://{alb_dns}"` fallback preserves current prod behavior even if
  the new env var is not set yet, so the change is **safe to roll out
  code-first** (Fix 2 can merge before Fix 1 reaches every environment).
- No new dependency, no scheme logic duplicated in Python.

### Fix 3: Lock the branch selection with unit tests

**File:** `studio/tests/app/common/core/background/test_sync_job.py`

The existing `TestTriggerProactiveDownload` cases never set
`INTERNAL_API_BASE_URL`, so they exercised the fallback only implicitly and gave
no positive coverage for the new env-driven branch. Two tests close that gap:

- `test_trigger_uses_internal_base_url` — env set → the POST targets
  `http://{dns}:8080/system-internal/sync-experiment/{ws}/{uid}`.
- `test_trigger_falls_back_to_https` — env unset (patched with `clear=True` so a
  host-provided value can't leak in) → the POST targets `https://{alb_dns}/...`,
  preserving the pre-fix prod behavior.

---

## Changed Files

| File | Change |
|------|--------|
| `studio/app/common/core/background/sync_job.py` | `_do_proactive_download_sync` reads `INTERNAL_API_BASE_URL` (fallback `https://{alb_dns}`) instead of hardcoding `https://`; `verify=False` comment clarified. |
| `infrastructure/terraform/background_service.tf` | Added `INTERNAL_API_BASE_URL` env, scheme/port derived from `enable_custom_domain`; inline note on the intentional `:8080` literal. |
| `studio/tests/app/common/core/background/test_sync_job.py` | Added 2 unit tests: env-set branch (`http://...:8080` used) and fallback branch (`https://{alb_dns}`). |

---

## Manual Test Plan

### Prerequisites

- Access to AWS Console (ECS, CloudWatch Logs) for the **dev** environment
- The dev ALB DNS name (`ALB_DNS_NAME`) — e.g. `development-optinist-lb-*.elb.amazonaws.com`
- The `INTERNAL_API_SECRET` value (Secrets Manager / task-def env) for the manual
  curl in Test 3
- A test user account able to publish an experiment on dev
- CloudWatch log groups:
  - Background tier: `/ecs/development-background-optinist-cloud-taskdef`
  - Public/API tier: `/ecs/development-public-optinist-cloud-taskdef`

> This fix is infra + env-driven. Test 1 is the end-to-end verification through a
> real sync run; Test 2 confirms the env is correctly injected after `terraform
> apply`; Test 3 is a standalone endpoint reachability check that does not require
> waiting for a sync cycle.

---

### Test 1: End-to-end — proactive download fires after a dev sync run (core fix)

**Objective:** Verify that after the terraform + code changes are deployed to
dev, publishing an experiment triggers a successful proactive-download POST
instead of the `Connection refused` warning.

#### Step 1: Confirm the deploy is live

1. In the AWS ECS Console, open the `development-background-optinist-cloud` service.
2. **Verify:** the running task uses the new task definition revision (created by
   the `terraform apply` that added `INTERNAL_API_BASE_URL`).
3. Open the task's **Configuration → Environment variables**.
4. **Verify:** `INTERNAL_API_BASE_URL` is present and equals
   `http://<alb_dns>:8080` (dev has `enable_custom_domain=false`).

#### Step 2: Publish an experiment

1. Log in to the dev app as the test user.
2. Publish an experiment (the same action that produced experiment 182 /
   `13/ee47c9b3` in test 720).
3. Note the workspace_id / unique_id (e.g. `13/ee47c9b3`).

#### Step 3: Wait one sync run (≤5 min)

1. Open CloudWatch Logs → `/ecs/development-background-optinist-cloud-taskdef`.

   Or via AWS CLI (tail the background tier and filter for the trigger lines):

   ```bash
   # Live tail (Ctrl-C to stop); shows both the success and the old refused warning
   aws logs tail /ecs/development-background-optinist-cloud-taskdef \
     --follow --since 10m \
     --filter-pattern '"Proactive download"'

   # Or a one-shot query of the last 10 minutes
   aws logs filter-log-events \
     --log-group-name /ecs/development-background-optinist-cloud-taskdef \
     --start-time $((($(date +%s) - 600) * 1000)) \
     --filter-pattern '"Proactive download"'
   ```
2. Wait for the next validation cycle to process the published experiment.
3. **Verify (background log) — PASS:** a line
   `Proactive download triggered for {workspace_id}/{unique_id}`
   appears (the success branch of `_do_proactive_download_sync`).
4. **Verify (background log) — the bug is gone:** there is **no**
   `Proactive download trigger error for ... port=443 ... Connection refused`
   warning for this experiment.

#### Step 4: Confirm the receiving tier handled the request

1. Open CloudWatch Logs → `/ecs/development-public-optinist-cloud-taskdef`.

   Or via AWS CLI (tail the public/API tier and filter for the handler line):

   ```bash
   # Live tail (Ctrl-C to stop)
   aws logs tail /ecs/development-public-optinist-cloud-taskdef \
     --follow --since 10m \
     --filter-pattern '"Proactive sync requested"'

   # Or a one-shot query of the last 10 minutes
   aws logs filter-log-events \
     --log-group-name /ecs/development-public-optinist-cloud-taskdef \
     --start-time $((($(date +%s) - 600) * 1000)) \
     --filter-pattern '"Proactive sync requested"'
   ```
2. **Verify:** a line `Proactive sync requested for {workspace_id}/{unique_id}`
   appears within seconds of the Step 3 success log — confirming the POST
   reached the `/system-internal/sync-experiment/{ws}/{uid}` handler on the
   public/API tier (`studio/app/common/routers/internal.py`).

#### Step 5: Confirm sync correctness is unchanged (regression guard)

1. **Verify the `Successfully validated` log** in the background tier
   (`/ecs/development-background-optinist-cloud-taskdef`):

   ```bash
   # Live tail (Ctrl-C to stop)
   aws logs tail /ecs/development-background-optinist-cloud-taskdef \
     --follow --since 10m \
     --filter-pattern '"Successfully validated"'

   # Or a one-shot query of the last 10 minutes
   aws logs filter-log-events \
     --log-group-name /ecs/development-background-optinist-cloud-taskdef \
     --start-time $((($(date +%s) - 600) * 1000)) \
     --filter-pattern '"Successfully validated"'
   ```

   A `Successfully validated {ws}/{uid}` line for the published experiment
   confirms validation completed.

2. **Verify `local_sync_status = synced` in the DB.** The status lives in the
   `experiment_records` table (`workspace_id`, `uid`, `local_sync_status`).
   Connect to the dev RDS instance (via bastion / ECS exec shell in the VPC) and
   run, substituting `<ws>` / `<uid>` (e.g. `13` / `ee47c9b3`):

   ```sql
   SELECT workspace_id, uid, local_sync_status
   FROM experiment_records
   WHERE workspace_id = <ws> AND uid = '<uid>';
   ```

   - **Verify:** `local_sync_status` is `synced` (not `pending` or `error`) —
     i.e. the fire-and-forget change did not alter the core sync outcome.

**Pass criteria:** Steps 3 (success log, no refused warning), 4 (receiving-tier
log), and 5 (still `synced`) all hold.

---

### Test 2: Env injection is environment-aware (terraform verification)

**Objective:** Verify the `enable_custom_domain` conditional resolves to the
correct scheme/port per environment.

1. In the dev workspace, run `terraform plan` (or inspect the applied task-def).
   - **Verify:** `INTERNAL_API_BASE_URL = http://<alb_dns>:8080` (dev,
     `enable_custom_domain=false`).
2. In the prod workspace, run `terraform plan` (no apply needed).
   - **Verify:** `INTERNAL_API_BASE_URL = https://<alb_dns>` (prod,
     `enable_custom_domain=true`) — implicit :443, matching the existing prod
     listener and preserving the current prod URL.

**Pass criteria:** dev resolves to `http://...:8080`, prod resolves to
`https://...`.

---

### Test 3 (Optional — root-cause isolation, run only if Test 1 is inconclusive): Standalone endpoint reachability (no sync cycle needed)

> **Not required for a normal pass.** Test 1 already exercises the real code path
> end-to-end (the success log in Step 3 proves the :8080 URL is reachable), and
> the old :443 failure is already evidenced by the test 720 logs in the *Symptom*
> section. Run this only when Test 1 gives an ambiguous result (e.g. neither the
> success log nor the refused warning appears) to isolate whether the cause is
> network/listener-side or code-side.

**Objective:** Directly confirm the dev endpoint is reachable at the HTTP :8080
URL the fix now targets, and unreachable at the old HTTPS :443 URL — isolating
the root cause from the sync flow.

Run from a host with network access to the dev ALB (e.g. a bastion / ECS exec
shell in the VPC). Replace `<alb_dns>`, `<secret>`, `<ws>`, `<uid>`, `<bucket>`.

1. **New path (fix target) — expect success:**
   ```bash
   curl -i -X POST \
     "http://<alb_dns>:8080/system-internal/sync-experiment/<ws>/<uid>?bucket_name=<bucket>&has_thumbnails=true" \
     -H "X-Internal-Secret: <secret>" \
     -H "Content-Type: application/json"
   ```
   - **Verify:** `HTTP/1.1 200 OK` (or `429 Too Many Requests` if the per-
     experiment rate limit was hit by Test 1 — still proves reachability). A
     `Proactive sync requested for ...` line appears in the public-tier log.

2. **Old path (pre-fix behavior) — expect connection refused:**
   ```bash
   curl -i -k -X POST \
     "https://<alb_dns>/system-internal/sync-experiment/<ws>/<uid>?bucket_name=<bucket>&has_thumbnails=true" \
     -H "X-Internal-Secret: <secret>"
   ```
   - **Verify:** `Connection refused` (no listener on :443) — this is exactly the
     `Errno 111` the job hit before the fix.

**Pass criteria:** the :8080 HTTP call succeeds; the :443 HTTPS call is refused —
demonstrating why the env-driven base URL is required in dev.

---

## Impact / Severity

Fire-and-forget, so the sync completes and `local_sync_status` flips to `synced`
regardless — test 720's core assertions pass unchanged. The only loss before this
fix was pre-warming: files were fetched on-demand at first public view rather than
pushed ahead of time. **Slower first view, not a functional break.** Low severity,
but the feature was entirely non-functional in dev and is now restored.

**Rollout safety:** the Python fallback keeps prod behavior identical if
`INTERNAL_API_BASE_URL` is absent, so Fix 2 (code) and Fix 1 (terraform) can ship
independently and in either order.

---
