### PR TITLE
Fix dataview empty-grid and phantom 'Workflow finished' snackbar

### DIFF
--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -224,7 +224,11 @@ export function useRunPipeline() {
       if (status === RUN_STATUS.START_SUCCESS) {
         dispatch(getExperiments())
       } else if (status === RUN_STATUS.FINISHED) {
-        enqueueSnackbar("Workflow finished", { variant: "success" })
+        // Only notify on an in-session run completion; loading an
+        // already-finished workflow lands on FINISHED without a running phase.
+        if (prevStatus === RUN_STATUS.START_SUCCESS) {
+          enqueueSnackbar("Workflow finished", { variant: "success" })
+        }
         isRunFinished = true
         dispatch(getExperiments())
       } else if (status === RUN_STATUS.ABORTED) {

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -224,8 +224,9 @@ export function useRunPipeline() {
       if (status === RUN_STATUS.START_SUCCESS) {
         dispatch(getExperiments())
       } else if (status === RUN_STATUS.FINISHED) {
-        // Only notify on an in-session run completion; loading an
-        // already-finished workflow lands on FINISHED without a running phase.
+        // Only a real in-session run transits START_SUCCESS -> FINISHED across
+        // renders; loading a finished workflow jumps straight to FINISHED, so
+        // this guard drops that phantom toast.
         if (prevStatus === RUN_STATUS.START_SUCCESS) {
           enqueueSnackbar("Workflow finished", { variant: "success" })
         }

--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -22,6 +22,19 @@ class ExperimentRecordService:
         return available
 
     @classmethod
+    def record_exists(cls, workspace_id: str, unique_id: str) -> bool:
+        with session_scope() as db:
+            return (
+                db.query(ExperimentRecord)
+                .filter(
+                    ExperimentRecord.workspace_id == workspace_id,
+                    ExperimentRecord.uid == unique_id,
+                )
+                .first()
+                is not None
+            )
+
+    @classmethod
     def regist_record_on_workflow_completed(
         cls, workspace_id: str, unique_id: str, generate_thumbnails: bool = True
     ):

--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -25,7 +25,7 @@ class ExperimentRecordService:
     def record_exists(cls, workspace_id: str, unique_id: str) -> bool:
         with session_scope() as db:
             return (
-                db.query(ExperimentRecord)
+                db.query(ExperimentRecord.id)
                 .filter(
                     ExperimentRecord.workspace_id == workspace_id,
                     ExperimentRecord.uid == unique_id,

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
@@ -11,6 +12,7 @@ from studio.app.common.core.cloud.storage_tracking import (
     get_current_user_storage_usage,
     get_user_storage_usage,
 )
+from studio.app.common.core.experiment.experiment import ExptConfig
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_record_services import (
     ExperimentRecordService,
@@ -20,6 +22,10 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteStorageLockError,
     RemoteSyncStatusFileUtil,
+)
+from studio.app.common.core.utils.datetime_utils import (
+    TIMEZONE_KEY,
+    get_datetime_for_timezone,
 )
 from studio.app.common.core.workflow.workflow import DataFilterParam, NodeItem, RunItem
 from studio.app.common.core.workflow.workflow_filter import WorkflowNodeDataFilter
@@ -38,10 +44,29 @@ from studio.app.common.core.workspace.workspace_dependencies import (
 )
 from studio.app.common.schemas.users import User
 from studio.app.common.schemas.workflow import CompleteStatus, PollRunResultResponse
+from studio.app.const import DATE_FORMAT
 
 router = APIRouter(prefix="/run", tags=["run"])
 
 logger = AppLogger.get_logger()
+
+# Max wait for the executor's async record write before the poll completes
+# anyway, so a dead post-process can't strand the run in a spinner. Sized to
+# cover thumbnail generation on large experiments.
+RECORD_WRITE_GRACE_SEC = 300
+
+
+def _finished_within_grace(expt_config: ExptConfig) -> bool:
+    finished_at = getattr(expt_config, "finished_at", None)
+    if not finished_at:
+        return False
+    try:
+        finished = datetime.strptime(finished_at, DATE_FORMAT)
+    except (ValueError, TypeError):
+        return False
+    tz = getattr(expt_config, TIMEZONE_KEY, None)
+    now = get_datetime_for_timezone(tz).replace(tzinfo=None)
+    return (now - finished).total_seconds() < RECORD_WRITE_GRACE_SEC
 
 
 async def _check_storage_quota(user_id: int) -> None:
@@ -217,20 +242,27 @@ async def run_result(
                 # Create CompleteStatus (converted from RemoteSyncStatus)
                 complete_status = CompleteStatus(sync_status.value)
 
-        # The executor writes the experiment record asynchronously after
-        # completion, so a poll can see all nodes finished before the row lands.
-        # Keep reporting "processing" until it exists, so the dataview isn't
-        # opened against a missing record.
+        # A poll can see all nodes finished before the executor's async record
+        # write lands; hold "processing" until it exists so the dataview isn't
+        # opened against a missing record, but only within the grace window.
         try:
-            if (
-                ExperimentRecordService.is_available()
-                and complete_status != CompleteStatus.PROCESSING
-                and NodeResult.is_all_nodes_already_finished(
-                    ExptConfigReader.read(workspace_id, uid)
-                )
-                and not ExperimentRecordService.record_exists(workspace_id, uid)
+            if ExperimentRecordService.is_available() and complete_status not in (
+                CompleteStatus.PROCESSING,
+                CompleteStatus.ERROR,
             ):
-                complete_status = CompleteStatus.PROCESSING
+                expt_config = ExptConfigReader.read(workspace_id, uid)
+                if NodeResult.is_all_nodes_already_finished(
+                    expt_config
+                ) and not ExperimentRecordService.record_exists(workspace_id, uid):
+                    if _finished_within_grace(expt_config):
+                        complete_status = CompleteStatus.PROCESSING
+                    else:
+                        logger.warning(
+                            "experiment_records row still absent for finished run "
+                            "[%s/%s]; completing poll without it",
+                            workspace_id,
+                            uid,
+                        )
         except Exception as e:
             logger.warning(
                 "Poll-time record existence check failed [%s/%s]: %s",

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -11,6 +11,9 @@ from studio.app.common.core.cloud.storage_tracking import (
     get_user_storage_usage,
 )
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_record_services import (
+    ExperimentRecordService,
+)
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
@@ -20,6 +23,7 @@ from studio.app.common.core.storage.remote_storage_controller import (
 from studio.app.common.core.workflow.workflow import DataFilterParam, NodeItem, RunItem
 from studio.app.common.core.workflow.workflow_filter import WorkflowNodeDataFilter
 from studio.app.common.core.workflow.workflow_result import (
+    NodeResult,
     WorkflowMonitor,
     WorkflowResult,
 )
@@ -211,6 +215,28 @@ async def run_result(
             if sync_status:
                 # Create CompleteStatus (converted from RemoteSyncStatus)
                 complete_status = CompleteStatus(sync_status.value)
+
+        # The executor writes the experiment record asynchronously after
+        # completion, so a poll can see all nodes finished before the row lands.
+        # Keep reporting "processing" until it exists, so the dataview isn't
+        # opened against a missing record.
+        try:
+            if (
+                ExperimentRecordService.is_available()
+                and complete_status != CompleteStatus.PROCESSING
+                and NodeResult.is_all_nodes_already_finished(
+                    ExptConfigReader.read(workspace_id, uid)
+                )
+                and not ExperimentRecordService.record_exists(workspace_id, uid)
+            ):
+                complete_status = CompleteStatus.PROCESSING
+        except Exception as e:
+            logger.warning(
+                "Poll-time record existence check failed [%s/%s]: %s",
+                workspace_id,
+                uid,
+                e,
+            )
 
         return PollRunResultResponse(
             nodeResults=node_results,

--- a/studio/tests/app/common/routers/test_run_result_record_gate.py
+++ b/studio/tests/app/common/routers/test_run_result_record_gate.py
@@ -8,7 +8,7 @@ dead executor post-process can't strand the run in a perpetual spinner.
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 from studio.app.common.core.workflow.workflow import NodeItem
@@ -18,7 +18,8 @@ from studio.app.const import DATE_FORMAT
 
 
 def _finished_at(seconds_ago: float) -> str:
-    return (datetime.now() - timedelta(seconds=seconds_ago)).strftime(DATE_FORMAT)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    return (now - timedelta(seconds=seconds_ago)).strftime(DATE_FORMAT)
 
 
 def _poll(

--- a/studio/tests/app/common/routers/test_run_result_record_gate.py
+++ b/studio/tests/app/common/routers/test_run_result_record_gate.py
@@ -3,37 +3,62 @@
 The executor writes the experiment_records row asynchronously after a run
 finishes, so a poll can observe all nodes finished before the row lands. The
 poll must keep reporting "processing" until the record exists, so the dataview
-is never opened against a missing record.
+is never opened against a missing record -- but only within a grace window, so a
+dead executor post-process can't strand the run in a perpetual spinner.
 """
 
 import asyncio
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 from studio.app.common.core.workflow.workflow import NodeItem
-from studio.app.common.routers.run import run_result
+from studio.app.common.routers.run import RECORD_WRITE_GRACE_SEC, run_result
 from studio.app.common.schemas.workflow import CompleteStatus
+from studio.app.const import DATE_FORMAT
 
 
-def _poll(record_present):
-    """Drive run_result with all nodes finished; record_exists is toggled."""
+def _finished_at(seconds_ago: float) -> str:
+    return (datetime.now() - timedelta(seconds=seconds_ago)).strftime(DATE_FORMAT)
+
+
+def _poll(
+    *,
+    record_present=False,
+    all_finished=True,
+    is_available=True,
+    finished_seconds_ago=0,
+    record_exists_raises=False,
+    complete_status=None,
+):
+    """Drive run_result with the gate inputs stubbed."""
+    expt_config = Mock(finished_at=_finished_at(finished_seconds_ago), timezone=None)
+
+    record_exists = Mock(
+        side_effect=RuntimeError("db down") if record_exists_raises else None,
+        return_value=record_present,
+    )
+
     with patch(
         "studio.app.common.routers.run.ExptConfigReader.ensure_synced_async",
         new=AsyncMock(),
     ), patch("studio.app.common.routers.run.WorkflowResult") as mock_wfr, patch(
         "studio.app.common.routers.run.RemoteStorageController.is_available",
-        return_value=False,
+        return_value=complete_status is not None,
+    ), patch(
+        "studio.app.common.routers.run.RemoteSyncStatusFileUtil.check_sync_status_file",
+        return_value=Mock(value=complete_status.value) if complete_status else None,
     ), patch(
         "studio.app.common.routers.run.ExperimentRecordService.is_available",
-        return_value=True,
+        return_value=is_available,
     ), patch(
         "studio.app.common.routers.run.NodeResult.is_all_nodes_already_finished",
-        return_value=True,
+        return_value=all_finished,
     ), patch(
         "studio.app.common.routers.run.ExptConfigReader.read",
-        return_value=Mock(),
+        return_value=expt_config,
     ), patch(
         "studio.app.common.routers.run.ExperimentRecordService.record_exists",
-        return_value=record_present,
+        record_exists,
     ):
         mock_wfr.return_value.observe = AsyncMock(return_value={})
         return asyncio.run(
@@ -47,13 +72,43 @@ def _poll(record_present):
         )
 
 
-def test_run_result_holds_processing_when_record_absent():
+def test_holds_processing_when_record_absent_within_grace():
     """All nodes finished but the record has not landed yet -> keep polling."""
     resp = _poll(record_present=False)
     assert resp.completeStatus == CompleteStatus.PROCESSING.value
 
 
-def test_run_result_completes_when_record_present():
+def test_completes_when_record_present():
     """Record present -> completion is not forced back to processing."""
     resp = _poll(record_present=True)
     assert resp.completeStatus is None
+
+
+def test_completes_when_record_absent_past_grace():
+    """Record never landed after the grace window -> complete, don't strand."""
+    resp = _poll(record_present=False, finished_seconds_ago=RECORD_WRITE_GRACE_SEC + 60)
+    assert resp.completeStatus is None
+
+
+def test_does_not_gate_while_still_running():
+    """Nodes still running -> gate must not fire mid-run."""
+    resp = _poll(record_present=False, all_finished=False)
+    assert resp.completeStatus is None
+
+
+def test_gate_off_in_standalone_mode():
+    """ExperimentRecordService unavailable -> no behavior change."""
+    resp = _poll(record_present=False, is_available=False)
+    assert resp.completeStatus is None
+
+
+def test_fails_open_when_record_check_raises():
+    """A read failure must not force processing nor 500 the poll."""
+    resp = _poll(record_exists_raises=True)
+    assert resp.completeStatus is None
+
+
+def test_terminal_error_not_masked_into_processing():
+    """A terminal ERROR completeStatus is preserved, not rewritten."""
+    resp = _poll(record_present=False, complete_status=CompleteStatus.ERROR)
+    assert resp.completeStatus == CompleteStatus.ERROR.value

--- a/studio/tests/app/common/routers/test_run_result_record_gate.py
+++ b/studio/tests/app/common/routers/test_run_result_record_gate.py
@@ -1,0 +1,59 @@
+"""Behavior tests for the run_result record-existence gate (issue #740 item #1).
+
+The executor writes the experiment_records row asynchronously after a run
+finishes, so a poll can observe all nodes finished before the row lands. The
+poll must keep reporting "processing" until the record exists, so the dataview
+is never opened against a missing record.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from studio.app.common.core.workflow.workflow import NodeItem
+from studio.app.common.routers.run import run_result
+from studio.app.common.schemas.workflow import CompleteStatus
+
+
+def _poll(record_present):
+    """Drive run_result with all nodes finished; record_exists is toggled."""
+    with patch(
+        "studio.app.common.routers.run.ExptConfigReader.ensure_synced_async",
+        new=AsyncMock(),
+    ), patch("studio.app.common.routers.run.WorkflowResult") as mock_wfr, patch(
+        "studio.app.common.routers.run.RemoteStorageController.is_available",
+        return_value=False,
+    ), patch(
+        "studio.app.common.routers.run.ExperimentRecordService.is_available",
+        return_value=True,
+    ), patch(
+        "studio.app.common.routers.run.NodeResult.is_all_nodes_already_finished",
+        return_value=True,
+    ), patch(
+        "studio.app.common.routers.run.ExptConfigReader.read",
+        return_value=Mock(),
+    ), patch(
+        "studio.app.common.routers.run.ExperimentRecordService.record_exists",
+        return_value=record_present,
+    ):
+        mock_wfr.return_value.observe = AsyncMock(return_value={})
+        return asyncio.run(
+            run_result(
+                workspace_id="1",
+                uid="exp123",
+                nodeDict=NodeItem(pendingNodeIdList=[]),
+                background_tasks=Mock(),
+                remote_bucket_name="",
+            )
+        )
+
+
+def test_run_result_holds_processing_when_record_absent():
+    """All nodes finished but the record has not landed yet -> keep polling."""
+    resp = _poll(record_present=False)
+    assert resp.completeStatus == CompleteStatus.PROCESSING.value
+
+
+def test_run_result_completes_when_record_present():
+    """Record present -> completion is not forced back to processing."""
+    resp = _poll(record_present=True)
+    assert resp.completeStatus is None


### PR DESCRIPTION
### Content

#### Summary
- Fixes issues #1 and #2 from #740, both stemming from the run-result poll and
  the executor observing the same experiment independently.
- **#1 (empty dataview):** a completed run could report FINISHED before the
  `experiment_records` row existed, so the dataview grid was empty until a
  manual reload. The poll now withholds completion until the row is present.
- **#2 (phantom snackbar):** loading/reproducing an already-finished workflow
  fired a "Workflow finished" snackbar even though nothing ran. The snackbar
  now fires only on an in-session run completion.
- This branch is meant to merge into `fix/import-sample-data-menu-740` (which
  carries fixes #3 and #4 of the same issue).

#### Design Decisions
- **#1 — keep the poll read-only, don't make it a second writer.** The issue
  suggested having the poll idempotently register the record itself. A first
  pass did exactly that, but a red-team review found it introduced a real
  data-integrity regression: `experiment_records` has no unique constraint on
  `(workspace_id, uid)`, so the poll and the executor (`snakemake_executor`
  post-process) could both pass an existence check and both `INSERT`,
  producing duplicate rows that later break the `.one()` reads in
  `regist_record_on_workflow_completed` / `update_name`. It also ran thumbnail
  generation on the request thread and let a read-access viewer trigger a
  write.
  - The migration tree currently has three heads, so adding the unique
    constraint that would make an upsert safe is risky and out of scope here.
  - Instead the poll stays read-only: when all nodes are finished but the row
    hasn't landed yet, it reports `completeStatus = processing`, which the
    frontend already treats as "keep polling". The executor remains the sole
    writer; once its row exists the next poll reports completion and the
    dataview opens against a present record. No new writer, no duplicate rows,
    no thumbnail work on the request path, no migration.
  - The check is gated on multiuser mode (where `experiment_records` is used)
    and wrapped in try/except so a read failure can never turn a poll into a
    500 (which the frontend would surface as a phantom "Workflow aborted").
- **#2 — gate the snackbar on the transition, not the value.** Real
  completions always go `START_SUCCESS -> FINISHED` (the poll reducer only
  promotes to FINISHED when the previous status was `START_SUCCESS`). Loading
  or reproducing a finished workflow jumps straight to FINISHED in a single
  reducer, so React never observes `START_SUCCESS` first. Requiring
  `prevStatus === START_SUCCESS` before enqueuing the snackbar suppresses the
  phantom while preserving every genuine completion toast. All other FINISHED
  side-effects (`getExperiments`, lock release) are left unchanged.

### Evidence
- Manual reproduction per the steps below; no automated e2e run recorded in
  this PR (the e2e suite already works around both bugs, see References).

### References
- Issue #740 (items 1 and 2).
- #726 — workflow finalisation race; same root architecture (poll and executor
  observing the same experiment independently). A future consolidation of #726
  could subsume the #1 guarantee.
- e2e suite workarounds this replaces: `waitForDataRows`
  (`frontend/e2e/06-dataview.spec.ts`) for #1, and the phantom-snackbar
  handling in `runTutorial` (`frontend/e2e/helpers.ts`) for #2.

#### Files changed
- `studio/app/common/routers/run.py` -- in `run_result`, hold
  `completeStatus = processing` while the workflow is finished but the
  `experiment_records` row has not been written yet (multiuser only,
  fail-open on error).
- `studio/app/common/core/experiment/experiment_record_services.py` -- add
  `ExperimentRecordService.record_exists()`, a read-only existence check used
  by the poll.
- `frontend/src/store/slice/Pipeline/PipelineHook.ts` -- fire the "Workflow
  finished" snackbar only when the previous status was `START_SUCCESS`.

### Manual Testcases
- **#1:** As a multiuser-mode user, run a workflow to completion. When the run
  spinner clears, open the dataview without reloading. Expected: the finished
  run's record is present (previously the grid could be empty until reload).
- **#1 (negative):** While a workflow is still running, poll responses continue
  to report the run as in progress. Expected: no premature completion.
- **#2:** Reproduce (or load) an experiment that already completed. Expected:
  no "Workflow finished" snackbar appears.
- **#2 (positive):** Start a fresh run and let it finish in-session. Expected:
  the "Workflow finished" snackbar appears exactly once on completion.
- Automated: `pytest studio/tests` and `cd frontend && yarn test` -- add poll
  coverage for the finished-but-record-absent case if the team wants it (see
  Test Coverage below).

### Unit, Integration, Contract Test Coverage
- No new tests added. The backend change reuses already-tested helpers
  (`NodeResult.is_all_nodes_already_finished`, `ExperimentRecordService`), and
  the frontend change is a single guard in an existing effect. A focused
  backend test for `run_result` returning `processing` when the record is
  absent would be the highest-value addition if desired.

### Others

#### Difficulties (if any)
- The alembic migration tree has three heads, which ruled out the
  unique-constraint approach for a clean self-healing writer.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `run_result` poll endpoint | Low | Read-only addition, multiuser-gated, wrapped in try/except (fails open to prior behavior). One extra experiment.yaml read per poll near completion. |
| Snackbar effect | Low | Narrows when a toast fires; real completions still go `START_SUCCESS -> FINISHED`. |
| Liveness | Low | If the executor never writes the record (e.g. its post-process throws), the poll would keep reporting `processing` until the user reloads/navigates; this degrades to the original empty-dataview behavior rather than a new data problem. |
