### PR TITLE
Sync assignment/usage models with migrations (#723 — PR1 of series)

### DIFF
--- a/studio/app/common/models/experiment.py
+++ b/studio/app/common/models/experiment.py
@@ -2,10 +2,11 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from sqlalchemy import Boolean
+from sqlalchemy import TIMESTAMP, Boolean
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy import Integer, Text
+from sqlalchemy import Index, Integer, Text, text
 from sqlalchemy.dialects.mysql import BIGINT
+from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import JSON, Column, DateTime, Field, ForeignKey, Relationship, String
 
 from studio.app.common.models.base import Base, TimestampMixin
@@ -31,6 +32,11 @@ class BackgroundTaskType(str, Enum):
 
 class ExperimentRecord(Base, TimestampMixin, table=True):
     __tablename__ = "experiment_records"
+
+    __table_args__ = (
+        Index("idx_local_sync_status", "local_sync_status"),
+        Index("idx_publish_sync_status", "publish_status", "local_sync_status"),
+    )
 
     workspace_id: int = Field(
         sa_column=Column(
@@ -156,8 +162,17 @@ class BackgroundTask(Base, TimestampMixin, table=True):
 
     __tablename__ = "background_tasks"
 
+    __table_args__ = (
+        Index("idx_background_tasks_status_created", "status", "created_at"),
+    )
+
     user_id: int = Field(
-        sa_column=Column(BIGINT(unsigned=True), nullable=False, index=True),
+        sa_column=Column(
+            BIGINT(unsigned=True),
+            nullable=False,
+            index=True,
+            comment="User who initiated the task",
+        ),
         description="User who initiated the deletion",
     )
     task_type: str = Field(
@@ -172,11 +187,20 @@ class BackgroundTask(Base, TimestampMixin, table=True):
         description="Type of resource being processed",
     )
     resource_id: str = Field(
-        sa_column=Column(String(100), nullable=False, index=True),
+        sa_column=Column(
+            String(100),
+            nullable=False,
+            index=True,
+            comment="ID of the resource (experiment UID or workspace ID)",
+        ),
         description="ID of the resource (experiment UID or workspace ID)",
     )
     workspace_id: Optional[int] = Field(
-        sa_column=Column(BIGINT(unsigned=True), nullable=True),
+        sa_column=Column(
+            BIGINT(unsigned=True),
+            nullable=True,
+            comment="Workspace ID for experiment tasks",
+        ),
         default=None,
         description="Workspace ID for experiment deletions",
     )
@@ -196,27 +220,66 @@ class BackgroundTask(Base, TimestampMixin, table=True):
         default=BackgroundTaskStatus.QUEUED.value,
     )
     retry_count: int = Field(
-        sa_column=Column(Integer(), nullable=False, default=0),
+        sa_column=Column(
+            Integer(),
+            nullable=False,
+            default=0,
+            comment="Number of retry attempts",
+        ),
         default=0,
         description="Number of retry attempts",
     )
     max_retries: int = Field(
-        sa_column=Column(Integer(), nullable=False, default=3),
+        sa_column=Column(
+            Integer(),
+            nullable=False,
+            default=3,
+            comment="Maximum retry attempts before marking as failed",
+        ),
         default=3,
         description="Maximum retry attempts before marking as failed",
     )
     error_message: Optional[str] = Field(
-        sa_column=Column(Text, nullable=True),
+        sa_column=Column(
+            Text,
+            nullable=True,
+            comment="Error message if task failed",
+        ),
         default=None,
         description="Error message if deletion failed",
     )
     started_at: Optional[datetime] = Field(
-        sa_column=Column(DateTime(timezone=True), nullable=True),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=True,
+            comment="When processing started",
+        ),
         default=None,
         description="When processing started",
     )
     completed_at: Optional[datetime] = Field(
-        sa_column=Column(DateTime(timezone=True), nullable=True),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=True,
+            comment="When processing completed",
+        ),
         default=None,
         description="When processing completed (success or final failure)",
+    )
+
+    # created_at/updated_at from TimestampMixin are nullable; this table's
+    # migration created them NOT NULL, so override nullable here to match.
+    created_at: Optional[datetime] = Field(
+        sa_column=Column(
+            TIMESTAMP,
+            nullable=False,
+            server_default=current_timestamp(),
+        ),
+    )
+    updated_at: Optional[datetime] = Field(
+        sa_column=Column(
+            TIMESTAMP,
+            nullable=False,
+            server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        ),
     )

--- a/studio/app/common/models/free_user.py
+++ b/studio/app/common/models/free_user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import INTEGER, TIMESTAMP, VARCHAR
+from sqlalchemy import INTEGER, TIMESTAMP, VARCHAR, Index
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import Column, Field, ForeignKey, SQLModel
@@ -9,6 +9,15 @@ from sqlmodel import Column, Field, ForeignKey, SQLModel
 
 class FreeUserAssignment(SQLModel, table=True):
     __tablename__ = "free_user_assignments"
+
+    __table_args__ = (
+        Index("idx_instance_id", "instance_id"),
+        Index("idx_last_activity", "last_activity"),
+        Index("idx_logged_out_at", "logged_out_at"),
+        Index("idx_active_workflow_count", "active_workflow_count"),
+        Index("idx_last_workflow_start", "last_workflow_start"),
+        Index("idx_idle_users", "active_workflow_count", "last_activity"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(

--- a/studio/app/common/models/instance_usage.py
+++ b/studio/app/common/models/instance_usage.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from sqlalchemy import TIMESTAMP
 from sqlalchemy import Enum as SQLEnum
+from sqlalchemy import Index
 from sqlalchemy.dialects.mysql import BIGINT, VARCHAR
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import Column, Field, SQLModel
@@ -16,6 +17,12 @@ class UsageTier(str, Enum):
 
 class InstanceUsageLog(SQLModel, table=True):
     __tablename__ = "instance_usage_log"
+
+    __table_args__ = (
+        Index("idx_usage_log_user_tier", "user_id", "tier"),
+        Index("idx_usage_log_active", "ended_at"),
+        Index("idx_usage_log_tier_started", "tier", "started_at"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(

--- a/studio/app/common/models/premium_user.py
+++ b/studio/app/common/models/premium_user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import INTEGER, TIMESTAMP, VARCHAR, Boolean, Enum
+from sqlalchemy import INTEGER, TIMESTAMP, VARCHAR, Boolean, Enum, Index
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import Column, Field, ForeignKey, SQLModel
@@ -9,6 +9,18 @@ from sqlmodel import Column, Field, ForeignKey, SQLModel
 
 class PremiumUserAssignment(SQLModel, table=True):
     __tablename__ = "premium_user_assignments"
+
+    __table_args__ = (
+        Index("idx_instance_id", "instance_id"),
+        Index("idx_last_activity", "last_activity"),
+        Index("idx_status", "status"),
+        Index("idx_instance_state", "instance_state"),
+        Index("idx_is_shared", "is_shared"),
+        Index("idx_last_state_check", "last_state_check"),
+        Index("idx_is_standby", "is_standby"),
+        Index("idx_standby_created_at", "standby_created_at"),
+        Index("idx_workflow_recovery", "active_workflow_count", "last_workflow_start"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(

--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -314,6 +314,11 @@ class StorageOperation(SQLModel, table=True):
 
     __tablename__ = "storage_operations"
 
+    __table_args__ = (
+        Index("idx_storage_ops_status_created", "status", "created_at"),
+        Index("idx_storage_ops_status_retry", "status", "retry_count"),
+    )
+
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
@@ -323,7 +328,13 @@ class StorageOperation(SQLModel, table=True):
         description="User ID for this storage operation",
     )
     idempotency_key: str = Field(
-        sa_column=Column(String(255), nullable=False, unique=True, index=True),
+        sa_column=Column(
+            String(255),
+            nullable=False,
+            unique=True,
+            index=True,
+            comment="Unique key to prevent duplicate operations",
+        ),
         description="Unique key to prevent duplicate operations",
     )
     operation_type: str = Field(
@@ -337,7 +348,11 @@ class StorageOperation(SQLModel, table=True):
         ),
     )
     bytes_delta: int = Field(
-        sa_column=Column(BIGINT, nullable=False),
+        sa_column=Column(
+            BIGINT,
+            nullable=False,
+            comment="Number of bytes to add or remove",
+        ),
         description="Number of bytes to add (positive) or remove (negative)",
     )
     status: str = Field(
@@ -354,19 +369,30 @@ class StorageOperation(SQLModel, table=True):
         default=StorageOperationStatus.PENDING.value,
     )
     error_message: Optional[str] = Field(
-        sa_column=Column(String(500), nullable=True),
+        sa_column=Column(
+            String(500),
+            nullable=True,
+            comment="Error message if operation failed",
+        ),
         default=None,
         description="Error message if operation failed",
     )
     # Retry tracking for failed storage operations
     retry_count: int = Field(
-        sa_column=Column(INTEGER, nullable=False, default=0),
+        sa_column=Column(
+            INTEGER,
+            nullable=False,
+            default=0,
+            comment="Number of retry attempts for failed operations",
+        ),
         default=0,
         description="Number of retry attempts for failed operations",
     )
     created_at: Optional[datetime] = Field(
         default_factory=get_current_datetime,
-        sa_column=Column(TIMESTAMP, server_default=func.current_timestamp()),
+        sa_column=Column(
+            TIMESTAMP, nullable=False, server_default=func.current_timestamp()
+        ),
     )
     completed_at: Optional[datetime] = Field(
         sa_column=Column(DateTime, nullable=True),


### PR DESCRIPTION
## Summary

The SQLAlchemy models under `studio/app/common/models/` have drifted away
from the schema the Alembic migrations actually built. On a database fully
migrated to head, `alembic check` reports ~100 "new upgrade operations",
meaning `alembic revision --autogenerate` can no longer be trusted: run
naively it would generate a migration that **drops** real tables, columns,
foreign keys, and ~40 performance indexes that exist in every deployed
environment.

Per the plan in issue #723, the fix is split into one PR per table-cluster
so review stays tractable. **This PR (PR1) covers the assignment / usage
cluster** — the busiest tables in the system, where the missing indexes
would be the most damaging if a bad autogenerate ever dropped them.

The migrations are the source of truth here (they built every existing DB),
so the models are brought up to match them: indexes, column comments, and
`nullable` flags are added to the model classes using the exact names and
columns the migrations created, so autogenerate sees no diff for these
tables.

> Note: this is a multi-PR series. `alembic check` only turns green once the
> whole series (PR1–PR3) lands; each PR reduces the diff. After this PR, none
> of the six tables below appear in `alembic check` output — the remaining
> diff belongs to the subscription cluster (PR2) and the misc / dead-schema
> cluster (PR3).

## Root Cause

Several later migrations were written or edited by hand without updating the
model classes, and some models were added without back-porting the
indexes/FKs their migrations created. Nothing in CI enforces model/migration
parity, so the gap compounded across the premium/free-manager and
subscription workstreams.

Because autogenerate treats the models as the desired state, every object
that exists in the DB but is missing from a model is reported as something to
**remove**:

- `remove_index` → index exists in the DB, absent from the model
- `modify_comment` / `modify_nullable` → column metadata differs
- (`remove_fk`, `remove_table`, `remove_column` also appear, but belong to
  PR2/PR3)

## Scope of this PR (assignment / usage cluster)

| Table | Model file | What was missing |
|-------|-----------|------------------|
| `premium_user_assignments` | `premium_user.py` | 9 indexes |
| `free_user_assignments` | `free_user.py` | 6 indexes |
| `instance_usage_log` | `instance_usage.py` | 3 indexes |
| `experiment_records` | `experiment.py` | 2 indexes |
| `storage_operations` | `subscription.py` | 2 indexes, 4 column comments, `created_at` NOT NULL |
| `background_tasks` | `experiment.py` | 1 index, 8 column comments, `created_at`/`updated_at` NOT NULL |

## Changed Files

### `app/common/models/premium_user.py`

Added `__table_args__` declaring the 9 migration-created indexes with their
exact names and column order:

```python
__table_args__ = (
    Index("idx_instance_id", "instance_id"),
    Index("idx_last_activity", "last_activity"),
    Index("idx_status", "status"),
    Index("idx_instance_state", "instance_state"),
    Index("idx_is_shared", "is_shared"),
    Index("idx_last_state_check", "last_state_check"),
    Index("idx_is_standby", "is_standby"),
    Index("idx_standby_created_at", "standby_created_at"),
    Index("idx_workflow_recovery", "active_workflow_count", "last_workflow_start"),
)
```

### `app/common/models/free_user.py`

Added `__table_args__` with the 6 free-assignment indexes
(`idx_instance_id`, `idx_last_activity`, `idx_logged_out_at`,
`idx_active_workflow_count`, `idx_last_workflow_start`, and the composite
`idx_idle_users` on `["active_workflow_count", "last_activity"]`).

### `app/common/models/instance_usage.py`

Added `__table_args__` with the 3 usage-log indexes
(`idx_usage_log_user_tier`, `idx_usage_log_active`,
`idx_usage_log_tier_started`).

### `app/common/models/experiment.py`

- `ExperimentRecord`: added `__table_args__` with `idx_local_sync_status`
  and `idx_publish_sync_status`.
- `BackgroundTask`: added `idx_background_tasks_status_created`; added SQL
  `comment=` to 8 columns (`user_id`, `resource_id`, `workspace_id`,
  `retry_count`, `max_retries`, `error_message`, `started_at`,
  `completed_at`) using the migration's exact wording; overrode
  `created_at`/`updated_at` as `nullable=False`.

> **Why override the timestamps on `BackgroundTask` only:** `created_at` /
> `updated_at` come from the shared `TimestampMixin`, which declares them
> nullable. The `background_tasks` migration created them `NOT NULL`, but
> `experiment_records` (same mixin) created them nullable. Changing the mixin
> would fix one table and break the other, so the two columns are overridden
> on `BackgroundTask` specifically.

### `app/common/models/subscription.py`

`StorageOperation` only (the rest of this file's tables belong to PR2):
added `__table_args__` with `idx_storage_ops_status_created` and
`idx_storage_ops_status_retry`; added SQL `comment=` to `idempotency_key`,
`bytes_delta`, `error_message`, `retry_count`; set `created_at` to
`nullable=False`.

## Notes / conventions

- **Index names and columns match the migrations exactly**, so autogenerate
  produces no drop-and-recreate for these tables.
- The existing Pydantic `description=` on `Field(...)` is left untouched; it
  does not map to a SQL `COLUMN COMMENT`. The SQL `comment=` is added on the
  `Column(...)` instead, which is what `alembic check` compares.
- Server defaults are not compared by `alembic check` (default
  `compare_server_default=False`), so they were left as-is; only `nullable`,
  comments, indexes, and FKs matter for parity.

## Verification

- Models import cleanly inside the backend container.
- `alembic check` against a DB at head no longer reports any of the six
  tables in this cluster (remaining diff is PR2/PR3 scope only).
- `flake8`, `black --check`, `isort --check` all pass on the 5 changed files.

## Testing

No dedicated behavioral test is added for this PR, and none is needed: the
change is pure schema-metadata alignment (declarative `Index` / `comment=` /
`nullable=` that mirror objects the DB already has). There is no runtime
logic change — no migration is generated, and ORM query behavior is
unchanged — so there is nothing new to exercise behaviorally.

The authoritative test for this class of change is `alembic check` itself
(it proves model == DB), which is run above. The permanent regression guard
is **PR4**, which wires `alembic check` into CI.

Two lightweight checks were done beyond `alembic check`:

- `alembic revision --autogenerate` produces no operations for these six
  tables (equivalent to the `alembic check` result above).
- Rows still insert into the tables whose `created_at` / `updated_at` were
  tightened to `NOT NULL` (`background_tasks`, `storage_operations`) — the
  `server_default` supplies the value, so no caller change is required.

> The testing rationale and the multi-PR branching strategy are the same for
> every PR in this series; to avoid repeating them in each PR they are
> recorded once on issue #723 rather than duplicated here.

## Diff stat

```
 studio/app/common/models/experiment.py     | 83 +++++++++++++++++++++++++----
 studio/app/common/models/free_user.py      | 11 +++-
 studio/app/common/models/instance_usage.py |  7 +++
 studio/app/common/models/premium_user.py   | 14 ++++-
 studio/app/common/models/subscription.py   | 36 +++++++++++--
 5 files changed, 134 insertions(+), 17 deletions(-)
```

## Why this is one PR of a series

The full drift is ~100 operations across 18 tables, split into one PR per
table-cluster for review tractability, and — more importantly — to isolate
the single destructive change in the series (the dead-schema drop in PR3)
from the zero-risk metadata alignment that PR1/PR2 and most of PR3 consist
of. This PR (PR1) is entirely in the zero-risk category: it changes no DB
and no runtime behavior. The full split rationale, testing strategy, and
branching model are recorded once on issue #723 to avoid repeating them in
each PR.

## Follow-up PRs in this series

- **PR2 (#762)** — subscription cluster: FKs, indexes, comments, nullable, and
  the index name/unique mismatches on `subscription_*` tables.
- **PR3 (#763)** — misc cluster (`users`, `workspaces`, `user_preferences`,
  `user_deletion_records`, `user_storage_usage`) plus an explicit decision on
  the dead schema (`taxes` table, `workspaces.type` column). The destructive
  drop, if chosen, is isolated from the metadata-only changes.
- **PR4 (#764)** — add `alembic check` to CI so drift cannot re-accumulate
  (only after PR1–PR3 make it green).

