### PR TITLE
Fix workflow finalization race on remote upload lock

### DIFF
--- a/studio/app/common/core/cloud/storage_tracking.py
+++ b/studio/app/common/core/cloud/storage_tracking.py
@@ -6,6 +6,7 @@ Extracted from cloud_utils.py for module cohesion.
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
+from sqlalchemy import update
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
@@ -175,8 +176,6 @@ def update_user_storage_usage(user_id: int, new_usage_bytes: int) -> bool:
     leaves the target row unchanged at flush time. The success is logged only
     after the commit lands.
     """
-    from sqlalchemy import update
-
     try:
         with session_scope() as db:
             try:

--- a/studio/app/common/core/cloud/storage_tracking.py
+++ b/studio/app/common/core/cloud/storage_tracking.py
@@ -168,23 +168,41 @@ def update_user_storage_usage(user_id: int, new_usage_bytes: int) -> bool:
     Update storage usage for a user.
     Returns True if successful or if table doesn't exist
     (fallback scenario).
+
+    Writes via a Core UPDATE keyed on user_id so concurrent writers (full
+    scan, incremental updates from multiple processes) do not race on an ORM
+    load-mutate-flush, which raises a stale-data error when a concurrent commit
+    leaves the target row unchanged at flush time. The success is logged only
+    after the commit lands.
     """
+    from sqlalchemy import update
+
     try:
         with session_scope() as db:
             try:
-                query_result = db.execute(
-                    select(UserStorageUsage).where(UserStorageUsage.user_id == user_id)
+                # Existence is checked with a SELECT rather than the UPDATE
+                # rowcount: MySQL reports rows *changed*, so an update to an
+                # identical value returns 0 even though the row exists.
+                exists = (
+                    db.execute(
+                        select(UserStorageUsage.id).where(
+                            UserStorageUsage.user_id == user_id
+                        )
+                    ).first()
+                    is not None
                 )
-                result_row = query_result.first()
-                existing_usage = result_row[0] if result_row else None
 
-                if existing_usage:
-                    existing_usage.storage_usage_bytes = new_usage_bytes
-                    existing_usage.last_updated = (
-                        SubscriptionService.get_current_datetime()
+                if exists:
+                    db.execute(
+                        update(UserStorageUsage)
+                        .where(UserStorageUsage.user_id == user_id)
+                        .values(
+                            storage_usage_bytes=new_usage_bytes,
+                            last_updated=SubscriptionService.get_current_datetime(),
+                        )
                     )
-                    db.add(existing_usage)
                 else:
+                    # No row for this user yet: create it with a plan-based quota.
                     statement = (
                         select(SubscriptionPlans.name.label("plan_name"))
                         .select_from(UserModel)
@@ -205,9 +223,9 @@ def update_user_storage_usage(user_id: int, new_usage_bytes: int) -> bool:
                             UserModel.active.is_(True),
                         )
                     )
-                    result = db.execute(statement).first()
+                    plan_result = db.execute(statement).first()
 
-                    if result and result.plan_name == PlanName.PREMIUM:
+                    if plan_result and plan_result.plan_name == PlanName.PREMIUM:
                         default_quota = StorageQuota.PREMIUM * StorageSize.GB
                     else:
                         default_quota = StorageQuota.FREE * StorageSize.GB
@@ -219,18 +237,17 @@ def update_user_storage_usage(user_id: int, new_usage_bytes: int) -> bool:
                     )
                     db.add(new_storage_usage)
 
-                logger.info(
-                    f"Updated storage usage for user "
-                    f"{user_id}: {new_usage_bytes} bytes"
-                )
-                return True
-
             except Exception as orm_error:
                 logger.warning(
                     f"UserStorageUsage table not accessible:"
                     f" {orm_error}, skipping storage update"
                 )
                 return True
+
+        logger.info(
+            f"Updated storage usage for user " f"{user_id}: {new_usage_bytes} bytes"
+        )
+        return True
 
     except Exception as e:
         logger.warning(f"Failed to update storage usage for " f"user {user_id}: {e}")

--- a/studio/app/common/core/cloud/storage_tracking.py
+++ b/studio/app/common/core/cloud/storage_tracking.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from sqlalchemy import update
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlmodel import select
 
 from studio.app.common.core.logger import AppLogger
@@ -236,7 +237,9 @@ def update_user_storage_usage(user_id: int, new_usage_bytes: int) -> bool:
                     )
                     db.add(new_storage_usage)
 
-            except Exception as orm_error:
+            except (ProgrammingError, OperationalError) as orm_error:
+                # Benign fallback for a missing/inaccessible table only; genuine
+                # write errors (StaleDataError, etc.) propagate and return False.
                 logger.warning(
                     f"UserStorageUsage table not accessible:"
                     f" {orm_error}, skipping storage update"

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -197,9 +197,11 @@ def _snakemake_execute_process(
         # ExptConfig is finalized, so a lock conflict (idempotent upload handled
         # by the concurrent observe path) still finalizes the DB. Finalization is
         # skipped only when observe never succeeded and never reached the lock.
-        observe_success, observe_lock_conflict = _observe_overall_with_lock_retry(
-            workspace_id, unique_id
-        )
+        (
+            observe_success,
+            observe_lock_conflict,
+            upload_confirmed,
+        ) = _observe_overall_with_lock_retry(workspace_id, unique_id)
         should_finalize = observe_success or observe_lock_conflict
 
         # Update experiment database record
@@ -214,11 +216,24 @@ def _snakemake_execute_process(
                 workspace_id, unique_id
             )
 
-        if observe_lock_conflict and not observe_success:
+        if observe_lock_conflict and not observe_success and upload_confirmed:
             logger.warning(
                 "observe_overall() upload stayed locked; finalized DB "
                 "registration and data usage regardless "
-                "(upload handled by the concurrent observe path). "
+                "(upload completed by the concurrent observe path, verified "
+                "via remote sync status). [workspace: %s] [unique_id: %s]",
+                workspace_id,
+                unique_id,
+            )
+        elif observe_lock_conflict and not observe_success:
+            # Local ExptConfig is finalized (DB is correct), but the redundant
+            # remote upload is unconfirmed; the periodic re-sync reconciles it.
+            logger.warning(
+                "observe_overall() upload stayed locked and the concurrent "
+                "observe path has not reported sync success; finalized DB "
+                "registration and data usage from the finalized local "
+                "ExptConfig, but the remote upload is unconfirmed and will be "
+                "reconciled by the periodic re-sync. "
                 "[workspace: %s] [unique_id: %s]",
                 workspace_id,
                 unique_id,
@@ -263,23 +278,49 @@ def _observe_overall_with_lock_retry(workspace_id: str, unique_id: str) -> tuple
     by whichever path wins the lock, so the conflict is retried a bounded number
     of times to let this path land its own upload once the lock frees.
 
+    A lock conflict only proves the other path holds the lock, not that its
+    upload succeeded, so the remote sync-status file (written SUCCESS by the
+    winning writer) is checked before reporting the upload as confirmed.
+
     Returns:
-        (observe_success, observe_lock_conflict):
-            observe_success is True when observe_overall() completed.
+        (observe_success, observe_lock_conflict, upload_confirmed):
+            observe_success is True when observe_overall() completed here.
             observe_lock_conflict is True when at least one attempt hit the
-            upload lock; the caller finalizes the DB even if it never succeeded.
+            upload lock; the caller finalizes the DB even if it never succeeded,
+            because the local ExptConfig is already finalized.
+            upload_confirmed is True when the remote upload is known complete —
+            either this path uploaded, or a lock conflict was accompanied by a
+            SUCCESS remote sync-status written by the path that won the lock.
     """
     observe_success = False
     observe_lock_conflict = False
+    upload_confirmed = False
     retry_max = RemoteSyncLockFileUtil.LOCK_CONFLICT_RETRY_MAX
 
     for attempt in range(1, retry_max + 1):
         try:
             asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
             observe_success = True
+            upload_confirmed = True
             break
         except RemoteStorageLockError as e:
             observe_lock_conflict = True
+            # A SUCCESS sync status proves the winner's upload landed; stop
+            # retrying our own.
+            if RemoteSyncStatusFileUtil.check_sync_status_success(
+                workspace_id, unique_id
+            ):
+                upload_confirmed = True
+                logger.info(
+                    "observe_overall() upload lock held by the concurrent "
+                    "observe path, which reported sync success (attempt %d/%d). "
+                    "[workspace: %s] [unique_id: %s]",
+                    attempt,
+                    retry_max,
+                    workspace_id,
+                    unique_id,
+                )
+                break
             logger.warning(
                 "observe_overall() upload lock conflict (attempt %d/%d): %s",
                 attempt,
@@ -295,7 +336,13 @@ def _observe_overall_with_lock_retry(workspace_id: str, unique_id: str) -> tuple
             )
             break
 
-    return observe_success, observe_lock_conflict
+    # The winner may have completed between our last attempt and now.
+    if observe_lock_conflict and not upload_confirmed:
+        upload_confirmed = RemoteSyncStatusFileUtil.check_sync_status_success(
+            workspace_id, unique_id
+        )
+
+    return observe_success, observe_lock_conflict, upload_confirmed
 
 
 def delete_dependencies(

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -30,6 +31,7 @@ from studio.app.common.core.snakemake.smk import ForceRun, SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
+    RemoteStorageLockError,
     RemoteSyncAction,
     RemoteSyncLockFileUtil,
     RemoteSyncStatusFileUtil,
@@ -191,30 +193,36 @@ def _snakemake_execute_process(
         RemoteSyncLockFileUtil.wait_for_lock_release(workspace_id, unique_id)
 
     try:
-        # Update workflow processing results
-        observe_success = False
-        try:
-            asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
-            observe_success = True
-        except Exception as e:
-            logger.error(
-                f"snakemake_execute post process (WorkflowResult) failed: {e}",
-                exc_info=True,
-            )
+        # Finalize workflow results. A remote upload-lock conflict (idempotent
+        # upload handled by the concurrent observe path) does not block DB
+        # finalization; only a genuine observe failure does.
+        observe_success, observe_lock_conflict = _observe_overall_with_lock_retry(
+            workspace_id, unique_id
+        )
+        should_finalize = observe_success or observe_lock_conflict
 
-        # Update experiment database record if observe_overall() succeeded
-        if observe_success and ExperimentRecordService.is_available():
+        # Update experiment database record
+        if should_finalize and ExperimentRecordService.is_available():
             ExperimentRecordService.regist_record_on_workflow_completed(
                 workspace_id, unique_id
             )
 
         # Data usage calculation
-        if observe_success:
+        if should_finalize:
             WorkspaceDataCapacityService.update_experiment_data_usage(
                 workspace_id, unique_id
             )
 
-        if not observe_success:
+        if observe_lock_conflict and not observe_success:
+            logger.warning(
+                "observe_overall() upload stayed locked; finalized DB "
+                "registration and data usage regardless "
+                "(upload handled by the concurrent observe path). "
+                "[workspace: %s] [unique_id: %s]",
+                workspace_id,
+                unique_id,
+            )
+        elif not should_finalize:
             logger.warning(
                 "Skipped experiment record registration and data usage update "
                 "due to observe_overall() failure. [workspace: %s] [unique_id: %s]",
@@ -241,6 +249,52 @@ def _snakemake_execute_process(
             )
 
     return snakemake_result
+
+
+def _observe_overall_with_lock_retry(workspace_id: str, unique_id: str) -> tuple:
+    """Run observe_overall() at finalization, tolerating upload-lock conflicts.
+
+    observe_overall() finalizes the local ExptConfig (node statuses) first, then
+    uploads the experiment to remote storage under the per-experiment lock. A
+    concurrent /run/result observe (main API process) may hold that lock, in
+    which case the upload raises RemoteStorageLockError even though the local
+    ExptConfig is already finalized. The upload is idempotent and is completed
+    by whichever path wins the lock, so the conflict is retried a bounded number
+    of times to let this path land its own upload once the lock frees.
+
+    Returns:
+        (observe_success, observe_lock_conflict):
+            observe_success is True when observe_overall() completed.
+            observe_lock_conflict is True when at least one attempt hit the
+            upload lock; the caller finalizes the DB even if it never succeeded.
+    """
+    observe_success = False
+    observe_lock_conflict = False
+    retry_max = RemoteSyncLockFileUtil.LOCK_CONFLICT_RETRY_MAX
+
+    for attempt in range(1, retry_max + 1):
+        try:
+            asyncio.run(WorkflowResult(workspace_id, unique_id).observe_overall())
+            observe_success = True
+            break
+        except RemoteStorageLockError as e:
+            observe_lock_conflict = True
+            logger.warning(
+                "observe_overall() upload lock conflict (attempt %d/%d): %s",
+                attempt,
+                retry_max,
+                e,
+            )
+            if attempt < retry_max:
+                time.sleep(RemoteSyncLockFileUtil.LOCK_CONFLICT_RETRY_BACKOFF_SECONDS)
+        except Exception as e:
+            logger.error(
+                f"snakemake_execute post process (WorkflowResult) failed: {e}",
+                exc_info=True,
+            )
+            break
+
+    return observe_success, observe_lock_conflict
 
 
 def delete_dependencies(

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -193,9 +193,10 @@ def _snakemake_execute_process(
         RemoteSyncLockFileUtil.wait_for_lock_release(workspace_id, unique_id)
 
     try:
-        # Finalize workflow results. A remote upload-lock conflict (idempotent
-        # upload handled by the concurrent observe path) does not block DB
-        # finalization; only a genuine observe failure does.
+        # Finalize workflow results. Reaching the upload lock proves the local
+        # ExptConfig is finalized, so a lock conflict (idempotent upload handled
+        # by the concurrent observe path) still finalizes the DB. Finalization is
+        # skipped only when observe never succeeded and never reached the lock.
         observe_success, observe_lock_conflict = _observe_overall_with_lock_retry(
             workspace_id, unique_id
         )

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -298,6 +298,13 @@ class RemoteSyncLockFileUtil:
     LOCK_WAIT_MAX_SECONDS = 300
     LOCK_WAIT_POLL_INTERVAL = 2
 
+    # Retry policy for operations that re-attempt on a lock conflict
+    # (RemoteStorageLockError) rather than waiting on the lock file.
+    # Used when an exclusive access is contended by another process and the
+    # operation is idempotent, so a short bounded retry can succeed.
+    LOCK_CONFLICT_RETRY_MAX = 3
+    LOCK_CONFLICT_RETRY_BACKOFF_SECONDS = 5
+
     @classmethod
     def __make_sync_lock_file_path(cls, workspace_id: str, unique_id: str) -> str:
         """

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -63,18 +63,24 @@ class WorkspaceDataCapacityService:
     def _update_exp_data_usage_db(
         cls, workspace_id: str, unique_id: str, data_usage: int
     ):
-        # Concurrent writers (main /run/result task + executor) often write the
-        # same value: a Core UPDATE (existence via SELECT, since a same-value
-        # UPDATE reports rowcount 0 on MySQL) avoids the ORM stale-data error.
-        # experiment_records has no unique constraint on (workspace_id, uid), so
-        # the check-then-write is serialized with a MySQL advisory lock to
-        # prevent duplicate INSERTs; best-effort if the lock is unavailable.
+        # Concurrent writers (main /run/result task + executor) write the same
+        # row. Two safeguards:
+        #   - Core UPDATE with an existence SELECT (not UPDATE rowcount, which is
+        #     0 for a same-value write on MySQL) avoids the ORM stale-data error.
+        #   - (workspace_id, uid) has no unique constraint, so the check-then-
+        #     write is serialized by a MySQL advisory lock, held on a dedicated
+        #     lock_db session and released only AFTER the inner write commits.
+        #     Spanning the commit is essential: otherwise a second writer could
+        #     acquire the lock and run its existence SELECT before this INSERT is
+        #     visible (REPEATABLE READ) and insert a duplicate. Best-effort:
+        #     proceeds unlocked if the lock backend is unavailable.
         lock_name = f"{cls._EXP_DATA_USAGE_LOCK_PREFIX}_{workspace_id}_{unique_id}"[:64]
-        with session_scope() as db:
+
+        with session_scope() as lock_db:
             got_lock = False
             try:
                 got_lock = (
-                    db.execute(
+                    lock_db.execute(
                         text("SELECT GET_LOCK(:name, :timeout) AS r"),
                         {
                             "name": lock_name,
@@ -90,37 +96,41 @@ class WorkspaceDataCapacityService:
                 )
 
             try:
-                exists = (
-                    db.execute(
-                        select(ExperimentRecord.id).where(
-                            ExperimentRecord.workspace_id == workspace_id,
-                            ExperimentRecord.uid == unique_id,
-                        )
-                    ).first()
-                    is not None
-                )
+                # Separate session: its commit lands while lock_db still holds
+                # the lock.
+                with session_scope() as db:
+                    exists = (
+                        db.execute(
+                            select(ExperimentRecord.id).where(
+                                ExperimentRecord.workspace_id == workspace_id,
+                                ExperimentRecord.uid == unique_id,
+                            )
+                        ).first()
+                        is not None
+                    )
 
-                if exists:
-                    db.execute(
-                        update(ExperimentRecord)
-                        .where(
-                            ExperimentRecord.workspace_id == workspace_id,
-                            ExperimentRecord.uid == unique_id,
+                    if exists:
+                        db.execute(
+                            update(ExperimentRecord)
+                            .where(
+                                ExperimentRecord.workspace_id == workspace_id,
+                                ExperimentRecord.uid == unique_id,
+                            )
+                            .values(data_usage=data_usage)
                         )
-                        .values(data_usage=data_usage)
-                    )
-                else:
-                    db.add(
-                        ExperimentRecord(
-                            workspace_id=workspace_id,
-                            uid=unique_id,
-                            data_usage=data_usage,
+                    else:
+                        db.add(
+                            ExperimentRecord(
+                                workspace_id=workspace_id,
+                                uid=unique_id,
+                                data_usage=data_usage,
+                            )
                         )
-                    )
             finally:
+                # Release after the inner write committed (lock spans commit).
                 if got_lock:
                     try:
-                        db.execute(
+                        lock_db.execute(
                             text("SELECT RELEASE_LOCK(:name)"), {"name": lock_name}
                         )
                     except Exception as e:

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import yaml
+from sqlalchemy import text
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, delete, select, update
 
@@ -54,42 +55,79 @@ class WorkspaceDataCapacityService:
         # Overwrite experiment config
         ExptConfigWriter(workspace_id, unique_id).overwrite(update_params)
 
+    # MySQL advisory-lock namespace for _update_exp_data_usage_db (name max 64).
+    _EXP_DATA_USAGE_LOCK_PREFIX = "exp_data_usage"
+    _EXP_DATA_USAGE_LOCK_TIMEOUT_SECONDS = 10
+
     @classmethod
     def _update_exp_data_usage_db(
         cls, workspace_id: str, unique_id: str, data_usage: int
     ):
-        # Concurrent writers (main process + executor) often write the same
-        # value; a Core UPDATE avoids the ORM stale-data error a same-value flush
-        # raises on MySQL. Existence is checked with a SELECT since a same-value
-        # UPDATE reports rowcount 0 (MySQL counts rows *changed*).
+        # Concurrent writers (main /run/result task + executor) often write the
+        # same value: a Core UPDATE (existence via SELECT, since a same-value
+        # UPDATE reports rowcount 0 on MySQL) avoids the ORM stale-data error.
+        # experiment_records has no unique constraint on (workspace_id, uid), so
+        # the check-then-write is serialized with a MySQL advisory lock to
+        # prevent duplicate INSERTs; best-effort if the lock is unavailable.
+        lock_name = f"{cls._EXP_DATA_USAGE_LOCK_PREFIX}_{workspace_id}_{unique_id}"[:64]
         with session_scope() as db:
-            exists = (
-                db.execute(
-                    select(ExperimentRecord.id).where(
-                        ExperimentRecord.workspace_id == workspace_id,
-                        ExperimentRecord.uid == unique_id,
-                    )
-                ).first()
-                is not None
-            )
+            got_lock = False
+            try:
+                got_lock = (
+                    db.execute(
+                        text("SELECT GET_LOCK(:name, :timeout) AS r"),
+                        {
+                            "name": lock_name,
+                            "timeout": cls._EXP_DATA_USAGE_LOCK_TIMEOUT_SECONDS,
+                        },
+                    ).scalar()
+                    == 1
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Advisory lock unavailable for experiment data usage "
+                    f"[{workspace_id}/{unique_id}]: {e}; proceeding without it"
+                )
 
-            if exists:
-                db.execute(
-                    update(ExperimentRecord)
-                    .where(
-                        ExperimentRecord.workspace_id == workspace_id,
-                        ExperimentRecord.uid == unique_id,
-                    )
-                    .values(data_usage=data_usage)
+            try:
+                exists = (
+                    db.execute(
+                        select(ExperimentRecord.id).where(
+                            ExperimentRecord.workspace_id == workspace_id,
+                            ExperimentRecord.uid == unique_id,
+                        )
+                    ).first()
+                    is not None
                 )
-            else:
-                db.add(
-                    ExperimentRecord(
-                        workspace_id=workspace_id,
-                        uid=unique_id,
-                        data_usage=data_usage,
+
+                if exists:
+                    db.execute(
+                        update(ExperimentRecord)
+                        .where(
+                            ExperimentRecord.workspace_id == workspace_id,
+                            ExperimentRecord.uid == unique_id,
+                        )
+                        .values(data_usage=data_usage)
                     )
-                )
+                else:
+                    db.add(
+                        ExperimentRecord(
+                            workspace_id=workspace_id,
+                            uid=unique_id,
+                            data_usage=data_usage,
+                        )
+                    )
+            finally:
+                if got_lock:
+                    try:
+                        db.execute(
+                            text("SELECT RELEASE_LOCK(:name)"), {"name": lock_name}
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to release advisory lock for experiment "
+                            f"data usage [{workspace_id}/{unique_id}]: {e}"
+                        )
 
     @classmethod
     def update_workspace_data_usage(

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 from sqlalchemy.exc import NoResultFound
-from sqlmodel import Session, delete, update
+from sqlmodel import Session, delete, select, update
 
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
@@ -58,24 +58,38 @@ class WorkspaceDataCapacityService:
     def _update_exp_data_usage_db(
         cls, workspace_id: str, unique_id: str, data_usage: int
     ):
+        # Concurrent writers (main process + executor) often write the same
+        # value; a Core UPDATE avoids the ORM stale-data error a same-value flush
+        # raises on MySQL. Existence is checked with a SELECT since a same-value
+        # UPDATE reports rowcount 0 (MySQL counts rows *changed*).
         with session_scope() as db:
-            try:
-                exp = (
-                    db.query(ExperimentRecord)
-                    .filter(
+            exists = (
+                db.execute(
+                    select(ExperimentRecord.id).where(
                         ExperimentRecord.workspace_id == workspace_id,
                         ExperimentRecord.uid == unique_id,
                     )
-                    .one()
+                ).first()
+                is not None
+            )
+
+            if exists:
+                db.execute(
+                    update(ExperimentRecord)
+                    .where(
+                        ExperimentRecord.workspace_id == workspace_id,
+                        ExperimentRecord.uid == unique_id,
+                    )
+                    .values(data_usage=data_usage)
                 )
-                exp.data_usage = data_usage
-            except NoResultFound:
-                exp = ExperimentRecord(
-                    workspace_id=workspace_id,
-                    uid=unique_id,
-                    data_usage=data_usage,
+            else:
+                db.add(
+                    ExperimentRecord(
+                        workspace_id=workspace_id,
+                        uid=unique_id,
+                        data_usage=data_usage,
+                    )
                 )
-                db.add(exp)
 
     @classmethod
     def update_workspace_data_usage(

--- a/studio/tests/app/common/core/cloud/test_storage_tracking_update.py
+++ b/studio/tests/app/common/core/cloud/test_storage_tracking_update.py
@@ -62,3 +62,27 @@ def test_success_log_not_emitted_when_commit_fails(caplog):
         "Updated storage usage for user 9" in r.message for r in caplog.records
     )
     assert any("Failed to update storage usage" in r.message for r in caplog.records)
+
+
+def test_genuine_db_error_reports_failure_not_success(caplog):
+    """A genuine write error (StaleDataError) must NOT be swallowed as the
+    benign 'table not accessible' fallback: the function reports failure."""
+    from sqlalchemy.orm.exc import StaleDataError
+
+    from studio.app.common.core.cloud.storage_tracking import update_user_storage_usage
+
+    db = MagicMock()
+    db.execute.side_effect = StaleDataError("stale")
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db)):
+        with caplog.at_level(logging.WARNING):
+            result = update_user_storage_usage(9, 111)
+
+    assert result is False
+    # Must not be misclassified as the benign missing-table fallback...
+    assert not any("table not accessible" in r.message for r in caplog.records)
+    # ...nor logged as success.
+    assert not any(
+        "Updated storage usage for user 9" in r.message for r in caplog.records
+    )
+    assert any("Failed to update storage usage" in r.message for r in caplog.records)

--- a/studio/tests/app/common/core/cloud/test_storage_tracking_update.py
+++ b/studio/tests/app/common/core/cloud/test_storage_tracking_update.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for update_user_storage_usage concurrency-safe write behavior.
+
+Guards two properties of the Core-UPDATE rewrite:
+  - an existing row is updated via a Core UPDATE (no ORM load-mutate, no insert)
+  - the "Updated storage usage" success log is emitted only after commit
+"""
+
+import logging
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+MODULE = "studio.app.common.core.cloud.storage_tracking"
+
+
+def _session_scope(db_mock, commit_raises=False):
+    """Build a session_scope replacement whose context-exit optionally raises,
+    simulating a commit failure at the end of the with-block."""
+
+    @contextmanager
+    def _cm():
+        try:
+            yield db_mock
+        finally:
+            if commit_raises:
+                raise RuntimeError("commit failed")
+
+    return _cm
+
+
+def test_existing_row_updated_via_core_update(caplog):
+    from studio.app.common.core.cloud.storage_tracking import update_user_storage_usage
+
+    db = MagicMock()
+    # Existence SELECT returns a row.
+    db.execute.return_value.first.return_value = (123,)
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db)):
+        with caplog.at_level(logging.INFO):
+            result = update_user_storage_usage(9, 111)
+
+    assert result is True
+    # SELECT (existence) + UPDATE, and no ORM insert.
+    assert db.execute.call_count == 2
+    db.add.assert_not_called()
+    assert any("Updated storage usage for user 9" in r.message for r in caplog.records)
+
+
+def test_success_log_not_emitted_when_commit_fails(caplog):
+    from studio.app.common.core.cloud.storage_tracking import update_user_storage_usage
+
+    db = MagicMock()
+    db.execute.return_value.first.return_value = (123,)
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db, commit_raises=True)):
+        with caplog.at_level(logging.INFO):
+            result = update_user_storage_usage(9, 111)
+
+    assert result is False
+    # The success log lives after the with-block, so a commit failure suppresses it.
+    assert not any(
+        "Updated storage usage for user 9" in r.message for r in caplog.records
+    )
+    assert any("Failed to update storage usage" in r.message for r in caplog.records)

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
@@ -198,6 +198,32 @@ class TestPostProcessObserveLockConflict:
         )
 
     @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_lock_conflict_then_genuine_failure_still_finalizes(
+        self, mock_observe, mock_experiment_record, mock_data_capacity
+    ):
+        """A lock conflict proves the local ExptConfig was finalized, so a later
+        genuine failure on the redundant upload does not un-prove it: the DB is
+        still finalized."""
+        mock_observe.observe_overall = AsyncMock(
+            side_effect=[self._make_lock_error(), RuntimeError("boom")]
+        )
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        with patch(f"{MODULE}.logger.error"):  # suppress intentional traceback
+            _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        # Loop breaks on the genuine failure at the 2nd attempt.
+        assert mock_observe.observe_overall.await_count == 2
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        mock_data_capacity.update_experiment_data_usage.assert_called_once_with(
+            WORKSPACE_ID, UNIQUE_ID
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
     def test_logs_lock_conflict_warning(
         self, mock_observe, mock_experiment_record, mock_data_capacity, caplog
     ):

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
@@ -25,10 +25,11 @@ def _patch_snakemake_execution():
         patch(f"{MODULE}.join_filepath", return_value="/tmp/fake"),
         patch(f"{MODULE}.SnakemakeApi") as mock_api_cls,
         patch(f"{MODULE}.RemoteStorageController") as mock_remote,
-        patch(f"{MODULE}.RemoteSyncLockFileUtil"),
+        patch(f"{MODULE}.RemoteSyncLockFileUtil") as mock_lock,
         patch(f"{MODULE}.RemoteSyncStatusFileUtil"),
         patch(f"{MODULE}.get_pickle_file"),
         patch(f"{MODULE}.DIRPATH"),
+        patch(f"{MODULE}.time.sleep"),  # avoid real backoff sleeps
     ):
         # Make snakemake execution itself succeed
         mock_ctx = MagicMock()
@@ -39,6 +40,10 @@ def _patch_snakemake_execution():
         mock_ctx.dag.return_value.__exit__ = MagicMock(return_value=False)
 
         mock_remote.is_available.return_value = False
+
+        # Provide real integer retry-policy constants (the class is mocked).
+        mock_lock.LOCK_CONFLICT_RETRY_MAX = 3
+        mock_lock.LOCK_CONFLICT_RETRY_BACKOFF_SECONDS = 0
         yield
 
 
@@ -129,5 +134,90 @@ class TestPostProcessObserveFailure:
             in record.message
             and WORKSPACE_ID in record.message
             and UNIQUE_ID in record.message
+            for record in caplog.records
+        )
+
+
+class TestPostProcessObserveLockConflict:
+    """A remote upload-lock conflict must not skip DB finalization.
+
+    The upload is idempotent and handled by the concurrent observe path, and
+    the local ExptConfig is already finalized before the upload step, so
+    registration and data-usage still run.
+    """
+
+    def _make_lock_error(self):
+        from studio.app.common.core.storage.remote_storage_controller import (
+            RemoteStorageLockError,
+        )
+
+        return RemoteStorageLockError(WORKSPACE_ID, UNIQUE_ID)
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_finalizes_when_lock_persists(
+        self, mock_observe, mock_experiment_record, mock_data_capacity
+    ):
+        """Every attempt hits the lock: DB is still finalized."""
+        mock_observe.observe_overall = AsyncMock(side_effect=self._make_lock_error())
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        # observe_overall retried up to the configured maximum
+        assert mock_observe.observe_overall.await_count == 3
+
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        mock_data_capacity.update_experiment_data_usage.assert_called_once_with(
+            WORKSPACE_ID, UNIQUE_ID
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_retry_succeeds_then_finalizes(
+        self, mock_observe, mock_experiment_record, mock_data_capacity
+    ):
+        """A transient lock clears on retry: observe succeeds, DB finalized."""
+        mock_observe.observe_overall = AsyncMock(
+            side_effect=[self._make_lock_error(), None]
+        )
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        assert mock_observe.observe_overall.await_count == 2
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        mock_data_capacity.update_experiment_data_usage.assert_called_once_with(
+            WORKSPACE_ID, UNIQUE_ID
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_logs_lock_conflict_warning(
+        self, mock_observe, mock_experiment_record, mock_data_capacity, caplog
+    ):
+        mock_observe.observe_overall = AsyncMock(side_effect=self._make_lock_error())
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        assert any(
+            "upload stayed locked" in record.message
+            and WORKSPACE_ID in record.message
+            and UNIQUE_ID in record.message
+            for record in caplog.records
+        )
+        # The "skipped" warning must NOT be emitted on a lock conflict.
+        assert not any(
+            "Skipped experiment record registration" in record.message
             for record in caplog.records
         )

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py
@@ -18,7 +18,16 @@ UNIQUE_ID = "test_unique_id"
 
 
 @pytest.fixture()
-def _patch_snakemake_execution():
+def mock_sync_status():
+    """Patch RemoteSyncStatusFileUtil; by default the concurrent observe path
+    has NOT reported sync success (so lock conflicts exhaust their retries)."""
+    with patch(f"{MODULE}.RemoteSyncStatusFileUtil") as mock_status:
+        mock_status.check_sync_status_success.return_value = False
+        yield mock_status
+
+
+@pytest.fixture()
+def _patch_snakemake_execution(mock_sync_status):
     """Patch everything except the post-process block under test."""
     with (
         patch(f"{MODULE}.SmkStatusLogger"),
@@ -26,7 +35,6 @@ def _patch_snakemake_execution():
         patch(f"{MODULE}.SnakemakeApi") as mock_api_cls,
         patch(f"{MODULE}.RemoteStorageController") as mock_remote,
         patch(f"{MODULE}.RemoteSyncLockFileUtil") as mock_lock,
-        patch(f"{MODULE}.RemoteSyncStatusFileUtil"),
         patch(f"{MODULE}.get_pickle_file"),
         patch(f"{MODULE}.DIRPATH"),
         patch(f"{MODULE}.time.sleep"),  # avoid real backoff sleeps
@@ -245,5 +253,64 @@ class TestPostProcessObserveLockConflict:
         # The "skipped" warning must NOT be emitted on a lock conflict.
         assert not any(
             "Skipped experiment record registration" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_upload_confirmed_stops_retry_and_finalizes(
+        self,
+        mock_observe,
+        mock_experiment_record,
+        mock_data_capacity,
+        mock_sync_status,
+        caplog,
+    ):
+        """A SUCCESS remote sync status (from the path that won the lock) proves
+        the redundant upload landed: stop retrying and finalize as confirmed."""
+        mock_observe.observe_overall = AsyncMock(side_effect=self._make_lock_error())
+        mock_sync_status.check_sync_status_success.return_value = True
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        # Confirmed on the 1st attempt: no further retries.
+        assert mock_observe.observe_overall.await_count == 1
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        mock_data_capacity.update_experiment_data_usage.assert_called_once_with(
+            WORKSPACE_ID, UNIQUE_ID
+        )
+        assert any(
+            "verified via remote sync status" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.usefixtures("_patch_snakemake_execution")
+    def test_unconfirmed_lock_logs_reconcile_warning(
+        self, mock_observe, mock_experiment_record, mock_data_capacity, caplog
+    ):
+        """Persistent lock with no sync-success: DB is finalized from the local
+        ExptConfig, and the unconfirmed remote upload is flagged for re-sync."""
+        mock_observe.observe_overall = AsyncMock(side_effect=self._make_lock_error())
+
+        from studio.app.common.core.snakemake.snakemake_executor import (
+            _snakemake_execute_process,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            _snakemake_execute_process(WORKSPACE_ID, UNIQUE_ID, MagicMock())
+
+        record_fn = mock_experiment_record.regist_record_on_workflow_completed
+        record_fn.assert_called_once_with(WORKSPACE_ID, UNIQUE_ID)
+        assert any(
+            "remote upload is unconfirmed and will be reconciled" in record.message
+            for record in caplog.records
+        )
+        assert not any(
+            "verified via remote sync status" in record.message
             for record in caplog.records
         )

--- a/studio/tests/app/common/core/workspace/test_exp_data_usage_db.py
+++ b/studio/tests/app/common/core/workspace/test_exp_data_usage_db.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for WorkspaceDataCapacityService._update_exp_data_usage_db.
+
+Guards that the check-then-write is serialized by a MySQL advisory lock so
+concurrent writers do not create duplicate experiment_records rows (the table
+has no unique constraint on (workspace_id, uid)), and that the lock is always
+released.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+MODULE = "studio.app.common.core.workspace.workspace_data_capacity_services"
+
+WORKSPACE_ID = "9"
+UNIQUE_ID = "c2f43bda"
+
+
+def _session_scope(db_mock):
+    @contextmanager
+    def _cm():
+        yield db_mock
+
+    return _cm
+
+
+def _sql_texts(db):
+    return [str(call.args[0]) for call in db.execute.call_args_list if call.args]
+
+
+def test_inserts_under_advisory_lock_when_absent():
+    from studio.app.common.core.workspace.workspace_data_capacity_services import (
+        WorkspaceDataCapacityService,
+    )
+
+    db = MagicMock()
+    db.execute.return_value.scalar.return_value = 1  # GET_LOCK acquired
+    db.execute.return_value.first.return_value = None  # record absent
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db)):
+        WorkspaceDataCapacityService._update_exp_data_usage_db(
+            WORKSPACE_ID, UNIQUE_ID, 4096
+        )
+
+    texts = _sql_texts(db)
+    assert any("GET_LOCK" in t for t in texts)
+    assert any("RELEASE_LOCK" in t for t in texts)
+    # Absent -> insert branch.
+    db.add.assert_called_once()
+
+
+def test_updates_without_insert_when_present():
+    from studio.app.common.core.workspace.workspace_data_capacity_services import (
+        WorkspaceDataCapacityService,
+    )
+
+    db = MagicMock()
+    db.execute.return_value.scalar.return_value = 1  # GET_LOCK acquired
+    db.execute.return_value.first.return_value = (5,)  # record present
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db)):
+        WorkspaceDataCapacityService._update_exp_data_usage_db(
+            WORKSPACE_ID, UNIQUE_ID, 4096
+        )
+
+    texts = _sql_texts(db)
+    assert any("GET_LOCK" in t for t in texts)
+    assert any("RELEASE_LOCK" in t for t in texts)
+    # Present -> UPDATE branch, no ORM insert.
+    db.add.assert_not_called()
+
+
+def test_proceeds_and_skips_release_when_lock_unavailable():
+    """If GET_LOCK errors (e.g. non-MySQL backend), the write still proceeds and
+    no RELEASE_LOCK is attempted."""
+    from studio.app.common.core.workspace.workspace_data_capacity_services import (
+        WorkspaceDataCapacityService,
+    )
+
+    db = MagicMock()
+
+    def _execute(statement, *args, **kwargs):
+        result = MagicMock()
+        if "GET_LOCK" in str(statement):
+            raise RuntimeError("no GET_LOCK on this backend")
+        result.first.return_value = None  # record absent
+        return result
+
+    db.execute.side_effect = _execute
+
+    with patch(f"{MODULE}.session_scope", _session_scope(db)):
+        WorkspaceDataCapacityService._update_exp_data_usage_db(
+            WORKSPACE_ID, UNIQUE_ID, 4096
+        )
+
+    texts = _sql_texts(db)
+    assert not any("RELEASE_LOCK" in t for t in texts)
+    # Write still proceeds despite the missing lock.
+    db.add.assert_called_once()

--- a/studio/tests/app/common/core/workspace/test_exp_data_usage_db.py
+++ b/studio/tests/app/common/core/workspace/test_exp_data_usage_db.py
@@ -1,10 +1,15 @@
 """
 Unit tests for WorkspaceDataCapacityService._update_exp_data_usage_db.
 
-Guards that the check-then-write is serialized by a MySQL advisory lock so
-concurrent writers do not create duplicate experiment_records rows (the table
-has no unique constraint on (workspace_id, uid)), and that the lock is always
-released.
+Guards the code structure of the advisory-lock serialization: the lock is
+acquired, the check-then-write runs, and the lock is released *after* the write
+(so it spans the write's commit).
+
+NOTE: these use a single mocked session and therefore validate ordering/branch
+structure only. The actual cross-connection guarantee — that a second writer
+cannot INSERT a duplicate row because the lock is held across the first writer's
+commit — needs two real DB connections and is validated by the manual test
+(Test 3 in the PR's manual test plan), not here.
 """
 
 from contextlib import contextmanager
@@ -44,7 +49,9 @@ def test_inserts_under_advisory_lock_when_absent():
 
     texts = _sql_texts(db)
     assert any("GET_LOCK" in t for t in texts)
-    assert any("RELEASE_LOCK" in t for t in texts)
+    # RELEASE_LOCK is the LAST statement — it runs after the write session's
+    # commit, so the lock spans the commit (the whole point of the fix).
+    assert "RELEASE_LOCK" in texts[-1]
     # Absent -> insert branch.
     db.add.assert_called_once()
 


### PR DESCRIPTION
## Summary

When a workflow finishes, two independent code paths upload-and-observe the **same** experiment
under a single remote-storage lock:

1. The `POST /run/result/{workspace}/{uid}` polling endpoint (`run.py` → `run_result` →
   `WorkflowResult.observe()`), running in the **main API process**. The frontend polls this every
   ~10s while the run is active.
2. The executor's finalization (`snakemake_executor.py` → `_snakemake_execute_process` →
   `WorkflowResult.observe_overall()`), running in the **snakemake executor subprocess**.

Both reach `WorkflowResult.__observe_nodes()` → `RemoteStorageWriter(... UPLOAD)`, which takes the
per-experiment lock. When the frontend's final poll overlaps the executor's finalization, the
executor loses the lock and raises `RemoteStorageLockError`. Previously the executor treated this as
`observe_success = False` and **skipped experiment-record registration and the data-usage update**
for that run.

This PR makes the executor finalization tolerant of that lock collision: the (idempotent) upload is
retried a bounded number of times, and DB registration + data-usage finalization now run regardless
of a residual lock conflict — because the local `ExptConfig` is already finalized before the upload
step and the upload itself is completed by whichever path wins the lock.

It also fixes a secondary, non-fatal concurrency defect in `update_user_storage_usage` flagged in the
same issue.

---

## Root Cause

`WorkflowResult.__observe_nodes()` performs two distinct kinds of work, in order:

1. **Local finalization** — iterates the nodes and writes their statuses (and the experiment-level
   `success` / `finished_at`) into the local `experiment.yaml`. This requires no lock.
2. **Remote upload** — only after all nodes are finished, uploads `experiment.yaml` and the JSON
   visualization files to S3 under the per-experiment lock (`RemoteStorageWriter`).

The exclusive lock is a lock **file** guarded by a check-then-create sequence
(`RemoteSyncLockFileUtil.check_sync_lock_file` → `create_sync_lock_file`). It is held only for the
duration of the upload (a few seconds).

The existing guard in `_snakemake_execute_process` waits for the `post_process` node's own upload
lock (`RemoteSyncLockFileUtil.wait_for_lock_release`) before calling `observe_overall()`, but that
guard does **not** cover a concurrent `/run/result` observe from the main process. Nothing serializes
those two writers, so a final poll landing on the finalization window makes the executor's
`RemoteStorageWriter.__init__` see the lock held → `RemoteStorageLockError`.

Because registration and data-usage were both gated on `observe_success`, a lock collision on the
**redundant** upload wrongly skipped the **critical** DB writes. Registration happens **only** on the
executor path, so the affected run's experiment record could be absent until a later S3 metadata
re-sync repopulated it.

### Evidence (subscr container log, task `dce18cabf5`)

```
14:42:11 INFO  __observe_nodes():212 - Uploading observation files to S3: 35 files   # main process (pid 100)
14:42:11 INFO  upload_experiment():1043 - Upload data ... [.../181/c2f43bda -> ...]
14:42:15 WARN  __init__():1029 - This data is locked because it is being processed.  # executor subprocess (pid 375)
14:42:15 ERROR _snakemake_execute_process():200 - snakemake_execute post process (WorkflowResult) failed:
               Remote data is temporary locked. [181/c2f43bda]
14:42:15 WARN  _snakemake_execute_process():218 - Skipped experiment record registration and data
               usage update due to observe_overall() failure. [workspace: 181] [unique_id: c2f43bda]
```

---

## Design Rationale

The issue proposed three directions. Each was analysed against the actual code path before choosing.

### Why NOT serialize the two observe paths (extend `wait_for_lock_release`)

The lock is a lock **file** with a non-atomic check-then-create sequence across two processes. Even if
`observe_overall()` waited on the same lock the `/run/result` path uses, the main process's poll could
still acquire the lock in the TOCTOU window between the wait returning and
`RemoteStorageWriter.__init__` creating the file. Truly serializing them would require replacing the
file-existence lock with a cross-process atomic primitive (e.g. `flock`) used by every reader/writer —
a broad, high-risk change to a core primitive. Rejected.

### Why retry alone is insufficient

Retrying `observe_overall()` on `RemoteStorageLockError` targets the transient nature of the lock, but
on its own it does not **guarantee** DB registration if the conflict happens to persist across every
attempt. It is a useful component, not a complete fix.

### Chosen approach — decouple DB finalization from the upload, plus a bounded retry

The upload is genuinely **redundant and idempotent**: whichever path wins the lock uploads the same
data, and the workflow output is never lost (`upload_experiment` succeeds on the winning path). The
work that DB registration actually depends on — the local `ExptConfig` node statuses — is written
**before** the upload step inside `__observe_nodes()`. Verified that
`ExperimentRecordService.regist_record_on_workflow_completed()` and
`WorkspaceDataCapacityService.update_experiment_data_usage()` read only local files/DB and do **not**
re-acquire the experiment upload lock (thumbnail generation operates on local files), so running them
during a lock conflict is safe.

Therefore:

- **Retry** `observe_overall()` a bounded number of times on `RemoteStorageLockError` (short backoff),
  so the executor lands its own upload once the short-lived lock frees.
- If the lock stays contended after the retries, **finalize the DB anyway** (registration +
  data-usage). Only a *genuine* observe failure (any non-lock exception) skips finalization, which
  preserves the original behavior for real errors.

---

## Changes

### 1. Executor finalization — `studio/app/common/core/snakemake/snakemake_executor.py`

- New helper `_observe_overall_with_lock_retry(workspace_id, unique_id)` runs `observe_overall()`,
  retrying on `RemoteStorageLockError` with a bounded count and backoff. Returns
  `(observe_success, observe_lock_conflict)`.
- `_snakemake_execute_process` now finalizes DB registration and data-usage when
  `observe_success or observe_lock_conflict` is true. A residual lock conflict logs a distinct
  warning ("upload stayed locked; finalized DB registration and data usage regardless"); a genuine
  observe failure keeps the original "Skipped …" warning and skips finalization.

### 2. Lock retry policy constants — `studio/app/common/core/storage/remote_storage_controller.py`

- Added `RemoteSyncLockFileUtil.LOCK_CONFLICT_RETRY_MAX` (3) and
  `LOCK_CONFLICT_RETRY_BACKOFF_SECONDS` (5), placed alongside the existing `LOCK_WAIT_*` constants so
  the lock domain owns the retry policy.

### 3. Storage-usage write concurrency safety — `studio/app/common/core/cloud/storage_tracking.py`

- `update_user_storage_usage` no longer uses the ORM load-mutate-flush, which raised a stale-data
  error ("expected to update 1 row(s); 0 were matched") when a concurrent commit left the target row
  unchanged at flush time. It now checks existence with a `SELECT` and writes via a Core `UPDATE`
  keyed on `user_id` (existence is not inferred from `UPDATE` rowcount, since MySQL reports rows
  *changed*, so an update to an identical value returns 0 even when the row exists).
- The "Updated storage usage …" success log is emitted only **after** the commit lands, removing the
  previously misleading optimistic log that fired before a commit that then failed.

### 4. Experiment data-usage write concurrency safety — `studio/app/common/core/workspace/workspace_data_capacity_services.py`

- `update_experiment_data_usage` is called from **both** the main process (`/run/result` background
  task) and the executor finalization; this PR makes the executor run it on a lock conflict too, so
  the two writers overlap more often — exactly when both compute the same folder size. Its
  `_update_exp_data_usage_db` helper had the same ORM load-mutate-flush that failed for
  `user_storage_usage`. It is switched to the same `SELECT` existence check + Core `UPDATE` keyed on
  `(workspace_id, uid)`, so a same-value concurrent write no longer raises `StaleDataError`.

---

## How It Works

### Before (lock collision skips DB registration)

```
executor finalization: observe_overall()
  → __observe_nodes(): local ExptConfig finalized (node statuses written)
  → RemoteStorageWriter.__init__(): lock held by concurrent /run/result upload
  → RemoteStorageLockError
  → observe_success = False
  → regist_record_on_workflow_completed()  SKIPPED
  → update_experiment_data_usage()         SKIPPED
  → "Skipped experiment record registration and data usage update"
```

### After (lock collision tolerated)

```
executor finalization: _observe_overall_with_lock_retry()
  → attempt 1: observe_overall() → RemoteStorageLockError (lock held) → backoff
  → attempt 2/3: retry once the short-lived lock frees
     ├─ success → observe_success = True
     └─ still locked → observe_lock_conflict = True (upload completed by the other path)
  → should_finalize = observe_success or observe_lock_conflict = True
  → regist_record_on_workflow_completed()  RUNS  (reads finalized local ExptConfig; no lock)
  → update_experiment_data_usage()         RUNS
  → on residual conflict: "upload stayed locked; finalized DB registration and data usage regardless"
```

---

## Automated Test Cases

### Backend: `tests/app/common/core/snakemake/test_snakemake_executor_post_process.py`

Existing coverage (regression):

| # | Test | Scenario | Expected |
|---|------|----------|----------|
| 1 | `TestPostProcessObserveSuccess::test_calls_record_and_data_usage` | `observe_overall()` succeeds | registration + data-usage called once |
| 2 | `TestPostProcessObserveFailure::test_skips_record_and_data_usage` | `observe_overall()` raises a non-lock error | registration + data-usage NOT called |
| 3 | `TestPostProcessObserveFailure::test_logs_warning` | same as #2 | "Skipped …" warning logged |

New coverage (this PR):

| # | Test | Scenario | Expected |
|---|------|----------|----------|
| 4 | `TestPostProcessObserveLockConflict::test_finalizes_when_lock_persists` | `RemoteStorageLockError` on every attempt | retried up to max; registration + data-usage still called once |
| 5 | `TestPostProcessObserveLockConflict::test_retry_succeeds_then_finalizes` | lock clears on the 2nd attempt | `observe_overall` awaited twice; registration + data-usage called once |
| 6 | `TestPostProcessObserveLockConflict::test_lock_conflict_then_genuine_failure_still_finalizes` | lock conflict then a non-lock error | loop breaks at 2nd attempt; DB still finalized (lock conflict proved local config finalized) |
| 7 | `TestPostProcessObserveLockConflict::test_logs_lock_conflict_warning` | lock persists | "upload stayed locked" warning logged; "Skipped …" warning NOT logged |

`update_user_storage_usage` regression (new file
`tests/app/common/core/cloud/test_storage_tracking_update.py`):

| # | Test | Scenario | Expected |
|---|------|----------|----------|
| 8 | `test_existing_row_updated_via_core_update` | existing row | Core UPDATE path (SELECT + UPDATE, no ORM insert); success log emitted |
| 9 | `test_success_log_not_emitted_when_commit_fails` | commit fails on context exit | returns False; success log suppressed; "Failed to update storage usage" logged |

> The `_update_exp_data_usage_db` change (Change 4) mirrors the `storage_tracking` fix and is not
> unit-tested in isolation (its caller is mocked in the post-process tests); it is exercised by the
> manual Test 3 double-write scenario below.

## Test Results

```
tests/app/common/core/snakemake/test_snakemake_executor_post_process.py   7 passed
tests/app/common/core/cloud/test_storage_tracking_update.py               2 passed
Affected suites (cloud_utils, storage_limit_alerts, storage_alerts_api_contract, +above)  99 passed
```

All pass. (Pre-existing `test_snakemake_executor_lccd.py` / `_suite2p.py` fail at collection due to
missing local test-data directories — unrelated to this change.)

---

## Manual Test Plan

### Prerequisites

- **Multiuser mode** with **S3 remote storage enabled** (`REMOTE_STORAGE_TYPE=2`), so the
  `RemoteStorageWriter` upload lock is active.
- A test user account (free tier is fine) with at least one runnable workflow (e.g. a tutorial).
- Browser DevTools open (Network tab, "Preserve log" enabled).
- Access to the **executor / subscr container logs**.
- Access to the DB to inspect the `experiment_records` and `user_storage_usage` tables.

> **Placeholders in the SQL below:** `{workspace_id}` is the numeric workspace id; `{unique_id}` is
> the experiment id returned by `POST /run` (also in the logs); `{user_id}` is the owning user
> (`SELECT user_id FROM workspaces WHERE id = {workspace_id};`). `success` is a MySQL `tinyint(1)`, so
> boolean true is `1`.

> **Why Test 2 is forced (not natural).** The real race needs a `/run/result` observe upload (main
> process) to hold the per-experiment lock at the exact instant the executor's `observe_overall()`
> reaches its own upload. Two things make this practically unhittable by just repeating runs:
> 1. `wait_for_lock_release()` runs before `observe_overall()` and, at the production value
>    `LOCK_WAIT_MAX_SECONDS = 300`, **waits out** any lock present at that moment — absorbing the
>    collision.
> 2. When the frontend keeps polling, the main process finalizes all node statuses first, so
>    `observe_overall()` short-circuits at its "all nodes already finished" early return and never
>    reaches the upload.
>
> Test 2 therefore forces the collision deterministically with two temporary levers (both reverted
> before merge): set `LOCK_WAIT_MAX_SECONDS = 0` so the guard no longer absorbs the lock, and hold the
> lock from a helper script while the frontend is detached so `observe_overall()` becomes the
> finalizer that reaches the upload. This drives the exact production code path
> (`observe_overall() → RemoteStorageLockError → retry → finalize`); the fix's handling does not depend
> on `LOCK_WAIT_MAX_SECONDS`, so the result carries over to the production value.

**Additional prerequisites for Test 2 (local Docker):**

- The `studio_data` volume is bind-mounted to the host, so a lock file created on the host appears in
  the container (no `docker exec` needed).
- The helper script `force_finalize_lock.sh` (watches the executor log for
  `snakemake_execute succeeded.`, then holds `output/{ws}/{uid}/remote_sync.lock` for N seconds).

---

### Test 1: Normal workflow completion registers the DB record (regression)

**Objective:** Confirm the happy path is unchanged — no lock collision, record registered.

1. Log in, open the Workflow (flowchart) page, and press **Run**. Stay on this page so the frontend
   keeps polling `POST /run/result/{ws}/{uid}` (every 10s) through completion.
2. Let the workflow complete.
3. In the executor logs, **verify**:
   - `snakemake_execute succeeded.`
   - No `observe_overall() upload lock conflict` messages.
   - No `Skipped experiment record registration …` warning.
4. In the DB, **verify** the experiment record exists and is finalized:
   ```sql
   SELECT uid, success, analyzed_at, data_usage
   FROM experiment_records
   WHERE workspace_id = {workspace_id} AND uid = '{unique_id}';
   ```
   **Expected:** exactly 1 row, `success = 1`, `analyzed_at` is NOT NULL, `data_usage > 0`.
5. **Verify** the experiment appears normally in the workspace experiment list.

**Pass criteria:** Steps 3-5 pass.

---

### Test 2: Finalization race — DB is registered despite the collision (core fix, forced reproduction)

**Objective:** Deterministically drive the executor's `observe_overall()` into a
`RemoteStorageLockError` at finalization and confirm the experiment record is still registered (before
the fix this was skipped). See the "Why Test 2 is forced" note above for the two temporary levers.

**Setup (temporary — revert before merge):**

- Set `RemoteSyncLockFileUtil.LOCK_WAIT_MAX_SECONDS = 0` in
  `studio/app/common/core/storage/remote_storage_controller.py` (default `300`), then restart the
  backend so it takes effect.

  > **Why `0` is required:** `wait_for_lock_release()` runs just before `observe_overall()` and, at the
  > default `300`, waits up to 300s for any lock already present to clear. The lock the helper holds
  > would be **waited out** there, and `observe_overall()` would then run lock-free — no conflict, so
  > the fixed path is never reached. With `0` the guard returns immediately, so the held lock survives
  > into `observe_overall()`'s upload and triggers the `RemoteStorageLockError`. (Holding the lock past
  > 300s instead is the impractical alternative.)

**Steps:**

1. Press **Run** on the Workflow page and note the `{unique_id}` from the URL (or `POST /run`).
2. Start the helper with a persistent hold, then **immediately navigate away from the Workflow page**
   so the frontend stops polling (this makes `observe_overall()` the node-finalizer that reaches the
   upload, instead of short-circuiting):
   ```sh
   ./force_finalize_lock.sh {workspace_id} {unique_id} 20
   ```
   The script waits for `snakemake_execute succeeded.`, then creates
   `output/{workspace_id}/{unique_id}/remote_sync.lock` and holds it for 20s.
3. In the executor logs, **verify** the conflict fired and the fix engaged:
   ```sh
   grep "{unique_id}" studio.log | grep -E \
     "upload lock conflict|upload stayed locked|Skipped experiment record"
   ```
   - `observe_overall() upload lock conflict (attempt n/3)` **appears** (the #726 condition), and
   - `Skipped experiment record registration …` **does NOT appear**.

   > Expected recovery: after `attempt 1/3`, the retry short-circuits (attempt 1 already finalized the
   > node statuses, so the re-read sees all-finished and skips the upload) and finalization proceeds —
   > so you typically see just `attempt 1/3` then a clean finish, no `stayed locked` line.
   >
   > The all-attempts-locked fallback (observe never succeeds) is unit-test-only: once attempt 1
   > finalizes the node statuses the retry short-circuits, so it is not reachable in this forced run. In
   > that fallback the executor finalizes the DB and, before treating the redundant upload as done,
   > verifies the remote sync-status — logging either
   > `upload stayed locked; ... verified via remote sync status` (the winning path wrote a SUCCESS
   > status) or `upload stayed locked ...; the remote upload is unconfirmed and will be reconciled by
   > the periodic re-sync` (no SUCCESS status yet). Both branches are pinned by the unit tests
   > `test_finalizes_when_lock_persists`, `test_upload_confirmed_stops_retry_and_finalizes`, and
   > `test_unconfirmed_lock_logs_reconcile_warning`.
4. In the DB, **verify** the record was registered/updated despite the collision:
   ```sql
   SELECT uid, success, data_usage
   FROM experiment_records
   WHERE workspace_id = {workspace_id} AND uid = '{unique_id}';
   ```
   **Expected:** exactly 1 row, `success = 1`, `data_usage > 0`.

**Pass criteria:** Step 3 shows `upload lock conflict` **with no** `Skipped …`, and Step 4 shows the
registered row. (Before the fix, the same collision logged `Skipped …` and left the record
unregistered.)

**Teardown:** the script auto-removes the lock; restore `LOCK_WAIT_MAX_SECONDS = 300` and remove
`force_finalize_lock.sh`.

> **Test artifact:** the lock holder here is a dummy file, so the executor's own observe upload may not
> land in S3 during this forced run — that is expected. Test 2 verifies **DB registration**; in the
> real race the concurrent `/run/result` upload provides the S3 files.

---

### Test 3: Storage & data-usage writes are concurrency-safe (secondary fixes)

**Objective:** Confirm neither `user_storage_usage` nor `experiment_records.data_usage` logs the
stale-data warning at finalization, success is logged only after commit, and the concurrent
main-vs-executor writers do **not** create duplicate `experiment_records` rows (the advisory lock in
`_update_exp_data_usage_db` serializes the check-then-write; the table has no unique constraint on
`(workspace_id, uid)`).

1. On the Workflow page, press **Run** and stay on the page through completion (so the main process's
   `/run/result` background task and the executor both write `data_usage`, and the full scan runs
   `update_user_storage_usage`).
2. In the logs, **verify the stale-data error is absent** for both tables. The old ORM flush raised a
   SQLAlchemy `StaleDataError` whose message is `... expected to update 1 row(s); 0 were matched`:
   ```sh
   # both must return NO matches for this run
   grep -nE "expected to update 1 row\(s\); 0 were matched" studio.log
   grep -n  "Failed to update storage usage for user" studio.log
   ```
   For the absence to be meaningful, confirm the concurrent write path actually ran this cycle
   (otherwise there was nothing to race). Both of these should be present:
   ```sh
   grep -nE "Triggering full S3 scan|Full S3 scan completed" studio.log   # full-scan reset ran
   grep -n  "Updated storage usage for user" studio.log                    # update_user_storage_usage ran
   ```
3. **Confirm the post-commit logging (interpretation of step 2 — no separate grep).** The
   `Updated storage usage …` INFO now follows the committed `with session_scope()` block, so the pre-fix
   failure signature — an `Updated storage usage for user {user_id}` INFO **immediately followed by**
   `… expected to update 1 row(s); 0 were matched` — can no longer occur. Step 2 already shows the
   `Updated …` line present **and** the error line absent, so that pairing does not appear; there is
   nothing extra to grep here. The failure-path ordering itself (success logged only *after* a
   successful commit, `Failed to update …` otherwise) is pinned deterministically by unit test #9
   `test_success_log_not_emitted_when_commit_fails`, since it cannot be observed at runtime once the
   Core `UPDATE` stops the commit from failing.
4. In the DB, **verify** both writes landed. Include the timestamp columns — `experiment_records` is
   often an **update of an existing row** (a re-run), so a fresh timestamp is what proves the write
   actually happened rather than reading a stale prior value:
   ```sql
   -- storage usage recomputed and timestamped
   SELECT user_id, storage_usage_bytes, delta_since_last_scan, last_full_scan, last_updated
   FROM user_storage_usage
   WHERE user_id = {user_id};

   -- experiment data usage set; updated_at is MySQL ON UPDATE CURRENT_TIMESTAMP
   SELECT uid, data_usage, updated_at, created_at
   FROM experiment_records
   WHERE workspace_id = {workspace_id} AND uid = '{unique_id}';
   ```
   **Expected:**
   - `user_storage_usage`: 1 row, `storage_usage_bytes > 0`, `last_updated` within this run's window.
   - `experiment_records`: exactly **1 row** (the main-process + executor double-write did not
     duplicate it), `data_usage > 0`, and `updated_at` within this run's window (for a re-run,
     `updated_at > created_at`).

   > Note: MySQL only bumps `updated_at` when a column value actually **changes**. If a re-run happens
   > to produce the identical `data_usage`, `updated_at` may stay unchanged — that is fine; the
   > decisive check remains the **absence of the stale-data error** in step 2 (the Core `UPDATE` no
   > longer raises on a same-value write).
5. **Concurrency (stronger) — overlap several finalizations.** Start **2–3 workflows for the same
   user as close to simultaneously as possible** (identical workflows finish at roughly the same time,
   so their finalizations — the heavy `user_storage_usage` write window — overlap). More concurrent
   runs = more writers contending on that one user row = a stronger test; the fix must still produce no
   stale-data error.

   > This stresses the shared **`user_storage_usage`** row (per-user). `experiment_records.data_usage`
   > is a **separate row per workflow**, so its intra-run main-vs-executor race is already covered by
   > steps 1–4 and is not what extra concurrent runs exercise.

   - a. Re-run the step-2 greps over the overlapping window — the stale-data error must be absent across
      all runs:
      ```sh
      grep -nE "expected to update 1 row\(s\); 0 were matched|Failed to update storage usage for user" studio.log
      ```
      **Expected:** no matches. (For the overlap to be meaningful, the runs' finalization activity —
      several `Full S3 scan completed for user {user_id}` and/or `Updated storage usage for user
      {user_id}` lines — should appear interleaved in the same window.)
   - b. Confirm every experiment's data usage landed:
      ```sql
      SELECT uid, data_usage, updated_at
      FROM experiment_records
      WHERE workspace_id = {workspace_id} AND uid IN ('{unique_id_1}', '{unique_id_2}' /*, '{unique_id_3}' */);
      ```
      **Expected:** one row per run, each with `data_usage > 0` and an `updated_at` within this run's
      window.
   - c. Confirm the advisory lock prevented duplicate rows (the concurrent main-vs-executor
      double-write is exactly the insert-branch race the lock guards):
      ```sql
      SELECT workspace_id, uid, COUNT(*) AS n
      FROM experiment_records
      WHERE workspace_id = {workspace_id}
      GROUP BY workspace_id, uid
      HAVING COUNT(*) > 1;
      ```
      **Expected:** 0 rows (each experiment has exactly one record).

**Pass criteria:** Steps 2-5 pass.

---

### Appendix: `force_finalize_lock.sh` (Test 2 helper, throwaway)

Local Docker debug helper — not committed. Watches the executor log for
`snakemake_execute succeeded.`, then holds the per-experiment lock so `observe_overall()` hits it.

```bash
#!/usr/bin/env bash
set -euo pipefail

STUDIO_DATA="${STUDIO_DATA:-/path/to/studio_data}"
LOG_FILE="${LOG_FILE:-$STUDIO_DATA/logs/studio.log}"

WS="${1:?usage: $0 <workspace_id> <unique_id> [hold_secs]}"
UID_="${2:?usage: $0 <workspace_id> <unique_id> [hold_secs]}"
HOLD="${3:-20}"

LOCK="$STUDIO_DATA/output/$WS/$UID_/remote_sync.lock"
[ -f "$LOG_FILE" ] || { echo "log not found: $LOG_FILE" >&2; exit 1; }

cleanup() { rm -f "$LOCK" 2>/dev/null && echo "[$(date +%T)] lock removed (cleanup)"; }
trap cleanup EXIT INT TERM

echo "[$(date +%T)] watching for 'snakemake_execute succeeded.' ..."
# process substitution so the touch fires the instant grep matches
grep -m1 -F "snakemake_execute succeeded." < <(tail -Fn0 "$LOG_FILE") >/dev/null

mkdir -p "$(dirname "$LOCK")"; touch "$LOCK"
echo "[$(date +%T)] lock CREATED -> expect: observe_overall() upload lock conflict (attempt n/3)"
sleep "$HOLD"
rm -f "$LOCK"; trap - EXIT INT TERM
echo "[$(date +%T)] lock removed after ${HOLD}s"
```

---

## Checklist

- [ ] **Test 1**: Normal completion registers the DB record (regression)
- [ ] **Test 2**: Finalization race (forced: `LOCK_WAIT_MAX_SECONDS=0` + `force_finalize_lock.sh`) — conflict logged, DB still registered, no "Skipped"
- [ ] **Test 3**: `user_storage_usage` + `experiment_records.data_usage` writes concurrency-safe, no stale-data warning, post-commit log, and no duplicate `experiment_records` rows (advisory lock)

---

## Risk Assessment

| Change | Blast radius | Risk | Mitigation |
|--------|-------------|------|------------|
| Finalize DB on lock conflict + bounded retry | Executor finalization path only | **Low** — DB writes only depend on the local `ExptConfig`, which is finalized before the upload step; registration/data-usage do not re-acquire the upload lock; finalization is skipped only when observe never succeeded and never reached the lock | New unit tests 4-7; manual Tests 1-2 |
| Lock retry constants on `RemoteSyncLockFileUtil` | New attributes only | **Very low** — additive constants | n/a |
| `update_user_storage_usage` Core UPDATE + post-commit log | Storage-usage writes | **Low** — same write semantics via a Core statement; existence checked by SELECT to avoid MySQL rows-changed ambiguity | Unit tests 8-9; manual Test 3 |
| `_update_exp_data_usage_db` Core UPDATE | `experiment_records.data_usage` writes | **Low** — mirror of the storage-usage fix; write semantics unchanged | Manual Test 3 (double-write) |

**Combined risk:** Low. The core change removes a false coupling (a best-effort, idempotent upload
gating a critical DB write) without weakening handling of real failures. The secondary change makes an
existing storage write concurrency-safe and its logging honest.

---

## Key Files

| File | Role |
|------|------|
| `studio/app/common/core/snakemake/snakemake_executor.py` | Executor finalization; new `_observe_overall_with_lock_retry` helper |
| `studio/app/common/core/storage/remote_storage_controller.py` | `RemoteSyncLockFileUtil` lock policy + `RemoteStorageWriter` lock |
| `studio/app/common/core/workflow/workflow_result.py` | `observe()` / `observe_overall()` / `__observe_nodes()` (local finalize before upload) |
| `studio/app/common/core/cloud/storage_tracking.py` | `update_user_storage_usage` concurrency-safe write |
| `studio/app/common/core/workspace/workspace_data_capacity_services.py` | `_update_exp_data_usage_db` concurrency-safe write |
| `studio/app/common/routers/run.py` | `/run/result` polling endpoint (the concurrent observe path) |
| `studio/tests/app/common/core/snakemake/test_snakemake_executor_post_process.py` | Backend unit tests (finalization) |
| `studio/tests/app/common/core/cloud/test_storage_tracking_update.py` | Backend unit tests (storage-usage write) |

---

## Review Feedback Addressed

| Review item | Severity | Resolution |
|-------------|----------|------------|
| `_update_exp_data_usage_db` shares the ORM stale-data pattern this PR fixes elsewhere, and the fix makes its concurrent execution more likely | Medium | **Fixed** — Change 4: applied the same `SELECT` + Core `UPDATE` treatment |
| "Only a genuine failure skips finalization" inaccurate for the lock-then-genuine-failure sequence | Low | **Reconciled** — behavior is intentional and safe (reaching the lock proves the local config is finalized); comment/PR text corrected and pinned by test #6 |
| No regression test for `update_user_storage_usage` | Low | **Fixed** — new tests #8-9 (Core UPDATE path, post-commit logging) |
| `from sqlalchemy import update` was a function-local import | Nit | **Fixed** — hoisted to module level |
| SELECT-then-INSERT TOCTOU on the first-ever insert for a user | Low | **Accepted** as documented — rare (only before a user's row exists) and self-healing (both writers compute the same value; the loser returns False and the next update corrects it). Not converted to an upsert to avoid MySQL-dialect coupling. |
