### PR TITLE
Sync subscription models with migrations (#723 — PR2 of series)

### DIFF
--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -15,7 +15,7 @@ from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
 class SubscriptionPlans(SQLModel, table=True):
     __tablename__ = "subscription_plans"
-    __table_args__ = (UniqueConstraint("id", name="idx_id"),)
+    __table_args__ = (Index("idx_subscription_plans_name", "name"),)
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
@@ -53,7 +53,7 @@ class SubscriptionPlans(SQLModel, table=True):
         description="Stripe price ID for this subscription plan",
     )
     created_at: Optional[datetime] = Field(
-        sa_column_kwargs={"server_default": current_timestamp()},
+        sa_column=Column(TIMESTAMP, nullable=False, server_default=current_timestamp()),
     )
 
     @property
@@ -136,11 +136,12 @@ class SubscriptionProvider(SQLModel, table=True):
         description="Provider name (e.g., 'stripe', 'paypal')",
     )
     created_at: Optional[datetime] = Field(
-        sa_column_kwargs={"server_default": current_timestamp()},
+        sa_column=Column(TIMESTAMP, nullable=False, server_default=current_timestamp()),
     )
     updated_at: Optional[datetime] = Field(
         sa_column=Column(
             TIMESTAMP,
+            nullable=False,
             server_default=func.current_timestamp(),
             onupdate=func.current_timestamp(),
         ),
@@ -153,15 +154,33 @@ class SubscriptionUserAccount(SQLModel, table=True):
         UniqueConstraint(
             "user_id", "provider_id", name="uq_sub_user_account_user_provider"
         ),
+        UniqueConstraint(
+            "provider_customer_id", name="idx_unique_provider_customer_id"
+        ),
+        Index("idx_subscription_user_accounts_user", "user_id"),
+        Index("idx_subscription_user_accounts_provider", "provider_id"),
     )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
     )
-    user_id: int = Field(sa_column=Column(BIGINT, nullable=False))
+    user_id: int = Field(
+        sa_column=Column(
+            BIGINT,
+            ForeignKey("users.id", name="fk_subscription_user_accounts_user"),
+            nullable=False,
+        )
+    )
     provider_id: int = Field(
-        sa_column=Column(BIGINT, nullable=False),
+        sa_column=Column(
+            BIGINT,
+            ForeignKey(
+                "subscription_providers.id",
+                name="fk_subscription_user_accounts_provider",
+            ),
+            nullable=False,
+        ),
         description="FK to subscription_providers.id",
     )
     provider_customer_id: str = Field(
@@ -169,11 +188,12 @@ class SubscriptionUserAccount(SQLModel, table=True):
         description="Provider's customer ID (e.g., Stripe customer ID)",
     )
     created_at: Optional[datetime] = Field(
-        sa_column_kwargs={"server_default": current_timestamp()},
+        sa_column=Column(TIMESTAMP, nullable=False, server_default=current_timestamp()),
     )
     updated_at: Optional[datetime] = Field(
         sa_column=Column(
             TIMESTAMP,
+            nullable=False,
             server_default=func.current_timestamp(),
             onupdate=func.current_timestamp(),
         ),
@@ -182,22 +202,50 @@ class SubscriptionUserAccount(SQLModel, table=True):
 
 class SubscriptionUserPurchase(SQLModel, table=True):
     __tablename__ = "subscription_user_purchases"
+    __table_args__ = (
+        Index("idx_subscription_purchase_history_user_id", "user_id"),
+        Index("idx_subscription_purchase_history_plan", "plan_id"),
+        Index("idx_subscription_purchase_history_created", "created_at"),
+        Index("idx_subscription_user_purchases_user_id", "user_id"),
+        Index(
+            "idx_subscription_user_purchases_user_plan_created",
+            "user_id",
+            "plan_id",
+            "created_at",
+        ),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
     )
     plan_id: int = Field(
-        sa_column=Column(BIGINT, nullable=False), description="1=FREE, 2=Premium"
+        sa_column=Column(
+            BIGINT,
+            ForeignKey(
+                "subscription_plans.id", name="fk_subscription_user_purchases_plan"
+            ),
+            nullable=False,
+        ),
+        description="1=FREE, 2=Premium",
     )
-    user_id: int = Field(sa_column=Column(BIGINT, nullable=False))
+    user_id: int = Field(
+        sa_column=Column(
+            BIGINT,
+            ForeignKey("users.id", name="fk_subscription_purchase_history_user"),
+            nullable=False,
+        )
+    )
     created_at: Optional[datetime] = Field(
         default_factory=get_current_datetime,
-        sa_column=Column(TIMESTAMP, server_default=func.current_timestamp()),
+        sa_column=Column(
+            TIMESTAMP, nullable=False, server_default=func.current_timestamp()
+        ),
     )
     updated_at: Optional[datetime] = Field(
         sa_column=Column(
             TIMESTAMP,
+            nullable=False,
             server_default=func.current_timestamp(),
             onupdate=func.current_timestamp(),
         ),
@@ -206,19 +254,41 @@ class SubscriptionUserPurchase(SQLModel, table=True):
 
 class SubscriptionCancellation(SQLModel, table=True):
     __tablename__ = "subscription_cancellations"
+    __table_args__ = (
+        Index("idx_subscription_cancellations_user", "cancelled_by_user_id"),
+        Index("idx_subscription_cancellations_purchase", "purchases_id"),
+        Index("idx_subscription_cancellations_cancelled_at", "cancelled_at"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
     )
-    cancelled_by_user_id: int = Field(sa_column=Column(BIGINT, nullable=False))
+    cancelled_by_user_id: int = Field(
+        sa_column=Column(
+            BIGINT,
+            ForeignKey(
+                "users.id", name="fk_subscription_cancellations_cancelled_by_user"
+            ),
+            nullable=False,
+        )
+    )
     purchases_id: int = Field(
-        sa_column=Column(BIGINT, nullable=False),
+        sa_column=Column(
+            BIGINT,
+            ForeignKey(
+                "subscription_user_purchases.id",
+                name="fk_subscription_cancellations_purchase",
+            ),
+            nullable=False,
+        ),
         description="FK to subscription_user_purchases.id",
     )
     cancelled_at: Optional[datetime] = Field(
         default_factory=get_current_datetime,
-        sa_column=Column(TIMESTAMP, server_default=func.current_timestamp()),
+        sa_column=Column(
+            TIMESTAMP, nullable=False, server_default=func.current_timestamp()
+        ),
     )
     reason: Optional[CancellationReason] = Field(
         sa_column=Column(
@@ -480,31 +550,52 @@ class SubscriptionAuditLog(SQLModel, table=True):
     """
 
     __tablename__ = "subscription_audit_log"
+    __table_args__ = (Index("idx_subscription_audit_log_user_id", "user_id"),)
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
         default=None,
     )
     user_id: int = Field(
-        sa_column=Column(BIGINT, nullable=False, index=True),
+        sa_column=Column(
+            BIGINT,
+            nullable=False,
+            comment="The user whose subscription was changed",
+        ),
         description="The user whose subscription was changed. "
         "No FK constraint — audit records must survive user deletion.",
     )
     changed_by: int = Field(
-        sa_column=Column(BIGINT, nullable=False),
+        sa_column=Column(
+            BIGINT,
+            nullable=False,
+            comment="Admin user ID who made the change",
+        ),
         description="Admin user ID who made the change. "
         "No FK constraint — audit records must survive user deletion.",
     )
     old_value: Dict[str, Any] = Field(
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(
+            JSON,
+            nullable=False,
+            comment="Subscription state before the change",
+        ),
         description="Subscription state before the change",
     )
     new_value: Dict[str, Any] = Field(
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(
+            JSON,
+            nullable=False,
+            comment="Subscription state after the change",
+        ),
         description="Subscription state after the change",
     )
     reason: str = Field(
-        sa_column=Column(Text, nullable=False),
+        sa_column=Column(
+            Text,
+            nullable=False,
+            comment="Admin-provided reason for the manual edit",
+        ),
         description="Admin-provided reason for the manual edit",
     )
     created_at: Optional[datetime] = Field(


### PR DESCRIPTION
## Summary

Second PR in the #723 series that brings the SQLAlchemy models under
`studio/app/common/models/` back in line with the schema the Alembic
migrations actually built. On a DB migrated to head, `alembic check` reports
~100 "new upgrade operations" because the models have drifted from the
migrations, which makes `alembic revision --autogenerate` untrustworthy (run
naively it would drop real FKs, indexes, and columns).

**This PR (PR2) covers the subscription cluster** — all `subscription_*`
tables. Like PR1, it is pure schema-metadata alignment: it adds declarative
foreign keys, indexes, column comments, and `nullable` flags (and removes one
spurious model-only constraint) so that autogenerate sees no diff for these
tables. No migration is generated and no runtime behavior changes.

## Why this is one PR of a series

The full drift is ~100 operations across 18 tables. It is split into one PR
per table-cluster for two reasons:

1. **Review tractability** — each PR maps to a coherent subsystem
   (assignment/usage, subscription, misc), so index/FK names can be checked
   against their migrations one area at a time. The clusters are independent
   (disjoint table sets) and can be merged in any order.
2. **Risk isolation (the more important reason)** — PR1, PR2, and most of PR3
   are zero-risk metadata alignment with no DB change. The dead-schema
   decision in PR3 (`taxes`, `workspaces.type`) is different in kind: it means
   a **real destructive migration**, which must get focused review and an
   independent revert boundary rather than being buried among harmless index
   additions.

This PR is entirely in the zero-risk category. The full rationale, testing
strategy, and branching model are recorded once on issue #723 to avoid
repeating them in each PR.

## Root Cause

See #723 / PR1. In short: later migrations were written by hand without
updating the models, and some models were added without back-porting the
FKs/indexes their migrations created. Because autogenerate treats the models
as the desired state, every object present in the DB but missing from a model
is reported as a `remove_*`. For the subscription cluster specifically, the
models were missing 6 foreign keys and ~15 indexes, several `NOT NULL` flags,
and 5 column comments — and additionally declared one unique constraint the
DB does not have.

## Changed Files

Only `app/common/models/subscription.py` (subscription classes; the
`storage_operations` table in the same file belongs to PR1).

### `SubscriptionPlans` (`subscription_plans`)

- **Removed** the model-only `UniqueConstraint("id", name="idx_id")` — `id`
  is already the primary key and no migration ever created this constraint,
  so autogenerate was reporting it as an `add_constraint`. This is the one
  case in the cluster where the model was ahead of the DB, so the fix is to
  delete from the model rather than add to it.
- Added `Index("idx_subscription_plans_name", "name")`.
- `created_at` → `nullable=False`.

> Note: `user_storage_usage` (PR3) legitimately has an `idx_id` unique
> constraint created by migration `61f6f5b6d03f`, so its identical-looking
> `__table_args__` is correct and is left untouched.

### `SubscriptionProvider` (`subscription_providers`)

- `created_at` / `updated_at` → `nullable=False`.

### `SubscriptionUserAccount` (`subscription_user_accounts`)

- Added FKs `fk_subscription_user_accounts_user` (`user_id → users.id`) and
  `fk_subscription_user_accounts_provider`
  (`provider_id → subscription_providers.id`).
- Added indexes `idx_subscription_user_accounts_user`,
  `idx_subscription_user_accounts_provider`, and unique constraint
  `idx_unique_provider_customer_id` on `provider_customer_id`.
- `created_at` / `updated_at` → `nullable=False`.
- Kept the existing `uq_sub_user_account_user_provider` unique constraint —
  it is real (created by migration `i901i9230023`) and already matches the DB.

### `SubscriptionUserPurchase` (`subscription_user_purchases`)

- Added FKs `fk_subscription_user_purchases_plan`
  (`plan_id → subscription_plans.id`) and `fk_subscription_purchase_history_user`
  (`user_id → users.id`).
- Added all 5 indexes the migrations created — 3 from the original table
  (`idx_subscription_purchase_history_user_id`, `_plan`, `_created`) and 2
  performance indexes from `i901i9280023`
  (`idx_subscription_user_purchases_user_id`,
  `idx_subscription_user_purchases_user_plan_created`). The two naming schemes
  coexist in the DB, so both are declared to match reality.
- `created_at` / `updated_at` → `nullable=False`.

### `SubscriptionCancellation` (`subscription_cancellations`)

- Added FKs `fk_subscription_cancellations_cancelled_by_user`
  (`cancelled_by_user_id → users.id`) and `fk_subscription_cancellations_purchase`
  (`purchases_id → subscription_user_purchases.id`).
- Added indexes `idx_subscription_cancellations_user`,
  `idx_subscription_cancellations_purchase`,
  `idx_subscription_cancellations_cancelled_at`.
- `cancelled_at` → `nullable=False`.

### `SubscriptionAuditLog` (`subscription_audit_log`)

- Added SQL `comment=` to `user_id`, `changed_by`, `old_value`, `new_value`,
  `reason` using the migration's exact wording.
- Replaced the column-level `index=True` on `user_id` (which produced the
  auto-named `ix_subscription_audit_log_user_id`) with an explicitly named
  `Index("idx_subscription_audit_log_user_id", "user_id")` in
  `__table_args__`, matching the migration. Without this, autogenerate wanted
  to drop the `idx_*` index and add the `ix_*` one.

> `subscription_users` (`UserSubscription`) already matched the DB and is
> left unchanged.

## Notes / conventions

- FK, index, and unique-constraint names match the migrations exactly, so
  autogenerate produces no drop-and-recreate for these tables.
- The existing Pydantic `description=` on `Field(...)` is left untouched; the
  SQL `comment=` on `Column(...)` is what `alembic check` compares.
- Server defaults are not compared by `alembic check`
  (`compare_server_default=False`), so `onupdate` / `server_default` were left
  as-is; only `nullable`, comments, indexes, FKs, and unique constraints
  matter for parity.

## Verification

- Models import cleanly and full model metadata builds inside the backend
  container.
- `alembic check` no longer reports any `subscription_*` table. (This PR
  branches from `develop-main`, which does not yet contain PR1/PR3, so their
  tables still appear in the check output — expected; the check only turns
  green once the whole series lands.)
- `flake8`, `black --check`, `isort --check` pass.

## Testing

No dedicated behavioral test is added, and none is needed: this is pure
schema-metadata alignment with no runtime logic change. The authoritative
test is `alembic check` (proves model == DB), run above; the permanent
regression guard is PR4 (`alembic check` in CI). See issue #723 for the
series-wide testing rationale.

## Diff stat

```
 studio/app/common/models/subscription.py | 125 +++++++++++++++++++++++++------
 1 file changed, 108 insertions(+), 17 deletions(-)
```

## Follow-up PRs in this series

- **PR1 (#761)** — assignment/usage cluster.
- **PR3 (#763)** — misc cluster (`users`, `workspaces`, `user_preferences`,
  `user_deletion_records`, `user_storage_usage`) plus the dead-schema decision
  (`taxes`, `workspaces.type`); the destructive drop, if chosen, is isolated
  from the metadata-only changes.
- **PR4 (#764)** — add `alembic check` to CI (only after PR1–PR3 make it green).

