### PR TITLE
Fix premium cleanup reaping grace-period ALB rules (#766, PR A)

### DIFF
--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -440,7 +440,9 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
 
         print(f"Found {len(premium_rules)} premium user ALB rules")
 
-        # Keep-set: ACTIVE/MIGRATING/TERMINATING all still own a live rule.
+        # Keep-set: ACTIVE/MIGRATING/TERMINATING are the only statuses that own
+        # a real ALB rule ARN (RESERVING/AUTOSCALING_POOL rows carry markers,
+        # not rule ARNs), so enumerating them keeps every live rule.
         # TERMINATING shares its DB value with PENDING_RELEASE (soft-release
         # grace), so an ACTIVE-only filter would reap a live rule mid-grace.
         # Recency guard: also keep any row touched within the grace window,

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -471,8 +471,7 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
         db_rule_arns = {
             a["alb_rule_arn"]
             for a in db_assignments
-            if a["alb_rule_arn"]
-            and a["alb_rule_arn"].startswith("arn:")
+            if a["alb_rule_arn"] and a["alb_rule_arn"].startswith("arn:")
         }
         print(f"Found {len(db_rule_arns)} keep-set assignments in database")
 

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -440,13 +440,10 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
 
         print(f"Found {len(premium_rules)} premium user ALB rules")
 
-        # Keep-set: ACTIVE/MIGRATING/TERMINATING are the only statuses that own
-        # a real ALB rule ARN (RESERVING/AUTOSCALING_POOL rows carry markers,
-        # not rule ARNs), so enumerating them keeps every live rule.
-        # TERMINATING shares its DB value with PENDING_RELEASE (soft-release
-        # grace), so an ACTIVE-only filter would reap a live rule mid-grace.
-        # Recency guard: also keep any row touched within the grace window,
-        # so a rule whose row is mid-transition is never seen as orphaned.
+        # Keep-set: ACTIVE/MIGRATING/TERMINATING (statuses that can own a live
+        # rule) plus any row touched within the grace window. TERMINATING
+        # aliases PENDING_RELEASE, so an ACTIVE-only filter would reap a rule
+        # mid soft-release grace; the recency guard covers rows mid-transition.
         grace_seconds = PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
@@ -469,11 +466,13 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
                 )
                 db_assignments = cursor.fetchall()
 
+        # Filter to real ARNs: marker rows (RESERVING/AUTOSCALING_POOL) carry
+        # placeholder strings, not rule ARNs, so they must not enter the keep-set.
         db_rule_arns = {
             a["alb_rule_arn"]
             for a in db_assignments
             if a["alb_rule_arn"]
-            and a["alb_rule_arn"].lower() != PremiumAssignment.STANDBY
+            and a["alb_rule_arn"].startswith("arn:")
         }
         print(f"Found {len(db_rule_arns)} keep-set assignments in database")
 

--- a/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
+++ b/infrastructure/terraform/premium_cleanup_package/premium_cleanup.py
@@ -440,14 +440,30 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
 
         print(f"Found {len(premium_rules)} premium user ALB rules")
 
-        # Get all active assignments from database
+        # Keep-set: ACTIVE/MIGRATING/TERMINATING all still own a live rule.
+        # TERMINATING shares its DB value with PENDING_RELEASE (soft-release
+        # grace), so an ACTIVE-only filter would reap a live rule mid-grace.
+        # Recency guard: also keep any row touched within the grace window,
+        # so a rule whose row is mid-transition is never seen as orphaned.
+        grace_seconds = PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS
         with get_db_connection() as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
                     """SELECT alb_rule_arn, target_group_arn, user_id
                        FROM premium_user_assignments
-                       WHERE status = %s AND is_standby = 0""",
-                    (PremiumAssignment.ACTIVE,),
+                       WHERE is_standby = 0
+                         AND (
+                             status IN (%s, %s, %s)
+                             OR last_activity >= DATE_SUB(
+                                 NOW(), INTERVAL %s SECOND
+                             )
+                         )""",
+                    (
+                        PremiumAssignment.ACTIVE,
+                        PremiumAssignment.MIGRATING,
+                        PremiumAssignment.TERMINATING,
+                        grace_seconds,
+                    ),
                 )
                 db_assignments = cursor.fetchall()
 
@@ -457,7 +473,7 @@ def cleanup_orphaned_alb_resources() -> Dict[str, Any]:
             if a["alb_rule_arn"]
             and a["alb_rule_arn"].lower() != PremiumAssignment.STANDBY
         }
-        print(f"Found {len(db_rule_arns)} active assignments in database")
+        print(f"Found {len(db_rule_arns)} keep-set assignments in database")
 
         # Find orphaned rules (in ALB but not in database)
         orphaned_rules = [

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -530,9 +530,7 @@ class TestCleanupOrphanedAlbResources:
 
             mock_elbv2.describe_rules.return_value = {
                 "Rules": [
-                    _premium_alb_rule(
-                        grace_rule_arn, "arn:aws:tg/premium-12", "rid-12"
-                    )
+                    _premium_alb_rule(grace_rule_arn, "arn:aws:tg/premium-12", "rid-12")
                 ]
             }
 
@@ -582,9 +580,7 @@ class TestCleanupOrphanedAlbResources:
 
             mock_elbv2.describe_rules.return_value = {
                 "Rules": [
-                    _premium_alb_rule(
-                        recent_rule_arn, "arn:aws:tg/premium-7", "rid-7"
-                    )
+                    _premium_alb_rule(recent_rule_arn, "arn:aws:tg/premium-7", "rid-7")
                 ]
             }
 

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -435,6 +435,95 @@ class TestCleanupOrphanedAlbResources:
             assert result["orphaned_rules_deleted"] == 1
             mock_elbv2.delete_rule.assert_called_once_with(RuleArn=orphan_arn)
 
+    def test_keeps_grace_period_assignment(self, mock_env_vars_premium):
+        """Regression (#766): a soft-released row in its grace window
+        (status == PENDING_RELEASE == 'terminating') still owns a live ALB
+        rule and must NOT be reaped as orphaned."""
+        grace_rule_arn = "arn:aws:rule/user-12-grace"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_cleanup.pymysql.connect") as mock_pymysql:
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    {
+                        "RuleArn": grace_rule_arn,
+                        "Priority": "100",
+                        "Conditions": [
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.ROUTING_ID),
+                                    "Values": ["rid-12"],
+                                },
+                            },
+                            {
+                                "Field": "http-header",
+                                "HttpHeaderConfig": {
+                                    "HttpHeaderName": (RoutingHeaders.USER_TIER),
+                                    "Values": ["premium"],
+                                },
+                            },
+                        ],
+                        "Actions": [
+                            {
+                                "Type": "forward",
+                                "TargetGroupArn": ("arn:aws:tg/premium-12"),
+                            }
+                        ],
+                    }
+                ]
+            }
+
+            # The grace row is returned by the keep-set query because it now
+            # covers TERMINATING (== PENDING_RELEASE) and the recency guard.
+            mock_connection = setup_db_mock(
+                fetchall_values=[
+                    [
+                        MockRow(
+                            {
+                                "alb_rule_arn": grace_rule_arn,
+                                "target_group_arn": ("arn:aws:tg/premium-12"),
+                                "user_id": 12,
+                            }
+                        )
+                    ],
+                ],
+            )
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_orphaned_alb_resources
+
+            result = cleanup_orphaned_alb_resources()
+
+            # Live rule survives the sweep.
+            assert result["orphaned_rules_deleted"] == 0
+            assert not mock_elbv2.delete_rule.called
+
+            # Pin the fix: keep-set query covers grace states + recency guard,
+            # not ACTIVE only (the ACTIVE-only filter is the bug).
+            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+            keep_set_call = next(
+                c
+                for c in mock_cursor.execute.call_args_list
+                if "premium_user_assignments" in c.args[0]
+                and "alb_rule_arn" in c.args[0]
+            )
+            keep_set_sql, keep_set_params = keep_set_call.args[0], keep_set_call.args[1]
+            assert "last_activity" in keep_set_sql
+            assert PremiumAssignment.MIGRATING in keep_set_params
+            assert PremiumAssignment.TERMINATING in keep_set_params
+            assert PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS in keep_set_params
+
     def test_skips_default_rule(self, mock_env_vars_premium):
         """Default ALB rule is never deleted."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(

--- a/studio/tests/infrastructure/test_premium_cleanup.py
+++ b/studio/tests/infrastructure/test_premium_cleanup.py
@@ -13,6 +13,76 @@ from conftest import MockRow, setup_db_mock
 TEST_INSTANCE_ID = "i-testlambda123"
 
 
+def _premium_alb_rule(rule_arn, tg_arn, routing_id, priority="100"):
+    """Build a describe_rules entry shaped like a premium per-user rule."""
+    return {
+        "RuleArn": rule_arn,
+        "Priority": priority,
+        "Conditions": [
+            {
+                "Field": "http-header",
+                "HttpHeaderConfig": {
+                    "HttpHeaderName": RoutingHeaders.ROUTING_ID,
+                    "Values": [routing_id],
+                },
+            },
+            {
+                "Field": "http-header",
+                "HttpHeaderConfig": {
+                    "HttpHeaderName": RoutingHeaders.USER_TIER,
+                    "Values": ["premium"],
+                },
+            },
+        ],
+        "Actions": [{"Type": "forward", "TargetGroupArn": tg_arn}],
+    }
+
+
+def setup_keepset_filtering_db_mock(candidate_rows):
+    """DB mock whose fetchall applies the orphan-sweep keep-set predicate using
+    the params the code actually passed to execute — so the keep-set tests are
+    behavioral, not SQL change-detectors.
+
+    A candidate row is returned iff its status is among the string params
+    (``status IN (...)``) OR the query carries a recency bound (an int param)
+    and the row is flagged recent (``last_activity >= NOW() - grace``). Removing
+    either clause from the production query drops the corresponding param, so the
+    row stops being returned and the sweep reaps it — turning the test red.
+
+    candidate_rows: dicts with alb_rule_arn, target_group_arn, user_id, status,
+    is_recent.
+    """
+    mock_cursor = MagicMock()
+    mock_cursor.rowcount = 1
+
+    def fetchall():
+        params = mock_cursor.execute.call_args.args[1]
+        status_params = {p for p in params if isinstance(p, str)}
+        has_recency_bound = any(isinstance(p, int) for p in params)
+        kept = []
+        for row in candidate_rows:
+            status_match = row["status"] in status_params
+            recency_match = has_recency_bound and row["is_recent"]
+            if status_match or recency_match:
+                kept.append(
+                    MockRow(
+                        {
+                            "alb_rule_arn": row["alb_rule_arn"],
+                            "target_group_arn": row["target_group_arn"],
+                            "user_id": row["user_id"],
+                        }
+                    )
+                )
+        return kept
+
+    mock_cursor.fetchall.side_effect = fetchall
+    mock_connection = MagicMock()
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+    return mock_connection
+
+
 class TestPremiumCleanupHandler:
     """Handler-level tests for premium_cleanup Lambda."""
 
@@ -438,7 +508,12 @@ class TestCleanupOrphanedAlbResources:
     def test_keeps_grace_period_assignment(self, mock_env_vars_premium):
         """Regression (#766): a soft-released row in its grace window
         (status == PENDING_RELEASE == 'terminating') still owns a live ALB
-        rule and must NOT be reaped as orphaned."""
+        rule and must NOT be reaped as orphaned.
+
+        Behavioral: the DB mock applies the keep-set predicate to the params the
+        code passes, so the ACTIVE-only pre-fix query would drop this row and
+        reap the rule — the assertions below are genuinely red before the fix.
+        """
         grace_rule_arn = "arn:aws:rule/user-12-grace"
 
         with patch.dict("os.environ", mock_env_vars_premium), patch(
@@ -455,49 +530,23 @@ class TestCleanupOrphanedAlbResources:
 
             mock_elbv2.describe_rules.return_value = {
                 "Rules": [
-                    {
-                        "RuleArn": grace_rule_arn,
-                        "Priority": "100",
-                        "Conditions": [
-                            {
-                                "Field": "http-header",
-                                "HttpHeaderConfig": {
-                                    "HttpHeaderName": (RoutingHeaders.ROUTING_ID),
-                                    "Values": ["rid-12"],
-                                },
-                            },
-                            {
-                                "Field": "http-header",
-                                "HttpHeaderConfig": {
-                                    "HttpHeaderName": (RoutingHeaders.USER_TIER),
-                                    "Values": ["premium"],
-                                },
-                            },
-                        ],
-                        "Actions": [
-                            {
-                                "Type": "forward",
-                                "TargetGroupArn": ("arn:aws:tg/premium-12"),
-                            }
-                        ],
-                    }
+                    _premium_alb_rule(
+                        grace_rule_arn, "arn:aws:tg/premium-12", "rid-12"
+                    )
                 ]
             }
 
-            # The grace row is returned by the keep-set query because it now
-            # covers TERMINATING (== PENDING_RELEASE) and the recency guard.
-            mock_connection = setup_db_mock(
-                fetchall_values=[
-                    [
-                        MockRow(
-                            {
-                                "alb_rule_arn": grace_rule_arn,
-                                "target_group_arn": ("arn:aws:tg/premium-12"),
-                                "user_id": 12,
-                            }
-                        )
-                    ],
-                ],
+            mock_connection = setup_keepset_filtering_db_mock(
+                [
+                    {
+                        "alb_rule_arn": grace_rule_arn,
+                        "target_group_arn": "arn:aws:tg/premium-12",
+                        "user_id": 12,
+                        # Grace row: status aliases PENDING_RELEASE, still recent.
+                        "status": PremiumAssignment.TERMINATING,
+                        "is_recent": True,
+                    }
+                ]
             )
             mock_pymysql.return_value = mock_connection
 
@@ -505,24 +554,62 @@ class TestCleanupOrphanedAlbResources:
 
             result = cleanup_orphaned_alb_resources()
 
-            # Live rule survives the sweep.
+            # Live rule survives the sweep (kept via the TERMINATING status).
             assert result["orphaned_rules_deleted"] == 0
             assert not mock_elbv2.delete_rule.called
 
-            # Pin the fix: keep-set query covers grace states + recency guard,
-            # not ACTIVE only (the ACTIVE-only filter is the bug).
-            mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
-            keep_set_call = next(
-                c
-                for c in mock_cursor.execute.call_args_list
-                if "premium_user_assignments" in c.args[0]
-                and "alb_rule_arn" in c.args[0]
+    def test_keeps_recently_active_row_outside_keepset(self, mock_env_vars_premium):
+        """Recency guard (#766): a row whose status is outside the keep-set but
+        that was touched within the grace window must be kept, exercising the
+        ``OR last_activity >= NOW() - grace`` branch on its own.
+
+        Behavioral: with only the status broadening (no recency bound) the
+        pre-fix query would drop this row and reap the rule.
+        """
+        recent_rule_arn = "arn:aws:rule/user-7-recent"
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "boto3.client"
+        ) as mock_boto3, patch("premium_cleanup.pymysql.connect") as mock_pymysql:
+            mock_elbv2 = MagicMock()
+
+            def boto3_client_side_effect(service):
+                if service == "elbv2":
+                    return mock_elbv2
+                return MagicMock()
+
+            mock_boto3.side_effect = boto3_client_side_effect
+
+            mock_elbv2.describe_rules.return_value = {
+                "Rules": [
+                    _premium_alb_rule(
+                        recent_rule_arn, "arn:aws:tg/premium-7", "rid-7"
+                    )
+                ]
+            }
+
+            mock_connection = setup_keepset_filtering_db_mock(
+                [
+                    {
+                        "alb_rule_arn": recent_rule_arn,
+                        "target_group_arn": "arn:aws:tg/premium-7",
+                        "user_id": 7,
+                        # Status the keep-set does not enumerate: kept only by
+                        # the recency guard (mid-transition row).
+                        "status": "mid-transition",
+                        "is_recent": True,
+                    }
+                ]
             )
-            keep_set_sql, keep_set_params = keep_set_call.args[0], keep_set_call.args[1]
-            assert "last_activity" in keep_set_sql
-            assert PremiumAssignment.MIGRATING in keep_set_params
-            assert PremiumAssignment.TERMINATING in keep_set_params
-            assert PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS in keep_set_params
+            mock_pymysql.return_value = mock_connection
+
+            from premium_cleanup import cleanup_orphaned_alb_resources
+
+            result = cleanup_orphaned_alb_resources()
+
+            # Rule survives purely because the row is recent.
+            assert result["orphaned_rules_deleted"] == 0
+            assert not mock_elbv2.delete_rule.called
 
     def test_skips_default_rule(self, mock_env_vars_premium):
         """Default ALB rule is never deleted."""


### PR DESCRIPTION
## Summary

A premium user on a **dedicated** instance can be silently downgraded to shared/free-tier
compute when the hourly `premium_cleanup` Lambda deletes their still-live ALB listener rule
and target group as "orphaned" — even though the assignment is protected by its 120-second
soft-release grace window.

The root cause is in `cleanup_orphaned_alb_resources`: it builds its "keep-set" from
**`ACTIVE`-only** assignments, so a soft-released row (in its grace period) is invisible to
the query and its live rule/TG is classified as orphaned and deleted.

This PR (PR A — the primary, urgent fix) broadens the keep-set to include the non-terminal
lifecycle states and adds a recency guard, so a grace-period (or otherwise mid-transition)
assignment can never be reaped. It is the minimal change that stops the incident; the
follow-up hardening lives in PR B (#768).

---

## Root Cause

A soft-released assignment in its grace window has `status = PENDING_RELEASE`, which shares
the same DB value as `TERMINATING` (`"terminating"`) — an intentional alias to avoid a
schema migration (`infrastructure/aws_constants.py`):

```python
TERMINATING     = "terminating"
PENDING_RELEASE = "terminating"   # same value; distinguished only by intent
```

`cleanup_orphaned_alb_resources` built its keep-set from `ACTIVE`-only rows and treated every
premium ALB rule not in that set as orphaned:

```python
# before
cursor.execute(
    """SELECT alb_rule_arn, target_group_arn, user_id
       FROM premium_user_assignments
       WHERE status = %s AND is_standby = 0""",
    (PremiumAssignment.ACTIVE,),          # ACTIVE only → grace-period rows excluded
)
...
orphaned_rules = [r for r in premium_rules if r["RuleArn"] not in db_rule_arns]  # deleted
```

Because the grace-period row is `terminating`, the query returned it as `Found 0 active
assignments`, so the user's still-live rule/TG was deemed orphaned and deleted **inside the
120 s grace window the soft-release promised to protect**. Meanwhile the live tab's heartbeat
flipped the row back to `active`, but nothing recreated the deleted ALB resources — leaving an
orphaned active assignment the user could not self-recover from.

Note the same file already used the correct multi-status pattern in
`cleanup_duplicate_alb_rules` (`WHERE status IN (%s, %s, %s)`); the orphan sweep was
inconsistent with it.

---

## The Fix

`infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` —
`cleanup_orphaned_alb_resources`:

```python
# after
grace_seconds = PremiumAssignment.PENDING_RELEASE_GRACE_SECONDS
cursor.execute(
    """SELECT alb_rule_arn, target_group_arn, user_id
       FROM premium_user_assignments
       WHERE is_standby = 0
         AND (
             status IN (%s, %s, %s)
             OR last_activity >= DATE_SUB(NOW(), INTERVAL %s SECOND)
         )""",
    (
        PremiumAssignment.ACTIVE,
        PremiumAssignment.MIGRATING,
        PremiumAssignment.TERMINATING,
        grace_seconds,
    ),
)
```

Two independent protections:

1. **Broadened keep-set** — `status IN (ACTIVE, MIGRATING, TERMINATING)`. All three states
   still own a live ALB rule; `TERMINATING` covers `PENDING_RELEASE`, so grace-period rows are
   now kept. This mirrors the existing `cleanup_duplicate_alb_rules` pattern.

2. **Recency guard** — `last_activity >= NOW() - PENDING_RELEASE_GRACE_SECONDS`. Any row
   touched within the grace window is kept regardless of status, so a rule whose row is
   mid-transition (a cleanup run racing a DB write) is never seen as orphaned. The bound
   reuses the same grace constant as the manager's grace-expiry check.

Orphan cleanup keeps its intended purpose — reaping only rules with **no** DB row at all
(e.g. Lambda died after creating ALB resources but before storing the assignment). Genuinely
terminating rows past their grace are still finalized by the premium-manager's grace-expiry
reaper, not by this sweep.

---

## Design Rationale

### Why a recency guard in addition to the status broadening

The status broadening alone fixes the reported incident. The recency guard is
defense-in-depth for the sweep's core premise — it races in-flight writes. A row briefly in
any other state (reassignment, migration handoff, a just-inserted row) whose `last_activity`
is within the grace window is now protected without having to enumerate every transient state.

### Why not de-alias `PENDING_RELEASE` from `TERMINATING` here

De-aliasing requires a column-value migration coordinated across the Lambda layer and the app
(both consume `aws_constants`). That is deliberately out of scope for the urgent fix and is
tracked as PR C under #766. PR A stops the active bleeding with a query-only change.

### Relationship to PR B (#768)

PR A prevents the deletion. PR B (`premium_manager`) makes missing-TG reconciliation
*heal* instead of `skip`, so any future divergence (regardless of cause) cannot become a
permanent strand. PR A + PR B together fully resolve the backend deadlock.

---

## Changed Files

| File | Change |
|------|--------|
| `infrastructure/terraform/premium_cleanup_package/premium_cleanup.py` | `cleanup_orphaned_alb_resources` keep-set broadened to `status IN (ACTIVE, MIGRATING, TERMINATING)` plus a grace-window recency guard; comment records the "only these statuses own a real rule ARN" invariant; log line reworded to "keep-set assignments". |
| `studio/tests/infrastructure/test_premium_cleanup.py` | Added `test_keeps_grace_period_assignment` and `test_keeps_recently_active_row_outside_keepset` regression tests, plus a `setup_keepset_filtering_db_mock` helper that makes them behavioral. |

---

## Test

The regression tests are **behavioral, not SQL change-detectors**. The default
`setup_db_mock` returns rows regardless of the executed SQL, so it cannot tell the fixed
query from the buggy one. These tests instead use `setup_keepset_filtering_db_mock`, whose
`fetchall` applies the keep-set predicate using the params the code actually passed —
`status IN (...)` via the string params, and the recency bound via the presence of the
integer grace-seconds param. Dropping either clause from the production query removes its
param, so the row stops being returned and the sweep reaps its rule — turning the test red.

- **`test_keeps_grace_period_assignment`** — a grace-period row
  (`PENDING_RELEASE == "terminating"`) that still owns a live ALB rule must **not** be reaped
  (`orphaned_rules_deleted == 0`, `delete_rule` never called). Kept via the `TERMINATING`
  status.
  - Verified **red** on the pre-fix `WHERE status = %s` source (rule reaped) and **green**
    after the fix.
- **`test_keeps_recently_active_row_outside_keepset`** — a row whose status is *outside* the
  keep-set but touched within the grace window must be kept, exercising the
  `OR last_activity >= NOW() - grace` branch on its own.
  - Verified **red** with only the status broadening (recency bound removed → rule reaped),
    so it independently pins the recency guard.
- Full `test_premium_cleanup.py` suite: **28 passed**.
- `flake8` clean on both changed files.

### Manual test — not required

No manual/staging test was run, and it is not needed for this change:

- The change is **query-only** — no control flow or resource-operation logic changed, only
  the keep-set `SELECT` was broadened.
- The one thing mocks cannot verify — that the new SQL executes against a real MySQL — is
  already covered because both added constructs are used **verbatim in currently-deployed
  Lambdas**: `status IN (%s, %s, %s)` (`premium_cleanup.py`, `cleanup_duplicate_alb_rules`)
  and `last_activity >= DATE_SUB(NOW(), INTERVAL %s SECOND)` (`premium_manager.py`
  grace-expiry, `premium_cleanup.py` stale-assignment sweep). Placeholder count (3 status +
  1 grace) matches the param tuple.
- A full end-to-end reproduction (dedicated user → soft-release → cleanup fired mid-grace →
  assert rule survives) requires staging ALB + RDS + timing control and is disproportionate
  to a query-only change; the unit test reproduces the same race deterministically.

---

## Relationship to other work

- **#766 (this issue):** PR A of a staged set — PR A (#767, this) → PR B (#768, auto-heal reconcile) → PR C (status de-alias) → PR D (frontend recovery).
- **#730 (parent):** structural premium-routing follow-up.

