### PR TITLE
fix: storage limit over RUN block, use correct GB

### DIFF
--- a/studio/app/common/core/cloud/cloud_utils.py
+++ b/studio/app/common/core/cloud/cloud_utils.py
@@ -2,7 +2,7 @@
 Cloud utilities for user context and subscription management.
 """
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from sqlmodel import select
@@ -20,7 +20,6 @@ from studio.app.common.core.subscription.constants import (
     StorageSize,
     SubscriptionLifecycleStatus,
     SubscriptionPeriods,
-    SubscriptionPlanIds,
     SubscriptionStatus,
     SubscriptionType,
 )
@@ -181,6 +180,65 @@ async def get_user_context_with_warnings(user_id: int) -> Optional[Dict[str, Any
         return None
 
 
+def _effective_quota_bytes(
+    status: Optional[SubscriptionLifecycleStatus], raw_quota_bytes: int
+) -> int:
+    """Storage quota actually applied, given lifecycle status.
+
+    Premium users past expiry (grace/warning/overdue) are held to the free-tier
+    limit even while their raw quota record still reads the premium quota;
+    everyone else (active, free, or an undeterminable status) uses the raw quota.
+    This is the single mapping shared by the warning banner and the enforcement
+    gates so they cannot disagree.
+    """
+    downgraded = {
+        SubscriptionLifecycleStatus.GRACE,
+        SubscriptionLifecycleStatus.WARNING,
+        SubscriptionLifecycleStatus.OVERDUE,
+    }
+    if status in downgraded:
+        return StorageQuota.FREE * StorageSize.GB
+    return raw_quota_bytes
+
+
+def get_effective_quota_bytes(
+    user_id: int, storage_info: Optional[Dict[str, Any]] = None
+) -> int:
+    """Return the storage quota to enforce for a user, in bytes.
+
+    Mirrors the effective quota that ``calculate_limit_warning`` uses so the
+    run/upload gates and the warning banner stay in agreement. Returns 0 when
+    the raw quota is unknown/disabled, letting callers skip enforcement exactly
+    as the pre-existing ``quota > 0`` guard did.
+    """
+    if storage_info is None:
+        storage_info = get_user_storage_usage(user_id)
+    raw_quota_bytes = storage_info.get("storage_quota_bytes", 0) if storage_info else 0
+    if raw_quota_bytes <= 0:
+        return 0
+
+    # Fail open to the raw quota on any lookup error: a transient DB issue must
+    # not turn a run/upload into a 500 (this runs on the request hot path).
+    try:
+        with session_scope() as db:
+            lifecycle = SubscriptionService.determine_lifecycle(db, user_id)
+    except Exception as e:
+        logger.warning(
+            f"Failed to determine subscription lifecycle for user {user_id}: {e}; "
+            f"enforcing raw quota {raw_quota_bytes}"
+        )
+        return raw_quota_bytes
+
+    if lifecycle is None:
+        logger.warning(
+            f"Could not determine subscription lifecycle for user {user_id}; "
+            f"enforcing raw quota {raw_quota_bytes}"
+        )
+        return raw_quota_bytes
+
+    return _effective_quota_bytes(lifecycle.status, raw_quota_bytes)
+
+
 async def calculate_limit_warning(user_id: int) -> Optional[LimitWarning]:
     """
     Calculate limit warning based on subscription and storage status.
@@ -197,8 +255,6 @@ async def calculate_limit_warning(user_id: int) -> Optional[LimitWarning]:
     """
     try:
         FREE_PLAN_LIMIT_BYTES = StorageQuota.FREE * StorageSize.GB
-        GRACE_PERIOD_DAYS = SubscriptionPeriods.GRACE_PERIOD_DAYS
-        WARNING_PERIOD_DAYS = SubscriptionPeriods.WARNING_PERIOD_DAYS
 
         logger.info(f"Calculating limit warning for user {user_id}")
 
@@ -233,98 +289,24 @@ async def calculate_limit_warning(user_id: int) -> Optional[LimitWarning]:
             )
             storage_quota_gb = storage_quota_bytes / StorageSize.GB
 
-            # Step 1: Determine subscription status
-            # Only look at premium subscriptions - free plan records
-            # should not trigger "premium expired" warnings
-            query_result = db.execute(
-                select(UserSubscription)
-                .where(UserSubscription.user_id == user_id)
-                .where(UserSubscription.plan_id == SubscriptionPlanIds.PREMIUM)
-                .order_by(UserSubscription.expiration.desc())
+            # Step 1: Determine subscription status.
+            # A malformed premium row (None returned) means no warning.
+            lifecycle = SubscriptionService.determine_lifecycle(db, user_id)
+            if lifecycle is None:
+                return None
+            subscription_status = lifecycle.status
+            subscription_end = lifecycle.subscription_end
+            grace_end = lifecycle.grace_end
+            deletion_date = lifecycle.deletion_date
+            days_remaining = lifecycle.days_remaining
+
+            # Step 2: Determine storage status against the effective quota
+            # (grace/warning/overdue are held to the free-tier limit), using the
+            # same mapping the enforcement gates apply.
+            effective_quota_bytes = _effective_quota_bytes(
+                subscription_status, storage_quota_bytes
             )
-            result_rows = query_result.all()
-
-            logger.info(
-                f"Found {len(result_rows)} premium subscription "
-                f"records for user {user_id}"
-            )
-
-            subscription_status = None
-            subscription_end = None
-            grace_end = None
-            deletion_date = None
-            days_remaining = None
-
-            if result_rows:
-                last_subscription_row = result_rows[0]
-
-                if hasattr(last_subscription_row, "__getitem__"):
-                    last_subscription = last_subscription_row[0]
-                else:
-                    last_subscription = last_subscription_row
-
-                # Safely access expiration with error handling
-                if hasattr(last_subscription, "expiration"):
-                    subscription_end = last_subscription.expiration
-                    if subscription_end is None:
-                        logger.error(
-                            f"User {user_id} subscription has None expiration date"
-                        )
-                        return None
-                    # Ensure subscription_end is timezone-aware for comparison
-                    if subscription_end.tzinfo is None:
-                        subscription_end = subscription_end.replace(tzinfo=timezone.utc)
-                else:
-                    logger.error(
-                        f"User {user_id} subscription object missing "
-                        f"expiration attribute: {dir(last_subscription)}"
-                    )
-                    return None
-                grace_end = subscription_end + timedelta(days=GRACE_PERIOD_DAYS)
-                deletion_date = grace_end + timedelta(days=WARNING_PERIOD_DAYS)
-                now = SubscriptionService.get_current_datetime()
-
-                logger.debug(f"User {user_id} subscription details:")
-                logger.debug(f"Subscription end: {subscription_end}")
-                logger.debug(f"Grace end: {grace_end}")
-                logger.debug(f"Deletion date: {deletion_date}")
-                logger.debug(f"Current time: {now}")
-
-                if subscription_end > now:
-                    subscription_status = SubscriptionLifecycleStatus.ACTIVE
-                elif now <= grace_end:
-                    subscription_status = SubscriptionLifecycleStatus.GRACE
-                    days_remaining = (grace_end - now).days
-                elif now <= deletion_date:
-                    subscription_status = SubscriptionLifecycleStatus.WARNING
-                    days_remaining = (deletion_date - now).days
-                else:
-                    subscription_status = SubscriptionLifecycleStatus.OVERDUE
-                    days_remaining = 0
-
-                logger.info(
-                    f"Final status: {subscription_status}, "
-                    f"days_remaining: {days_remaining}"
-                )
-            else:
-                subscription_status = (
-                    SubscriptionLifecycleStatus.FREE
-                )  # Never had premium
-
-            # Step 2: Determine storage status
-            # For users in grace/warning/overdue period, compare against free tier limit
-            # since that's what they'll have after their subscription fully expires
-            match subscription_status:
-                case (
-                    SubscriptionLifecycleStatus.GRACE
-                    | SubscriptionLifecycleStatus.WARNING
-                    | SubscriptionLifecycleStatus.OVERDUE
-                ):
-                    effective_quota_bytes = FREE_PLAN_LIMIT_BYTES
-                    effective_quota_gb = StorageQuota.FREE
-                case _:
-                    effective_quota_bytes = storage_quota_bytes
-                    effective_quota_gb = storage_quota_gb
+            effective_quota_gb = effective_quota_bytes / StorageSize.GB
 
             storage_exceeded = current_usage_bytes > effective_quota_bytes
             excess_bytes = max(0, current_usage_bytes - effective_quota_bytes)

--- a/studio/app/common/core/subscription/subscription_service.py
+++ b/studio/app/common/core/subscription/subscription_service.py
@@ -269,11 +269,14 @@ class SubscriptionService:
             .where(UserSubscription.user_id == user_id)
             .where(UserSubscription.plan_id == SubscriptionPlanIds.PREMIUM)
             .order_by(UserSubscription.expiration.desc())
+            .limit(1)
         )
         result_rows = query_result.all()
 
-        logger.info(
-            f"Found {len(result_rows)} premium subscription records for user {user_id}"
+        logger.debug(
+            "Found %d premium subscription records for user %s",
+            len(result_rows),
+            user_id,
         )
 
         if not result_rows:
@@ -322,7 +325,7 @@ class SubscriptionService:
             status = SubscriptionLifecycleStatus.OVERDUE
             days_remaining = 0
 
-        logger.info(f"Final status: {status}, days_remaining: {days_remaining}")
+        logger.debug("Final status: %s, days_remaining: %s", status, days_remaining)
 
         return SubscriptionLifecycle(
             status=status,

--- a/studio/app/common/core/subscription/subscription_service.py
+++ b/studio/app/common/core/subscription/subscription_service.py
@@ -1,15 +1,18 @@
-from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from datetime import datetime, timedelta, timezone
+from typing import List, NamedTuple, Optional, Tuple
 
 import stripe
 from fastapi import HTTPException
 from sqlalchemy import and_, exists
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from studio.app.common import models as common_model
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.subscription.constants import (
     DeletionPriority,
+    SubscriptionLifecycleStatus,
+    SubscriptionPeriods,
+    SubscriptionPlanIds,
     SubscriptionPlanType,
     SubscriptionStatusType,
     SubscriptionUserStatus,
@@ -28,6 +31,16 @@ from studio.app.common.models.user import User
 from studio.app.common.models.user_preferences import UserPreferences
 
 logger = AppLogger.get_logger()
+
+
+class SubscriptionLifecycle(NamedTuple):
+    """Resolved premium-subscription lifecycle for a user."""
+
+    status: SubscriptionLifecycleStatus
+    days_remaining: Optional[int]
+    subscription_end: Optional[datetime]
+    grace_end: Optional[datetime]
+    deletion_date: Optional[datetime]
 
 
 class SubscriptionService:
@@ -235,6 +248,88 @@ class SubscriptionService:
             )
             .order_by(common_model.UserSubscription.expiration.desc())
             .first()
+        )
+
+    @staticmethod
+    def determine_lifecycle(
+        db: Session, user_id: int
+    ) -> Optional[SubscriptionLifecycle]:
+        """Resolve a user's premium-subscription lifecycle status.
+
+        Returns FREE when the user never had premium. Returns None when a premium
+        row exists but is malformed (missing/None expiration) so callers can decide
+        how to fail: the warning banner shows nothing, enforcement falls open to
+        the raw quota.
+        """
+        GRACE_PERIOD_DAYS = SubscriptionPeriods.GRACE_PERIOD_DAYS
+        WARNING_PERIOD_DAYS = SubscriptionPeriods.WARNING_PERIOD_DAYS
+
+        query_result = db.execute(
+            select(UserSubscription)
+            .where(UserSubscription.user_id == user_id)
+            .where(UserSubscription.plan_id == SubscriptionPlanIds.PREMIUM)
+            .order_by(UserSubscription.expiration.desc())
+        )
+        result_rows = query_result.all()
+
+        logger.info(
+            f"Found {len(result_rows)} premium subscription records for user {user_id}"
+        )
+
+        if not result_rows:
+            return SubscriptionLifecycle(
+                status=SubscriptionLifecycleStatus.FREE,
+                days_remaining=None,
+                subscription_end=None,
+                grace_end=None,
+                deletion_date=None,
+            )
+
+        last_subscription_row = result_rows[0]
+        if hasattr(last_subscription_row, "__getitem__"):
+            last_subscription = last_subscription_row[0]
+        else:
+            last_subscription = last_subscription_row
+
+        if not hasattr(last_subscription, "expiration"):
+            logger.error(
+                f"User {user_id} subscription object missing "
+                f"expiration attribute: {dir(last_subscription)}"
+            )
+            return None
+
+        subscription_end = last_subscription.expiration
+        if subscription_end is None:
+            logger.error(f"User {user_id} subscription has None expiration date")
+            return None
+        if subscription_end.tzinfo is None:
+            subscription_end = subscription_end.replace(tzinfo=timezone.utc)
+
+        grace_end = subscription_end + timedelta(days=GRACE_PERIOD_DAYS)
+        deletion_date = grace_end + timedelta(days=WARNING_PERIOD_DAYS)
+        now = get_current_datetime()
+
+        days_remaining = None
+        if subscription_end > now:
+            status = SubscriptionLifecycleStatus.ACTIVE
+        elif now <= grace_end:
+            status = SubscriptionLifecycleStatus.GRACE
+            days_remaining = (grace_end - now).days
+        elif now <= deletion_date:
+            status = SubscriptionLifecycleStatus.WARNING
+            days_remaining = (deletion_date - now).days
+        else:
+            status = SubscriptionLifecycleStatus.OVERDUE
+            days_remaining = 0
+
+        logger.info(f"Final status: {status}, days_remaining: {days_remaining}")
+
+        return SubscriptionLifecycle(
+            status=status,
+            days_remaining=days_remaining,
+            subscription_end=subscription_end,
+            grace_end=grace_end,
+            deletion_date=deletion_date,
         )
 
     @staticmethod

--- a/studio/app/common/routers/files.py
+++ b/studio/app/common/routers/files.py
@@ -18,6 +18,7 @@ from studio.app.common.core.auth.auth_dependencies import (
     get_current_user,
     get_user_remote_bucket_name,
 )
+from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
 from studio.app.common.core.cloud.storage_tracking import (
     get_current_user_storage_usage,
     get_user_storage_usage,
@@ -630,9 +631,11 @@ async def create_file(
             current_user.id, force_live=False
         )
         storage_info = get_user_storage_usage(current_user.id)
+        quota_limit = get_effective_quota_bytes(
+            current_user.id, storage_info=storage_info
+        )
 
-        if storage_info and storage_info["storage_quota_bytes"] > 0:
-            quota_limit = storage_info["storage_quota_bytes"]
+        if quota_limit > 0:
             storage_usage_percent = (current_usage / quota_limit) * 100
 
             # Block file upload if over quota (100%)

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -6,6 +6,7 @@ from studio.app.common.core.auth.auth_dependencies import (
     get_current_user,
     get_user_remote_bucket_name,
 )
+from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
 from studio.app.common.core.cloud.storage_tracking import (
     get_current_user_storage_usage,
     get_user_storage_usage,
@@ -43,9 +44,9 @@ async def _check_storage_quota(user_id: int) -> None:
     """Raise 403 if user has exceeded their storage quota."""
     current_usage = await get_current_user_storage_usage(user_id, force_live=False)
     storage_info = get_user_storage_usage(user_id)
+    quota_limit = get_effective_quota_bytes(user_id, storage_info=storage_info)
 
-    if storage_info and storage_info["storage_quota_bytes"] > 0:
-        quota_limit = storage_info["storage_quota_bytes"]
+    if quota_limit > 0:
         usage_percent = (current_usage / quota_limit) * 100
 
         if usage_percent >= 100:

--- a/studio/tests/app/common/core/cloud/test_cloud_utils.py
+++ b/studio/tests/app/common/core/cloud/test_cloud_utils.py
@@ -1377,3 +1377,176 @@ def test_ensure_bucket_returns_none_when_user_not_found():
 
     assert result is None
     db.commit.assert_not_called()
+
+
+# ============================================================================
+# Tests for get_effective_quota_bytes() - shared enforcement quota (issue #721)
+# ============================================================================
+
+FREE_QUOTA_BYTES = StorageQuota.FREE * StorageSize.GB
+PREMIUM_QUOTA_BYTES = StorageQuota.PREMIUM * StorageSize.GB
+
+
+def _mock_lifecycle_db(expiration):
+    """Build a mocked session_scope whose lifecycle query returns one premium row."""
+    mock_db = Mock()
+    mock_subscription = Mock()
+    mock_subscription.expiration = expiration
+    mock_db.execute.return_value.all.return_value = [[mock_subscription]]
+    return mock_db
+
+
+def _run_effective_quota(expiration, raw_quota_bytes):
+    from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
+
+    with patch("studio.app.common.core.cloud.cloud_utils.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(expiration)
+        return get_effective_quota_bytes(
+            1, storage_info={"storage_quota_bytes": raw_quota_bytes}
+        )
+
+
+def test_effective_quota_overdue_premium_downgraded_to_free():
+    """Overdue premium with a still-raw premium record enforces the free limit."""
+    grace = SubscriptionPeriods.GRACE_PERIOD_DAYS
+    warning = SubscriptionPeriods.WARNING_PERIOD_DAYS
+    expiration = get_current_datetime() - timedelta(days=grace + warning + 5)
+
+    assert _run_effective_quota(expiration, PREMIUM_QUOTA_BYTES) == FREE_QUOTA_BYTES
+
+
+def test_effective_quota_grace_downgraded_to_free():
+    """A user just inside the grace period is held to the 5GB free limit."""
+    expiration = get_current_datetime() - timedelta(days=1)
+
+    assert _run_effective_quota(expiration, PREMIUM_QUOTA_BYTES) == FREE_QUOTA_BYTES
+
+
+def test_effective_quota_warning_downgraded_to_free():
+    """A user in the post-grace warning window is held to the 5GB free limit."""
+    grace = SubscriptionPeriods.GRACE_PERIOD_DAYS
+    expiration = get_current_datetime() - timedelta(days=grace + 1)
+
+    assert _run_effective_quota(expiration, PREMIUM_QUOTA_BYTES) == FREE_QUOTA_BYTES
+
+
+def test_effective_quota_active_premium_uses_raw():
+    """An active premium user keeps the full raw quota - no downgrade."""
+    expiration = get_current_datetime() + timedelta(days=30)
+
+    assert _run_effective_quota(expiration, PREMIUM_QUOTA_BYTES) == PREMIUM_QUOTA_BYTES
+
+
+def test_effective_quota_free_user_uses_raw():
+    """A user who never had premium (no rows) enforces their raw quota (5GB)."""
+    from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
+
+    with patch("studio.app.common.core.cloud.cloud_utils.session_scope") as mock_scope:
+        mock_db = Mock()
+        mock_db.execute.return_value.all.return_value = []  # never had premium
+        mock_scope.return_value.__enter__.return_value = mock_db
+
+        result = get_effective_quota_bytes(
+            1, storage_info={"storage_quota_bytes": FREE_QUOTA_BYTES}
+        )
+
+    assert result == FREE_QUOTA_BYTES
+
+
+def test_effective_quota_zero_raw_quota_returns_zero():
+    """Unknown/disabled quota (<=0) returns 0 so callers skip enforcement."""
+    from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
+
+    assert get_effective_quota_bytes(1, storage_info={"storage_quota_bytes": 0}) == 0
+    assert get_effective_quota_bytes(1, storage_info={}) == 0
+
+
+def test_effective_quota_malformed_row_fails_open_to_raw():
+    """A premium row with None expiration cannot be classified -> enforce raw quota."""
+    from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
+
+    with patch("studio.app.common.core.cloud.cloud_utils.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(None)
+
+        result = get_effective_quota_bytes(
+            1, storage_info={"storage_quota_bytes": PREMIUM_QUOTA_BYTES}
+        )
+
+    assert result == PREMIUM_QUOTA_BYTES
+
+
+# ============================================================================
+# Run gate uses the effective quota (issue #721)
+# ============================================================================
+
+
+def test_run_gate_blocks_overdue_user_over_effective_quota():
+    """End-to-end: _check_storage_quota raises 403 for an overdue user over the
+    free effective quota even though their raw quota record still reads premium.
+
+    get_effective_quota_bytes is NOT stubbed, so this proves the gate is wired to
+    the effective quota (the fix), not the raw storage_quota_bytes.
+    """
+    from fastapi import HTTPException
+
+    from studio.app.common.routers.run import _check_storage_quota
+
+    used = 6_886_941_631  # 6.4 GB - the issue's reproduction value
+    grace = SubscriptionPeriods.GRACE_PERIOD_DAYS
+    warning = SubscriptionPeriods.WARNING_PERIOD_DAYS
+    overdue_expiration = get_current_datetime() - timedelta(days=grace + warning + 5)
+
+    with patch(
+        "studio.app.common.routers.run.get_current_user_storage_usage",
+        new=AsyncMock(return_value=used),
+    ), patch(
+        "studio.app.common.routers.run.get_user_storage_usage",
+        return_value={"storage_quota_bytes": PREMIUM_QUOTA_BYTES},
+    ), patch(
+        "studio.app.common.core.cloud.cloud_utils.session_scope"
+    ) as mock_scope:
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(
+            overdue_expiration
+        )
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(_check_storage_quota(13))
+
+    assert exc.value.status_code == 403
+    assert "Storage quota exceeded" in exc.value.detail
+
+
+def test_run_gate_allows_active_user_under_raw_quota():
+    """End-to-end: an active premium user under their raw quota is unaffected."""
+    from studio.app.common.routers.run import _check_storage_quota
+
+    active_expiration = get_current_datetime() + timedelta(days=30)
+
+    with patch(
+        "studio.app.common.routers.run.get_current_user_storage_usage",
+        new=AsyncMock(return_value=50 * StorageSize.GB),
+    ), patch(
+        "studio.app.common.routers.run.get_user_storage_usage",
+        return_value={"storage_quota_bytes": PREMIUM_QUOTA_BYTES},
+    ), patch(
+        "studio.app.common.core.cloud.cloud_utils.session_scope"
+    ) as mock_scope:
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(
+            active_expiration
+        )
+        # Should not raise (50GB well under the raw premium effective quota)
+        asyncio.run(_check_storage_quota(1))
+
+
+def test_effective_quota_db_error_fails_open_to_raw():
+    """A DB error while resolving lifecycle must fail open to the raw quota,
+    never propagate (which would 500 the run/upload)."""
+    from studio.app.common.core.cloud.cloud_utils import get_effective_quota_bytes
+
+    with patch("studio.app.common.core.cloud.cloud_utils.session_scope") as mock_scope:
+        mock_scope.side_effect = Exception("DB connection lost")
+
+        result = get_effective_quota_bytes(
+            1, storage_info={"storage_quota_bytes": PREMIUM_QUOTA_BYTES}
+        )
+
+    assert result == PREMIUM_QUOTA_BYTES

--- a/studio/tests/app/common/core/cloud/test_cloud_utils.py
+++ b/studio/tests/app/common/core/cloud/test_cloud_utils.py
@@ -1550,3 +1550,101 @@ def test_effective_quota_db_error_fails_open_to_raw():
         )
 
     assert result == PREMIUM_QUOTA_BYTES
+
+
+# ============================================================================
+# Upload gate uses the effective quota (issue #721)
+# ============================================================================
+
+
+def _call_create_file(user_id, filename="test.tiff"):
+    """Invoke create_file for the given user. workspace_id/filename and the
+    background_tasks/file/db/remote_bucket_name args are inert for the gate: it
+    reads only current_user.id and raises before touching the rest."""
+    from studio.app.common.routers.files import create_file
+
+    return asyncio.run(
+        create_file(
+            workspace_id="1",
+            filename=filename,
+            background_tasks=Mock(),
+            file=Mock(),
+            current_user=Mock(id=user_id),
+            db=Mock(),
+            remote_bucket_name="",
+        )
+    )
+
+
+def test_upload_gate_blocks_overdue_user_over_effective_quota():
+    """End-to-end: create_file raises 403 for an overdue user over the free
+    effective quota even though their raw quota record still reads premium.
+
+    get_effective_quota_bytes is NOT stubbed, so this proves the upload gate is
+    wired to the effective quota (the fix), not the raw storage_quota_bytes.
+    """
+    from fastapi import HTTPException
+
+    used = 6_886_941_631  # 6.4 GB - the issue's reproduction value
+    # Guard the premise: over the free limit but under the raw premium quota,
+    # so a 403 can only mean the gate used the effective (downgraded) quota.
+    assert FREE_QUOTA_BYTES < used < PREMIUM_QUOTA_BYTES
+    grace = SubscriptionPeriods.GRACE_PERIOD_DAYS
+    warning = SubscriptionPeriods.WARNING_PERIOD_DAYS
+    overdue_expiration = get_current_datetime() - timedelta(days=grace + warning + 5)
+
+    with patch(
+        "studio.app.common.routers.files.get_current_user_storage_usage",
+        new=AsyncMock(return_value=used),
+    ), patch(
+        "studio.app.common.routers.files.get_user_storage_usage",
+        return_value={"storage_quota_bytes": PREMIUM_QUOTA_BYTES},
+    ), patch(
+        "studio.app.common.core.cloud.cloud_utils.session_scope"
+    ) as mock_scope:
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(
+            overdue_expiration
+        )
+        with pytest.raises(HTTPException) as exc:
+            _call_create_file(13)
+
+    assert exc.value.status_code == 403
+    assert "Storage quota exceeded" in exc.value.detail
+
+
+def test_upload_gate_allows_active_user_under_raw_quota():
+    """End-to-end: an active premium user well under their raw quota is not
+    blocked - proves active premium keeps the raw quota (not downgraded to free)
+    through the real create_file gate.
+    """
+    active_expiration = get_current_datetime() + timedelta(days=30)
+
+    with patch(
+        "studio.app.common.routers.files.get_current_user_storage_usage",
+        new=AsyncMock(return_value=50 * StorageSize.GB),
+    ), patch(
+        "studio.app.common.routers.files.get_user_storage_usage",
+        return_value={"storage_quota_bytes": PREMIUM_QUOTA_BYTES},
+    ), patch(
+        "studio.app.common.core.cloud.cloud_utils.session_scope"
+    ) as mock_scope, patch(
+        "studio.app.common.routers.files.create_directory"
+    ), patch(
+        "studio.app.common.routers.files.open", create=True
+    ), patch(
+        "studio.app.common.routers.files.shutil"
+    ), patch(
+        "studio.app.common.routers.files.WorkspaceDataCapacityService.is_available",
+        return_value=False,
+    ), patch(
+        "studio.app.common.routers.files.RemoteStorageController.is_available",
+        return_value=False,
+    ):
+        mock_scope.return_value.__enter__.return_value = _mock_lifecycle_db(
+            active_expiration
+        )
+        # 50GB is far under the raw premium quota; would only 403 if the gate
+        # wrongly downgraded an active premium user to the free limit.
+        result = _call_create_file(1, filename="test.csv")
+
+    assert result == {"file_path": "test.csv"}

--- a/studio/tests/app/common/core/subscription/test_subscription_service.py
+++ b/studio/tests/app/common/core/subscription/test_subscription_service.py
@@ -65,3 +65,34 @@ class TestExpirationDeletion:
         assert len(result) == 1
         assert result[0]["user_id"] == 123
         assert result[0]["excess_bytes"] > 0
+
+
+class TestDetermineLifecycle:
+    """SubscriptionService.determine_lifecycle() classification tests."""
+
+    @staticmethod
+    def _mock_db(expiration):
+        db = Mock()
+        subscription = Mock()
+        subscription.expiration = expiration
+        db.execute.return_value.all.return_value = [[subscription]]
+        return db
+
+    def test_none_expiration_returns_none(self):
+        assert SubscriptionService.determine_lifecycle(self._mock_db(None), 1) is None
+
+    def test_no_premium_rows_is_free(self):
+        from studio.app.common.core.subscription.constants import (
+            SubscriptionLifecycleStatus,
+        )
+        from studio.app.common.core.subscription.subscription_service import (
+            SubscriptionLifecycle,
+        )
+
+        db = Mock()
+        db.execute.return_value.all.return_value = []
+
+        result = SubscriptionService.determine_lifecycle(db, 1)
+
+        assert isinstance(result, SubscriptionLifecycle)
+        assert result.status == SubscriptionLifecycleStatus.FREE


### PR DESCRIPTION
# Pull Request: Enforce storage limits against the effective quota, not the raw quota

**Current Branch:** fix/effective-quota-enforcement-721
**Target Branch:** develop-main

----------
### Content

#### Summary
- Expired-premium (grace/warning/overdue) and free users over their effective
  free-tier limit but under the raw premium record could still run workflows and
  upload files: the enforcement gates divided usage by the raw
  `storage_quota_bytes`, while the grace→free-tier downgrade lived only in the
  warning path. The banner said "over quota" while the run/upload succeeded.
- This fix extracts one shared effective-quota computation and routes both the
  run gate (`_check_storage_quota`) and the upload gate (`create_file`) through
  it, so enforcement and the warning banner can no longer disagree. Closes #721.

#### Design Decisions
- **One shared mapping, no drift.** The effective-quota rule
  (grace/warning/overdue → free-tier limit; active/free → raw) now lives in one
  function, `_effective_quota_bytes(status, raw_quota_bytes)`, used by both
  `calculate_limit_warning` (banner) and `get_effective_quota_bytes`
  (enforcement). The subscription-lifecycle determination that both need was
  extracted from `calculate_limit_warning` into `SubscriptionService.determine_lifecycle`,
  co-located with the other subscription-timeline logic.
  `calculate_limit_warning`'s external behavior is unchanged (verified by its ~24
  existing tests).
- **Enforcement scope matches the warning banner (grace/warning/overdue), by
  design.** Issue #721's "Verify after fix" explicitly lists grace *and* free
  users as expected-403 alongside overdue, and matching the banner's status set
  is the whole point of the fix. Blocking only OVERDUE would re-introduce the
  gate-vs-banner disagreement.
- **Fix uses the effective value regardless of the raw record.** During
  grace/overdue the raw quota is intended to stay at the premium value while the
  effective limit is the free-tier limit, so enforcement must apply the downgrade
  itself rather than depend on the downgrade webhook having rewritten the raw value.
- **Fail open on the hot path.** `get_effective_quota_bytes` runs on every run and
  upload. It returns `0` when the raw quota is unknown/≤0 (caller's existing
  `quota_limit > 0` guard then skips enforcement, preserving self-hosted / no-S3
  behavior), and it wraps the lifecycle DB lookup in try/except, degrading to raw
  quota on any error so a transient DB issue cannot turn a run/upload into a 500.
- **Rejected:** touching the display endpoints (`storage_limit_alerts.py`,
  `users_me.py`) that still show raw-quota percentage — out of scope for #721
  (display, not enforcement) and a separate product decision. Also rejected:
  fixing the downgrade webhook as the primary fix (insufficient alone).

### Evidence
From the issue, the same request shows the disagreement this fix removes:
```
calculate_limit_warning():410 - User 13: Creating limit warning (storage_exceeded: True)   <- banner: over 5 GB
get_user_storage_usage():135 - ... storage_usage=6886941631, storage_quota=214748364800, storage_usage_percent=3.21%
"POST /run/11/tutorial1 HTTP/1.1" 200                                                       <- gate let it through
```
After the fix, the run gate computes `6,886,941,631 / 5,368,709,120 = 128% ≥ 100`
→ 403 (asserted by `test_run_gate_blocks_overdue_user_over_effective_quota`).

### References
- Issue: https://github.com/arayabrain/araya-optinist/issues/721
- Blame: `_check_storage_quota` added in `146e451f8` reading the raw quota from
  the start.

#### Files changed
- `studio/app/common/core/subscription/subscription_service.py` — added the
  `SubscriptionLifecycle` type and `SubscriptionService.determine_lifecycle`
  (returns FREE for no-premium, `None` for a malformed row), co-located with the
  other subscription-timeline queries.
- `studio/app/common/core/cloud/cloud_utils.py` — added `_effective_quota_bytes`
  (shared mapping) and `get_effective_quota_bytes` (enforcement entry, fails open);
  both consume `SubscriptionService.determine_lifecycle`; refactored
  `calculate_limit_warning` to use them (behavior-preserving).
- `studio/app/common/routers/run.py` — `_check_storage_quota` now enforces against
  `get_effective_quota_bytes`.
- `studio/app/common/routers/files.py` — `create_file` upload gate now enforces
  against `get_effective_quota_bytes`.
- `studio/tests/app/common/core/cloud/test_cloud_utils.py` — added tests for the
  effective-quota downgrade (overdue/grace/warning → free-tier limit; active/free
  → raw; zero raw → 0; malformed row → raw; DB error → raw) and end-to-end
  run-gate block/allow tests.
- `studio/tests/app/common/core/subscription/test_subscription_service.py` — added
  `determine_lifecycle` coverage (FREE for no-premium, `None` for a malformed row).

### Manual Testcases
1. As an overdue/grace (or free) user with usage between 5 GB and 200 GB, RUN a
   workflow → 403 `Cannot run job: Storage quota exceeded (…% used)`, percentage
   computed against 5 GB.
2. Same user uploads a file → 403 `Cannot upload file: Storage quota exceeded`.
3. Active premium user under 200 GB → runs and uploads succeed (unaffected).
- `docker compose -f docker-compose.test.yml run --rm test_studio_backend poetry run pytest studio/tests/app/ -m "not heavier_processing"`
  → 1175 passed, 15 skipped (pre-fix full-suite baseline; post-fix targeted
  cloud/router run: 108 passed).

### Unit, Integration, Contract Test Coverage
- Unit: `get_effective_quota_bytes` (all lifecycle branches, zero-quota, malformed
  row, DB-error fail-open); `SubscriptionService.determine_lifecycle` (FREE,
  malformed → None); refactored `calculate_limit_warning` still green across its
  existing suite.
- Integration: `_check_storage_quota` end-to-end (patches only storage usage +
  `session_scope`, not the function under test) asserting 403 for an
  overdue-over-effective-quota user and no-raise for an active-under-raw-quota user.

### Others

#### Difficulties (if any)
- None blocking. The refactor had to be behavior-preserving for the login hot path
  (`calculate_limit_warning` runs on every login); the two early `return None`
  paths for malformed subscription rows were preserved via the helper returning
  `None`.

#### Residual LOW findings / follow-ups (non-blocking)
- Display endpoints (`storage_limit_alerts.py`, `users_me.py`) still report the
  raw-quota percentage, so an over-quota user sees a blocked run but a low % on the
  usage widget. Separate follow-up.
- `SubscriptionService.determine_lifecycle` logs "Found N …" / "Final status …" at
  INFO; these now also fire on every run/upload. Consider demoting to DEBUG later.
- A premium row with a null expiration fails open to the raw premium quota
  (documented, users cannot self-insert subscription rows).
- Two `session_scope` opens per gate call (one for storage_info, one for
  lifecycle); not worth a callback-passing refactor.
- Secondary defect in the issue (`refresh_storage_usage` StaleDataError) is
  explicitly out of scope: it affects persistence only, not the read the gate uses.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Storage enforcement (run/upload gates) | Medium | Newly blocks grace/warning/overdue/free users over the free-tier limit — intended per #721; active premium unaffected. Fails open to raw quota on DB error / unknown quota, so it cannot harden into 500s or block self-hosted/no-S3. |
| `calculate_limit_warning` refactor | Low | Behavior-preserving; covered by ~24 existing tests, all green. Runs on login. |
| New hot-path DB query | Low | One extra `select(UserSubscription)` per run/upload, wrapped in try/except with fail-open. |
