### PR TITLE
Re-arm `premiumAssigned` on reachable recovery to fix free-tier stranding

### DIFF
--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -466,6 +466,70 @@ describe("PremiumAssignmentProvider — unreachable state machine", () => {
     expect(ctxRef.current?.unreachable.state.isUnreachableTerminal).toBe(false)
   })
 
+  test("local reachable recovery (concurrent success, no probe) re-arms premiumAssigned", async () => {
+    // #754: a concurrent premium failure tore routing down, then a concurrent
+    // premium success emits reachable and clears the machine before the
+    // half-open probe arms. The exit side must re-arm premiumAssigned, or the
+    // user is stranded on free tier until reload.
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    // Teardown choke-point flips the machine and turns routing off.
+    act(() => {
+      routingService.setPremiumAssigned(false)
+      routingService.emitPremiumUnreachable({ status: 503, sentAt: 1000 })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    // Concurrent success emits reachable — recovery NOT via the probe.
+    act(() => {
+      routingService.emitPremiumReachable({ status: 200, sentAt: 2000 })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    })
+
+    expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+
+  test("peer reachable recovery also ends with premiumAssigned re-armed", async () => {
+    // Guards the leader/peer symmetry: both reachable paths re-arm routing.
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+    })
+
+    act(() => {
+      routingService.setPremiumAssigned(false)
+      fireTabSync("PREMIUM_INSTANCE_UNREACHABLE", {
+        instance_id: "inst-A",
+        unreachable_since: 5000,
+        failed_probes: 0,
+        is_terminal: false,
+      })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(true)
+    })
+
+    act(() => {
+      fireTabSync("PREMIUM_INSTANCE_REACHABLE", { instance_id: "inst-A" })
+    })
+    await waitFor(() => {
+      expect(ctxRef.current?.unreachable.state.instanceUnreachable).toBe(false)
+    })
+
+    expect(routingService.isPremiumAssigned()).toBe(true)
+  })
+
   test("late echo of unreachable does not re-log", async () => {
     mockedGetStatus.mockResolvedValue(dedicatedStatus)
     const ctxRef = renderProvider()

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -478,8 +478,10 @@ describe("PremiumAssignmentProvider — unreachable state machine", () => {
       expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
     })
 
-    // Teardown choke-point flips the machine and turns routing off.
+    // Teardown choke-point flips the machine and turns routing off, but keeps
+    // the instance identity (only release/logout nulls it).
     act(() => {
+      routingService.setPremiumInstanceId("inst-A")
       routingService.setPremiumAssigned(false)
       routingService.emitPremiumUnreachable({ status: 503, sentAt: 1000 })
     })

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -641,8 +641,10 @@ describe("RoutingService", () => {
 
   describe("emitPremiumReachable re-arms premiumAssigned (exit side)", () => {
     test("recovery not routed through the probe still re-arms routing", () => {
-      // Teardown turned routing off (concurrent failure), then a concurrent
-      // success emits reachable without going through the half-open probe.
+      // Teardown turned routing off (concurrent failure) but keeps the instance
+      // identity, then a concurrent success emits reachable without going
+      // through the half-open probe.
+      routingService.setPremiumInstanceId("inst-A")
       routingService.setPremiumAssigned(false)
 
       routingService.emitPremiumReachable({ status: 200 })
@@ -651,6 +653,7 @@ describe("RoutingService", () => {
     })
 
     test("re-arm holds even when a listener throws", () => {
+      routingService.setPremiumInstanceId("inst-A")
       routingService.setPremiumAssigned(false)
       routingService.onPremiumReachable(() => {
         throw new Error("boom")
@@ -662,11 +665,26 @@ describe("RoutingService", () => {
     })
 
     test("re-arm is idempotent when already assigned (probe path)", () => {
+      routingService.setPremiumInstanceId("inst-A")
       routingService.setPremiumAssigned(true)
 
       routingService.emitPremiumReachable({ status: 200 })
 
       expect(routingService.isPremiumAssigned()).toBe(true)
+    })
+
+    test("late post-release reachable does not resurrect routing", () => {
+      // A premium request was in flight, then release/logout cleared the
+      // instance identity. The late verified 200 must not re-arm routing, or it
+      // recreates the (assigned, instanceId=null) desync resetForRelease prevents.
+      routingService.setPremiumInstanceId("inst-A")
+      routingService.setPremiumAssigned(true)
+      routingService.resetForRelease()
+      expect(routingService.getPremiumInstanceId()).toBeNull()
+
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(routingService.isPremiumAssigned()).toBe(false)
     })
   })
 

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -639,6 +639,37 @@ describe("RoutingService", () => {
     })
   })
 
+  describe("emitPremiumReachable re-arms premiumAssigned (exit side)", () => {
+    test("recovery not routed through the probe still re-arms routing", () => {
+      // Teardown turned routing off (concurrent failure), then a concurrent
+      // success emits reachable without going through the half-open probe.
+      routingService.setPremiumAssigned(false)
+
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(routingService.isPremiumAssigned()).toBe(true)
+    })
+
+    test("re-arm holds even when a listener throws", () => {
+      routingService.setPremiumAssigned(false)
+      routingService.onPremiumReachable(() => {
+        throw new Error("boom")
+      })
+
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(routingService.isPremiumAssigned()).toBe(true)
+    })
+
+    test("re-arm is idempotent when already assigned (probe path)", () => {
+      routingService.setPremiumAssigned(true)
+
+      routingService.emitPremiumReachable({ status: 200 })
+
+      expect(routingService.isPremiumAssigned()).toBe(true)
+    })
+  })
+
   describe("premiumInstanceId", () => {
     test("setPremiumInstanceId / getPremiumInstanceId round-trip", () => {
       expect(routingService.getPremiumInstanceId()).toBeNull()

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -331,10 +331,11 @@ export class RoutingService {
     if (sentAt > this.lastReachableSentAt) {
       this.lastReachableSentAt = sentAt
     }
-    // Re-arm routing at the source of truth: a response that reached here
-    // passed shouldEmitPremiumReachable (verified serving-instance identity),
-    // so routing must be on for every listener path. Idempotent (probe re-arm).
-    this.setPremiumAssigned(true)
+    // Re-arm routing at the source of truth for every listener path. Gate on a
+    // live premiumInstanceId so a late post-release 200 can't resurrect routing.
+    if (this.premiumInstanceId != null && !this.premiumAssigned) {
+      this.setPremiumAssigned(true)
+    }
     this.reachableListeners.forEach((listener) => {
       try {
         listener(detail)

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -331,6 +331,10 @@ export class RoutingService {
     if (sentAt > this.lastReachableSentAt) {
       this.lastReachableSentAt = sentAt
     }
+    // Re-arm routing at the source of truth: a response that reached here
+    // passed shouldEmitPremiumReachable (verified serving-instance identity),
+    // so routing must be on for every listener path. Idempotent (probe re-arm).
+    this.setPremiumAssigned(true)
     this.reachableListeners.forEach((listener) => {
       try {
         listener(detail)


### PR DESCRIPTION
## Summary

Under ordinary concurrent SPA traffic, a **single** premium failure could permanently
downgrade a premium user to free tier until the next browser reload — even though the
dedicated instance was healthy and the state machine correctly reported it as reachable.

The teardown/recovery split was asymmetric. The axios teardown choke-point turns
`premiumAssigned` **off** on a genuine failure, but the state machine's local "reachable"
recovery handler turned the machine healthy again **without turning `premiumAssigned`
back on**. When a concurrently-successful premium response drove recovery *before* the
half-open probe re-armed (which is what re-arms `premiumAssigned` in the normal path),
routing was left off with no probe scheduled to ever restore it.

This is a distinct, **pre-existing** defect on the *recovery / re-arm* (exit) side of
premium routing — separate from the recent *teardown-suppression* (entry) hardening in
#745 / #750.

## Root Cause

Two layers disagreed on the recovery side:

- **axios teardown choke-point** (`tearDownPremiumRoutingUnlessWarmup` in `axios.ts`)
  sets `setPremiumAssigned(false)` and emits `premiumUnreachable` on a genuine
  (non-warm-up, non-stale) failure. Entry side is correct.
- **the machine's local reachable handler** (`onPremiumReachable` in
  `useInstanceUnreachableMachine.ts`) cleared the machine on recovery
  (`instanceUnreachable = false`, `CLEAR`, log `instance_reachable`, broadcast the peer
  event) but **did not call `setPremiumAssigned(true)`**.

Every sibling recovery path already re-armed routing — the peer
`PREMIUM_INSTANCE_REACHABLE` handler, `retryProbe`, the half-open probe re-arm effect,
and the reassignment-to-different-instance branch. Only the **local leader**
`onPremiumReachable` was asymmetric.

### Why the normal path masked it

In the intended recovery flow, `premiumAssigned` is re-armed by the **half-open probe
re-arm** (~30 s after going unreachable): the probe flips `premiumAssigned = true` first,
then the next real request confirms reachability and the handler just clears the machine.
Because the probe already re-armed routing, the handler's missing re-arm was invisible.

### How the invariant broke (concurrent traffic)

1. In-flight premium requests all carry premium headers.
2. One request fails (network error) → `tearDownPremiumRoutingUnlessWarmup`: not
   warm-up, not stale → `setPremiumAssigned(false)` + emit unreachable → machine flips.
3. A concurrent premium request (already in flight) returns `200` from the **correct**
   dedicated instance → `shouldEmitPremiumReachable` is true → local `onPremiumReachable`
   → machine `CLEAR`. **`premiumAssigned` stays `false`.**
4. End state: `instanceUnreachable = false` (so the half-open re-arm, gated on
   `instanceUnreachable === true`, never runs) **and** `premiumAssigned = false`
   permanently → all subsequent requests go to free tier → stranded until reload.

## Fix

**Robust option (single source of truth).** `RoutingService.emitPremiumReachable` now
sets `premiumAssigned = true` itself. A response that passes `shouldEmitPremiumReachable`
has already strictly verified the serving-instance identity (`x-served-by-instance`
equals the expected dedicated instance), so it is proof the instance is serving —
routing must be on regardless of which listener path (local, peer, or a future caller)
handles the event. This closes the class for **all** callers, not just the leader
handler.

- Safe: reachable never fires for a wrong-instance / ALB-fallback `200` (that path is
  `isInstanceMismatch` → teardown, not reachable).
- Idempotent: setting it during the half-open probe (where it is already `true`) is a
  no-op.

**Guarded re-arm (review follow-up).** The re-arm is gated on a live instance identity.
A premium request's markers are frozen at *send* time, so a request in flight during
`resetForRelease()` / logout / downgrade can land a verified `200` **after** release and
re-arm routing while `premiumInstanceId` is already `null` — recreating the
`(premiumAssigned=true, instanceId=null)` desync `resetForRelease` exists to prevent (the
#605 class). Gating on `premiumInstanceId != null` blocks the stray post-release re-arm
**without** breaking the core fix: the teardown choke-point clears only `premiumAssigned`
and keeps `premiumInstanceId`. The `!premiumAssigned` check keeps steady-state responses
write-free.

```ts
// RoutingService.emitPremiumReachable, after advancing the reachable watermark
// Re-arm routing at the source of truth for every listener path. Gate on a
// live premiumInstanceId so a late post-release 200 can't resurrect routing.
if (this.premiumInstanceId != null && !this.premiumAssigned) {
  this.setPremiumAssigned(true)
}
```

## Changed Files

| File | Change |
|------|--------|
| `frontend/src/utils/routing/RoutingService.ts` | `emitPremiumReachable` re-arms `premiumAssigned` before notifying listeners (source-of-truth re-arm), gated on `premiumInstanceId != null && !premiumAssigned`. |
| `frontend/src/utils/routing/RoutingService.test.ts` | New `describe` — exit-side re-arm: recovery not routed through the probe, re-arm holds when a listener throws, idempotency on the probe path, and no re-arm on a late post-release reachable. |
| `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx` | Two integration tests guarding leader/peer symmetry — both reachable recovery paths end with `premiumAssigned === true`. |

## Test Coverage

Deterministic red/green — the exit-side assertions fail before the fix and pass after:

- **Unit** (`RoutingService.test.ts`): an unreachable→reachable sequence that does **not**
  pass through the half-open probe leaves `premiumAssigned === true`. Red before (stays
  `false`), green after.
- **Integration** (`PremiumUnreachableIntegration.test.tsx`): local leader reachable path
  and peer reachable path both end with `premiumAssigned === true`.
- **Post-release resurrection guard** (`RoutingService.test.ts`): a premium request in
  flight → `resetForRelease()` (nulls `premiumInstanceId`) → a late verified `200` leaves
  `premiumAssigned === false`. Red without the `premiumInstanceId != null` gate, green
  with it.

### Results

```
RoutingService.test.ts                 all passed (+4 new)
PremiumUnreachableIntegration.test.tsx all passed (+2 new)

Focused suites (routing / axios / contexts): 13 suites, 256 tests passed, 0 failed
```

Red-check confirmation: with the production re-arm reverted, the exit-side assertion tests
fail; the peer-path and idempotency tests stay green (peer already re-armed). Separately,
with the `premiumInstanceId != null` gate removed, the post-release resurrection test fails
— proving each test exercises exactly the branch it guards.

---

## Manual Test Plan

The race is a timing/concurrency condition, but DevTools **Block request URL** surfaces
it reliably: it fails a **single** request by URL while the instance stays healthy and
serves concurrent requests with `200` — manufacturing the isolated-failure +
concurrent-success condition, and failing instantly so the flip happens before the
concurrent `200` lands.

> **CRITICAL PRECONDITION — the test user must hold a DEDICATED assignment.** This fix and
> its ui-events exist only on the dedicated recovery path. Before testing, confirm
> `GET /users/me/premium/status` returns `assignment.is_shared: **false**`.
>
> - If `is_shared: true` (a **shared** assignment), the unreachable state machine never
>   engages (it is dedicated-only), so **no** ui-events fire and blocking requests instead
>   exposes a *separate* stranding bug (shared torn down with no recovery) — tracked in
>   **#756**, **not** #754. Do not test #754 on a shared user.
> - If you see **zero** ui-events (`instance_unreachable` etc.) and/or
>   `Conditions not met for auto-assignment: {isPremiumUser: false}` in the Console, the
>   session is not on the dedicated premium path — fix the precondition before proceeding
>   (subscription must be exactly `"Premium"`/`"Premium"`; clear stale `premium_assigned`
>   / `routing_id` from localStorage; ensure `/status` reports `is_shared: false`).

### Prerequisites

- A premium-subscribed user account (`subscription_plan_name` and `subscription_status`
  both exactly `"Premium"`) that receives a **dedicated** (`is_shared: false`) instance.
- Browser DevTools open (Network tab, Console tab, Application tab).
- Network tab **"Preserve log"** enabled.
- Console filtered to premium ui-events is helpful (the flow logs `instance_unreachable`,
  `instance_unreachable_popup_shown`, `instance_reachable`,
  `instance_unreachable_popup_dismissed`).

### Test 1: Isolated premium failure + concurrent success must not strand routing (core fix)

**Objective:** After a single premium request is failed while the dedicated instance
keeps serving other requests, `premiumAssigned` must return to `true` and subsequent
requests must carry routing headers — **without** a browser reload.

#### Step 1: Establish a healthy dedicated premium assignment

1. Open DevTools **Network** tab, filter to `premium`.
2. Log in as the premium user and wait for the assignment flow to complete.
3. **Verify:** the assignment is **dedicated** — `GET /users/me/premium/status` (and/or
   `POST /users/me/premium/assign`) returns `assigned: true`, **`is_shared: false`**, and
   an `instance_id`. If `is_shared: true`, stop — this is not a #754 scenario (see the
   Critical Precondition above).
4. In the **Application** tab > Local Storage, **verify:** `premium_assigned` is `"true"`
   and `routing_id` holds a hex value.
5. Trigger a normal premium data request (e.g. navigate to a workspace list) and
   **verify** in Network that the request carries the `x-routing-id` request header and
   the response is `200 OK`.

**Checkpoint:** Healthy dedicated assignment; no "instance unresponsive" snackbar.

#### Step 2: Block a single premium request URL

1. In the Network tab, find a repeatable premium data request —
   `GET /workspaces?offset=0&limit=50` is a good target.
2. Right-click it > **Block request URL**.
3. Keep the app running so other premium requests continue in the background (leave the
   page open; do not reload).

#### Step 3: Trigger the blocked request alongside concurrent traffic

1. Perform the action that issues `GET /workspaces?offset=0&limit=50` (e.g. refresh the
   workspace list in-app, **not** a browser reload) so it fires **while** at least one
   other premium request is in flight.
2. **Observe** the ui-events fire within ~1 second, in this order:
   - `instance_unreachable`
   - `instance_unreachable_popup_shown`
   - `instance_reachable`
   - `instance_unreachable_popup_dismissed`
3. **Verify:** the "instance unresponsive" snackbar appears and then self-dismisses as the
   machine returns to healthy.

**Checkpoint:** The machine flipped to unreachable and immediately recovered from a
concurrent success — the exact race, without waiting for the ~30 s half-open probe.

#### Step 4: Verify routing is still armed (the fix)

1. Remove the block: Network tab > **Unblock** the request URL (or DevTools Network
   conditions), so the next request is allowed through.
2. Trigger another premium data request in-app.
3. **Verify (fixed):** the request carries the `x-routing-id` header and is served by the
   dedicated instance (`x-served-by-instance` matches the assigned instance hash).
4. In the **Application** tab, **verify:** `premium_assigned` is still `"true"`.
   - **Before this fix:** `premium_assigned` was `"false"`, subsequent requests carried
     **no** routing headers and were served by the free tier, and only a browser reload
     restored premium — even though the instance was healthy the whole time.

**Expected result:** Premium routing is retained end-to-end with no reload.

### Test 2: Warm-up / staleness teardown-suppression not regressed (#745 / #750)

**Objective:** Confirm the entry-side hardening still holds — a transient `5xx` **within
the warm-up grace** must **not** tear premium routing down. This PR only changes the
recovery (exit) side and must not regress this.

**Failure injection:** same as Test 1 — DevTools **Block request URL** on a single premium
request (surfaces as a network error at the same choke-point). No proxy needed. What
differs is only the **timing** (fire within the warm-up window) and the **expected
result** (no teardown). Note this is the inverse of #750 Test 2, which fires **after**
warm-up and asserts the failure **does** tear down.

**Warm-up window basics:**

- A **plain browser reload (F5) re-arms the grace** — no new `/assign` needed. The state
  machine co-arms warm-up on every fresh mount's first dedicated transition
  (`useInstanceUnreachableMachine.ts`, covering "reload/new-tab onto an existing
  instance"). A normal `sign out → sign in` showing only `/status` (no `/assign`) is
  expected and does **not** prevent warm-up.
- **Effective window ≈ 15 s** from the reload (`DEDICATED_HANDOFF_GRACE_MS = 15000`).
- During warm-up the failure is swallowed silently — **no premium ui-event fires at all**.
  The **absence** of any ui-event is the expected signal, not the presence of one.

#### Step 1: Establish a healthy dedicated premium assignment

Same as Test 1 Step 1 — log in as the premium user, confirm `is_shared: false`.

#### Step 2: Reload, then fire a single transient `5xx` within ~15 s

Pre-stage the block **before** reloading so you can fire within the window:

1. **Pre-register the block (disabled).** DevTools > Network > **⋮** > **Network request
   blocking** > add `*/workspaces?offset=0&limit=50`. Leave it **off** for now.
2. **Reload the page (F5 / Cmd-R)** — this is **T0** (only `/status` fires; `/assign` is
   not expected, which is fine).
3. **Within ~15 s**: enable the block → fire the request in-app (refresh the workspace
   list, **not** another reload) → disable the block (transient blip).

> Tip: if you miss the ~15 s window, `instance_unreachable` fires and routing tears down
> (the #750 Test 2 behavior) — reload again and retry.

#### Step 3: Verify suppression held (no teardown)

- **No premium ui-event fires** (no `instance_unreachable`, no "instance unresponsive"
  snackbar) — the failure is absorbed silently. The absence of ui-events is the pass signal.
- In the **Application** tab, `premium_assigned` stays `"true"`; no permanent unreachable
  state.
- After unblocking, the next premium request still carries `x-routing-id` and is served by
  the dedicated instance (no stranding on free tier). Matches #745 / #750 behavior.

### Test 3 (OPTIONAL): Half-open probe recovery unchanged (idempotent re-arm)

**Status:** *Optional.* The probe-path idempotency is already covered deterministically by
`RoutingService.test.ts`. Manual reproduction is slow (≥30 s waits, longer on backoff) and
the "no double-arm" assertion is barely hand-observable. Run only as a smoke check that slow
recovery still works; the required manual gates are Test 1 + Test 2.

**Objective:** The normal (non-concurrent) recovery path is unchanged — a sustained outage
still recovers via the ~30 s half-open probe, with no flip-flop.

**How it works:** the probe re-arm only sets `premium_assigned` back to `"true"` so the
**next** request can test the instance — it does **not** itself confirm recovery. Recovery is
confirmed only when a real request then returns a verified `200` (`instance_reachable`).
Initial probe delay is 30 s (`INITIAL_PROBE_DELAY_MS`), doubling on each failed probe.

**Steps (normal operations only):**

1. Establish a healthy dedicated assignment (`is_shared: false`); **wait >15 s after the
   reload** so the failure is past warm-up (genuine, not suppressed).
2. Block the target URL (e.g. `*/workspaces?offset=0&limit=50`) and **keep it blocked**;
   fire a premium request.
   → `instance_unreachable` ui-event + "instance unresponsive" snackbar; `premium_assigned`
   goes `"false"`.
3. **Wait ~30 s** → `instance_probe_armed` ui-event; `premium_assigned` returns to `"true"`
   (probe only — recovery not yet confirmed).
4. **Unblock the URL**, then fire a premium request.
   → `instance_reachable` ui-event + snackbar dismisses; `premium_assigned` stays `"true"`,
   served by the dedicated instance.
5. **Verify:** a single clean recovery — no unreachable/reachable oscillation or duplicated
   events (probe re-arm and the new source-of-truth re-arm are idempotent).

> If you skip step 4 (leave it blocked), the probe request re-fails → `instance_probe_failure`
> and the delay backs off (60 s, 120 s, …). Unblocking is required to observe recovery.

> **Note (covered by automated test):** the post-release resurrection guard
> (`premiumInstanceId != null`) is verified deterministically by
> `RoutingService.test.ts › late post-release reachable does not resurrect routing`;
> it is not part of the manual plan because the in-flight-during-release timing cannot
> be reproduced reliably by hand.

## Acceptance Criteria

- [x] After a genuine premium failure immediately followed by a concurrent successful
      premium response, `premiumAssigned` returns to `true` and subsequent requests carry
      `x-routing-id` — without a browser reload.
- [x] No regression to the warm-up (#745) or staleness (#750) teardown-suppression paths.
- [x] The half-open probe recovery path is unchanged (idempotent re-arm).
- [x] A late verified `200` arriving after release/logout/downgrade does **not** re-arm
      `premiumAssigned` (no `(premiumAssigned=true, instanceId=null)` desync).

## Relationship to Other Work

- **#730 (parent):** registered as a new child bug, following the #742 / #737 precedent.
- **#745 / #750:** same investigation lineage; both fixed the *teardown* (entry) side.
  This is the complementary *recovery* (exit) side, best reviewed as a sibling of #750.
- **#733:** the structural refactor (`PremiumAssignmentContext` → explicit state machine)
  subsumes this tactical fix later; shipping now as a quick-win.
- **#756 (shared-teardown-asymmetry, new sibling issue):** manual validation surfaced a
  distinct bug — a **shared** assignment is torn down by the entry side but has no
  dedicated-only recovery, so it strands on free tier. This fix's `emitPremiumReachable`
  re-arm *partially masks* it (recovers only when a concurrent premium success lands after
  teardown) but does not close it. Tracked and fixed separately in **#756** (Option A:
  scope the teardown to dedicated assignments).
