### PR TITLE
Skip premium routing teardown for shared assignments to prevent free-tier stranding

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -1076,6 +1076,10 @@ export const PremiumAssignmentProvider: React.FC<{
                 statusResult: status,
               }
             })
+            // Reached only for a shared assignment (dedicated returns above).
+            // Keep the flag consistent with the polled assignment so the
+            // teardown gate holds even for a shared state seen only via polling.
+            routingService.setPremiumShared(true)
           } else {
             setState((prev) => ({ ...prev, statusResult: status }))
 

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -489,6 +489,7 @@ export const PremiumAssignmentProvider: React.FC<{
         if (result.assigned) {
           routingService.setPremiumAssigned(true)
           routingService.setPremiumInstanceId(result.instance_id_hash ?? null)
+          routingService.setPremiumShared(result.is_shared ?? false)
           try {
             const tokenRes = await getBeaconTokenApi()
             beaconTokenRef.current = tokenRes.data.token
@@ -630,6 +631,7 @@ export const PremiumAssignmentProvider: React.FC<{
         routingService.setPremiumInstanceId(
           assignmentResult.instance_id_hash ?? null,
         )
+        routingService.setPremiumShared(assignmentResult.is_shared ?? false)
         try {
           const tokenRes = await getBeaconTokenApi()
           beaconTokenRef.current = tokenRes.data.token
@@ -658,6 +660,7 @@ export const PremiumAssignmentProvider: React.FC<{
         routingService.setPremiumInstanceId(
           assignmentResponse.instance_id_hash ?? null,
         )
+        routingService.setPremiumShared(assignmentResponse.is_shared ?? false)
         try {
           const tokenRes = await getBeaconTokenApi()
           beaconTokenRef.current = tokenRes.data.token
@@ -954,6 +957,9 @@ export const PremiumAssignmentProvider: React.FC<{
     }))
     routingService.setPremiumAssigned(true)
     routingService.setPremiumInstanceId(result.instance_id_hash ?? null)
+    // Dedicated by definition (only reached for !is_shared), but set explicitly
+    // so the upgrade from a prior shared assignment clears the shared flag.
+    routingService.setPremiumShared(result.is_shared ?? false)
     try {
       const tokenRes = await getBeaconTokenApi()
       beaconTokenRef.current = tokenRes.data.token

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -1079,6 +1079,12 @@ export const PremiumAssignmentProvider: React.FC<{
             // Reached only for a shared assignment (dedicated returns above).
             // Keep the flag consistent with the polled assignment so the
             // teardown gate holds even for a shared state seen only via polling.
+            // Refresh the instance hash too: a dedicated→shared transition seen
+            // only via polling would otherwise leave the stale dedicated hash,
+            // skewing routing telemetry.
+            routingService.setPremiumInstanceId(
+              assignment.instance_id_hash ?? null,
+            )
             routingService.setPremiumShared(true)
           } else {
             setState((prev) => ({ ...prev, statusResult: status }))

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -206,6 +206,18 @@ const dedicatedStatus: PremiumStatusResult = {
   },
 }
 
+const sharedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-shared",
+    is_shared: true,
+    assigned_at: "2023-01-01T00:00:00Z",
+    status: "active",
+  },
+}
+
 // --- Tests ---
 
 describe("PremiumAssignmentProvider — unreachable state machine", () => {
@@ -222,6 +234,28 @@ describe("PremiumAssignmentProvider — unreachable state machine", () => {
 
   afterEach(() => {
     jest.clearAllTimers()
+  })
+
+  test("shared /status assignment forwards is_shared to routingService.setPremiumShared", async () => {
+    // Wiring guard: the establishment site must forward is_shared so the axios
+    // teardown gate (isPremiumShared) sees a shared assignment.
+    mockedGetStatus.mockResolvedValue(sharedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+    expect(routingService.isPremiumShared()).toBe(true)
+  })
+
+  test("dedicated /status assignment leaves premiumShared false", async () => {
+    mockedGetStatus.mockResolvedValue(dedicatedStatus)
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+    })
+    expect(routingService.isPremiumShared()).toBe(false)
   })
 
   test("HEALTHY → DEGRADED on emitPremiumUnreachable, then clears on emitPremiumReachable", async () => {

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -47,6 +47,7 @@ const mockIsWithinPremiumWarmup = jest.fn<boolean, []>(() => false)
 const mockIsStalePremiumFailure = jest.fn<boolean, [number | undefined]>(
   () => false,
 )
+const mockIsPremiumShared = jest.fn<boolean, []>(() => false)
 
 const mockIsDataviewPublicOutputsRequest = jest.fn<boolean, [string]>(
   () => false,
@@ -76,6 +77,7 @@ jest.mock("utils/routing/RoutingService", () => ({
     getRoutingToken: mockGetRoutingToken,
     isWithinPremiumWarmup: mockIsWithinPremiumWarmup,
     isStalePremiumFailure: mockIsStalePremiumFailure,
+    isPremiumShared: mockIsPremiumShared,
   },
 }))
 
@@ -651,6 +653,72 @@ describe("axios premium-routing interceptors", () => {
     // ...but a stale failure never tears premium routing down.
     expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
     expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+  })
+
+  it("does NOT clear premiumAssigned on a 502/503 when the assignment is shared", async () => {
+    // Shared (pool) assignments have no dedicated-only recovery (state machine /
+    // probe), so tearing premium routing down here would strand them on free tier
+    // with nothing to re-arm. Past warm-up and non-stale, the choke-point still
+    // skips teardown for a shared assignment. The request still falls back to free
+    // tier so it resolves.
+    mockRequiresPremiumRouting.mockReturnValue(true)
+    mockIsWithinPremiumWarmup.mockReturnValue(false)
+    mockIsStalePremiumFailure.mockReturnValue(false)
+    mockIsPremiumShared.mockReturnValue(true)
+
+    let callCount = 0
+    responses.set("/shared-5xx", () => {
+      callCount += 1
+      if (callCount === 1) {
+        return { status: 503, data: { detail: "shared instance blip" } }
+      }
+      return { status: 200, data: { ok: true }, headers: {} }
+    })
+    mockGetRoutingHeaders
+      .mockReturnValueOnce({
+        "X-Routing-ID": "rid-outgoing",
+        "X-User-Tier": "premium",
+      })
+      .mockReturnValue({})
+
+    const res = await axiosInstance.get("/shared-5xx")
+
+    // Falls back so the request still resolves...
+    expect(res.status).toBe(200)
+    // ...but a shared assignment is never torn down.
+    expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+  })
+
+  it("DOES clear premiumAssigned on a 502/503 for a dedicated assignment", async () => {
+    // Control for the shared case: a non-shared (dedicated) assignment past
+    // warm-up and non-stale must still tear down and hand off to the recovery
+    // state machine.
+    mockRequiresPremiumRouting.mockReturnValue(true)
+    mockIsWithinPremiumWarmup.mockReturnValue(false)
+    mockIsStalePremiumFailure.mockReturnValue(false)
+    mockIsPremiumShared.mockReturnValue(false)
+
+    let callCount = 0
+    responses.set("/dedicated-5xx", () => {
+      callCount += 1
+      if (callCount === 1) {
+        return { status: 503, data: { detail: "dedicated down" } }
+      }
+      return { status: 200, data: { ok: true }, headers: {} }
+    })
+    mockGetRoutingHeaders
+      .mockReturnValueOnce({
+        "X-Routing-ID": "rid-outgoing",
+        "X-User-Tier": "premium",
+      })
+      .mockReturnValue({})
+
+    const res = await axiosInstance.get("/dedicated-5xx")
+
+    expect(res.status).toBe(200)
+    expect(mockSetPremiumAssigned).toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).toHaveBeenCalledTimes(1)
   })
 
   it("does NOT emit unreachable on instance mismatch when _outgoingInstanceId is unset (startup race)", async () => {

--- a/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts
@@ -588,6 +588,37 @@ describe("axios premium-routing interceptors", () => {
     expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
   })
 
+  it("does NOT clear premiumAssigned on instance mismatch when the assignment is shared", async () => {
+    // The teardown guard lives in the single choke-point, so the success-path
+    // instance-mismatch caller is gated for shared too: a 200 from a different
+    // instance must not tear a shared assignment down (it has no dedicated-only
+    // recovery to hand off to).
+    mockGetRoutingHeaders.mockReturnValue({
+      "X-Routing-ID": "rid-outgoing",
+      "X-User-Tier": "premium",
+    })
+    mockGetPremiumInstanceId.mockReturnValue("expected-instance-hash")
+    mockIsWithinPremiumWarmup.mockReturnValue(false)
+    mockIsStalePremiumFailure.mockReturnValue(false)
+    mockIsPremiumShared.mockReturnValue(true)
+
+    responses.set("/shared-mismatch", {
+      status: 200,
+      data: { ok: true },
+      headers: {
+        "x-routing-id": "rid-outgoing",
+        "x-served-by-instance": "free-tier-instance-hash",
+      },
+    })
+    const res = await axiosInstance.get("/shared-mismatch")
+
+    expect(res.status).toBe(200)
+    // Shared is never torn down, on either teardown caller.
+    expect(mockSetPremiumAssigned).not.toHaveBeenCalledWith(false)
+    expect(mockEmitPremiumUnreachable).not.toHaveBeenCalled()
+    expect(mockEmitPremiumReachable).not.toHaveBeenCalled()
+  })
+
   it("does NOT clear premiumAssigned on a 502/503 during the warm-up grace", async () => {
     // A transient 5xx from a freshly-assigned dedicated instance is expected
     // during warm-up. Tearing down premiumAssigned here would strand premium

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -234,6 +234,10 @@ const tearDownPremiumRoutingUnlessWarmup = (
   // routing, since the state machine suppresses the event and never arms a
   // recovery probe.
   if (routingService.isStalePremiumFailure(detail.sentAt)) return
+  // Shared assignments have no dedicated-only recovery (state machine / probe),
+  // so a permanent downgrade here would strand them on free tier with nothing to
+  // re-arm. The per-request free-tier retry in the caller still serves the request.
+  if (routingService.isPremiumShared()) return
   routingService.setPremiumAssigned(false)
   routingService.emitPremiumUnreachable(detail)
 }

--- a/frontend/src/utils/routing/RoutingService.test.ts
+++ b/frontend/src/utils/routing/RoutingService.test.ts
@@ -730,6 +730,51 @@ describe("RoutingService", () => {
     })
   })
 
+  describe("premiumShared flag", () => {
+    test("defaults to false", () => {
+      expect(routingService.isPremiumShared()).toBe(false)
+    })
+
+    test("setPremiumShared / isPremiumShared round-trip and persist", () => {
+      routingService.setPremiumShared(true)
+      expect(routingService.isPremiumShared()).toBe(true)
+      expect(localStorageMock.getItem("premium_shared")).toBe("true")
+
+      routingService.setPremiumShared(false)
+      expect(routingService.isPremiumShared()).toBe(false)
+      expect(localStorageMock.getItem("premium_shared")).toBe("false")
+    })
+
+    test("loads shared flag from localStorage on initialization", () => {
+      localStorageMock.setItem("premium_shared", "true")
+
+      const newService = new RoutingService()
+      expect(newService.isPremiumShared()).toBe(true)
+    })
+
+    test("clearRoutingInfo clears the shared flag", () => {
+      routingService.setPremiumShared(true)
+      routingService.clearRoutingInfo()
+
+      expect(routingService.isPremiumShared()).toBe(false)
+      expect(localStorageMock.getItem("premium_shared")).toBeNull()
+    })
+
+    test("resetForRelease clears the shared flag", () => {
+      routingService.setPremiumShared(true)
+      routingService.resetForRelease()
+
+      expect(routingService.isPremiumShared()).toBe(false)
+    })
+
+    test("updateRoutingInfo for a non-premium user clears the shared flag", () => {
+      routingService.setPremiumShared(true)
+      routingService.updateRoutingInfo(createFreeUser())
+
+      expect(routingService.isPremiumShared()).toBe(false)
+    })
+  })
+
   describe("premium warm-up window", () => {
     // Intentionally longer than DEDICATED_HANDOFF_GRACE_MS (15000) so the axios
     // window contains the machine's grace window — see PREMIUM_WARMUP_GRACE_MS.

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -63,6 +63,10 @@ export class RoutingService {
   private storedTier: UserTier | null = null
   private premiumAssigned: boolean = false
   private premiumInstanceId: string | null = null
+  // Whether the current assignment is a shared (pool) instance. Shared has no
+  // dedicated-only recovery (state machine / probe), so the teardown choke-point
+  // must not permanently downgrade it — see tearDownPremiumRoutingUnlessWarmup.
+  private premiumShared: boolean = false
   // Warm-up grace window (epoch ms) after a fresh dedicated assignment.
   private premiumWarmupUntil: number | null = null
   // Monotonic sentAt of the last response confirmed to come from the assigned
@@ -86,6 +90,7 @@ export class RoutingService {
   private readonly TIER_STORAGE_KEY = "routing_tier"
   private readonly PREMIUM_ASSIGNED_KEY = "premium_assigned"
   private readonly PREMIUM_INSTANCE_ID_KEY = "premium_instance_id"
+  private readonly PREMIUM_SHARED_KEY = "premium_shared"
   private unreachableListeners: Set<PremiumUnreachableListener> = new Set()
   private reachableListeners: Set<PremiumReachableListener> = new Set()
 
@@ -95,6 +100,7 @@ export class RoutingService {
     this.loadTierFromStorage()
     this.loadPremiumAssignedFromStorage()
     this.loadPremiumInstanceIdFromStorage()
+    this.loadPremiumSharedFromStorage()
   }
 
   /**
@@ -171,6 +177,7 @@ export class RoutingService {
     if (!isPremium) {
       this.setPremiumAssigned(false)
       this.setPremiumInstanceId(null)
+      this.setPremiumShared(false)
       // Reset the reachable watermark alongside clearRoutingInfo / resetForRelease
       // so all three "premium goes away" paths leave watermark state consistent.
       this.lastReachableSentAt = 0
@@ -188,6 +195,7 @@ export class RoutingService {
     this.storedTier = null
     this.premiumAssigned = false
     this.premiumInstanceId = null
+    this.premiumShared = false
     this.premiumWarmupUntil = null
     this.lastReachableSentAt = 0
     this.lastFetch = 0
@@ -195,6 +203,7 @@ export class RoutingService {
     this.clearTierFromStorage()
     this.clearPremiumAssignedFromStorage()
     this.clearPremiumInstanceIdFromStorage()
+    this.clearPremiumSharedFromStorage()
   }
 
   /**
@@ -215,6 +224,7 @@ export class RoutingService {
   resetForRelease(): void {
     this.setPremiumAssigned(false)
     this.setPremiumInstanceId(null)
+    this.setPremiumShared(false)
     this.clearRoutingToken()
     this.lastReachableSentAt = 0
   }
@@ -261,6 +271,22 @@ export class RoutingService {
    */
   getPremiumInstanceId(): string | null {
     return this.premiumInstanceId
+  }
+
+  /**
+   * Set whether the current assignment is a shared (pool) instance.
+   * Set alongside the instance ID whenever an assignment is established.
+   */
+  setPremiumShared(shared: boolean): void {
+    this.premiumShared = shared
+    this.savePremiumSharedToStorage(shared)
+  }
+
+  /**
+   * Whether the current assignment is a shared (pool) instance.
+   */
+  isPremiumShared(): boolean {
+    return this.premiumShared
   }
 
   /**
@@ -553,6 +579,34 @@ export class RoutingService {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn("Failed to clear premium instance ID from localStorage:", e)
+    }
+  }
+
+  private loadPremiumSharedFromStorage(): void {
+    try {
+      this.premiumShared =
+        localStorage.getItem(this.PREMIUM_SHARED_KEY) === "true"
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to load premium shared from localStorage:", e)
+    }
+  }
+
+  private savePremiumSharedToStorage(shared: boolean): void {
+    try {
+      localStorage.setItem(this.PREMIUM_SHARED_KEY, String(shared))
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to save premium shared to localStorage:", e)
+    }
+  }
+
+  private clearPremiumSharedFromStorage(): void {
+    try {
+      localStorage.removeItem(this.PREMIUM_SHARED_KEY)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to clear premium shared from localStorage:", e)
     }
   }
 }


### PR DESCRIPTION
## Summary

A premium user whose current assignment is **shared** (`is_shared: true`) could be
permanently downgraded to free tier by a **single** transient premium request failure —
until the next browser reload.

The premium recovery machinery (the unreachable state machine, the half-open probe, the
unreachable notifications) is intentionally **dedicated-only**: a shared assignment is a
transient/pool state whose recovery model is "keep polling `/status` to upgrade to
dedicated", not "probe and reassign". The axios teardown choke-point, however, downgraded
**any** premium-assigned user — shared or dedicated — on a genuine failure. That
asymmetry meant a shared assignment was torn down (`premiumAssigned = false`) with nothing
to re-arm it: the state machine never engaged, and polling on a shared assignment does not
re-arm routing (only an upgrade to dedicated does). Result: stranded on free tier.

This PR scopes the teardown to **dedicated** assignments, aligning the entry side with the
existing recovery boundary.

## Root Cause — entry/recovery asymmetry for shared assignments

**Entry side treated shared as premium.** When `/status` returned an existing assignment,
the client called `setPremiumAssigned(true)` + `setPremiumInstanceId(hash)` regardless of
`is_shared`, so a shared user sent premium routing headers and was subject to teardown. On
a genuine failure (network error / 5xx), the axios error interceptor called
`handlePremiumRoutingError` → `tearDownPremiumRoutingUnlessWarmup`, which set
`setPremiumAssigned(false)` and emitted `premiumUnreachable`. That choke-point gated only
on warm-up and staleness — it had **no shared/dedicated check**.

**Recovery side excludes shared** (by design):

- The unreachable state machine early-returns for shared (`if (!a?.assigned || a.is_shared)
  return`) — no flip, no `instance_unreachable`, no half-open probe.
- Polling re-establishes routing only on an upgrade to dedicated (`assignment &&
  !assignment.is_shared` → `finalizeDedicatedAssignment`); the shared branch updates state
  but never calls `setPremiumAssigned(true)`.
- The unreachable notifications are dedicated-only.

So once teardown set `premiumAssigned = false` for a shared user, **nothing re-armed it**:
the machine never flipped (no probe), and subsequent requests carried no premium headers
(so they could not emit reachable). Stranded until reload.

### Why it strands even though shared keeps polling

`shouldPoll` returns true for shared, so a shared user does keep polling `/status`. But
polling on a **shared** result does not re-arm `premiumAssigned` — only an upgrade to
dedicated (or a successful re-trigger `/assign`) does. So if the backend keeps returning
the shared assignment, polling alone never lifts the free-tier strand. What prevents the
strand is keeping `premiumAssigned` armed in the first place (this fix); polling then
continues to handle the shared→dedicated upgrade.

## Fix — scope the teardown to dedicated assignments (Option A)

Align the **entry** boundary with the existing **recovery** boundary: do not permanently
downgrade a **shared** assignment on a transient failure.

- `RoutingService` now tracks whether the current assignment is shared — a `premiumShared`
  flag, set alongside `setPremiumInstanceId` at every assignment-establishment site and
  cleared on release / logout / downgrade. It is **persisted to localStorage** (like
  `premiumInstanceId`) so the gate is correct in the reload window before `/status`
  resolves.
- `tearDownPremiumRoutingUnlessWarmup` gains a shared guard, mirroring the existing
  warm-up / staleness suppression:

```ts
if (routingService.isWithinPremiumWarmup()) return
if (routingService.isStalePremiumFailure(detail.sentAt)) return
// Shared assignments have no dedicated-only recovery (state machine / probe),
// so a permanent downgrade here would strand them on free tier with nothing to
// re-arm. The per-request free-tier retry in the caller still serves the request.
if (routingService.isPremiumShared()) return
routingService.setPremiumAssigned(false)
routingService.emitPremiumUnreachable(detail)
```

Because the guard lives inside the single choke-point, it covers **both** teardown callers
— the 502/503/network-error path and the success-path `isInstanceMismatch` (ALB fallback)
detection.

**What this means for a shared user**

- A failing request is still served: `handlePremiumRoutingError` still performs the
  per-request free-tier retry (headers stripped) — only the *permanent* downgrade is
  suppressed.
- `premiumAssigned` stays armed, so when the shared instance recovers the very next request
  resumes premium routing — no reload needed.
- Entitlement is unaffected: a genuine subscription downgrade still clears everything via
  `updateRoutingInfo` on `getMe` (which now also clears `premiumShared`). There is no path
  where a non-premium user keeps premium routing.

### Alternatives considered (not taken)

- **Extend recovery to shared** (give shared its own probe/reassign semantics): large blast
  radius across the state machine, notifications, and polling; best folded into #733.
- **Stop sending routing headers for shared**: unsafe — `/status` returns an `alb_rule_arn`
  + `target_group_arn` for shared, so the header is required to reach the shared premium
  target group.

## Changed Files

| File | Change |
|------|--------|
| `frontend/src/utils/routing/RoutingService.ts` | Add `premiumShared` state: `setPremiumShared` / `isPremiumShared`, localStorage load/save/clear, and clearing in `clearRoutingInfo` / `resetForRelease` / `updateRoutingInfo` (non-premium). |
| `frontend/src/utils/axios.ts` | `tearDownPremiumRoutingUnlessWarmup` skips the teardown when `isPremiumShared()` (covers both the error and instance-mismatch callers). |
| `frontend/src/contexts/PremiumAssignmentContext.tsx` | Set `setPremiumShared(is_shared)` alongside `setPremiumInstanceId` at all four assignment-establishment sites (manual assign, `/status`-existing, `/assign`, `finalizeDedicatedAssignment`), plus a defensive `setPremiumShared(true)` in the polling shared branch so a shared state reached only via polling still gates teardown. |
| `frontend/src/utils/routing/RoutingService.test.ts` | Unit tests for the `premiumShared` flag: round-trip, persistence, and clearing on the three "premium goes away" paths. |
| `frontend/src/utils/__tests__/axiosPremiumInterceptor.test.ts` | Interceptor tests: shared 5xx does NOT tear down; shared instance-mismatch (success path) does NOT tear down; dedicated 5xx still tears down (control). |
| `frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx` | Wiring tests: a shared `/status` assignment forwards `is_shared` → `routingService.isPremiumShared()` is `true`; a dedicated one leaves it `false`. |

## Test Coverage

- **Unit** (`RoutingService.test.ts`): `premiumShared` defaults false, round-trips and
  persists, loads from localStorage on init, and is cleared by `clearRoutingInfo`,
  `resetForRelease`, and `updateRoutingInfo` for a non-premium user.
- **Interceptor** (`axiosPremiumInterceptor.test.ts`): a 502/503 **and** a success-path
  instance-mismatch (200 from the wrong instance) while `isPremiumShared()` is true both
  leave `premiumAssigned` armed and emit nothing, and the request still resolves via
  free-tier fallback; the dedicated control still tears down and emits.
- **Wiring** (`PremiumUnreachableIntegration.test.tsx`): rendering the provider against a
  shared `/status` result leaves `routingService.isPremiumShared() === true` (a dedicated
  result leaves it `false`), asserting the establishment sites forward `is_shared`.

### Results

```
RoutingService.test.ts                 all passed (+6 new)
axiosPremiumInterceptor.test.ts        all passed (+3 new)
PremiumUnreachableIntegration.test.tsx all passed (+2 new)

Focused suites (routing / axios / contexts): 22 suites, 402 tests passed, 0 failed
```

Red-check confirmation: with the shared guard removed, the "shared 5xx does not tear down"
test fails; the dedicated control stays green — proving the test exercises exactly the new
gate.

---

## Manual Test Plan

> **Reproduction requires a SHARED assignment.** This bug only affects users whose
> `GET /users/me/premium/status` returns `assignment.is_shared: **true**`. A dedicated
> assignment (`is_shared: false`) takes the dedicated recovery path (#754) and will not
> reproduce this. Confirm the assignment type in `/status` before testing.

> **Observability note (read first).** For a shared assignment there is **no** UI tier
> badge that flips to "free". By existing design a shared user sees the persistent
> *"Please wait while your dedicated premium resource is being prepared."* snackbar and the
> account/subscription pages still show **Premium** (that is entitlement, not instance
> health). The fix operates on the routing layer, so **verify it in the Network tab**, not
> by watching for a UI tier change.

### Test priority

| Test | Role | Priority |
|------|------|----------|
| **Test 1** | Core fix — the behavior this PR changes | **High** |
| **Test 2** | Regression guard (dedicated path unchanged) | Medium |
| **Test 3** | Safety-net (entitlement gate intact) | Medium |

Test 1 is the primary verification; Test 2 and Test 3 guard against side effects.

### Prerequisites

- A premium-subscribed user (`subscription_plan_name` and `subscription_status` both
  exactly `"Premium"`) that is currently placed on a **shared** instance
  (`/status` → `assignment.is_shared: true`).
- Browser DevTools open (Network tab, Console tab, Application tab).
- Network tab **"Preserve log"** enabled.

### Test 1: A transient failure on a shared assignment must not strand routing (core fix)

**Objective:** After a single premium request on a shared assignment fails, premium
routing must remain armed — subsequent requests still carry routing headers and resume on
the shared instance — **without** a browser reload.

#### Step 1: Establish a shared premium assignment

1. Log in as the premium user and wait for the assignment flow to settle.
2. **Verify:** `GET /users/me/premium/status` returns `assignment.is_shared: true` with an
   `instance_id`.
3. In the **Application** tab > Local Storage, **verify:** `premium_assigned` is `"true"`,
   `premium_shared` is `"true"`, and `routing_id` holds a hex value (the routing token,
   used to build the `x-routing-id` header while premium is armed).
4. Trigger a normal premium data request (e.g. the workspace list) and **verify** in
   Network that it carries the `x-routing-id` request header and returns `200 OK`.

**Checkpoint:** Shared premium assignment active; the "preparing dedicated resource"
snackbar is visible (expected for shared).

#### Step 2: Block a premium request URL

1. In the Network tab, right-click a repeatable premium request
   (`GET /workspaces?offset=0&limit=50` is a good target) > **Block request URL**.

#### Step 3: Trigger the blocked request

1. Perform the in-app action that issues the blocked request (refresh the workspace list —
   **not** a browser reload).
2. **Observe** in Network: the blocked request fails (`net::ERR_BLOCKED_BY_CLIENT`), then a
   **retry without premium headers** is issued and returns `200` from the free tier (the
   `Using free tier while premium instance provisions` line appears in the Console).
3. **Verify (no ui-events):** no `instance_unreachable` snackbar appears (shared has no
   unreachable machinery — expected).
4. In the **Application** tab, **verify (the fix):** `premium_assigned` is **still `"true"`**
   (before this fix it flipped to `"false"` here).

#### Step 4: Confirm premium routing resumes without a reload

1. Remove the block (Network tab > **Unblock** the request URL).
2. Trigger another premium data request in-app.
3. **Verify (fixed):** the request carries the `x-routing-id` header again and is served by
   the shared premium instance (`x-served-by-instance` matches the stored hash) — **no
   browser reload was needed.**
   - **Before this fix:** `premium_assigned` was `"false"`, subsequent requests carried no
     routing headers and were served by the free tier, and only a browser reload restored
     premium.

**Expected result:** Premium routing is retained end-to-end; on unblock, the user is back
on the shared premium instance immediately.

### Test 2: Dedicated assignment still tears down and recovers (regression guard)

**Objective:** Confirm the fix did not change the dedicated path.

1. With a **dedicated** assignment (`/status` → `is_shared: false`), block a premium
   request URL and trigger it (as in #754's plan).
2. **Verify:** the dedicated path still fires `instance_unreachable`, tears down
   (`premium_assigned` → `"false"`), and recovers via the half-open probe / a concurrent
   success — unchanged from #754.

### Test 3: Subscription downgrade still drops premium (entitlement gate intact)

**Objective:** While on a shared premium session, confirm that losing the subscription
entitlement fully tears down premium routing. This is the safety-net (negative) test: it
proves the fix does **not** open a hole where a non-premium user keeps premium routing.

> **Mechanism note.** This teardown is **not** driven by the axios teardown choke-point that
> this PR changed. It is driven by the periodic `GET /users/me`: the moment
> `subscription_status` is no longer `"Premium"`, the premium-specific state
> (`premium_assigned`, `premium_shared`, `premium_instance_id`) is cleared and `routing_tier`
> flips to `free`. That path is entitlement-driven and is unaffected by this fix — so this
> test also confirms the newly added `premium_shared` flag is cleared there too.
>
> Note that `routing_id` (the per-user routing token) is **not** premium-specific and
> intentionally persists here (it is only cleared on logout). It is inert while
> `premium_assigned` is `"false"`, so no premium routing header is sent.

#### Step 1: Establish a shared premium assignment (same as Test 1, Step 1)

1. Log in as the premium user and wait for the assignment flow to settle.
2. **Verify:** `GET /users/me/premium/status` returns `assignment.is_shared: true` with an
   `instance_id`.
3. In the **Application** tab > Local Storage, **verify:** `premium_assigned` is `"true"`,
   `premium_shared` is `"true"`, and `routing_id` holds a hex value.
4. Trigger a normal premium data request (e.g. the workspace list) and **verify** in
   Network that it carries the `x-routing-id` request header and returns `200 OK`.

#### Step 2: Move the account off premium

Make `GET /users/me` return a non-premium user, by either:

- **(a)** having the backend actually downgrade / cancel the account's subscription, **or**
- **(b)** overriding the `GET /users/me` response in DevTools so `subscription_status` (and
  `subscription_plan_name`) is anything other than `"Premium"` (e.g. `"Free"`).

#### Step 3: Let the periodic `GET /users/me` fire

1. Wait for the next periodic `GET /users/me` (or refresh the page to force it).
2. **Observe** in Network: the `GET /users/me` response now carries a non-premium
   `subscription_status`.

#### Step 4: Confirm premium routing is fully cleared

1. In the **Application** tab > Local Storage, **verify** the premium-specific state is
   cleared:
   - `premium_assigned` → `"false"`
   - `premium_shared` → `"false"` (the flag added by this PR)
   - `premium_instance_id` → removed
   - `routing_tier` → `"free"`
2. Trigger any further data request and **verify** in Network that it carries **no**
   `x-routing-id` header and is served by the free tier.

**Expected result:** Losing entitlement fully tears down premium routing. This is driven by
entitlement, not instance health, and is unaffected by the fix.

## Acceptance Criteria

- [x] A premium user on a **shared** assignment hit by an isolated transient failure is
      **not** permanently downgraded to free tier; premium routing resumes on the shared
      instance without a browser reload.
- [x] **Dedicated** behavior is unchanged: teardown, `instance_unreachable`, the half-open
      probe, and reassignment all fire exactly as before.
- [x] A genuine subscription downgrade still clears premium routing (no unentitled premium).
- [x] No regression to warm-up (#745), staleness (#750), or exit-side re-arm (#754).

## Known limitation (by design)

Shared has **no circuit breaker**. If a shared instance is *permanently* dead (not just a
transient blip), `premiumAssigned` stays armed, so every request pays a failed-first-attempt
+ free-tier retry (double round-trips) until `/status`/`/assign` re-places the user
elsewhere. This is the deliberate flip side of not tearing down — and strictly better than
the pre-fix silent strand (every request on free tier with no recovery). A shared
degraded/backoff state is deferred to #733.

## Relationship to Other Work

- **#730 (parent):** a new child bug, sibling to #754 / #750 / #745.
- **#754:** the exit-side re-arm (dedicated recovery). Its `emitPremiumReachable` re-arm
  only *partially masked* this bug (recovered a shared user only when a concurrent premium
  success happened to land after teardown). This PR closes the shared gap directly.
- **#733:** the structural refactor into an explicit state machine would subsume a fuller
  shared/dedicated parity (giving shared its own degraded/recovery UX) if that becomes a
  product requirement.
