### PR TITLE
Fix admin GUI edit for users with no subscription record

### DIFF
--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -6,6 +6,7 @@ from firebase_admin import auth as firebase_auth
 from firebase_admin.auth import UserNotFoundError, UserRecord
 from firebase_admin.exceptions import FirebaseError
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from studio.app.common.core.auth.auth import authenticate_user
@@ -548,6 +549,25 @@ async def update_user(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+def _insert_or_reselect(db: Session, row, model, user_id: int):
+    """Insert ``row`` inside a SAVEPOINT. Both subscription_users and
+    user_storage_usage are unique on user_id, so a concurrent writer can win
+    the race; on conflict, re-select and return the existing row instead of
+    surfacing a 500."""
+    try:
+        with db.begin_nested():
+            db.add(row)
+            db.flush()
+        return row
+    except IntegrityError:
+        existing = (
+            db.query(model).filter(model.user_id == user_id).with_for_update().first()
+        )
+        if existing is None:
+            raise
+        return existing
+
+
 async def update_user_subscription_admin(
     db: Session,
     user_id: int,
@@ -575,46 +595,78 @@ async def update_user_subscription_admin(
             raise HTTPException(
                 status_code=400, detail=f"Invalid plan_id: {data.plan_id}"
             )
+        if data.plan_id == SubscriptionPlanIds.PREMIUM and data.expiration is None:
+            raise HTTPException(
+                status_code=400, detail="expiration is required for the premium plan"
+            )
 
         subscription = (
             db.query(UserSubscription)
             .filter(UserSubscription.user_id == user_id)
             .first()
         )
-        if subscription is None:
-            raise HTTPException(
-                status_code=400, detail="User has no subscription record"
-            )
+        subscription_existed = subscription is not None
 
         storage = (
             db.query(UserStorageUsage)
             .filter(UserStorageUsage.user_id == user_id)
             .first()
         )
-        if storage is None:
-            raise HTTPException(status_code=400, detail="User has no storage record")
+        storage_existed = storage is not None
 
-        # Capture old values before applying changes
-        # Normalize expiration to UTC ISO string for consistent audit format
+        # Capture old values before applying changes.
+        # A missing row is recorded as None so the audit reflects that the
+        # record was created rather than edited.
+        old_plan_id = None
         old_expiration_str = None
-        if subscription.expiration:
-            old_exp = subscription.expiration
-            if old_exp.tzinfo is None:
-                old_exp = old_exp.replace(tzinfo=timezone.utc)
-            old_expiration_str = old_exp.isoformat()
+        if subscription_existed:
+            old_plan_id = subscription.plan_id
+            # Normalize expiration to UTC ISO string for consistent audit format
+            if subscription.expiration:
+                old_exp = subscription.expiration
+                if old_exp.tzinfo is None:
+                    old_exp = old_exp.replace(tzinfo=timezone.utc)
+                old_expiration_str = old_exp.isoformat()
 
         old_value = SubscriptionAuditSnapshot(
-            plan_id=subscription.plan_id,
+            plan_id=old_plan_id,
             expiration=old_expiration_str,
-            storage_quota_bytes=storage.storage_quota_bytes,
+            storage_quota_bytes=(
+                storage.storage_quota_bytes if storage_existed else None
+            ),
         )
 
         # Apply changes
         # For Free plan, expiration is not meaningful — default to now
         expiration = data.expiration or datetime.now(timezone.utc)
+        # This admin repair path does not provision an S3 bucket; it only fixes
+        # subscription/quota rows. A user missing these rows in practice already
+        # has a bucket from signup. Add ensure_user_bucket_exists here if that
+        # assumption ever stops holding.
+        if not subscription_existed:
+            subscription = _insert_or_reselect(
+                db,
+                UserSubscription(
+                    user_id=user_id, plan_id=data.plan_id, expiration=expiration
+                ),
+                UserSubscription,
+                user_id,
+            )
         subscription.plan_id = data.plan_id
         subscription.expiration = expiration
         subscription.scheduled_downgrade = False
+
+        if not storage_existed:
+            storage = _insert_or_reselect(
+                db,
+                UserStorageUsage(
+                    user_id=user_id,
+                    storage_usage_bytes=0,
+                    storage_quota_bytes=data.storage_quota_bytes,
+                ),
+                UserStorageUsage,
+                user_id,
+            )
         storage.storage_quota_bytes = data.storage_quota_bytes
 
         # Write audit log

--- a/studio/app/common/core/users/crud_users.py
+++ b/studio/app/common/core/users/crud_users.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Type, TypeVar
 
 from fastapi import HTTPException
 from fastapi_pagination.ext.sqlmodel import paginate
@@ -549,9 +550,14 @@ async def update_user(
         raise HTTPException(status_code=400, detail=str(e))
 
 
-def _insert_or_reselect(db: Session, row, model, user_id: int):
-    """Insert ``row`` inside a SAVEPOINT. Both subscription_users and
-    user_storage_usage are unique on user_id, so a concurrent writer can win
+_UniqueRow = TypeVar("_UniqueRow")
+
+
+def _insert_or_reselect(
+    db: Session, row: _UniqueRow, model: Type[_UniqueRow], user_id: int
+) -> _UniqueRow:
+    """Insert ``row`` (a UserSubscription or UserStorageUsage instance) inside a
+    SAVEPOINT. Both tables are unique on user_id, so a concurrent writer can win
     the race; on conflict, re-select and return the existing row instead of
     surfacing a 500."""
     try:
@@ -613,6 +619,24 @@ async def update_user_subscription_admin(
             .first()
         )
         storage_existed = storage is not None
+
+        # These rows should already exist from signup provisioning; the admin
+        # path materializing them repairs a state that "shouldn't happen", so
+        # surface it in case rows are going missing from a systemic cause.
+        if not subscription_existed or not storage_existed:
+            missing = [
+                name
+                for name, existed in (
+                    ("subscription_users", subscription_existed),
+                    ("user_storage_usage", storage_existed),
+                )
+                if not existed
+            ]
+            logger.warning(
+                "Admin subscription update creating missing %s row(s) for user %s",
+                ", ".join(missing),
+                user_id,
+            )
 
         # Capture old values before applying changes.
         # A missing row is recorded as None so the audit reflects that the

--- a/studio/app/common/schemas/users.py
+++ b/studio/app/common/schemas/users.py
@@ -97,9 +97,9 @@ class UserUpdate(BaseModel):
 class SubscriptionAuditSnapshot(BaseModel):
     """Typed snapshot of subscription state for audit log old_value/new_value."""
 
-    plan_id: int
+    plan_id: Optional[int] = None
     expiration: Optional[str] = None
-    storage_quota_bytes: int
+    storage_quota_bytes: Optional[int] = None
 
 
 class UserSubscriptionUpdate(BaseModel):

--- a/studio/tests/app/common/routers/test_users_admin_subscription.py
+++ b/studio/tests/app/common/routers/test_users_admin_subscription.py
@@ -8,15 +8,42 @@ Tests the admin subscription update feature including:
 - Edge cases
 """
 
+import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import BIGINT as GENERIC_BIGINT
+from sqlalchemy import BigInteger
+from sqlalchemy.dialects.mysql import BIGINT as MYSQL_BIGINT
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
 
+from studio.app.common.core.users import crud_users
+from studio.app.common.models import User as UserModel
+from studio.app.common.models.subscription import (
+    SubscriptionAuditLog,
+    UserStorageUsage,
+    UserSubscription,
+)
 from studio.app.common.schemas.users import (
     SubscriptionAuditSnapshot,
     UserSubscriptionUpdate,
 )
+
+
+# SQLite only autoincrements an INTEGER PRIMARY KEY, not BIGINT.
+@compiles(BigInteger, "sqlite")
+@compiles(GENERIC_BIGINT, "sqlite")
+@compiles(MYSQL_BIGINT, "sqlite")
+def _bigint_as_integer_sqlite(type_, compiler, **kw):
+    return "INTEGER"
+
+
+FREE_PLAN = 1
+PREMIUM_PLAN = 2
 
 # ============================================================================
 # Schema Validation Tests (UserSubscriptionUpdate)
@@ -174,3 +201,209 @@ class TestSubscriptionAuditSnapshot:
         assert dumped["plan_id"] == 2
         assert dumped["expiration"] == "2026-12-31T23:59:59+00:00"
         assert dumped["storage_quota_bytes"] == 214748364800
+
+    def test_snapshot_all_fields_null(self):
+        """Snapshot allows every field null (record did not exist before)."""
+        snapshot = SubscriptionAuditSnapshot()
+        assert snapshot.plan_id is None
+        assert snapshot.expiration is None
+        assert snapshot.storage_quota_bytes is None
+        assert snapshot.dict() == {
+            "plan_id": None,
+            "expiration": None,
+            "storage_quota_bytes": None,
+        }
+
+    def test_snapshot_mixed_null(self):
+        """Snapshot allows one row present and the other absent."""
+        snapshot = SubscriptionAuditSnapshot(plan_id=1, storage_quota_bytes=None)
+        assert snapshot.plan_id == 1
+        assert snapshot.storage_quota_bytes is None
+
+
+# ============================================================================
+# CRUD Tests (update_user_subscription_admin) — real DB session
+# ============================================================================
+
+
+@pytest.fixture()
+def db():
+    """In-memory SQLite session with all tables created."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # Only the tables this logic touches — the full metadata includes tables
+    # with MySQL-specific DDL that SQLite cannot create.
+    tables = [
+        UserModel.__table__,
+        UserSubscription.__table__,
+        UserStorageUsage.__table__,
+        SubscriptionAuditLog.__table__,
+    ]
+    # Drop the MySQL "ON UPDATE CURRENT_TIMESTAMP" default (invalid SQLite DDL).
+    for table in tables:
+        for col in table.columns:
+            arg = getattr(col.server_default, "arg", None)
+            if arg is not None and "ON UPDATE" in str(arg):
+                col.server_default = None
+    SQLModel.metadata.create_all(engine, tables=tables)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture()
+def seeded_user(db):
+    """An active user; returns its id. No subscription/storage rows."""
+    user = UserModel(
+        organization_id=1,
+        uid="uid-test",
+        name="Test User",
+        email="test@example.com",
+        attributes={},
+        active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user.id
+
+
+@pytest.fixture()
+def admin_user():
+    return SimpleNamespace(id=99, organization=SimpleNamespace(id=1))
+
+
+def _call(db, user_id, data, admin_user):
+    # get_user_with_context re-queries with joins irrelevant to this logic;
+    # stub it so the test focuses on the upsert + audit behavior.
+    async def _stub(_db, _uid):
+        return _uid
+
+    original = crud_users.get_user_with_context
+    crud_users.get_user_with_context = _stub
+    try:
+        return asyncio.run(
+            crud_users.update_user_subscription_admin(db, user_id, data, admin_user)
+        )
+    finally:
+        crud_users.get_user_with_context = original
+
+
+class TestUpdateUserSubscriptionAdminCRUD:
+    """Business-logic + audit coverage for the admin subscription upsert."""
+
+    def test_creates_both_rows_when_missing(self, db, seeded_user, admin_user):
+        data = UserSubscriptionUpdate(
+            plan_id=PREMIUM_PLAN,
+            expiration=datetime(2026, 12, 31, tzinfo=timezone.utc),
+            storage_quota_bytes=214748364800,
+            reason="grant premium",
+        )
+        _call(db, seeded_user, data, admin_user)
+
+        sub = (
+            db.query(UserSubscription)
+            .filter(UserSubscription.user_id == seeded_user)
+            .one()
+        )
+        storage = (
+            db.query(UserStorageUsage)
+            .filter(UserStorageUsage.user_id == seeded_user)
+            .one()
+        )
+        assert sub.plan_id == PREMIUM_PLAN
+        assert storage.storage_quota_bytes == 214748364800
+
+        log = db.query(SubscriptionAuditLog).one()
+        assert log.old_value == {
+            "plan_id": None,
+            "expiration": None,
+            "storage_quota_bytes": None,
+        }
+        assert log.new_value["plan_id"] == PREMIUM_PLAN
+        assert log.new_value["storage_quota_bytes"] == 214748364800
+
+    def test_creates_subscription_when_only_storage_exists(
+        self, db, seeded_user, admin_user
+    ):
+        db.add(
+            UserStorageUsage(
+                user_id=seeded_user,
+                storage_usage_bytes=0,
+                storage_quota_bytes=5368709120,
+            )
+        )
+        db.commit()
+
+        data = UserSubscriptionUpdate(
+            plan_id=PREMIUM_PLAN,
+            expiration=datetime(2026, 12, 31, tzinfo=timezone.utc),
+            storage_quota_bytes=214748364800,
+            reason="upgrade",
+        )
+        _call(db, seeded_user, data, admin_user)
+
+        assert (
+            db.query(UserSubscription)
+            .filter(UserSubscription.user_id == seeded_user)
+            .one()
+            .plan_id
+            == PREMIUM_PLAN
+        )
+        log = db.query(SubscriptionAuditLog).one()
+        # storage existed -> its old quota is recorded; subscription did not.
+        assert log.old_value["plan_id"] is None
+        assert log.old_value["storage_quota_bytes"] == 5368709120
+
+    def test_updates_existing_rows(self, db, seeded_user, admin_user):
+        db.add(
+            UserSubscription(
+                user_id=seeded_user,
+                plan_id=PREMIUM_PLAN,
+                expiration=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        db.add(
+            UserStorageUsage(
+                user_id=seeded_user,
+                storage_usage_bytes=0,
+                storage_quota_bytes=214748364800,
+            )
+        )
+        db.commit()
+
+        data = UserSubscriptionUpdate(
+            plan_id=FREE_PLAN,
+            expiration=None,
+            storage_quota_bytes=5368709120,
+            reason="downgrade to free",
+        )
+        _call(db, seeded_user, data, admin_user)
+
+        assert (
+            db.query(UserSubscription)
+            .filter(UserSubscription.user_id == seeded_user)
+            .one()
+            .plan_id
+            == FREE_PLAN
+        )
+        log = db.query(SubscriptionAuditLog).one()
+        assert log.old_value["plan_id"] == PREMIUM_PLAN
+        assert log.old_value["storage_quota_bytes"] == 214748364800
+        assert log.new_value["storage_quota_bytes"] == 5368709120
+
+    def test_premium_requires_expiration(self, db, seeded_user, admin_user):
+        from fastapi import HTTPException
+
+        data = UserSubscriptionUpdate(
+            plan_id=PREMIUM_PLAN,
+            expiration=None,
+            storage_quota_bytes=214748364800,
+            reason="premium no expiration",
+        )
+        with pytest.raises(HTTPException) as exc:
+            _call(db, seeded_user, data, admin_user)
+        assert exc.value.status_code == 400
+        assert db.query(UserSubscription).count() == 0

--- a/studio/tests/app/common/routers/test_users_admin_subscription.py
+++ b/studio/tests/app/common/routers/test_users_admin_subscription.py
@@ -243,14 +243,21 @@ def db():
         SubscriptionAuditLog.__table__,
     ]
     # Drop the MySQL "ON UPDATE CURRENT_TIMESTAMP" default (invalid SQLite DDL).
+    # These Table objects are process-global, so restore the defaults afterward.
+    stripped = []
     for table in tables:
         for col in table.columns:
             arg = getattr(col.server_default, "arg", None)
             if arg is not None and "ON UPDATE" in str(arg):
+                stripped.append((col, col.server_default))
                 col.server_default = None
-    SQLModel.metadata.create_all(engine, tables=tables)
-    with Session(engine) as session:
-        yield session
+    try:
+        SQLModel.metadata.create_all(engine, tables=tables)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for col, default in stripped:
+            col.server_default = default
 
 
 @pytest.fixture()

--- a/studio/tests/app/common/routers/test_users_admin_subscription.py
+++ b/studio/tests/app/common/routers/test_users_admin_subscription.py
@@ -9,6 +9,7 @@ Tests the admin subscription update feature including:
 """
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -35,6 +36,9 @@ from studio.app.common.schemas.users import (
 
 
 # SQLite only autoincrements an INTEGER PRIMARY KEY, not BIGINT.
+# NOTE: @compiles mutates SQLAlchemy's process-global dialect-compiler registry
+# on import, not just this module - every SQLite-backed test in the same process
+# that builds DDL from a BigInteger/BIGINT column will emit INTEGER too.
 @compiles(BigInteger, "sqlite")
 @compiles(GENERIC_BIGINT, "sqlite")
 @compiles(MYSQL_BIGINT, "sqlite")
@@ -301,14 +305,20 @@ def _call(db, user_id, data, admin_user):
 class TestUpdateUserSubscriptionAdminCRUD:
     """Business-logic + audit coverage for the admin subscription upsert."""
 
-    def test_creates_both_rows_when_missing(self, db, seeded_user, admin_user):
+    def test_creates_both_rows_when_missing(self, db, seeded_user, admin_user, caplog):
         data = UserSubscriptionUpdate(
             plan_id=PREMIUM_PLAN,
             expiration=datetime(2026, 12, 31, tzinfo=timezone.utc),
             storage_quota_bytes=214748364800,
             reason="grant premium",
         )
-        _call(db, seeded_user, data, admin_user)
+        with caplog.at_level(logging.WARNING):
+            _call(db, seeded_user, data, admin_user)
+
+        # Both rows were missing -> the warning names both tables.
+        assert "creating missing" in caplog.text
+        assert "subscription_users" in caplog.text
+        assert "user_storage_usage" in caplog.text
 
         sub = (
             db.query(UserSubscription)
@@ -321,6 +331,7 @@ class TestUpdateUserSubscriptionAdminCRUD:
             .one()
         )
         assert sub.plan_id == PREMIUM_PLAN
+        assert sub.scheduled_downgrade is False
         assert storage.storage_quota_bytes == 214748364800
 
         log = db.query(SubscriptionAuditLog).one()
@@ -364,7 +375,7 @@ class TestUpdateUserSubscriptionAdminCRUD:
         assert log.old_value["plan_id"] is None
         assert log.old_value["storage_quota_bytes"] == 5368709120
 
-    def test_updates_existing_rows(self, db, seeded_user, admin_user):
+    def test_updates_existing_rows(self, db, seeded_user, admin_user, caplog):
         db.add(
             UserSubscription(
                 user_id=seeded_user,
@@ -387,7 +398,11 @@ class TestUpdateUserSubscriptionAdminCRUD:
             storage_quota_bytes=5368709120,
             reason="downgrade to free",
         )
-        _call(db, seeded_user, data, admin_user)
+        with caplog.at_level(logging.WARNING):
+            _call(db, seeded_user, data, admin_user)
+
+        # Both rows existed -> no "creating missing" warning.
+        assert "creating missing" not in caplog.text
 
         assert (
             db.query(UserSubscription)
@@ -414,3 +429,83 @@ class TestUpdateUserSubscriptionAdminCRUD:
             _call(db, seeded_user, data, admin_user)
         assert exc.value.status_code == 400
         assert db.query(UserSubscription).count() == 0
+
+    def test_creates_storage_when_only_subscription_exists(
+        self, db, seeded_user, admin_user, caplog
+    ):
+        db.add(
+            UserSubscription(
+                user_id=seeded_user,
+                plan_id=PREMIUM_PLAN,
+                expiration=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        db.commit()
+
+        data = UserSubscriptionUpdate(
+            plan_id=FREE_PLAN,
+            expiration=None,
+            storage_quota_bytes=5368709120,
+            reason="repair storage",
+        )
+        with caplog.at_level(logging.WARNING):
+            _call(db, seeded_user, data, admin_user)
+
+        # Only storage was missing -> the warning names it and not the
+        # subscription table (guards against inverted label/flag pairing).
+        assert "user_storage_usage" in caplog.text
+        assert "subscription_users" not in caplog.text
+
+        assert (
+            db.query(UserStorageUsage)
+            .filter(UserStorageUsage.user_id == seeded_user)
+            .one()
+            .storage_quota_bytes
+            == 5368709120
+        )
+        log = db.query(SubscriptionAuditLog).one()
+        # subscription existed -> its old plan recorded; storage did not -> null.
+        assert log.old_value["plan_id"] == PREMIUM_PLAN
+        assert log.old_value["storage_quota_bytes"] is None
+
+
+class TestInsertOrReselect:
+    """The SAVEPOINT + IntegrityError -> re-select concurrency guard."""
+
+    def test_returns_existing_row_on_unique_conflict(self, db, seeded_user):
+        existing = UserSubscription(
+            user_id=seeded_user,
+            plan_id=PREMIUM_PLAN,
+            expiration=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        db.add(existing)
+        db.commit()
+
+        # A concurrent writer's row would collide on the user_id unique
+        # constraint; the guard must return the winner, not the duplicate.
+        duplicate = UserSubscription(
+            user_id=seeded_user,
+            plan_id=FREE_PLAN,
+            expiration=datetime(2027, 1, 1, tzinfo=timezone.utc),
+        )
+        result = crud_users._insert_or_reselect(
+            db, duplicate, UserSubscription, seeded_user
+        )
+
+        assert result.plan_id == PREMIUM_PLAN
+        assert (
+            db.query(UserSubscription)
+            .filter(UserSubscription.user_id == seeded_user)
+            .count()
+            == 1
+        )
+
+    def test_reraises_when_no_existing_row(self, db):
+        from sqlalchemy.exc import IntegrityError
+
+        # expiration is NOT NULL: this raises IntegrityError on flush for a
+        # reason other than the unique constraint, and no row exists to
+        # re-select, so the error must propagate rather than be swallowed.
+        bad = UserSubscription(user_id=424242, plan_id=PREMIUM_PLAN, expiration=None)
+        with pytest.raises(IntegrityError):
+            crud_users._insert_or_reselect(db, bad, UserSubscription, 424242)


### PR DESCRIPTION
### Content

#### Summary
- The admin Account Manager could only *update* an existing subscription. For a
  user with no `subscription_users` row (never-subscribed free user, or a user
  whose subscription was removed during test cleanup), `PUT
  /admin/users/{id}/subscription` returned `400 "User has no subscription
  record"` and there was no create path — the only recourse was raw SQL.
- `update_user_subscription_admin` is now an **upsert**: when the
  `subscription_users` and/or `user_storage_usage` row is missing it is created
  with the submitted plan/quota; when it exists the prior behavior is unchanged.
  The audit log records missing rows as `null` in `old_value` so the entry
  reads as "created" rather than "edited".

#### Design Decisions
- **Upsert the existing PUT rather than add a POST.** Smallest change that makes
  the one endpoint the UI already calls complete; no new route, no frontend
  branching on "does a record exist".
- **Audit snapshot fields made optional.** `SubscriptionAuditSnapshot.plan_id`
  and `storage_quota_bytes` were non-nullable; recording a genuinely-absent row
  as `None` would have raised a pydantic `ValidationError` and turned the 400
  into a 500. They are now `Optional`. `new_value` is still always fully
  populated from `UserSubscriptionUpdate`, so the relaxation only affects
  `old_value`.
- **Two independent existence flags, not one.** The two rows are queried
  separately and can be missing independently (partial cleanup). Each of
  `subscription_existed` / `storage_existed` gates only its own field in the
  audit `old_value`, so a mixed state is recorded truthfully.
- **Concurrency guard mirrors the checkout path.** Both target tables are unique
  on `user_id`. `_insert_or_reselect` wraps each insert in a `SAVEPOINT`
  (`begin_nested`) and, on `IntegrityError`, re-selects the row a concurrent
  writer created — the same pattern `CheckoutService` already uses — instead of
  surfacing a spurious 500.
- **Premium requires an expiration.** A new premium subscription created without
  an expiration would be born already expired (`expiration or now()`). The
  endpoint now rejects premium with no expiration (400); free still defaults to
  now, which is meaningless for free and matches signup provisioning.
- **Storage bucket intentionally not provisioned here.** This is a
  record-repair path; a user missing these rows in practice already has a bucket
  from signup. Documented inline with the upgrade path
  (`ensure_user_bucket_exists`) if that assumption ever changes. Bucket/storage
  provisioning is out of scope per the issue.

### Evidence
```
$ docker-compose -f docker-compose.test.yml run --rm -w /app test_studio_backend \
    python -m pytest studio/tests/app/common/routers/test_users_admin_subscription.py -q
20 passed, 43 warnings in 0.38s

# no cross-contamination from the test module's sqlite type/DDL shims:
$ ... python -m pytest studio/tests/app/common/routers \
    studio/tests/app/common/core/subscription studio/tests/app/common/schemas -q
495 passed, 3 skipped, 45 warnings in 16.99s
```

### References
- Issue #720 — "Admin GUI cannot change a user's plan / quota if no subscription record"
- Prior art for the concurrency guard: `CheckoutService` subscription insert
  (`begin_nested` + `IntegrityError` fallback-to-update).

#### Files changed
- `studio/app/common/core/users/crud_users.py` — `update_user_subscription_admin`
  now upserts both rows instead of 400-ing when they are missing; independent
  `subscription_existed` / `storage_existed` flags drive an honest audit
  `old_value`; premium without an expiration is rejected with 400. New helper
  `_insert_or_reselect` guards the inserts against the unique-constraint race.
- `studio/app/common/schemas/users.py` — `SubscriptionAuditSnapshot.plan_id` and
  `storage_quota_bytes` made `Optional[int]` so `old_value` can represent a row
  that did not exist.
- `studio/tests/app/common/routers/test_users_admin_subscription.py` — added a
  DB-backed `TestUpdateUserSubscriptionAdminCRUD` class exercising the upsert,
  plus snapshot tests for the all-null / mixed-null cases. Includes SQLite shims
  (BIGINT→INTEGER compilation, stripping MySQL `ON UPDATE` defaults, per-table
  `create_all`) so the MySQL-shaped models can run under an in-memory session.

### Manual Testcases
1. **Never-subscribed user.** As an org admin, pick a user where `SELECT * FROM
   subscription_users WHERE user_id = {N}` is empty. In the Account Manager set
   their plan and storage quota and save.
   - Expected: request returns 200; `subscription_users` and `user_storage_usage`
     rows now exist with the chosen plan and `storage_quota_bytes`; a
     `subscription_audit_log` row records the change with `old_value` fields
     null.
2. **Existing subscriber (regression).** As an admin, change plan/quota for a
   user who already has both rows.
   - Expected: 200; rows updated in place; audit `old_value` reflects the real
     prior plan/quota.
3. **Premium without expiration.** As an admin, submit `plan_id = premium` with
   no expiration.
   - Expected: 400 "expiration is required for the premium plan"; no rows
     created or changed.
4. Automated: `docker-compose -f docker-compose.test.yml run --rm -w /app
   test_studio_backend python -m pytest
   studio/tests/app/common/routers/test_users_admin_subscription.py` — all 20
   tests pass.

### Unit, Integration, Contract Test Coverage
- Schema: existing `UserSubscriptionUpdate` / `SubscriptionAuditSnapshot`
  validation tests, plus new all-null and mixed-null snapshot cases.
- CRUD (in-memory DB session): both rows created when missing; subscription
  created when only storage exists (mixed, audit records real old quota + null
  plan); existing rows updated with prior values captured in the audit; premium
  without expiration rejected and nothing written.

### Others

#### Difficulties
- No DB-session fixture existed for these CRUD functions. The models use
  MySQL-specific constructs (`BIGINT` primary keys, `ON UPDATE CURRENT_TIMESTAMP`
  server defaults) that in-memory SQLite cannot create or autoincrement. The
  test builds only the four tables it touches, strips the MySQL `ON UPDATE`
  default, and compiles `BIGINT`→`INTEGER` on the SQLite dialect. These shims
  are confined to the test module and were verified not to affect the broader
  suite (495 passed).

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `update_user_subscription_admin` (admin-only) | Low | Single admin endpoint; existing update path behavior unchanged; new branch covered by tests. |
| `SubscriptionAuditSnapshot` schema | Low | Only consumers are this function's two `.dict()` calls into JSON audit columns; nothing reads the fields back expecting non-null; `new_value` still fully populated. |
| Concurrency | Low | `begin_nested` + `IntegrityError` fallback mirrors the proven checkout path; on the near-impossible double-admin race one request updates instead of 500-ing. |
| Storage bucket | Low | Path intentionally does not provision a bucket; target users already have one from signup. Documented inline. Separate from the raw-vs-effective quota enforcement bug tracked in the issue. |
