### PR TITLE
Fix stale (out-of-order) premium failure stranding premium routing

### DIFF
--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -308,6 +308,59 @@ describe("PremiumAssignmentProvider — unreachable state machine", () => {
     )
   })
 
+  test("stale failure that tears routing down must not strand premium routing", async () => {
+    // Phase 2 repro (grievance B). The axios teardown choke-point has no
+    // staleness knowledge: past warm-up it tears premiumAssigned down on any
+    // 5xx. The machine, however, suppresses a stale failure (older sentAt than
+    // the last reachable) and never flips to unreachable — so no recovery probe
+    // arms. Nothing re-arms premiumAssigned → premium routing is stranded on
+    // free tier until the next reload.
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Healthy, dedicated, steady state: clear the warm-up window so the
+    // interceptor teardown is no longer warm-up-suppressed.
+    act(() => {
+      routingService.setPremiumAssigned(true)
+      routingService.clearPremiumWarmup()
+    })
+    expect(routingService.isWithinPremiumWarmup()).toBe(false)
+
+    // A successful premium response sets the reachable watermark at sentAt=2000.
+    act(() => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+    })
+
+    // A request sent earlier (sentAt=1500) 5xxs late. Mirror the axios choke-point
+    // (tearDownPremiumRoutingUnlessWarmup): past warm-up it still skips teardown
+    // for a stale failure, so routing is left intact.
+    act(() => {
+      const detail = { status: 503, sentAt: 1500 }
+      if (
+        !routingService.isWithinPremiumWarmup() &&
+        !routingService.isStalePremiumFailure(detail.sentAt)
+      ) {
+        routingService.setPremiumAssigned(false)
+        routingService.emitPremiumUnreachable(detail)
+      }
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // The failure is recognized as stale (1500 < watermark 2000), so the
+    // choke-point never tears routing down and the machine never flips.
+    expect(routingService.isStalePremiumFailure(1500)).toBe(true)
+    expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+
+    // Invariant: a stale failure must not downgrade routing to free tier.
+    expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+
   test("peer UNREACHABLE broadcast applies state including failed_probes/is_terminal", async () => {
     mockedGetStatus.mockResolvedValue(dedicatedStatus)
     const ctxRef = renderProvider()

--- a/frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts
+++ b/frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts
@@ -11,7 +11,6 @@ import {
   computeNextProbeDelayMs,
   computeProbeFailure,
   hasReachedProbeCap,
-  isStaleFailure,
   shouldClearUnreachableForAssignment,
   shouldFlipToUnreachable,
   shouldHydrateFromSnapshot,
@@ -122,33 +121,6 @@ describe("hasReachedProbeCap", () => {
 
   it("returns true beyond the cap", () => {
     expect(hasReachedProbeCap(MAX_FAILED_PROBES + 10)).toBe(true)
-  })
-})
-
-describe("isStaleFailure", () => {
-  it("suppresses a failure whose request predates the last reachable", () => {
-    expect(isStaleFailure(100, 200, 300)).toBe(true)
-  })
-
-  it("does not suppress a failure newer than the last reachable", () => {
-    expect(isStaleFailure(300, 200, 400)).toBe(false)
-  })
-
-  it("does not suppress when detail.sentAt equals lastReachable", () => {
-    // Equal sentAt means the failure is no older than the success — treat
-    // as current evidence rather than stale.
-    expect(isStaleFailure(200, 200, 300)).toBe(false)
-  })
-
-  it("falls back to now when sentAt is undefined (treat event as current)", () => {
-    // Undefined sentAt should behave as a fresh event — no suppression.
-    expect(isStaleFailure(undefined, 200, 300)).toBe(false)
-  })
-
-  it("suppresses undefined-sentAt event only if now predates lastReachable", () => {
-    // Contrived: a listener fires with now < lastReachable (clock went back
-    // or tests inject explicit timestamps). Still the defined semantics.
-    expect(isStaleFailure(undefined, 500, 400)).toBe(true)
   })
 })
 

--- a/frontend/src/contexts/premium/unreachableMachine.ts
+++ b/frontend/src/contexts/premium/unreachableMachine.ts
@@ -50,16 +50,6 @@ export const computeNextProbeDelayMs = (failedProbes: number): number =>
 export const hasReachedProbeCap = (failedProbes: number): boolean =>
   failedProbes >= MAX_FAILED_PROBES
 
-// True when the failure's request predates the last reachable — stale evidence, do not act on it.
-export const isStaleFailure = (
-  detailSentAt: number | undefined,
-  lastReachableSentAt: number,
-  now: number,
-): boolean => {
-  const sentAt = detailSentAt ?? now
-  return sentAt < lastReachableSentAt
-}
-
 export const computeProbeFailure = (
   prevFailed: number,
 ): { nextFailed: number; nextTerminal: boolean } => {

--- a/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
+++ b/frontend/src/contexts/premium/useInstanceUnreachableMachine.ts
@@ -16,7 +16,6 @@ import {
   UnreachableSnapshot,
   computeNextProbeDelayMs,
   computeProbeFailure,
-  isStaleFailure,
   shouldClearUnreachableForAssignment,
   shouldHydrateFromSnapshot,
   unreachableMachineReducer,
@@ -66,7 +65,7 @@ export interface UseInstanceUnreachableMachineArgs {
 export interface InstanceUnreachableHandle {
   state: UnreachableMachineState
   retryProbe: () => void
-  // Clears the refs the reducer doesn't own (hydrated, watermark, snapshot, prev-instance). Use on explicit release/logout.
+  // Clears the refs the reducer doesn't own (hydrated, snapshot, prev-instance). Use on explicit release/logout.
   reset: () => void
 }
 
@@ -88,8 +87,6 @@ export function useInstanceUnreachableMachine({
   const hydratedFromSnapshotRef = useRef(false)
   // Gate for snapshot writes — a fresh tab must not wipe a peer's snapshot before hydrating.
   const hasEverBeenUnreachableRef = useRef(false)
-  // Watermark for suppressing out-of-order failures older than the last success.
-  const lastReachableSentAtRef = useRef(0)
   // Last dedicated instance_id — lets the effect below detect a reassignment to a different instance.
   const prevDedicatedInstanceIdRef = useRef<string | undefined>(undefined)
   // Timestamp of the most recent transition onto a dedicated instance (initial
@@ -160,13 +157,9 @@ export function useInstanceUnreachableMachine({
         return
       }
 
-      if (
-        isStaleFailure(
-          detail.sentAt,
-          lastReachableSentAtRef.current,
-          Date.now(),
-        )
-      ) {
+      // Stale/out-of-order failure — suppressed at the same watermark the axios
+      // teardown choke-point uses (single source of truth in RoutingService).
+      if (routingService.isStalePremiumFailure(detail.sentAt)) {
         return
       }
 
@@ -238,12 +231,9 @@ export function useInstanceUnreachableMachine({
       })
     })
 
-    const unsubReachable = routingService.onPremiumReachable((detail) => {
-      // Update watermark even when healthy — a later stale failure still needs suppression.
-      const sentAt = detail.sentAt ?? Date.now()
-      if (sentAt > lastReachableSentAtRef.current) {
-        lastReachableSentAtRef.current = sentAt
-      }
+    const unsubReachable = routingService.onPremiumReachable(() => {
+      // The reachable watermark is advanced in RoutingService.emitPremiumReachable
+      // (before listeners run), so no local bookkeeping is needed here.
       if (!unreachableRef.current) return
       probingRef.current = false
       unreachableRef.current = false
@@ -405,7 +395,6 @@ export function useInstanceUnreachableMachine({
     probingRef.current = false
     hydratedFromSnapshotRef.current = false
     hasEverBeenUnreachableRef.current = false
-    lastReachableSentAtRef.current = 0
     prevDedicatedInstanceIdRef.current = undefined
     dedicatedSinceRef.current = null
     dispatch({ type: "CLEAR" })

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -44,6 +44,9 @@ const mockGetPremiumInstanceId = jest.fn<string | null, []>(() => null)
 const mockIsPremiumAssigned = jest.fn<boolean, []>(() => false)
 const mockGetRoutingToken = jest.fn<string | null, []>(() => null)
 const mockIsWithinPremiumWarmup = jest.fn<boolean, []>(() => false)
+const mockIsStalePremiumFailure = jest.fn<boolean, [number | undefined]>(
+  () => false,
+)
 
 const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
   () => false,
@@ -72,6 +75,7 @@ jest.mock("utils/routing/RoutingService", () => ({
     isPremiumAssigned: mockIsPremiumAssigned,
     getRoutingToken: mockGetRoutingToken,
     isWithinPremiumWarmup: mockIsWithinPremiumWarmup,
+    isStalePremiumFailure: mockIsStalePremiumFailure,
   },
 }))
 
@@ -612,6 +616,39 @@ describe("axios premium-routing interceptors", () => {
     // Falls back so the request still resolves...
     expect(res.status).toBe(200)
     // ...but premium routing is NOT torn down during warm-up.
+    expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+  })
+
+  it("does NOT clear premiumAssigned on a stale 502/503 (older than the last reachable)", async () => {
+    // A late-arriving 5xx whose request was sent before the last confirmed-
+    // reachable response is an out-of-order echo, not a live outage. Past warm-up
+    // the choke-point still skips teardown: the machine suppresses the stale
+    // event (never flips), so tearing down here would strand premium routing.
+    mockRequiresPremiumRouting.mockReturnValue(true)
+    mockIsWithinPremiumWarmup.mockReturnValue(false)
+    mockIsStalePremiumFailure.mockReturnValue(true)
+
+    let callCount = 0
+    responses.set("/stale-5xx", () => {
+      callCount += 1
+      if (callCount === 1) {
+        return { status: 503, data: { detail: "late echo" } }
+      }
+      return { status: 200, data: { ok: true }, headers: {} }
+    })
+    mockGetRoutingHeaders
+      .mockReturnValueOnce({
+        "X-Routing-ID": "rid-outgoing",
+        "X-User-Tier": "premium",
+      })
+      .mockReturnValue({})
+
+    const res = await axiosInstance.get("/stale-5xx")
+
+    // Falls back so the request still resolves...
+    expect(res.status).toBe(200)
+    // ...but a stale failure never tears premium routing down.
     expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
     expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
   })

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -229,6 +229,11 @@ const tearDownPremiumRoutingUnlessWarmup = (
   detail: PremiumUnreachableDetail,
 ): void => {
   if (routingService.isWithinPremiumWarmup()) return
+  // Stale/out-of-order failure (request sent before the last confirmed-reachable
+  // response) — an echo, not a live outage. Tearing down here would strand
+  // routing, since the state machine suppresses the event and never arms a
+  // recovery probe.
+  if (routingService.isStalePremiumFailure(detail.sentAt)) return
   routingService.setPremiumAssigned(false)
   routingService.emitPremiumUnreachable(detail)
 }

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -753,4 +753,65 @@ describe("RoutingService", () => {
       expect(routingService.isWithinPremiumWarmup()).toBe(false)
     })
   })
+
+  describe("reachable watermark / stale premium failure", () => {
+    const T0 = 1_000_000
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(T0)
+      routingService = new RoutingService()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    test("no failure is stale before any reachable is observed", () => {
+      expect(routingService.isStalePremiumFailure(100)).toBe(false)
+    })
+
+    test("emitPremiumReachable advances the watermark; an older failure is stale", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      expect(routingService.isStalePremiumFailure(1500)).toBe(true)
+    })
+
+    test("a failure newer than the watermark is not stale", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      expect(routingService.isStalePremiumFailure(2500)).toBe(false)
+    })
+
+    test("a failure sent at exactly the watermark is not stale", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      expect(routingService.isStalePremiumFailure(2000)).toBe(false)
+    })
+
+    test("undefined sentAt is treated as now — not stale when the watermark is in the past", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      expect(routingService.isStalePremiumFailure(undefined)).toBe(false)
+    })
+
+    test("undefined sentAt is stale only if now predates the watermark", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: T0 + 5000 })
+      expect(routingService.isStalePremiumFailure(undefined)).toBe(true)
+    })
+
+    test("the watermark is monotonic — an older reachable does not lower it", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      routingService.emitPremiumReachable({ status: 200, sentAt: 1000 })
+      expect(routingService.isStalePremiumFailure(1500)).toBe(true)
+    })
+
+    test("clearRoutingInfo resets the watermark", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      routingService.clearRoutingInfo()
+      expect(routingService.isStalePremiumFailure(1500)).toBe(false)
+    })
+
+    test("resetForRelease resets the watermark", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      routingService.resetForRelease()
+      expect(routingService.isStalePremiumFailure(1500)).toBe(false)
+    })
+  })
 })

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -813,5 +813,11 @@ describe("RoutingService", () => {
       routingService.resetForRelease()
       expect(routingService.isStalePremiumFailure(1500)).toBe(false)
     })
+
+    test("updateRoutingInfo downgrade to free resets the watermark", () => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+      routingService.updateRoutingInfo(createFreeUser())
+      expect(routingService.isStalePremiumFailure(1500)).toBe(false)
+    })
   })
 })

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -65,6 +65,11 @@ export class RoutingService {
   private premiumInstanceId: string | null = null
   // Warm-up grace window (epoch ms) after a fresh dedicated assignment.
   private premiumWarmupUntil: number | null = null
+  // Monotonic sentAt of the last response confirmed to come from the assigned
+  // instance. A failure whose request was sent before this is a stale/out-of-order
+  // echo; the teardown choke-point and the state machine use it to ignore such
+  // failures instead of tearing routing down.
+  private lastReachableSentAt = 0
   private lastFetch: number = 0
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
   // Warm-up grace duration. Intentionally longer than DEDICATED_HANDOFF_GRACE_MS
@@ -181,6 +186,7 @@ export class RoutingService {
     this.premiumAssigned = false
     this.premiumInstanceId = null
     this.premiumWarmupUntil = null
+    this.lastReachableSentAt = 0
     this.lastFetch = 0
     this.clearTokenFromStorage()
     this.clearTierFromStorage()
@@ -207,6 +213,7 @@ export class RoutingService {
     this.setPremiumAssigned(false)
     this.setPremiumInstanceId(null)
     this.clearRoutingToken()
+    this.lastReachableSentAt = 0
   }
 
   /**
@@ -278,6 +285,16 @@ export class RoutingService {
     this.premiumWarmupUntil = null
   }
 
+  /**
+   * Whether a premium failure is stale — its request was sent before the last
+   * response confirmed reachable, so it is an out-of-order echo rather than a
+   * live outage. The teardown choke-point and the state machine both consult
+   * this so a stale failure never tears premium routing down.
+   */
+  isStalePremiumFailure(sentAt: number | undefined): boolean {
+    return (sentAt ?? Date.now()) < this.lastReachableSentAt
+  }
+
   // Pure notifier — telemetry lives in listeners so tests can emit without side effects.
   onPremiumUnreachable(listener: PremiumUnreachableListener): () => void {
     this.unreachableListeners.add(listener)
@@ -305,6 +322,12 @@ export class RoutingService {
   }
 
   emitPremiumReachable(detail: PremiumReachableDetail): void {
+    // Advance the reachable watermark before notifying — the teardown
+    // choke-point and the state machine read it to suppress stale failures.
+    const sentAt = detail.sentAt ?? Date.now()
+    if (sentAt > this.lastReachableSentAt) {
+      this.lastReachableSentAt = sentAt
+    }
     this.reachableListeners.forEach((listener) => {
       try {
         listener(detail)

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -171,6 +171,9 @@ export class RoutingService {
     if (!isPremium) {
       this.setPremiumAssigned(false)
       this.setPremiumInstanceId(null)
+      // Reset the reachable watermark alongside clearRoutingInfo / resetForRelease
+      // so all three "premium goes away" paths leave watermark state consistent.
+      this.lastReachableSentAt = 0
     }
 
     this.lastFetch = Date.now()


### PR DESCRIPTION
## Summary

A late-arriving **stale** premium `5xx` — a failure whose request was sent *before*
a later successful response — tore premium routing down while the state machine
suppressed the same failure as stale. Because the machine never flipped to
unreachable, the recovery probe never armed, so nothing re-enabled routing:
premium was silently downgraded to free tier until the next reload.

This is a **pre-existing** bug that predates #745, surfaced while investigating a
reload/new-tab stranding report and split out to keep #745 scoped. See Relationship
to Other Work for how it sits beside #745.

---

## Root Cause

Two independent layers, coupled by an unstated invariant:

- The axios teardown choke-point (`tearDownPremiumRoutingUnlessWarmup`) tears
  `premiumAssigned` down on any premium `5xx` past warm-up. It has **no staleness
  knowledge**.
- The reachable **watermark** (the `sentAt` of the last response confirmed to come
  from the assigned instance) lived **only in the state machine**
  (`lastReachableSentAtRef`). The machine uses it to **suppress** out-of-order
  failures — it never flips to unreachable for a stale one.

So on a stale failure: axios sets `premiumAssigned = false`, the machine suppresses
the event (no flip), and the half-open recovery probe — gated on
`instanceUnreachable` — never arms. Nothing re-enables routing → stranded.

This is the **same invariant** already established for the warm-up case ("a suppressed
event must not leave routing torn down"), left unmet for the *staleness* suppression
path.

**Timing dependency**: requires two concurrent premium requests where the older one
fails *after* the newer one succeeds (advancing the watermark). Realistic under
normal concurrent SPA traffic; not deterministically reproducible by hand.

---

## Fix — staleness at the choke-point, watermark as single source of truth

Keep the teardown decision in one place with all signals, and give the watermark a
single owner so the machine and axios can never disagree.

- **`RoutingService`** owns the reachable watermark (`lastReachableSentAt`),
  advanced in `emitPremiumReachable`; exposes `isStalePremiumFailure(sentAt)`;
  resets it in `clearRoutingInfo` / `resetForRelease`.
- **`axios`** (`tearDownPremiumRoutingUnlessWarmup`) skips teardown for a stale
  failure alongside the warm-up guard — a stale failure now neither tears down nor
  emits.
- **`useInstanceUnreachableMachine`** drops its local watermark ref and delegates
  the stale check to `routingService.isStalePremiumFailure` (same source as the
  choke-point).
- **`unreachableMachine`** — remove the now-unused pure `isStaleFailure` (logic
  moved into `RoutingService`).

**Why this layer**: the root cause of this class of bug is two layers holding
independent state under an unstated invariant. Consolidating the teardown decision
into the single choke-point and making the watermark a single source of truth
closes the class, not just the symptom.

---

## Files changed

### Frontend — source

- `frontend/src/utils/routing/RoutingService.ts` — own + reset the reachable
  watermark; `isStalePremiumFailure`.
- `frontend/src/utils/axios.ts` — gate the teardown choke-point on
  `isStalePremiumFailure`.
- `frontend/src/contexts/premium/useInstanceUnreachableMachine.ts` — delegate the
  stale check to `RoutingService`; drop the local watermark ref.
- `frontend/src/contexts/premium/unreachableMachine.ts` — remove the unused pure
  `isStaleFailure`.

### Frontend — tests

- `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` — a stale `502/503`
  (past warm-up) does NOT tear routing down (guards the real choke-point).
- `frontend/src/utils/routing/RoutingService.test.ts` — reachable-watermark advance,
  `isStalePremiumFailure` (older / newer / equal / undefined / monotonic), reset
  paths.
- `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx` —
  end-to-end repro: a stale failure keeps `premiumAssigned` true (routing not
  stranded) while the machine still suppresses the flip.
- `frontend/src/contexts/premium/__tests__/unreachableMachine.test.ts` — remove the
  pure `isStaleFailure` tests (coverage relocated to `RoutingService.test.ts`).

---

## Automated verification

```
cd frontend
CI=true yarn test --testPathPattern "premium|Premium|routing|Routing"
```

- All premium/routing suites pass.
- **Red/green verified**: the interceptor guard test fails if the staleness guard
  is removed from the choke-point; the integration repro failed before the fix
  (`premiumAssigned` stayed false) and passes after.

---

## Manual Test Plan

### Injecting the failure — why a proxy, not DevTools request-block alone

Unlike #745 (where any single warm-up `5xx`/network error reproduces the bug), this
fix hinges on **relative ordering**, not just failure injection. The repro needs two
concurrent premium requests where the **older** one (smaller `sentAt`) fails
**after** the **newer** one succeeds and advances the reachable watermark. DevTools'
"Network request blocking" can inject a failure (a blocked request surfaces as a
network error and hits the same `(502/503 || network error) && requiresPremiumRouting()`
choke-point), but it **cannot control the arrival order**, which is the crux here.

So DevTools request-block is reusable for *failure injection* but is **not
sufficient** on its own for the stale case. Use a local proxy to make the ordering
deterministic; keep DevTools open only for verification (Network tab).

**Deterministic recipe (local proxy — mitmproxy / Charles / Fiddler)**

Configure the proxy to hold and fail exactly the **first** matching premium data
request, and pass everything else through:

- Match a premium **data** request that carries the `X-Routing-ID` request header
  (e.g. an experiments/workspace list or a `/run/result` poll). **Never** match
  `/users/me/premium/status` or `/assign`.
- For the **first** matched request: delay ~2–3 s, then return `503` (this becomes
  the older request that fails late).
- Let **subsequent** matched requests pass through with their real `200` from the
  dedicated instance (this becomes the newer request that succeeds first).

mitmproxy sketch (`mitmproxy -s stale.py`):

```python
# stale.py — fail only the FIRST premium data request, after a delay
import time
_failed_once = False

def request(flow):
    global _failed_once
    if "X-Routing-ID" not in flow.request.headers:
        return
    if "/premium/status" in flow.request.path or "/premium/assign" in flow.request.path:
        return
    if not _failed_once:
        _failed_once = True
        time.sleep(2.5)  # let a later request return 200 first → advances the watermark
        flow.response = http.Response.make(503, b"stale-injected", {"Content-Type": "text/plain"})
```

---

### Test 1 (OPTIONAL — automated-covered): A stale (out-of-order) 5xx does NOT strand premium routing

**Status**: *Optional.* The positive behavior this test targets is already covered
**deterministically** by the automated suites — `axiosPremiumInterceptor.test.ts`
(stale `502/503` past warm-up does not tear down), `RoutingService.test.ts`
(`isStalePremiumFailure`), and the `PremiumUnreachableIntegration.test.tsx`
end-to-end repro — with red/green verification. **There is no dependency-free manual
reproduction**: forcing the stale ordering requires delaying one specific failure,
which needs injected control (a proxy or a Console fetch/XHR patch) — DevTools
request-block fails instantly and only produces the *non-stale* ordering (Test 2).
So the only manual option is the proxy recipe below, and it mainly reconstructs what
the integration test already asserts. **Run it only if a proxy is readily available;
otherwise rely on the automated coverage** and treat Test 2 + the baseline as the
required manual gate.

**Objective**: A late-arriving `5xx` whose request was sent *before* a later
successful response must not downgrade premium routing to free tier.

**Prerequisites**
- A premium user with a healthy dedicated assignment.
- The proxy configured as above (required for a deterministic run; there is no
  proxy-free manual alternative for the stale ordering).
- DevTools open (Network tab, "Preserve log" on); premium telemetry is verified via
  `POST /users/me/premium/ui-event`.
- **Baseline (no-failure happy path)**: with no `5xx` injected, fire a few premium
  requests and confirm they all return `200` from the dedicated instance carrying
  `x-routing-id`, and that **no** `instance_unreachable` ui-event is sent. This
  guards that recording the reachable watermark on the success path did not disturb
  normal routing. (No separate test case needed — the watermark advance is also
  covered by `RoutingService.test.ts`.)

**Steps (deterministic — proxy)**
1. Establish a healthy dedicated assignment; wait past the ~15 s warm-up (so the
   result is attributed to staleness, not the warm-up grace).
2. With the proxy armed, trigger the target premium request **twice** in quick
   succession (two actions on the same page, or throttle + a repeated poll) so both
   are in flight together. The first is held ~2.5 s then `503`; the second returns
   `200` from the dedicated instance first and advances the watermark.
3. **Verify (Network)**: the late `503` falls back to free tier and resolves, and
   **no** `event_type: "instance_unreachable"` ui-event is sent (it is suppressed as
   stale).
4. **Verify (routing preserved)**: disable the proxy rule, then trigger another
   premium request — it still carries `x-routing-id` / instance headers and is served
   by the dedicated instance (`premiumAssigned` stayed true).
5. **Contrast (pre-fix)**: before this fix, the stale `503` tore routing down and it
   never re-armed (free tier until the next reload).

**Checkpoint**: an out-of-order failure is ignored at the routing layer, not
mistaken for a live outage.

---

### Test 2 (REQUIRED manual gate): A genuine, non-stale 5xx STILL tears routing down + warns (regression guard)

**Status**: *Required — proxy not needed.* Together with the baseline in Test 1's
prerequisites, this is the manual coverage that the automated tests cannot fully
substitute: confirming the change did not degrade real premium routing. A **single**
failing request is enough — no proxy, no ordering control. **The REQUIRED gate is
steps 1–4 (teardown + emit).**
Auto-recovery is *informational only* — see the recovery note after step 4; do **not**
block #750 on observing it (a pre-existing recovery bug, #754, confounds it).

**Objective**: The new `isStalePremiumFailure` gate must suppress **only** truly
out-of-order failures. A normal failure — one whose request was sent **at or after**
the last reachable response (`sentAt >= watermark`) — must still tear premium routing
down and surface the warning, exactly as before this PR. This is the primary
regression the staleness gate could introduce (over-suppression of legitimate
failures).

**Prerequisites**
- A premium user with a healthy dedicated assignment.
- DevTools open (Network tab, "Preserve log" on). No proxy required — a **single**
  failing request suffices (same failure-injection method as in #745's Test 2).

**Steps**
1. Establish a healthy dedicated assignment; wait past the ~15 s warm-up window.
2. Make the instance fail a **single, current** premium request (newest in flight):
   e.g. `aws ec2 stop-instances --instance-ids <instance_id>`, or DevTools
   request-block on that one request's URL. Because no later success follows it, its
   `sentAt` is at/after the watermark → **not** stale.
3. Trigger a premium-routed request so it hits the `502/503` / network-error path.
4. **Verify (Network)**: the request falls back to free tier and succeeds, and a
   `POST /users/me/premium/ui-event` with `event_type: "instance_unreachable"` **is**
   sent (the failure is **not** suppressed). *(End of the REQUIRED gate.)*
5. **Verify (UI)**: the "temporarily unreachable. Retrying…" warning appears — the
   failure is treated as a live outage, as required.

**Recovery note (informational, NOT a #750 gate)**: #750 does not change the recovery
path. Auto-recovery may not happen here — under concurrent traffic a parallel
`reachable` clears the machine without re-arming `premiumAssigned`, stranding routing
until reload. That is the pre-existing **#754**, not a #750 regression.

**Checkpoint**: the staleness gate is scoped to out-of-order failures only; a normal
outage is still detected (torn down + warned) — no regression in the genuine-failure
path.

---

## Relationship to Other Work

**Relationship to #745:**
#745 introduced the teardown choke-point and the warm-up
gate, but not the staleness gate; the bug this PR fixes (inline teardown + machine
stale suppression) predates it. It surfaced while investigating #745's reload/new-tab
stranding report: #745 keeps that reload regression (grievance A), this PR carries
the pre-existing stale bug (grievance B). Shares #745's choke-point/warm-up mechanism
— best reviewed after #745 lands (or stacked on it).
