### PR TITLE
Fix shared premium polling stall past the pollInterval cap

### DIFF
--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -211,7 +211,11 @@ export const PremiumAssignmentProvider: React.FC<{
   const [autoAssignGeneration, setAutoAssignGeneration] = useState(0)
   const needsReassignAfterReleaseRef = useRef(false)
 
-  // Polling state with backoff
+  // Polling state with backoff.
+  // NOTE: pollAttempts is dual-purpose — it's the attempt counter (MAX_POLL_ATTEMPTS
+  // stop, re-trigger threshold) AND a keep-alive tick: it's in the poll effect's
+  // dependency array, so incrementing it every cycle re-runs the effect and
+  // reschedules the next poll even after pollInterval saturates (needed for shared).
   const [pollInterval, setPollInterval] = useState(INITIAL_POLL_INTERVAL_MS)
   const [pollAttempts, setPollAttempts] = useState(() => {
     const stored = ssRead(SS_POLL_ATTEMPTS)
@@ -1159,7 +1163,8 @@ export const PremiumAssignmentProvider: React.FC<{
           )
           // Increment for shared too — a changing dep re-runs the effect and
           // reschedules the next poll once pollInterval saturates at the cap.
-          // Shared stop still excluded (:991); re-trigger is null-only.
+          // The MAX_POLL_ATTEMPTS stop still excludes shared (!isOnShared), and
+          // the re-trigger check runs only in the null-assignment branch.
           setPollAttempts((prev) => prev + 1)
           // Exponential backoff capped at MAX_POLL_INTERVAL_MS
           setPollInterval((prev) =>

--- a/frontend/src/contexts/PremiumAssignmentContext.tsx
+++ b/frontend/src/contexts/PremiumAssignmentContext.tsx
@@ -1157,10 +1157,10 @@ export const PremiumAssignmentProvider: React.FC<{
           console.warn(
             "Still on temporary instance, will retry with backoff...",
           )
-          const isOnShared = assignment?.is_shared === true
-          if (!isOnShared) {
-            setPollAttempts((prev) => prev + 1)
-          }
+          // Increment for shared too — a changing dep re-runs the effect and
+          // reschedules the next poll once pollInterval saturates at the cap.
+          // Shared stop still excluded (:991); re-trigger is null-only.
+          setPollAttempts((prev) => prev + 1)
           // Exponential backoff capped at MAX_POLL_INTERVAL_MS
           setPollInterval((prev) =>
             Math.min(prev * BACKOFF_MULTIPLIER, MAX_POLL_INTERVAL_MS),

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -390,11 +390,12 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
     expect(ctxRef.current?.error).toBeNull()
   })
 
-  test("polling on shared neither terminates nor increments pollAttempts", async () => {
-    // Isolates the cap-bypass + counter-freeze: across multiple shared polls,
-    // error must stay null and pollAttempts must not be persisted (the provider
-    // only writes the SS key when the counter is >0, so a null read proves no
-    // increment occurred).
+  test("polling on shared does not terminate and keeps the counter advancing", async () => {
+    // Cap-bypass: across multiple shared polls error stays null and the
+    // assignment stays shared (the MAX_POLL_ATTEMPTS stop excludes shared).
+    // pollAttempts must advance every cycle — that dependency change is what
+    // re-runs the effect and reschedules the next poll once pollInterval
+    // saturates, so the loop cannot stall (a frozen counter used to kill it).
     mockGetPremiumStatus.mockResolvedValue(sharedStatus)
 
     const ctxRef = renderProvider()
@@ -412,7 +413,8 @@ describe("PremiumAssignmentProvider — polling routing restore", () => {
 
     expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
     expect(ctxRef.current?.error).toBeNull()
-    expect(sessionStorage.getItem(SS_POLL_ATTEMPTS)).toBeNull()
+    // Counter advanced (>0) and is persisted — proves the loop kept re-running.
+    expect(Number(sessionStorage.getItem(SS_POLL_ATTEMPTS))).toBeGreaterThan(0)
   })
 
   test("repeated shared-status polls do not churn assignmentResult identity", async () => {

--- a/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
@@ -330,4 +330,39 @@ describe("PremiumAssignmentProvider — shared polling does not stall at the cap
       )
     })
   })
+
+  test("shared-origin user whose /status goes null keeps polling and never stops", async () => {
+    // The MAX_POLL_ATTEMPTS stop is gated on the STORED assignment
+    // (state.assignmentResult?.is_shared, :990). The null-status branch (:1084)
+    // preserves assignmentResult, so a shared-origin user stays shared even
+    // after /status returns null — isOnShared stays true and the stop never
+    // fires, no matter how high the (now-incrementing) counter climbs. Guards
+    // against a future change that clears assignmentResult on null and thereby
+    // re-enables the stop for these users.
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+    // Re-trigger assign (fires in the null branch) stays retryable — never
+    // finalizes a dedicated instance, so the assignment remains shared.
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+
+    // Assignment is lost on the backend: /status now returns null.
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+
+    // Advance well past MAX_POLL_ATTEMPTS (40) — the stop must not fire.
+    for (let i = 0; i < 45; i++) {
+      await advanceOnePollCycle()
+    }
+
+    // Still shared (assignmentResult preserved), no error surfaced, and polling
+    // kept running the whole time.
+    expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    expect(ctxRef.current?.assignmentResult).not.toBeNull()
+    expect(ctxRef.current?.error).toBeNull()
+    expect(mockGetPremiumStatus.mock.calls.length).toBeGreaterThan(40)
+  })
 })

--- a/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
@@ -13,6 +13,8 @@
  *  2. A delayed shared→dedicated upgrade is still finalized and clears
  *     premium_shared.
  *  3. The dedicated MAX_POLL_ATTEMPTS stop is unchanged.
+ *  4. A shared-origin user whose /status goes null keeps polling and never
+ *     stops (the MAX_POLL_ATTEMPTS stop stays excluded for shared).
  */
 
 import React from "react"
@@ -333,12 +335,12 @@ describe("PremiumAssignmentProvider — shared polling does not stall at the cap
 
   test("shared-origin user whose /status goes null keeps polling and never stops", async () => {
     // The MAX_POLL_ATTEMPTS stop is gated on the STORED assignment
-    // (state.assignmentResult?.is_shared, :990). The null-status branch (:1084)
-    // preserves assignmentResult, so a shared-origin user stays shared even
-    // after /status returns null — isOnShared stays true and the stop never
-    // fires, no matter how high the (now-incrementing) counter climbs. Guards
-    // against a future change that clears assignmentResult on null and thereby
-    // re-enables the stop for these users.
+    // (state.assignmentResult?.is_shared). The null-status branch only updates
+    // statusResult and preserves assignmentResult, so a shared-origin user
+    // stays shared even after /status returns null — isOnShared stays true and
+    // the stop never fires, no matter how high the (now-incrementing) counter
+    // climbs. Guards against a future change that clears assignmentResult on
+    // null and thereby re-enables the stop for these users.
     mockGetPremiumStatus.mockResolvedValue(sharedStatus)
     // Re-trigger assign (fires in the null branch) stays retryable — never
     // finalizes a dedicated instance, so the assignment remains shared.

--- a/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * Tests for the shared-assignment polling stall fix.
+ *
+ * A shared assignment must keep polling /status until the backend upgrades it
+ * to dedicated. The poll effect re-schedules only when a dependency changes;
+ * once pollInterval saturates at MAX_POLL_INTERVAL_MS a stable shared
+ * assignment left every other dependency unchanged and the loop stalled after
+ * ~3 polls. Incrementing pollAttempts for shared too keeps a dependency moving
+ * so the loop stays alive.
+ *
+ * Covers:
+ *  1. Shared status keeps being polled past the pollInterval cap (no stall).
+ *  2. A delayed shared→dedicated upgrade is still finalized and clears
+ *     premium_shared.
+ *  3. The dedicated MAX_POLL_ATTEMPTS stop is unchanged.
+ */
+
+import React from "react"
+
+import { SnackbarProvider } from "notistack"
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals"
+import { act, render, waitFor } from "@testing-library/react"
+
+import type {
+  PremiumAssignmentResult,
+  PremiumReleaseResult,
+  PremiumStatusResult,
+  PremiumHeartbeatResult,
+  RoutingInfo,
+} from "api/premium/PremiumAssignmentApi"
+import { UserTier } from "const/Subscription"
+import type { TabSyncMessage, TabSyncMessageType } from "utils/crossTabSync"
+
+// --- Module mocks (must precede provider import) ---
+
+const mockUser = {
+  id: 1,
+  uid: "test-uid",
+  subscription_plan_name: "Premium",
+  subscription_status: "Premium",
+}
+
+const mockDispatchFn = jest.fn(() => Promise.resolve())
+const mockLogoutFn = jest.fn()
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      user: { currentUser: mockUser, logoutGeneration: 0 },
+      pipeline: { run: { status: "StartUninitialized" } },
+    }),
+  useDispatch: () => mockDispatchFn,
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  __esModule: true,
+  getMe: () => ({ type: "user/getMe" }),
+}))
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  __esModule: true,
+  logout: mockLogoutFn,
+}))
+
+const mockAssignPremiumInstance = jest.fn<
+  Promise<PremiumAssignmentResult>,
+  []
+>()
+const mockReleasePremiumInstance = jest.fn<Promise<PremiumReleaseResult>, []>()
+const mockGetPremiumStatus = jest.fn<Promise<PremiumStatusResult>, []>()
+const mockGetBeaconTokenApi = jest
+  .fn<Promise<{ data: { token: string } }>, []>()
+  .mockResolvedValue({ data: { token: "t" } })
+const mockSendPremiumHeartbeat = jest
+  .fn<Promise<PremiumHeartbeatResult>, []>()
+  .mockResolvedValue({} as PremiumHeartbeatResult)
+const mockGetRoutingInfo = jest
+  .fn<Promise<RoutingInfo | null>, []>()
+  .mockResolvedValue(null)
+const mockLogPremiumUiEvent = jest.fn<
+  Promise<void>,
+  [string, Record<string, unknown>?]
+>()
+
+jest.mock("api/premium/PremiumAssignmentApi", () => ({
+  __esModule: true,
+  assignPremiumInstance: mockAssignPremiumInstance,
+  releasePremiumInstance: mockReleasePremiumInstance,
+  getPremiumStatus: mockGetPremiumStatus,
+  getBeaconTokenApi: mockGetBeaconTokenApi,
+  sendPremiumHeartbeat: mockSendPremiumHeartbeat,
+  getRoutingInfo: mockGetRoutingInfo,
+  logPremiumUiEvent: mockLogPremiumUiEvent,
+}))
+
+jest.mock("hooks/useSleepDetection", () => ({
+  __esModule: true,
+  useSleepDetection: () => undefined,
+}))
+
+const mockTabSyncHandlers: Map<
+  TabSyncMessageType,
+  Set<(msg: TabSyncMessage) => void>
+> = new Map()
+
+jest.mock("utils/crossTabSync", () => ({
+  __esModule: true,
+  tabSync: {
+    broadcast: () => {},
+    broadcastLogout: () => {},
+    broadcastPremiumReleased: () => {},
+    on: (type: TabSyncMessageType, handler: (m: TabSyncMessage) => void) => {
+      if (!mockTabSyncHandlers.has(type))
+        mockTabSyncHandlers.set(type, new Set())
+      mockTabSyncHandlers.get(type)!.add(handler)
+      return () => mockTabSyncHandlers.get(type)?.delete(handler)
+    },
+    onAny: () => () => {},
+    destroy: () => {},
+  },
+  syncActivityAcrossTabs: () => {},
+  getLastActivityFromAnyTab: () => 0,
+  onActivityFromOtherTab: () => () => {},
+  CrossTabLeaderElection: class {
+    constructor(onBecomeLeader: () => void) {
+      setTimeout(onBecomeLeader, 0)
+    }
+    getIsLeader() {
+      return true
+    }
+    destroy() {}
+  },
+}))
+
+// require() not import — static imports hoist above the mock vars.
+const { PremiumAssignmentProvider, usePremiumAssignment } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("contexts/PremiumAssignmentContext")
+const { routingService } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("utils/routing/RoutingService")
+
+// --- Helpers ---
+
+type Ctx = ReturnType<typeof usePremiumAssignment>
+
+const Harness: React.FC<{ ctxRef: { current: Ctx | null } }> = ({ ctxRef }) => {
+  ctxRef.current = usePremiumAssignment()
+  return null
+}
+
+const renderProvider = () => {
+  const ctxRef: { current: Ctx | null } = { current: null }
+  render(
+    <SnackbarProvider maxSnack={3}>
+      <PremiumAssignmentProvider>
+        <Harness ctxRef={ctxRef} />
+      </PremiumAssignmentProvider>
+    </SnackbarProvider>,
+  )
+  return ctxRef
+}
+
+/** Status endpoint returning a stable shared assignment. */
+const sharedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "shared-1",
+    is_shared: true,
+    assigned_at: "2026-06-22T00:00:00Z",
+    status: "active",
+  },
+}
+
+/** Status endpoint returning a dedicated assignment (the upgrade). */
+const dedicatedStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: {
+    instance_id: "inst-A",
+    is_shared: false,
+    assigned_at: "2026-06-22T00:00:00Z",
+    status: "active",
+  },
+}
+
+/** Status endpoint returning null assignment (no assignment exists). */
+const nullAssignmentStatus: PremiumStatusResult = {
+  user_id: 1,
+  subscription_type: UserTier.PREMIUM,
+  is_premium: true,
+  assignment: null,
+}
+
+/** A retryable assign response (assigned: false, scaling_in_progress: true). */
+const retryableAssignment: PremiumAssignmentResult = {
+  message: "scaling in progress",
+  instance_id: "",
+  assigned: false,
+  is_shared: false,
+  assignment_source: "pending",
+  scaling_in_progress: true,
+  retry_after: 30,
+}
+
+/**
+ * Advance timers and flush microtasks to simulate one polling cycle.
+ * Each call advances 60s (≥ any backoff interval, incl. the saturated cap).
+ */
+const advanceOnePollCycle = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(60_000)
+    await Promise.resolve()
+  })
+}
+
+// --- Tests ---
+
+describe("PremiumAssignmentProvider — shared polling does not stall at the cap", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockTabSyncHandlers.clear()
+    localStorage.clear()
+    sessionStorage.clear()
+    routingService.clearRoutingInfo()
+    routingService.setPremiumAssigned(false)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test("keeps polling /status past the pollInterval cap for a stable shared assignment", async () => {
+    // Every /status returns the same shared assignment — pollInterval saturates
+    // (30000 → 45000 → 60000 → 60000…) after ~3 polls. Pre-fix, once the
+    // interval stopped changing no dependency moved and polling stalled at 3.
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+
+    const ctxRef = renderProvider()
+
+    // autoAssignOnLogin consumes the first /status and records the shared state.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+    expect(mockGetPremiumStatus).toHaveBeenCalledTimes(1)
+
+    // Advance well past the point where pollInterval saturates. Pre-fix this
+    // would stall at 4 total /status calls (1 mount + 3 polls); with the fix
+    // the loop keeps re-scheduling.
+    for (let i = 0; i < 6; i++) {
+      await advanceOnePollCycle()
+    }
+
+    // Still on shared, and /status kept being polled beyond the ~3-poll stall.
+    expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    expect(mockGetPremiumStatus.mock.calls.length).toBeGreaterThan(4)
+  })
+
+  test("finalizes a delayed shared→dedicated upgrade and clears premium_shared", async () => {
+    // Start on a stable shared assignment.
+    mockGetPremiumStatus.mockResolvedValue(sharedStatus)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+    })
+    expect(routingService.isPremiumShared()).toBe(true)
+
+    // Poll past the interval cap while still shared — loop must survive.
+    for (let i = 0; i < 5; i++) {
+      await advanceOnePollCycle()
+    }
+    expect(ctxRef.current?.assignmentResult?.is_shared).toBe(true)
+
+    // Backend completes the migration: /status now returns dedicated.
+    mockGetPremiumStatus.mockResolvedValue(dedicatedStatus)
+    await advanceOnePollCycle()
+
+    // The dedicated assignment is finalized without a browser reload.
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult?.assigned).toBe(true)
+      expect(ctxRef.current?.assignmentResult?.is_shared).toBe(false)
+      expect(ctxRef.current?.assignmentResult?.instance_id).toBe("inst-A")
+    })
+    expect(routingService.isPremiumShared()).toBe(false)
+    expect(routingService.isPremiumAssigned()).toBe(true)
+
+    // Polling stops now that the assignment is dedicated and healthy.
+    mockGetPremiumStatus.mockClear()
+    await advanceOnePollCycle()
+    await advanceOnePollCycle()
+    expect(mockGetPremiumStatus).not.toHaveBeenCalled()
+  })
+
+  test("dedicated MAX_POLL_ATTEMPTS stop is unchanged", async () => {
+    // A non-shared retry loop (null status + retryable assign) must still stop
+    // at MAX_POLL_ATTEMPTS — the shared fix must not remove that stop.
+    mockGetPremiumStatus.mockResolvedValue(nullAssignmentStatus)
+    mockAssignPremiumInstance.mockResolvedValue(retryableAssignment)
+
+    const ctxRef = renderProvider()
+
+    await waitFor(() => {
+      expect(mockAssignPremiumInstance).toHaveBeenCalledTimes(1)
+    })
+
+    // Advance through all 40 poll cycles to reach MAX_POLL_ATTEMPTS.
+    for (let i = 0; i < 40; i++) {
+      await advanceOnePollCycle()
+    }
+
+    await waitFor(() => {
+      expect(ctxRef.current?.assignmentResult).toBeNull()
+      expect(ctxRef.current?.error).toContain(
+        "No premium instance available after extended wait",
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

A premium user on a **shared** assignment is supposed to poll `GET /premium/status`
indefinitely until the backend upgrades them to a **dedicated** instance. In practice the
poll loop **stopped after ~3 attempts (~2 minutes)** whenever the same shared assignment
kept being returned. If the backend's shared→dedicated migration took longer than that,
the frontend never saw the dedicated `/status`, so it stayed on the shared assignment —
`assignmentResult.is_shared` and `localStorage.premium_shared` remained `true` — until the
next browser reload.

This PR removes the shared-only `pollAttempts` freeze that was silently killing the loop,
so shared polling stays alive until the upgrade lands.

---

## Root Cause

The polling loop is **dependency-driven**: the effect schedules one `setTimeout`; when it
fires it updates state; that state change re-runs the effect, which schedules the next
`setTimeout`. Its dependency array is:

```
[isPremiumUser, isTabLeader, state.assignmentResult,
 unreachable.state.instanceUnreachable, pollInterval, pollAttempts]
```

When the **same** shared assignment is returned every cycle, none of the dependencies keep
changing:

| Dependency | Behaviour for a stable shared assignment |
|---|---|
| `state.assignmentResult` | **Unchanged** — the "same instance" branch returns `{ ...prev, statusResult }`, preserving the `assignmentResult` reference. |
| `statusResult` | Changes, but is **not in the dependency array** — cannot drive a re-run. |
| `pollAttempts` | **Frozen for shared** — `if (!isOnShared) setPollAttempts(prev + 1)`. |
| `instanceUnreachable` | Stays `false` for shared. |
| `pollInterval` | Grows `30000 → 45000 → 60000`, then **saturates** at the cap (`Math.min(60000 * 1.5, 60000) = 60000`). |

Once `pollInterval` reaches `MAX_POLL_INTERVAL_MS`, it stops changing. At that point **no
dependency changes after a poll**, the effect does not re-run, the next `setTimeout` is
never scheduled, and **polling silently dies.**

### Timeline (matches the observation exactly)

- `t=0`: effect runs, schedules `setTimeout(30000)`.
- `t≈30s`: poll #1 → interval `30000 → 45000` (changed → re-run → reschedule).
- `t≈75s`: poll #2 → interval `45000 → 60000` (changed → re-run → reschedule).
- `t≈135s`: poll #3 → interval `60000 → 60000` (**unchanged → no re-run → no reschedule → STOP**).

### Why the two guards cancelled each other out

The intent "shared should poll past the cap" was already enforced on the **stop** side —
`if (pollAttempts >= MAX_POLL_ATTEMPTS && !isOnShared)` excludes shared from the max-attempts
stop. But a **second** guard also froze `pollAttempts` for shared. That freeze was redundant
for the stop purpose (the stop already excludes shared regardless of the counter's value),
and it removed the last per-cycle dependency change that kept the loop alive — so the loop
died by a *different* mechanism (interval saturation) than the one that was guarded against.

Both guards were introduced together in an earlier "code quality" change; they were meant to
reinforce each other but instead worked against each other.

### Why a plain sign-in didn't reproduce it

If the dedicated instance is ready within the first one or two polls (before `pollInterval`
saturates), a dedicated `/status` triggers `finalizeDedicatedAssignment`, `assignmentResult`
changes → `shouldPoll` becomes false → the loop stops **correctly** (upgraded). The bug only
surfaced when the migration took longer than ~3 poll cycles.

---

## Changes

**File**: `frontend/src/contexts/PremiumAssignmentContext.tsx`

### Drop the shared-only `pollAttempts` freeze

```typescript
// Before:
const isOnShared = assignment?.is_shared === true
if (!isOnShared) {
  setPollAttempts((prev) => prev + 1)
}

// After:
setPollAttempts((prev) => prev + 1)
```

Incrementing `pollAttempts` every cycle (shared included) keeps a dependency moving, so the
effect re-runs and reschedules the next poll even after `pollInterval` saturates. The loop
stays alive until the shared→dedicated upgrade lands.

### Why this is safe (all `pollAttempts` readers reviewed)

| Reader | Effect of a growing counter for shared |
|---|---|
| `MAX_POLL_ATTEMPTS` stop (`&& !isOnShared`) | Shared already excluded — the counter's value is irrelevant; shared keeps polling. |
| Re-trigger-assign modulo check | Lives in the **null-assignment** branch only; never reached while a shared assignment is present. |
| `SS_POLL_ATTEMPTS` persistence | Now written each shared poll. Harmless: on refresh a high restored value still can't stop shared (stop excludes shared). |

**Secondary behaviour note**: the growing counter is harmless even in the rare transition
*shared → assignment lost (`status` returns null)*, and specifically **does not** bring the
`MAX_POLL_ATTEMPTS` stop into play. The stop (`:990-991`) is gated on the **stored**
assignment (`state.assignmentResult?.is_shared`), and the null-status branch (`:1084`) updates
only `statusResult` — it preserves `assignmentResult`. So a shared-origin user's stored
assignment **stays shared**, `isOnShared` stays `true`, and the stop stays excluded no matter
how high `pollAttempts` climbs. The actual behaviour is: keep polling at the 60s cap,
re-trigger `assign` up to `MAX_RETRIGGER_ATTEMPTS` (5), then continue status-only polling
indefinitely — never surfacing an error and never stranding to free tier. (The stop and the
removed freeze read `isOnShared` from **different** scopes — the stop from the stored
assignment `:990`, the old freeze from the freshly polled `assignment` `:1045` — which is why
the counter's growth cannot reach the stop for shared-origin users.)

---

## Tests

**New file**: `frontend/src/contexts/__tests__/PremiumSharedPollingStall.test.tsx` (3 tests)

1. **No stall** — with `/status` returning the same shared assignment every call, advancing
   past `pollInterval` saturation keeps polling `/status` (**red before the fix**: stops at
   4 total calls = mount + 3 polls; **green after**: keeps polling).
2. **Delayed upgrade** — after several stable shared polls, a dedicated `/status` is still
   finalized (`assignmentResult` becomes dedicated, `premium_shared` → `false`) without a
   reload, and polling then stops.
3. **Dedicated stop unchanged** — a non-shared retry loop still stops at
   `MAX_POLL_ATTEMPTS`.

**Updated**: `frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx`

The test `polling on shared neither terminates nor increments pollAttempts` pinned the
**buggy** behaviour (frozen counter). Renamed to `polling on shared does not terminate and
keeps the counter advancing` and updated to assert the corrected semantics: error stays
null, assignment stays shared, and `SS_POLL_ATTEMPTS` advances (`> 0`) — proving the loop
keeps re-running.

**Results**: `src/contexts/__tests__/` 125 passed · `src/contexts/premium/__tests__/`
56 passed · ESLint clean on changed files. Red-before-green confirmed by reverting the fix.

---

## Manual Test Plan

> **How Test 1 and Test 2 differ** — both build on the *same* substrate (a stable shared
> assignment polled **past `pollInterval` saturation**), but assert **opposite terminal
> outcomes**, so they are complementary rather than redundant:
>
> | | Test 1 | Test 2 |
> |---|---|---|
> | Assignment during the test | Never changes (stays shared) | Flips shared → **dedicated** mid-test |
> | How the flip is delivered | n/a | `/status` returns non-null `is_shared: false` → **direct finalize, no `/assign`** (`:1046-1058`) |
> | Invariant under test | Polling **does not stop** (the loop stays alive) | The now-alive loop **picks up the upgrade without a reload**, then **stops cleanly** |
> | What it guards | Necessary condition — the loop is not silently killed | Sufficient/value condition — the alive loop actually *delivers* the dedicated upgrade and converges |
>
> A visible `POST /premium/assign` during the flip means you took the **null-status →
> re-trigger** path (Test 3), not Test 2's direct-finalize path — see Test 2 Step 2's warning.
>
> Test 1 alone can't prove the extra polls accomplish anything (a live loop could still fail
> to finalize a changed `/status`); Test 2 alone can't isolate the stall (a fast migration
> never reaches saturation). Both are needed.
>
> **Making the checks reproducible** — the pass/fail signal is **count-based, not clock-based**.
> The discriminator is whether a **4th background poll (poll #4) and beyond** appear: the old
> code fired **exactly 3 polls** (#1 `+30s`, #2 `+75s`, #3 `+135s`) and then stalled, so *3
> polls happen even before the fix*. Judge by the **poll number**, not by hitting exact
> timestamps (those depend on network latency and are only a rough guide). Count background
> polls only — ignore the one-off `/status` fired at mount. Also: **keep the tab in the
> foreground** for the whole run — background tabs throttle `setTimeout`, which distorts the
> cadence. Deterministic timing itself is already covered by the fake-timer unit tests; the
> manual pass only confirms real-network integration.

### Prerequisites

- A premium-subscribed user account.
- Access to a backend/test setup where a user can be placed on a **shared** assignment while
  the shared→dedicated migration is **slow** (takes more than ~2.5 minutes). If provisioning
  is fast, use DevTools **Local Overrides** (below) to hold the `/status` response on shared.
- Browser DevTools open: **Network** tab (Preserve log ON, filter `status`), **Console** tab,
  **Application** tab (Local Storage).

#### Holding a stable shared state with Local Overrides (recommended for a reliable repro)

1. DevTools → **Sources** → **Overrides** → enable **Enable Local Overrides**.
2. Trigger one `GET /users/me/premium/status` so it appears in the Network tab.
3. Right-click the request → **Override content**, and edit the response body so
   `assignment.is_shared` is `true` and `assignment.instance_id` is a fixed value (e.g.
   `"i-shared-test"`). Save.
4. All subsequent `/status` responses now return the same shared assignment, deterministically
   reproducing the "stable shared" condition.

Local Overrides fixes the response **content** deterministically; it does **not** shorten the
poll interval. The wall-clock cadence stays at the real `30 → 45 → 60s` schedule, so plan for
a few minutes of observation per run.

---

### Test 1: Shared polling does not stall after ~2 minutes (core fix)

**Objective**: A stable shared assignment keeps polling `/status` past the point where
`pollInterval` saturates (previously it stopped after ~3 polls).

#### Step 1: Establish a shared assignment

1. Log in as the premium user. Open DevTools (Network + Application).
2. Wait for the assignment flow to settle on **shared**.
3. **Verify** in Application → Local Storage: `premium_shared` is `"true"`.
4. **Verify** in Network: `GET /users/me/premium/status` returns `assignment.is_shared: true`.
   (If provisioning is fast, apply the Local Overrides step above now.)

#### Step 2: Observe the poll cadence past saturation

1. Keep the tab **focused** (foreground) and **do not reload**. Watch
   `GET /users/me/premium/status` in the Network tab.
2. **Observe** (informational, not a hard gate): the interval grows `30 → 45 → 60s` — polls
   land near `+30s`, `+75s`, `+135s`. Treat these as approximate; network latency shifts them.
3. Continue watching for **at least 4–5 minutes total** (enough to clear poll #3 at `+135s`
   and see poll #4 at ~`+195s` and beyond, at the ~60s cap).
4. **Verify (this fix — the pass/fail gate)**: a **4th background poll (poll #4) appears**, and
   polling keeps going (`≥ 4` polls, arriving at ~60s intervals).
   - *Before the fix*: polling stopped at **exactly 3 polls** (#1/#2/#3, ~2¼ min) — poll #4
     never appeared. Three polls occur either way; the presence of **poll #4** is the
     discriminator, not the timing.
5. **Verify** in Application → Local Storage: `premium_shared` remains `"true"` throughout
   (still on shared, still polling — not stranded).

**Expected**: `/status` polling continues indefinitely at the ~60s cap while shared
(**poll #4 and beyond** observed).

---

### Test 2: A delayed shared→dedicated upgrade is picked up without a reload

**Objective**: Once the backend completes the migration, the frontend finalizes the dedicated
assignment **directly from the next `/status` poll** — no `/assign` re-trigger and no browser
reload needed. (The distinct null-status → re-trigger-`/assign` recovery is Test 3's concern.)

#### Step 1: Sit on shared past saturation

1. Repeat Test 1 Steps 1–2 until **poll #4 or later** has fired (past poll #3 at `+135s`, where
   the old code would have stalled) — roughly > 3 minutes.

#### Step 2: Complete the migration

1. Make the backend return a **dedicated** assignment for this user (complete the real
   migration, or — if using Local Overrides — **edit** the override so `assignment.is_shared`
   is `false`, `instance_id` is the dedicated id, and `instance_id_hash` is the dedicated hash,
   then Save).

   > ⚠️ **Edit the override — do not remove/disable it.** This test targets the *direct*
   > upgrade path where a `/status` poll returns a **non-null, `is_shared: false`** assignment
   > and finalizes it straight from the status branch
   > (`finalizeDedicatedAssignment(result, status)`, `PremiumAssignmentContext.tsx:1046-1058`)
   > — **no `/assign` is called**. If you instead *remove* the override, real `/status` will
   > (until the backend actually has a dedicated instance ready) return `assignment: null`,
   > which drops into the **null-status → re-trigger `/assign`** branch (`:1098-1140`). That
   > reaches the same "dedicated assigned" end state but via a **different mechanism** — it is
   > the path exercised by **Test 3 Step 2**, not the direct-finalize path this test is meant
   > to prove. Editing the override (non-null, `is_shared: false`) keeps the transition
   > deterministic and on the intended path.

#### Step 3: Verify the upgrade lands automatically

1. Wait for the next `GET /users/me/premium/status` poll (≤ ~60s).
2. **Verify** in Network: that poll returns `assignment.is_shared: false`.
3. **Verify (the discriminator)** in Network: **no `POST /users/me/premium/assign` fires**
   between the last shared poll and the finalize. Test 2's path finalizes directly from
   `/status`; a visible `/assign` means you fell onto the null-status re-trigger path (Test 3),
   not this one.
4. **Verify** in Application → Local Storage: `premium_shared` flips to `"false"`.
5. **Verify** in Console (optional): a log line similar to `Premium instance now available`.
6. **Verify**: subsequent `/status` polling **stops** (the assignment is now dedicated and
   healthy) — no more `/status` requests appear in the Network tab.
7. **Verify**: no browser reload was required at any point.

**Expected**: The dedicated upgrade is finalized **directly from the `/status` poll (no
`/assign`)** on the first post-migration poll, and polling stops.

---

### Test 3: Regression — fast dedicated path and dedicated max-attempts unchanged

**Objective**: The happy path and the dedicated `MAX_POLL_ATTEMPTS` stop are unaffected.

#### Step 1: Fast dedicated sign-in

1. Log in as a premium user in an environment where a **dedicated** instance is placed quickly.
2. **Verify**: the assignment settles to dedicated within the first one or two polls;
   `premium_shared` is `"false"`; `/status` polling stops.

#### Step 2: Dedicated provisioning that never succeeds (optional — see reproducibility note)

**Reproducibility**: this path is **deterministically reproducible as to its input**, but
**impractical to drive to completion by wall clock** — the terminal stop only fires at
`MAX_POLL_ATTEMPTS` (40), i.e. ~35–40 min at the 60s cap. It is therefore marked *optional*,
and the same stop is already covered deterministically by the **"Dedicated stop unchanged"**
unit test (Test 3 in `PremiumSharedPollingStall.test.tsx`). Run the manual variant only if you
need real-network confirmation.

To reproduce the input deterministically (no debug flags):

1. **Precondition** — the re-trigger path only runs when a *stale* assignment already exists
   (`state.assignmentResult != null`, `PremiumAssignmentContext.tsx:1088`). First let the user
   settle on an assignment, *then* start returning null. A never-assigned fresh null does
   **not** exercise the re-trigger branch.
2. Using **Local Overrides**, override **both** endpoints:
   - `GET /users/me/premium/status` → `assignment: null` (with **no** `error` field — a
     `status.error` would divert to the error-backoff branch, not this path).
   - `POST /users/me/premium/assign` → a **retryable** result (`assigned: false`); it must
     **not** return a hard error or an `assigned: true`, either of which would leave this path.
3. **Verify**: polling backs off to the 60s cap, re-triggers `/assign` up to
   `MAX_RETRIGGER_ATTEMPTS` (5), then continues status-only polling, and eventually stops with
   a "No premium instance available after extended wait" error (the `MAX_POLL_ATTEMPTS` stop
   still fires for the non-shared path). Expect ~35–40 min to reach the stop.

**Expected**: No change from previous behaviour for dedicated flows.

---

## Impact / Severity

- **Medium** (degraded, self-limited, reload-recoverable). A shared premium user is **not**
  upgraded to dedicated if the backend migration takes more than ~2 minutes; they remain on
  shared (still premium/shared-pool compute — **not** a free-tier strand) until a reload.
- Restores the polling guarantee that #756's shared-recovery premise relies on.

## Relationship to Other Work

- **#730 (parent)**: a new child bug, now fixed.
- **#756**: not the cause; #756 stays correct as-is. This PR restores the "shared keeps
  polling until dedicated" guarantee #756 assumes.
- **#733**: the polling loop is a candidate for the state-machine refactor; a robust
  self-scheduling loop (independent of incidental dependency changes) could fold into it.
