### PR TITLE
Demote stale synced experiments if files not on S3

### DIFF
--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -4,7 +4,7 @@ import re
 import time
 import uuid
 from subprocess import CalledProcessError
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import aioboto3
 import boto3
@@ -705,6 +705,34 @@ class S3StorageController(BaseRemoteStorageController):
             f"[{workspace_id}/{unique_id}]"
         )
         return True
+
+    async def experiment_prefix_exists(
+        self, workspace_id: str, unique_id: str
+    ) -> Tuple[Optional[bool], Optional[str]]:
+        """
+        Check whether any object exists under an experiment's S3 output prefix.
+
+        Returns a tri-state so callers can distinguish confirmed absence from
+        an unverifiable check:
+            - True: at least one object present (error is None)
+            - False: prefix confirmed empty
+            - None: could not check (transient/S3 error)
+        """
+        prefix = self.make_s3_output_prefix(workspace_id, unique_id)
+        try:
+            async with self.__get_s3_client() as client:
+                result = await client.list_objects_v2(
+                    Bucket=self.bucket_name, Prefix=prefix, MaxKeys=5
+                )
+                if result.get("KeyCount", 0) == 0:
+                    return False, f"No data found in S3 for {workspace_id}/{unique_id}"
+        except Exception as e:
+            logger.error(
+                f"S3 existence check error for {workspace_id}/{unique_id}: {e}"
+            )
+            return None, f"Could not verify S3 data: {str(e)}"
+
+        return True, None
 
     async def validate_experiment_in_s3(
         self, workspace_id: str, unique_id: str

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -272,9 +272,11 @@ async def public_reproduce_experiment(
             and record.local_sync_status == LocalSyncStatus.synced.value
         ):
             bucket = _resolve_workspace_remote_bucket_name(db, workspace_id)
-            exists, s3_error = await _validate_experiment_exists_in_s3(
-                workspace_id, unique_id, bucket
-            )
+            exists = None
+            if bucket:
+                exists, s3_error = await _validate_experiment_exists_in_s3(
+                    workspace_id, unique_id, bucket
+                )
             if exists is False:
                 logger.error(
                     f"Experiment {workspace_id}/{unique_id} marked synced but not "

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -264,6 +264,35 @@ async def public_reproduce_experiment(
         unique_id=unique_id,
     )
     if not display_validation.is_displayable:
+        # A 'synced' row that won't display may have lost its files from S3 after
+        # publishing; confirm on S3 and demote so the background sync job re-checks it.
+        if (
+            RemoteStorageController.is_available()
+            and hasattr(record, "local_sync_status")
+            and record.local_sync_status == LocalSyncStatus.synced.value
+        ):
+            bucket = _resolve_workspace_remote_bucket_name(db, workspace_id)
+            exists, s3_error = await _validate_experiment_exists_in_s3(
+                workspace_id, unique_id, bucket
+            )
+            if exists is False:
+                logger.error(
+                    f"Experiment {workspace_id}/{unique_id} marked synced but not "
+                    f"present in S3 ({s3_error}); demoting to error"
+                )
+                db.execute(
+                    update(models.ExperimentRecord)
+                    .where(models.ExperimentRecord.id == record.id)
+                    .where(
+                        models.ExperimentRecord.publish_status == PublishStatus.on.value
+                    )
+                    .where(
+                        models.ExperimentRecord.local_sync_status
+                        == LocalSyncStatus.synced.value
+                    )
+                    .values(local_sync_status=LocalSyncStatus.error.value)
+                )
+                db.commit()
         # Data is not available locally - check if we should return pending or error
         if hasattr(record, "local_sync_status"):
             if record.local_sync_status == LocalSyncStatus.pending.value:
@@ -394,7 +423,7 @@ async def _ensure_experiment_downloaded(
 
 async def _validate_experiment_exists_in_s3(
     workspace_id: str, unique_id: str, bucket_name: str
-) -> Tuple[bool, Optional[str]]:
+) -> Tuple[Optional[bool], Optional[str]]:
     """
     Check if experiment data exists in S3.
 
@@ -404,7 +433,10 @@ async def _validate_experiment_exists_in_s3(
         bucket_name: The S3 bucket name
 
     Returns:
-        Tuple of (exists, error_message). If exists is True, error_message is None.
+        Tuple of (exists, error_message):
+        - True: data confirmed present (error_message is None)
+        - False: data confirmed absent
+        - None: could not check (transient/S3 error) - caller must not treat as absent
     """
     if not RemoteStorageController.is_available():
         return True, None  # Skip validation if S3 not configured
@@ -421,7 +453,7 @@ async def _validate_experiment_exists_in_s3(
                 return False, f"No data found in S3 for {workspace_id}/{unique_id}"
     except Exception as e:
         logger.error(f"S3 validation error for {workspace_id}/{unique_id}: {e}")
-        return False, f"Could not verify S3 data: {str(e)}"
+        return None, f"Could not verify S3 data: {str(e)}"
 
     return True, None
 

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -273,6 +273,7 @@ async def public_reproduce_experiment(
         ):
             bucket = _resolve_workspace_remote_bucket_name(db, workspace_id)
             exists = None
+            s3_error = None
             if bucket:
                 exists, s3_error = await _validate_experiment_exists_in_s3(
                     workspace_id, unique_id, bucket
@@ -443,21 +444,9 @@ async def _validate_experiment_exists_in_s3(
     if not RemoteStorageController.is_available():
         return True, None  # Skip validation if S3 not configured
 
-    s3_controller = S3StorageController(bucket_name)
-    s3_path = S3StorageController.make_s3_output_prefix(workspace_id, unique_id)
-
-    try:
-        async with s3_controller._S3StorageController__get_s3_client() as client:
-            result = await client.list_objects_v2(
-                Bucket=bucket_name, Prefix=s3_path, MaxKeys=5
-            )
-            if result.get("KeyCount", 0) == 0:
-                return False, f"No data found in S3 for {workspace_id}/{unique_id}"
-    except Exception as e:
-        logger.error(f"S3 validation error for {workspace_id}/{unique_id}: {e}")
-        return None, f"Could not verify S3 data: {str(e)}"
-
-    return True, None
+    return await S3StorageController(bucket_name).experiment_prefix_exists(
+        workspace_id, unique_id
+    )
 
 
 @router.get(

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -576,6 +576,53 @@ class TestPublicDataviewReproduceWorkflow:
         mock_db.execute.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_publish_blocks_when_s3_check_unverifiable(self):
+        """Publish must block (400) when the S3 check is unverifiable (None)."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.core.storage.remote_storage_controller import (
+            RemoteStorageType,
+        )
+        from studio.app.common.routers.dataview import PublishFlags
+
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = 123
+        mock_user.remote_bucket_name = "test-bucket"
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.workspace_id = "1"
+        mock_record.uid = "test_uid"
+        mock_record.publish_status = 0
+        mock_record.local_sync_status = LocalSyncStatus.synced.value
+        mock_record.version = 0
+
+        mock_validation = MagicMock()
+        mock_validation.can_publish = True
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_user_owned_dataview_record",
+            return_value=mock_record,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageType.get_activated_type",
+            return_value=RemoteStorageType.S3,
+        ), patch(
+            "studio.app.common.routers.dataview._validate_experiment_exists_in_s3",
+            new=AsyncMock(return_value=(None, "Could not verify S3 data")),
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator.validate",
+            return_value=mock_validation,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await publish_dataview_records(
+                    id=1, flag=PublishFlags.on, db=mock_db, current_user=mock_user
+                )
+
+        assert exc_info.value.status_code == 400
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reproduce_synced_s3_check_fails_does_not_demote(self):
         """A transient S3 check failure (None) must not demote a synced row."""
         from unittest.mock import AsyncMock
@@ -622,3 +669,57 @@ class TestPublicDataviewReproduceWorkflow:
 
         assert response.status_code == 503
         mock_db.execute.assert_not_called()
+
+
+class TestValidateExperimentExistsInS3:
+    """Exercise the real tri-state S3 existence check against a mocked client."""
+
+    @staticmethod
+    def _s3_client_ctx(*, key_count=None, raise_exc=None):
+        from unittest.mock import AsyncMock
+
+        client = MagicMock()
+        if raise_exc is not None:
+            client.list_objects_v2 = AsyncMock(side_effect=raise_exc)
+        else:
+            client.list_objects_v2 = AsyncMock(return_value={"KeyCount": key_count})
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=client)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    async def _run(self, ctx):
+        from studio.app.common.core.storage.s3_storage_controller import (
+            S3StorageController,
+        )
+        from studio.app.common.routers.dataview import _validate_experiment_exists_in_s3
+
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController.is_available",
+            return_value=True,
+        ), patch.object(
+            S3StorageController,
+            "_S3StorageController__get_s3_client",
+            return_value=ctx,
+        ):
+            return await _validate_experiment_exists_in_s3("1", "exp123", "test-bucket")
+
+    @pytest.mark.asyncio
+    async def test_present_returns_true(self):
+        exists, error = await self._run(self._s3_client_ctx(key_count=3))
+        assert exists is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_confirmed_absent_returns_false(self):
+        exists, error = await self._run(self._s3_client_ctx(key_count=0))
+        assert exists is False
+        assert error is not None
+
+    @pytest.mark.asyncio
+    async def test_transient_error_returns_none(self):
+        exists, error = await self._run(
+            self._s3_client_ctx(raise_exc=Exception("throttled"))
+        )
+        assert exists is None
+        assert error is not None

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -473,3 +473,152 @@ class TestPublicDataviewReproduceWorkflow:
         # Verify bulk update was executed and committed
         mock_db.execute.assert_called_once()
         mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reproduce_synced_but_missing_in_s3_demotes_to_error(self):
+        """A synced row whose files are gone from S3 is demoted to error."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import public_reproduce_experiment
+
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.local_sync_status = LocalSyncStatus.synced.value
+
+        mock_validation = MagicMock()
+        mock_validation.is_displayable = False
+        mock_validation.reason = "Data not available"
+
+        mock_db = MagicMock()
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_dataview_record",
+            return_value=mock_record,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+            "check_sync_status_unsynced",
+            return_value=False,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview._validate_experiment_exists_in_s3",
+            new=AsyncMock(return_value=(False, "No data found in S3")),
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator."
+            "validate_for_display",
+            return_value=mock_validation,
+        ):
+            response = await public_reproduce_experiment(
+                workspace_id="1", unique_id="exp123", db=mock_db
+            )
+
+        assert response.status_code == 503
+        mock_db.execute.assert_called_once()
+        mock_db.commit.assert_called_once()
+        # Pin that the statement demotes synced -> error (SET target and guard)
+        params = mock_db.execute.call_args[0][0].compile().params
+        assert params["local_sync_status"] == LocalSyncStatus.error.value
+        assert params["local_sync_status_1"] == LocalSyncStatus.synced.value
+
+    @pytest.mark.asyncio
+    async def test_reproduce_synced_present_in_s3_does_not_demote(self):
+        """A synced row still present in S3 is not demoted (transient local miss)."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import public_reproduce_experiment
+
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.local_sync_status = LocalSyncStatus.synced.value
+
+        mock_validation = MagicMock()
+        mock_validation.is_displayable = False
+        mock_validation.reason = "Data not available"
+
+        mock_db = MagicMock()
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_dataview_record",
+            return_value=mock_record,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+            "check_sync_status_unsynced",
+            return_value=False,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview._validate_experiment_exists_in_s3",
+            new=AsyncMock(return_value=(True, None)),
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator."
+            "validate_for_display",
+            return_value=mock_validation,
+        ):
+            response = await public_reproduce_experiment(
+                workspace_id="1", unique_id="exp123", db=mock_db
+            )
+
+        assert response.status_code == 503
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reproduce_synced_s3_check_fails_does_not_demote(self):
+        """A transient S3 check failure (None) must not demote a synced row."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import public_reproduce_experiment
+
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.local_sync_status = LocalSyncStatus.synced.value
+
+        mock_validation = MagicMock()
+        mock_validation.is_displayable = False
+        mock_validation.reason = "Data not available"
+
+        mock_db = MagicMock()
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_dataview_record",
+            return_value=mock_record,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteSyncStatusFileUtil."
+            "check_sync_status_unsynced",
+            return_value=False,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview._validate_experiment_exists_in_s3",
+            new=AsyncMock(return_value=(None, "Could not verify S3 data")),
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator."
+            "validate_for_display",
+            return_value=mock_validation,
+        ):
+            response = await public_reproduce_experiment(
+                workspace_id="1", unique_id="exp123", db=mock_db
+            )
+
+        assert response.status_code == 503
+        mock_db.execute.assert_not_called()

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -525,7 +525,7 @@ class TestPublicDataviewReproduceWorkflow:
         # Pin that the statement demotes synced -> error (SET target and guard)
         params = mock_db.execute.call_args[0][0].compile().params
         assert params["local_sync_status"] == LocalSyncStatus.error.value
-        assert params["local_sync_status_1"] == LocalSyncStatus.synced.value
+        assert LocalSyncStatus.synced.value in params.values()
 
     @pytest.mark.asyncio
     async def test_reproduce_synced_present_in_s3_does_not_demote(self):


### PR DESCRIPTION
### Content

#### Summary
- A published experiment can be marked `local_sync_status = synced` yet be undisplayable because its output files were later removed from S3. Previously the public reproduce endpoint just returned a data error and left the row stuck at `synced` forever, so the background sync job never re-checked it.
- On a `synced` row that fails display validation, `public_reproduce_experiment` now confirms against S3 and, **only when the data is confirmed absent**, demotes the row to `error` so the background sync job picks it up on its next pass.
- A transient S3 check failure (network/throttle/creds) no longer demotes a healthy row — it is left as `synced` and retried later.

#### Design Decisions
- **Tri-state S3 check instead of a boolean.** `_validate_experiment_exists_in_s3` now returns `True` (confirmed present) / `False` (confirmed absent, `KeyCount == 0`) / `None` (couldn't check — exception). The demotion path and the publish path need opposite fail-safe directions: demotion must **not** fire on uncertainty (don't corrupt a healthy row), while publish must **block** on uncertainty (don't publish data we can't confirm). A single boolean cannot serve both, which is why the exception case previously caused false demotions.
- **Demotion guarded by `if exists is False`**, so only a confirmed-absent object triggers the status change. The publish caller keeps `if not exists:` — `not None` and `not False` are both truthy, so it still blocks publish on absent **and** unknown (behavior unchanged there).
- **Idempotent UPDATE.** The demotion `UPDATE` is scoped with `WHERE publish_status = on AND local_sync_status = synced`, so concurrent requests converge and a second demotion is a no-op.
- **Rejected:** re-downloading from S3 on this path (the row is already `synced`, so `needs_sync` is false by design — the real problem is upstream data loss, not a local miss), and changing the publish caller's contract (its existing fail-safe was already correct).

### Evidence
```
$ docker compose -f docker-compose.test.yml run --rm test_studio_backend \
    python -m pytest studio/tests/app/common/routers/test_dataview_publish.py -q
............. [100%]
13 passed, 3 warnings in 0.17s
```
Backend test image built locally; the three demote/S3 tests pass alongside the existing suite.

Log emitted on a real demotion (existing logger, unchanged format):
```
Experiment {workspace_id}/{unique_id} marked synced but not present in S3
(No data found in S3 ...); demoting to error
```

### References
- Endpoint: `public_reproduce_experiment` in `studio/app/common/routers/dataview.py`
- Helper whose contract changed: `_validate_experiment_exists_in_s3`

#### Files changed
- `studio/app/common/routers/dataview.py` — add the confirm-on-S3-and-demote block to `public_reproduce_experiment`; change `_validate_experiment_exists_in_s3` to a tri-state (`True`/`False`/`None`) so transient failures are distinguishable from confirmed absence.
- `studio/tests/app/common/routers/test_dataview_publish.py` — three new tests covering demote-on-absent, no-demote-when-present, and no-demote-on-transient-error; the absent-case test also asserts the emitted `UPDATE` sets `synced → error`.

### Manual Testcases
1. **Files lost from S3** — As a viewer, request `GET /public/.../reproduce/{workspace_id}/{unique_id}` for a `synced`, published experiment whose S3 output prefix has been emptied. Expected: `503` data-error response, and the row's `local_sync_status` flips to `error` (verify in DB); the background sync job re-checks it thereafter.
2. **Transient S3 error** — Same request while S3 is briefly unreachable (`list_objects_v2` raises). Expected: `503` response, row **stays** `synced` (no DB write), retried on a later request.
3. **Data present but locally missing** — `synced` row, files present in S3 but not on local EBS. Expected: `503` response, row stays `synced` (no demotion).
4. Automated: `pytest studio/tests/app/common/routers/test_dataview_publish.py -- all 13 tests pass`

### Unit, Integration, Contract Test Coverage
- `test_reproduce_synced_but_missing_in_s3_demotes_to_error` — confirmed-absent → demote; asserts the compiled `UPDATE` sets `local_sync_status = error` under a `synced` guard.
- `test_reproduce_synced_present_in_s3_does_not_demote` — present → no `db.execute`.
- `test_reproduce_synced_s3_check_fails_does_not_demote` — transient `None` → no `db.execute`.

### Others

#### Difficulties (if any)
- None. Local conda envs lack the full backend dependency set (`stripe`, etc.), so verification was run via the Docker test image.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `_validate_experiment_exists_in_s3` return contract | Low | Now tri-state; both call sites audited. Publish caller's `if not exists:` unchanged and still correct for the new `None`. |
| `public_reproduce_experiment` demotion write | Low | Guarded, idempotent `UPDATE`; only fires on confirmed-absent data; new branch covered by tests. |
| Background sync job interaction | Low | Demotion to `error` is the documented signal for re-check; no new coupling introduced. |
