### PR TITLE
Fix Import sample data menu no-op and stuck-menu backdrop

### DIFF
--- a/frontend/src/components/Layout/Tooltips.tsx
+++ b/frontend/src/components/Layout/Tooltips.tsx
@@ -40,9 +40,10 @@ const Tooltips: FC = () => {
   const { enqueueSnackbar } = useSnackbar()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const category = "tutorial"
+  const workspaceReady = typeof workspaceId === "number"
 
   const handleImportSampleDataClick = () => {
-    if (typeof workspaceId === "number") {
+    if (workspaceReady) {
       dispatch(importSampleData({ workspaceId, category }))
         .unwrap()
         .then(() => {
@@ -88,7 +89,9 @@ const Tooltips: FC = () => {
           <ListItemText>Go to documentation page</ListItemText>
         </MenuItem>
         <MenuItem
+          disabled={!workspaceReady}
           onClick={() => {
+            handleClose()
             setDialogOpen(true)
           }}
         >

--- a/frontend/src/components/Layout/Tooltips.tsx
+++ b/frontend/src/components/Layout/Tooltips.tsx
@@ -17,7 +17,11 @@ import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { getExperiments } from "store/slice/Experiments/ExperimentsActions"
 import { reset } from "store/slice/VisualizeItem/VisualizeItemSlice"
 import { importSampleData } from "store/slice/Workflow/WorkflowActions"
-import { selectCurrentWorkspaceId } from "store/slice/Workspace/WorkspaceSelector"
+import {
+  selectActiveTab,
+  selectCurrentWorkspaceId,
+} from "store/slice/Workspace/WorkspaceSelector"
+import { WORKSPACE_TABS } from "store/slice/Workspace/WorkspaceType"
 import { AppDispatch } from "store/store"
 
 const Tooltips: FC = () => {
@@ -39,6 +43,8 @@ const Tooltips: FC = () => {
   const dispatch: AppDispatch = useDispatch()
   const { enqueueSnackbar } = useSnackbar()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
+  const activeTab = useSelector(selectActiveTab)
+  const isRecordTab = activeTab === WORKSPACE_TABS.RECORD
   const category = "tutorial"
   const workspaceReady = typeof workspaceId === "number"
 
@@ -89,7 +95,7 @@ const Tooltips: FC = () => {
           <ListItemText>Go to documentation page</ListItemText>
         </MenuItem>
         <MenuItem
-          disabled={!workspaceReady}
+          disabled={!isRecordTab}
           onClick={() => {
             handleClose()
             setDialogOpen(true)

--- a/frontend/src/components/Layout/__tests__/Tooltips.test.tsx
+++ b/frontend/src/components/Layout/__tests__/Tooltips.test.tsx
@@ -17,9 +17,12 @@ jest.mock("notistack", () => ({
 
 const mockStore = configureMockStore([])
 
-const renderWithWorkspaceId = (workspaceId: number | undefined) => {
+const renderWithTab = (
+  workspaceId: number | undefined,
+  selectedTab: number,
+) => {
   const store = mockStore({
-    workspace: { currentWorkspace: { workspaceId } },
+    workspace: { currentWorkspace: { workspaceId, selectedTab } },
   })
   return render(
     <Provider store={store}>
@@ -33,16 +36,16 @@ const openDocumentationMenu = () => {
 }
 
 describe("Tooltips documentation menu", () => {
-  it("disables 'Import sample data' before the workspace loads", () => {
-    renderWithWorkspaceId(undefined)
+  it("disables 'Import sample data' when not on the Record tab", () => {
+    renderWithTab(1, 0)
     openDocumentationMenu()
 
     const item = screen.getByText("Import sample data").closest("li")
     expect(item).toHaveAttribute("aria-disabled", "true")
   })
 
-  it("enables 'Import sample data' once the workspace is loaded", () => {
-    renderWithWorkspaceId(1)
+  it("enables 'Import sample data' on the Record tab", () => {
+    renderWithTab(1, 2)
     openDocumentationMenu()
 
     const item = screen.getByText("Import sample data").closest("li")
@@ -50,7 +53,7 @@ describe("Tooltips documentation menu", () => {
   })
 
   it("closes the menu when opening the import dialog so its backdrop stops blocking clicks", async () => {
-    renderWithWorkspaceId(1)
+    renderWithTab(1, 2)
     openDocumentationMenu()
 
     fireEvent.click(screen.getByText("Import sample data"))

--- a/frontend/src/components/Layout/__tests__/Tooltips.test.tsx
+++ b/frontend/src/components/Layout/__tests__/Tooltips.test.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable no-undef */
+import "@testing-library/jest-dom"
+import { Provider } from "react-redux"
+
+import configureMockStore from "redux-mock-store"
+
+import { describe, it } from "@jest/globals"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+import Tooltips from "components/Layout/Tooltips"
+
+jest.mock("notistack", () => ({
+  useSnackbar: () => ({
+    enqueueSnackbar: jest.fn(),
+  }),
+}))
+
+const mockStore = configureMockStore([])
+
+const renderWithWorkspaceId = (workspaceId: number | undefined) => {
+  const store = mockStore({
+    workspace: { currentWorkspace: { workspaceId } },
+  })
+  return render(
+    <Provider store={store}>
+      <Tooltips />
+    </Provider>,
+  )
+}
+
+const openDocumentationMenu = () => {
+  fireEvent.click(screen.getByTestId("MenuBookIcon").closest("button")!)
+}
+
+describe("Tooltips documentation menu", () => {
+  it("disables 'Import sample data' before the workspace loads", () => {
+    renderWithWorkspaceId(undefined)
+    openDocumentationMenu()
+
+    const item = screen.getByText("Import sample data").closest("li")
+    expect(item).toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("enables 'Import sample data' once the workspace is loaded", () => {
+    renderWithWorkspaceId(1)
+    openDocumentationMenu()
+
+    const item = screen.getByText("Import sample data").closest("li")
+    expect(item).not.toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("closes the menu when opening the import dialog so its backdrop stops blocking clicks", async () => {
+    renderWithWorkspaceId(1)
+    openDocumentationMenu()
+
+    fireEvent.click(screen.getByText("Import sample data"))
+
+    expect(screen.getByText("Import sample data?")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Go to documentation page"),
+      ).not.toBeInTheDocument(),
+    )
+  })
+})

--- a/frontend/src/store/slice/Workspace/WorkspaceType.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceType.ts
@@ -3,6 +3,12 @@ import { StatusROI } from "components/Workspace/Visualize/Plot/ImagePlot"
 
 export const WORKSPACE_SLICE_NAME = "workspace"
 
+export const WORKSPACE_TABS = {
+  WORKFLOW: 0,
+  VISUALIZE: 1,
+  RECORD: 2,
+} as const
+
 export type ItemsWorkspace = {
   id: number
   display_number?: number


### PR DESCRIPTION
# Pull Request: Fix Import sample data menu no-op and stuck-menu backdrop

**Current Branch:** fix/import-sample-data-menu-740
**Target Branch:** develop-main

----------
### Content

#### Summary
Fixes two documentation-menu bugs surfaced by the e2e work in #740, both in
`Tooltips.tsx`. (#3) "Import sample data" could be clicked on pages where it had
no meaningful target (dashboard, workspaces list, and the Workflow/Visualize
tabs), where it either did nothing or would import into whatever workspace
happened to still be in Redux state. It is now enabled only on a workspace's
Record tab. (#4) Selecting "Import sample data" opened the confirm dialog but
left the MUI Menu open behind it, so the menu's invisible backdrop swallowed
every subsequent click; the menu now closes when the dialog opens. #740 is an
umbrella of 6 separable bugs; this branch takes only the two that share this one
component, the rest are listed as follow-ups below.

#### Design Decisions
- **#3 gate on the Record tab, not on "a workspace id exists".** An earlier
  pass disabled the item until `typeof workspaceId === "number"`
  (`workspaceReady`). Testing showed that predicate is too weak: `workspaceId`
  is held in Redux `currentWorkspace` and persists after you leave a workspace,
  so on the dashboard and workspaces-list pages the button stayed enabled and
  would import sample data into the last-opened workspace. This reconciles the
  two in-flight branches for this bug by taking the stronger gate from
  `feature/import-sample`: `disabled={!isRecordTab}` where
  `isRecordTab = activeTab === WORKSPACE_TABS.RECORD`. "Import sample data" only
  makes sense inside a workspace's Record view, so gating on the active tab
  greys it out everywhere it does not, instead of relying on a stale id.
- **Kept the #4 `handleClose()` fix that `feature/import-sample` dropped.** That
  branch's version removed the `handleClose()` call, which would reintroduce the
  stuck-menu backdrop bug. This combine preserves it: the menu still closes
  before the dialog opens.
- **Added a `WORKSPACE_TABS` enum** (`WORKFLOW: 0, VISUALIZE: 1, RECORD: 2`) in
  `WorkspaceType.ts` so the tab index is named at the call site rather than a
  bare `2`. The order matches `WorkspaceTabs.tsx`.
- **Kept the handler guard.** `handleImportSampleDataClick` still checks
  `typeof workspaceId === "number"` before dispatching (belt-and-suspenders,
  harmless) rather than relying solely on the disabled attribute.
- **Left the sibling "Go to documentation page" untouched.** It also does not
  close the menu, but it opens a new tab with no dialog/backdrop, so it does not
  cause the click-swallowing bug. Kept out to hold scope.

### Evidence
Full frontend suite (identical command to the Docker `test_studio_frontend`
service, `cross-env CI=true react-app-rewired test`):
```
Test Suites: 57 passed, 57 total
Tests:       5 skipped, 673 passed, 678 total
```
Scoped `Tooltips.test.tsx` (3 tests) passes. The #4 test has teeth: with the
`handleClose()` line removed, the "closes the menu ..." test fails while the
other two pass.

### References
- Closes part of #740 (items #3 and #4). Related: #726 (finalisation race,
  overlaps #740 item #1), #720 (admin upsert, related to #740 item 5).
- Reconciles branch `feature/import-sample` (commit "Import sample data only in
  Record page"), whose Record-tab gating is adopted here while keeping this
  branch's #4 menu-close fix.

#### Files changed
- `frontend/src/components/Layout/Tooltips.tsx` -- enable "Import sample data"
  only on the Record tab (`disabled={!isRecordTab}`); close the menu when
  opening the confirm dialog; keep the `workspaceId` handler guard.
- `frontend/src/store/slice/Workspace/WorkspaceType.ts` -- add the
  `WORKSPACE_TABS` enum used by the tab gate.
- `frontend/src/components/Layout/__tests__/Tooltips.test.tsx` -- item disabled
  off the Record tab, enabled on it, and the menu closes when the dialog opens.

### Manual Testcases
- [x] On the dashboard or the workspaces list, open the documentation menu (book
   icon): "Import sample data" is greyed/disabled. (Before: it was clickable and
   would import into the last-opened workspace or no-op.)
- [x] Open a workspace, stay on the Workflow or Visualize tab, open the menu:
   "Import sample data" is disabled. Switch to the Record tab, open the menu:
   it is enabled.
- [x] On the Record tab, click "Import sample data", confirm: the menu closes as
   the dialog opens; after the dialog, clicking anywhere on the page works
   immediately. (Before: an invisible menu backdrop swallowed all clicks until
   the user pressed Escape.)
- [x] Automated: `cd frontend && CI=true yarn test:ci` -- 57 suites / 673 tests
   pass (5 skipped). Scoped:
   `CI=true yarn test:ci --testPathPattern="Layout/__tests__/Tooltips"` -- 3
   tests pass.

### Unit, Integration, Contract Test Coverage
- Unit: `Tooltips.test.tsx` covers the Record-tab gate (#3) and the
  menu-closes-on-open behavior (#4). The #4 test is a regression guard,
  removing `handleClose()` fails it.
- Integration: driven by the Playwright suite on the separate e2e branch
  (`importSampleData` in `frontend/e2e/helpers.ts`).

### Others

#### Follow-ups (out of scope for this branch)
- **#740 remaining items**, each on its own branch per the issue: #1/#2
  poll-vs-executor finalisation race (overlaps #726), #5 Record-tab download
  a11y, fresh-DB seed migration for `organization`/`roles`/`subscription_plans`,
  and the Tutorial2 by-uid rerun crash.
- **e2e cleanup, once this ships:** on the e2e branch, remove the now-obsolete
  Escape-retry workaround in `importSampleData` and update the stale "known
  quirk" notes in `frontend/e2e/helpers.ts` and `frontend/e2e/README.md`.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `Tooltips.tsx` (documentation menu) | Low | Single presentational component; no API/store/type changes beyond the new tab enum. Full frontend suite green; tests guard both fixes. |
| `WORKSPACE_TABS` enum | Low | New named constants only; no behavioral change to existing tab code. |
| e2e suite (separate branch) | Low | Existing `importSampleData` helper is compatible; cleanup deferred to that branch. |
