### PR TITLE
Sync misc models with migrations (#723 — PR3 of series)

### DIFF
--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -2,7 +2,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from sqlalchemy import BIGINT, INTEGER, JSON, TIMESTAMP, Boolean, DateTime
+from sqlalchemy import (
+    BIGINT,
+    DECIMAL,
+    INTEGER,
+    JSON,
+    TIMESTAMP,
+    Boolean,
+    Date,
+    DateTime,
+)
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint
 from sqlalchemy.sql import func
@@ -242,7 +251,10 @@ class SubscriptionCancellation(SQLModel, table=True):
 
 class UserStorageUsage(SQLModel, table=True):
     __tablename__ = "user_storage_usage"
-    __table_args__ = (UniqueConstraint("id", name="idx_id"),)
+    __table_args__ = (
+        UniqueConstraint("id", name="idx_id"),
+        Index("idx_user_storage_usage_user_id", "user_id"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
@@ -408,6 +420,10 @@ class UserDeletionRecord(SQLModel, table=True):
     """
 
     __tablename__ = "user_deletion_records"
+    __table_args__ = (
+        Index("idx_user_deletion_records_user_id", "user_id"),
+        Index("idx_user_deletion_records_status_started", "status", "started_at"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
@@ -418,7 +434,11 @@ class UserDeletionRecord(SQLModel, table=True):
         description="FK to users.id being deleted",
     )
     user_uid: str = Field(
-        sa_column=Column(String(128), nullable=False),
+        sa_column=Column(
+            String(128),
+            nullable=False,
+            comment="Firebase UID for recovery checks",
+        ),
         description="Firebase UID for recovery checks",
     )
     step: str = Field(
@@ -452,13 +472,19 @@ class UserDeletionRecord(SQLModel, table=True):
         default=DeletionStatus.IN_PROGRESS.value,
     )
     error: Optional[str] = Field(
-        sa_column=Column(Text, nullable=True),
+        sa_column=Column(
+            Text,
+            nullable=True,
+            comment="Error message if deletion failed",
+        ),
         default=None,
         description="Error message if deletion failed",
     )
     started_at: Optional[datetime] = Field(
         default_factory=get_current_datetime,
-        sa_column=Column(TIMESTAMP, server_default=func.current_timestamp()),
+        sa_column=Column(
+            TIMESTAMP, nullable=False, server_default=func.current_timestamp()
+        ),
     )
     completed_at: Optional[datetime] = Field(
         sa_column=Column(DateTime, nullable=True),
@@ -467,6 +493,7 @@ class UserDeletionRecord(SQLModel, table=True):
     updated_at: Optional[datetime] = Field(
         sa_column=Column(
             TIMESTAMP,
+            nullable=False,
             server_default=func.current_timestamp(),
             onupdate=func.current_timestamp(),
         ),
@@ -510,4 +537,47 @@ class SubscriptionAuditLog(SQLModel, table=True):
     created_at: Optional[datetime] = Field(
         default_factory=get_current_datetime,
         sa_column=Column(TIMESTAMP, server_default=func.current_timestamp()),
+    )
+
+
+class Taxes(SQLModel, table=True):
+    """
+    UNUSED / dead schema. Created by migration
+    `af8c4144cd54_add_stripe_integration_tables` but never wired to any code:
+    tax calculation is handled by Stripe (session.total_details.breakdown.taxes),
+    not this table. Mapped here only so `alembic check` matches the DB without
+    a destructive migration. Candidate for an explicit drop in a future PR.
+    """
+
+    __tablename__ = "taxes"
+    __table_args__ = (
+        Index("idx_taxes_type", "tax_type"),
+        Index("idx_taxes_active", "is_active"),
+    )
+
+    id: Optional[int] = Field(
+        sa_column=Column(BIGINT, primary_key=True, nullable=False, autoincrement=True),
+        default=None,
+    )
+    tax_type: str = Field(sa_column=Column(String(50), nullable=False))
+    tax_name: str = Field(sa_column=Column(String(100), nullable=False))
+    tax_rate: float = Field(
+        sa_column=Column(DECIMAL(precision=5, scale=4), nullable=False)
+    )
+    is_active: bool = Field(
+        sa_column=Column(Boolean, nullable=False, server_default="1"), default=True
+    )
+    effective_date: datetime = Field(sa_column=Column(Date, nullable=False))
+    created_at: Optional[datetime] = Field(
+        sa_column=Column(
+            TIMESTAMP, nullable=False, server_default=func.current_timestamp()
+        ),
+    )
+    updated_at: Optional[datetime] = Field(
+        sa_column=Column(
+            TIMESTAMP,
+            nullable=False,
+            server_default=func.current_timestamp(),
+            onupdate=func.current_timestamp(),
+        ),
     )

--- a/studio/app/common/models/user.py
+++ b/studio/app/common/models/user.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from sqlalchemy import Index
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import (
@@ -34,7 +35,10 @@ class UserRole(Base, table=True):
 
 class User(Base, TimestampMixin, table=True):
     __tablename__ = "users"
-    __table_args__ = (UniqueConstraint("uid", name="idx_uid"),)
+    __table_args__ = (
+        UniqueConstraint("uid", name="idx_uid"),
+        Index("idx_users_organization_active", "organization_id", "active"),
+    )
 
     organization_id: int = Field(
         sa_column=Column(

--- a/studio/app/common/models/user_preferences.py
+++ b/studio/app/common/models/user_preferences.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from sqlalchemy import TIMESTAMP
 from sqlalchemy import Enum as SQLEnum
+from sqlalchemy import Index, UniqueConstraint
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.sql import func
 from sqlalchemy.sql.functions import current_timestamp
@@ -13,6 +14,13 @@ from studio.app.common.core.subscription.constants import DeletionPriority  # no
 
 class UserPreferences(SQLModel, table=True):
     __tablename__ = "user_preferences"
+    # Migration created two objects on user_id: an unnamed UniqueConstraint
+    # (reflected as index "user_id") plus a separate non-unique index
+    # "ix_user_preferences_user_id". Declare both to match the DB exactly.
+    __table_args__ = (
+        UniqueConstraint("user_id"),
+        Index("ix_user_preferences_user_id", "user_id"),
+    )
 
     id: Optional[int] = Field(
         sa_column=Column(
@@ -23,10 +31,8 @@ class UserPreferences(SQLModel, table=True):
     user_id: int = Field(
         sa_column=Column(
             BIGINT(unsigned=True),
-            ForeignKey("users.id"),
+            ForeignKey("users.id", name="fk_user_preferences_user"),
             nullable=False,
-            unique=True,
-            index=True,
         ),
     )
     deletion_priority: Optional[str] = Field(

--- a/studio/app/common/models/workspace.py
+++ b/studio/app/common/models/workspace.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
+from sqlalchemy import Index, Integer
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.sql.functions import current_timestamp
 from sqlmodel import Column, Field, ForeignKey, Relationship, String, UniqueConstraint
@@ -29,6 +30,7 @@ class WorkspacesShareUser(Base, table=True):
 
 class Workspace(Base, TimestampMixin, table=True):
     __tablename__ = "workspaces"
+    __table_args__ = (Index("idx_workspaces_user_deleted", "user_id", "deleted"),)
 
     name: str = Field(sa_column=Column(String(100), nullable=False))
     user_id: int = Field(
@@ -37,6 +39,14 @@ class Workspace(Base, TimestampMixin, table=True):
         ),
     )
     deleted: bool = Field(nullable=False)
+    # Reserved column added ahead of PR #393 (arayabrain/araya-optinist#393).
+    # Not yet used by any code; added early so alembic autogenerate stays
+    # conflict-free until #393 merges. No SQL comment — the migration that
+    # created the column set none, and adding one here would create drift.
+    type: int = Field(
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+        default=0,
+    )
     input_data_usage: int = Field(
         sa_column=Column(
             BIGINT(unsigned=True), nullable=False, comment="data usage in bytes"


### PR DESCRIPTION
## Summary

Third and final model-alignment PR in the #723 series. It brings the
remaining drifted tables — `users`, `workspaces`, `user_preferences`,
`user_deletion_records`, `user_storage_usage` — back in line with the schema
the migrations built, and resolves the two pieces of **dead schema** the issue
flagged (`taxes` table, `workspaces.type` column).

Like PR1 and PR2, this is pure schema-metadata alignment: it adds declarative
indexes, column comments, `nullable` flags, and one model class. **It contains
no destructive migration and makes no change to any database** — see the
dead-schema decision below.

Once this PR merges alongside PR1 and PR2, `alembic check` passes on a
head DB, which unblocks PR4 (wiring `alembic check` into CI).

## Why this is one PR of a series

The full drift is ~100 operations across 18 tables, split into one PR per
table-cluster for review tractability and, more importantly, to isolate the
one potentially destructive change (dropping dead schema) from the zero-risk
metadata alignment. The full rationale, testing strategy, and branching model
are recorded once on issue #723.

This PR was the natural home for the dead-schema decision. As decided below,
that decision is to **map, not drop**, so this PR also stays entirely in the
zero-risk category. If a reviewer prefers to physically drop the dead schema,
that becomes a separate, clearly-scoped destructive PR rather than being
bundled here.

## Dead-schema decision (map, not drop)

The issue flagged two objects that exist in every DB but had no model. There
were two options for each: add a model (so the DB is unchanged) or write a
migration that drops them. This PR chooses **add a model** for both, keeping
the DB untouched:

### `taxes` table → mapped as unused

A new `Taxes` model mirrors the table created by
`af8c4144cd54_add_stripe_integration_tables`. The class docstring records that
it is **unused / dead schema**: tax calculation is handled by Stripe
(`session.total_details.breakdown.taxes`), not this table, and there are zero
code references. It is mapped only so `alembic check` matches the DB without a
destructive migration, and is marked as a candidate for an explicit drop in a
future PR.

- Rationale: dropping a real table in every environment is a one-way,
  destructive change. Mapping it is reversible and risk-free, and defers the
  drop decision to reviewers. If the team prefers to drop it, that is done in
  its own PR.

### `workspaces.type` column → kept (reserved for PR #393)

The `type` column is **not** stray drift — it was added ahead of
[PR #393](https://github.com/arayabrain/araya-optinist/pull/393) as a reserved
column, so that a later `alembic` autogenerate for #393 would not conflict.
PR #393 is expected to merge, so the column stays. This PR simply adds the
matching `type` field to the `Workspace` model (`Integer`, `NOT NULL`,
`server_default="0"`), with a code comment explaining the reservation.

> Neither the `taxes` columns nor `workspaces.type` carry a SQL comment in
> their migrations, so **no `comment=` is added** to them — doing so would
> introduce a *new* `modify_comment` diff. The explanatory notes live in code
> comments / the class docstring instead.

## Changed Files

### `app/common/models/subscription.py`

- **`Taxes`** — new model (see above): columns `id`, `tax_type`, `tax_name`,
  `tax_rate` (`DECIMAL(5,4)`), `is_active`, `effective_date` (`Date`),
  `created_at`, `updated_at`; indexes `idx_taxes_type`, `idx_taxes_active`.
- **`UserDeletionRecord`** (`user_deletion_records`): added indexes
  `idx_user_deletion_records_user_id` and
  `idx_user_deletion_records_status_started`; added SQL `comment=` to
  `user_uid` and `error`; `started_at` / `updated_at` → `nullable=False`.
- **`UserStorageUsage`** (`user_storage_usage`): added
  `idx_user_storage_usage_user_id` (the existing `idx_id` unique constraint
  already matched the migration and is kept).

### `app/common/models/user.py`

- **`User`** (`users`): added `Index("idx_users_organization_active",
  "organization_id", "active")` (the existing `idx_uid` unique is kept).

### `app/common/models/workspace.py`

- **`Workspace`** (`workspaces`): added the reserved `type` column (see above)
  and `Index("idx_workspaces_user_deleted", "user_id", "deleted")`.

### `app/common/models/user_preferences.py`

- **`UserPreferences`** (`user_preferences`): the DB has two objects on
  `user_id` — an unnamed `UniqueConstraint` (reflected as index `user_id`) and
  a separate **non-unique** index `ix_user_preferences_user_id`. The model
  previously declared `unique=True, index=True` on the column, which produces a
  single **unique** `ix_user_preferences_user_id` — the wrong shape. Fixed by
  removing the column-level flags and declaring both objects explicitly in
  `__table_args__` (`UniqueConstraint("user_id")` +
  `Index("ix_user_preferences_user_id", "user_id")`), and naming the FK
  `fk_user_preferences_user` to match the migration.

## Notes / conventions

- Index / FK / unique-constraint names match the migrations exactly, so
  autogenerate produces no drop-and-recreate for these tables.
- Existing Pydantic `description=` values are left as-is; SQL `comment=` on the
  `Column(...)` is what `alembic check` compares, and is only added where the
  migration set one.
- Server defaults are not compared by `alembic check`
  (`compare_server_default=False`); only `nullable`, comments, indexes, FKs,
  and unique constraints matter for parity.

## Verification

- Models import cleanly and full metadata builds inside the backend container.
- `alembic check` no longer reports `taxes`, `user_deletion_records`,
  `user_storage_usage`, `user_preferences`, `users`, or `workspaces`. (This PR
  branches from `develop-main` without PR1/PR2, so their tables still appear —
  expected; the check turns fully green only once all three land.)
- `flake8`, `black --check`, `isort --check` pass.

## Testing

No dedicated behavioral test is added, and none is needed: pure
schema-metadata alignment with no runtime logic change and no DB change (the
dead schema is mapped, not dropped). The authoritative test is `alembic check`
(run above); the permanent regression guard is PR4 (`alembic check` in CI).
See issue #723 for the series-wide testing rationale.

## Diff stat

```
 studio/app/common/models/subscription.py     | 80 +++++++++++++++++++++++++--
 studio/app/common/models/user.py             |  6 ++-
 studio/app/common/models/user_preferences.py | 12 +++--
 studio/app/common/models/workspace.py        | 10 ++++
 4 files changed, 99 insertions(+), 9 deletions(-)
```

## Follow-up PRs in this series

- **PR1 (#761)** — assignment/usage cluster.
- **PR2 (#762)** — subscription cluster.
- **PR4 (#764)** — add `alembic check` to CI so drift cannot re-accumulate.
  Only after PR1–PR3 are all merged (which is when `alembic check` first
  passes).

