### PR TITLE
Add alembic check CI guard (#723 — PR4 of series)

### DIFF
--- a/.github/workflows/alembic-check.yml
+++ b/.github/workflows/alembic-check.yml
@@ -1,0 +1,28 @@
+name: Alembic Check
+
+# DRAFT: not enabled yet. `alembic check` only passes once the model-sync PRs
+# in this series are merged, so the automatic trigger is left commented out to
+# avoid failing open PRs. To enable, uncomment the `pull_request` block below.
+on:
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - develop-main
+  #     - future
+  #     - "future/**"
+  #   paths:
+  #     - "studio/app/common/models/**"
+  #     - "studio/alembic/**"
+  #     - "docker-compose.alembic-check.yml"
+  #     - ".github/workflows/alembic-check.yml"
+
+jobs:
+  alembic_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run alembic check
+        shell: bash
+        run: make alembic_check

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ test_contract:
 	# build/run
 	@$(call run_test_service, test_studio_backend, $(PYTEST) studio/tests/app/common/routers/test_*_contract.py -v)
 
+.PHONY: alembic_check
+alembic_check:
+	# Migrate a fresh DB to head, then run `alembic check` to assert the
+	# SQLAlchemy models and the migrations describe the same schema.
+	docker compose -f docker-compose.alembic-check.yml down -v
+	docker compose -f docker-compose.alembic-check.yml build alembic_check
+	docker compose -f docker-compose.alembic-check.yml run --rm alembic_check
+	docker compose -f docker-compose.alembic-check.yml down -v
+
 
 ############################## For Building ##############################
 

--- a/docker-compose.alembic-check.yml
+++ b/docker-compose.alembic-check.yml
@@ -1,0 +1,48 @@
+# Brings up a throwaway MySQL, migrates it to head, then runs `alembic check`
+# to assert the SQLAlchemy models and the migrations describe the same schema.
+# Credentials are inline (not from studio/config/.env, which is gitignored) so
+# this runs unchanged in CI. Invoked via `make alembic_check`.
+services:
+  db:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: studio
+      MYSQL_USER: studio_db_user
+      MYSQL_PASSWORD: studio_db_password
+      TZ: UTC
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  alembic_check:
+    image: test_studio_backend
+    build:
+      context: .
+      dockerfile: studio/config/docker/Dockerfile.test
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      PYTHONPATH: .
+      TZ: UTC
+      MYSQL_SERVER: db:3306
+      MYSQL_USER: studio_db_user
+      MYSQL_PASSWORD: studio_db_password
+      MYSQL_DATABASE: studio
+      MYSQL_SSL_MODE: ""
+      # Dummy Stripe values: importing the app config / models requires them,
+      # same as docker-compose.test.yml. Not used by the check itself.
+      STRIPE_CALLBACK_URL: http://localhost:8000
+      STRIPE_SECRET_KEY: sk_test_dummy_123
+      STRIPE_WEBHOOK_SECRET: whsec_dummy_123
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      bash -c "
+        alembic upgrade head &&
+        alembic check
+      "


### PR DESCRIPTION
## Summary

Final PR in the #723 series. It adds a CI guard that migrates a fresh
database to head and runs `alembic check`, asserting that the SQLAlchemy
models and the Alembic migrations describe the same schema. This is the
regression guard that stops the drift fixed by PR1–PR3 from silently
re-accumulating.

## Why a guard is needed

Nothing in CI currently enforces model/migration parity, which is exactly how
the ~100-operation drift in #723 built up. Once the models are corrected
(PR1–PR3), this guard keeps them correct: any future PR that changes a model
without a matching migration (or vice-versa) fails `alembic check`.

The check is cheap — it only needs a migrated DB — and catches a class of bug
that is otherwise invisible until someone runs `alembic revision
--autogenerate` and ships a destructive migration.

## How it works

`alembic check` compares the models (autogenerate's "desired state") against a
live DB. Run against a DB migrated to head, an empty diff means models and
migrations agree; any diff exits non-zero and fails the job.

The stack mirrors the issue's reproduce steps:

1. Bring up a throwaway MySQL 8.4.
2. `alembic upgrade head` — build the schema purely from the migrations.
3. `alembic check` — assert the models match that schema.

## Changed Files

### `docker-compose.alembic-check.yml` (new)

A dedicated compose stack:

- `db` — throwaway MySQL 8.4 with a healthcheck. Credentials are **inline**,
  not read from `studio/config/.env` (which is gitignored and absent in CI),
  so the stack runs identically locally and in CI.
- `alembic_check` — the backend test image (`Dockerfile.test`), depends on
  `db` being healthy, and runs `alembic upgrade head && alembic check`. Points
  at the DB via `MYSQL_SERVER=db:3306`; `MYSQL_SSL_MODE` is blank to avoid TLS
  in the ephemeral container; dummy `STRIPE_*` values are set because importing
  the app config/models requires them (same as `docker-compose.test.yml`).

### `Makefile` (new target)

`alembic_check` — brings the stack up, runs the one-shot check, and tears it
down (`down -v` before and after for a clean DB each run). Same entry point for
local use and CI, matching the existing `make test_*` convention.

### `.github/workflows/alembic-check.yml` (new)

A workflow that checks out and runs `make alembic_check`. Trigger is
`workflow_dispatch` only; the `pull_request` block (scoped to model/migration
paths) is present but commented out.

## Activation (after PR1–PR3 merge)

1. Confirm `alembic check` passes on `develop-main` (all three model-sync PRs
   merged).
2. Uncomment the `pull_request` block in
   `.github/workflows/alembic-check.yml`. That single change is the entire
   activation — no other edits needed.
3. Mark this PR ready for review / merge.

## Verification

Because this branch is off `develop-main` (without PR1–PR3), the models still
drift from the migrations, so running the guard here is expected to **fail** —
which is the correct behavior and confirms the plumbing end-to-end. Locally,
`make alembic_check`:

- brought up MySQL, ran `alembic upgrade head` (all migrations applied),
- ran `alembic check`, which reported the expected drift and exited non-zero,
  propagating a non-zero status through `make` (no connection/setup errors).

`docker compose -f docker-compose.alembic-check.yml config` and the workflow
YAML both parse. Once PR1–PR3 are merged, the same command exits 0.

## Diff stat

```
 .github/workflows/alembic-check.yml | 28 ++++++++++++++++++++++
 Makefile                            |  9 +++++++
 docker-compose.alembic-check.yml    | 48 +++++++++++++++++++++++++++++++++++++
 3 files changed, 85 insertions(+)
```

## Series

- **PR1 (#761)** — assignment/usage cluster.
- **PR2 (#762)** — subscription cluster.
- **PR3 (#763)** — misc cluster + dead-schema decision.
- **PR4 (#764)** — this PR (CI guard). Depends on PR1–PR3; activate after they
  merge.

