### PR TITLE
Heal missing target groups for premium assignments (PR B of #766)

### DIFF
--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -1969,6 +1969,7 @@ def publish_premium_metrics(
     idle_instances: int,
     tg_port_drift_detected: int = 0,
     tg_port_drift_fixed: int = 0,
+    tg_healed_missing: int = 0,
 ) -> None:
     """
     Publish premium tier monitoring metrics to CloudWatch.
@@ -1980,6 +1981,8 @@ def publish_premium_metrics(
     - IdleInstances: Count of instances with no assigned users
     - TargetGroupPortDriftDetected: drifting per-user TGs observed this cycle
     - TargetGroupPortDriftFixed: drifting per-user TGs converged this cycle
+    - HealedMissingTargetGroup: stranded rows (TG gone) dropped for reprovision
+      this cycle — a non-zero value means a #766-class strand actually occurred
     """
     cloudwatch: "CloudWatchClient" = boto3.client("cloudwatch")
 
@@ -2025,13 +2028,20 @@ def publish_premium_metrics(
                     "Unit": "Count",
                     "Timestamp": datetime.now(timezone.utc),
                 },
+                {
+                    "MetricName": "HealedMissingTargetGroup",
+                    "Value": tg_healed_missing,
+                    "Unit": "Count",
+                    "Timestamp": datetime.now(timezone.utc),
+                },
             ],
         )
         print(
             f"Published metrics: active_users={active_users}, idle_users={idle_users}, "
             f"running_instances={running_instances}, idle_instances={idle_instances}, "
             f"tg_port_drift_detected={tg_port_drift_detected}, "
-            f"tg_port_drift_fixed={tg_port_drift_fixed}"
+            f"tg_port_drift_fixed={tg_port_drift_fixed}, "
+            f"tg_healed_missing={tg_healed_missing}"
         )
 
     except Exception as e:
@@ -2189,6 +2199,7 @@ def handle_scheduled_monitoring(event: Dict[str, Any], context: Any) -> Dict[str
                 idle_instances=idle_instances,
                 tg_port_drift_detected=reconcile_summary.get("drift_detected", 0),
                 tg_port_drift_fixed=reconcile_summary.get("drift_fixed", 0),
+                tg_healed_missing=reconcile_summary.get("healed_missing_tg", 0),
             )
 
             # 11. Stop orphaned EC2 instances not in ECS cluster
@@ -3070,24 +3081,37 @@ def _assign_premium_user_impl(
                 )
                 invoke_migration_async()
 
-            # If a dedicated assignment's target group no longer exists, its
-            # stored ARNs are dead. Drop the row and fall through to a fresh
-            # assignment that recreates the rule/TG, rather than reusing a
-            # broken route. Shared/pool rows use the shared TG (handled above).
+            # If a dedicated assignment's target group is authoritatively gone,
+            # its stored ARNs are dead. Drop the row and fall through to a fresh
+            # assignment that recreates the rule/TG, rather than reusing a broken
+            # route. Shared/pool rows use the shared TG (handled above).
+            # Fail-open: a transient probe error (throttle/5xx) is not a
+            # confirmed miss, so keep reusing rather than 500 or drop the row.
             if (
                 existing_assignment
                 and not existing_assignment.get("is_shared")
                 and existing_instance_id != PremiumAssignment.AUTOSCALING_POOL
-                and not target_group_exists(existing_assignment.get("target_group_arn"))
             ):
-                print(
-                    f"Existing assignment for user {user_id} has a missing "
-                    f"target group ({existing_assignment.get('target_group_arn')})"
-                    f" - dropping the stale row so a fresh assignment "
-                    f"reprovisions ALB routing"
-                )
-                remove_user_assignment(user_id)
-                existing_assignment = None
+                existing_tg_arn = existing_assignment.get("target_group_arn")
+                try:
+                    tg_confirmed_missing = not target_group_exists(existing_tg_arn)
+                except Exception as tg_probe_error:
+                    tg_confirmed_missing = False
+                    print(
+                        f"Target group probe failed for user {user_id} "
+                        f"({existing_tg_arn}): {tg_probe_error} — reusing "
+                        f"existing assignment (fail-open)"
+                    )
+                if tg_confirmed_missing:
+                    # Drops the DB row only; any orphaned ALB rule is reaped by
+                    # premium_cleanup. Next assign reprovisions rule + TG.
+                    print(
+                        f"Existing assignment for user {user_id} has a missing "
+                        f"target group ({existing_tg_arn}) - dropping the stale "
+                        f"row so a fresh assignment reprovisions ALB routing"
+                    )
+                    remove_user_assignment(user_id)
+                    existing_assignment = None
 
             if existing_assignment:
                 return {
@@ -5566,7 +5590,9 @@ def reconcile_premium_target_group_ports() -> Dict[str, Any]:
         try:
             if not target_group_exists(tg_arn):
                 # Heal instead of skip: a missing TG leaves the row a permanent
-                # strand. Drop it so the next assign reprovisions the rule/TG.
+                # strand. Drop the row (any orphaned ALB rule is reaped by
+                # premium_cleanup) so the next assign reprovisions the rule/TG.
+                # A transient probe raise is caught below as an error, not a heal.
                 summary["healed_missing_tg"] += 1
                 print(
                     f"reconcile: user {user_id} TG {tg_arn} gone — dropping "

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3070,6 +3070,25 @@ def _assign_premium_user_impl(
                 )
                 invoke_migration_async()
 
+            # If a dedicated assignment's target group no longer exists, its
+            # stored ARNs are dead. Drop the row and fall through to a fresh
+            # assignment that recreates the rule/TG, rather than reusing a
+            # broken route. Shared/pool rows use the shared TG (handled above).
+            if (
+                existing_assignment
+                and not existing_assignment.get("is_shared")
+                and existing_instance_id != PremiumAssignment.AUTOSCALING_POOL
+                and not target_group_exists(existing_assignment.get("target_group_arn"))
+            ):
+                print(
+                    f"Existing assignment for user {user_id} has a missing "
+                    f"target group ({existing_assignment.get('target_group_arn')})"
+                    f" - dropping the stale row so a fresh assignment "
+                    f"reprovisions ALB routing"
+                )
+                remove_user_assignment(user_id)
+                existing_assignment = None
+
             if existing_assignment:
                 return {
                     "statusCode": 200,
@@ -5506,7 +5525,7 @@ def reconcile_premium_target_group_ports() -> Dict[str, Any]:
         "drift_detected": 0,
         "drift_fixed": 0,
         "skipped_no_host_port": 0,
-        "skipped_missing_tg": 0,
+        "healed_missing_tg": 0,
         "errors": 0,
     }
 
@@ -5546,8 +5565,14 @@ def reconcile_premium_target_group_ports() -> Dict[str, Any]:
 
         try:
             if not target_group_exists(tg_arn):
-                summary["skipped_missing_tg"] += 1
-                print(f"reconcile: user {user_id} TG {tg_arn} gone — skipping")
+                # Heal instead of skip: a missing TG leaves the row a permanent
+                # strand. Drop it so the next assign reprovisions the rule/TG.
+                summary["healed_missing_tg"] += 1
+                print(
+                    f"reconcile: user {user_id} TG {tg_arn} gone — dropping "
+                    f"stale assignment so next assign reprovisions routing"
+                )
+                remove_user_assignment(user_id)
                 continue
 
             actual_port = get_host_port_for_instance(instance_id)

--- a/infrastructure/terraform/premium_manager_package/premium_manager.py
+++ b/infrastructure/terraform/premium_manager_package/premium_manager.py
@@ -3110,7 +3110,14 @@ def _assign_premium_user_impl(
                         f"target group ({existing_tg_arn}) - dropping the stale "
                         f"row so a fresh assignment reprovisions ALB routing"
                     )
-                    remove_user_assignment(user_id)
+                    try:
+                        remove_user_assignment(user_id)
+                    except Exception as remove_error:
+                        # Row already gone (concurrent heal / second assign) is
+                        # the wanted outcome — fall through. Re-raise real DB
+                        # errors to fail fast.
+                        if "No assignment found" not in str(remove_error):
+                            raise
                     existing_assignment = None
 
             if existing_assignment:
@@ -5593,12 +5600,14 @@ def reconcile_premium_target_group_ports() -> Dict[str, Any]:
                 # strand. Drop the row (any orphaned ALB rule is reaped by
                 # premium_cleanup) so the next assign reprovisions the rule/TG.
                 # A transient probe raise is caught below as an error, not a heal.
-                summary["healed_missing_tg"] += 1
                 print(
                     f"reconcile: user {user_id} TG {tg_arn} gone — dropping "
                     f"stale assignment so next assign reprovisions routing"
                 )
+                # Count the heal only after the drop succeeds; a raise is
+                # caught below as an error, not a heal.
                 remove_user_assignment(user_id)
+                summary["healed_missing_tg"] += 1
                 continue
 
             actual_port = get_host_port_for_instance(instance_id)

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -471,6 +471,64 @@ class TestEarlyCheckAndCleanup:
             assert not mock_elbv2.create_rule.called
             mock_get_existing.assert_called_once_with(test_user_id)
 
+    def test_reuse_drops_assignment_when_target_group_missing(
+        self, mock_env_vars_premium
+    ):
+        """A dedicated assignment whose target group was reaped must NOT be
+        reused as-is — the stored ARNs are dead. The guard drops the stale row
+        and falls through to a fresh assignment instead of returning
+        ``assignment_source == "existing"``."""
+        import premium_manager
+
+        existing = {
+            "user_id": 12,
+            "instance_id": "i-dedicated",
+            "target_group_arn": "arn:aws:tg/premium-12-gone",
+            "alb_rule_arn": "arn:aws:rule/premium-12-gone",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment", return_value=existing
+        ), patch(
+            "premium_manager.target_group_exists", return_value=False
+        ) as mock_tg_exists, patch(
+            "premium_manager.remove_user_assignment"
+        ) as mock_remove, patch(
+            # First call on the fresh-assignment path: raise a sentinel so the
+            # test proves control fell through without exercising the whole path.
+            "premium_manager.register_orphaned_stopped_instances",
+            side_effect=RuntimeError("reached fresh assignment path"),
+        ):
+            mock_ec2 = MagicMock()
+            # Assigned instance is still running, so the EC2 state check keeps
+            # the row — the missing TG is the only reason it is dropped.
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+            }
+            mock_elbv2 = MagicMock()
+
+            with pytest.raises(RuntimeError, match="reached fresh assignment path"):
+                premium_manager._assign_premium_user_impl(
+                    12,
+                    {"tier": "premium"},
+                    "uid_12",
+                    mock_ec2,
+                    mock_elbv2,
+                    8000,
+                    "vpc-123",
+                    "arn:aws:listener/test",
+                )
+
+            # Healed: the dead assignment was dropped, triggered by the missing
+            # TG, and it was NOT returned as an existing reuse.
+            mock_tg_exists.assert_called_once_with("arn:aws:tg/premium-12-gone")
+            mock_remove.assert_called_once_with(12)
+
     def test_exception_handler_cleans_up_alb_rule(self, mock_env_vars_premium):
         """Exception handler cleans up ALB rule."""
         print("Testing Exception Handler ALB Rule Cleanup")
@@ -4329,12 +4387,17 @@ class TestReconcilePremiumTargetGroupPorts:
             assert mock_elbv2.register_targets.call_count == 1
             assert mock_elbv2.deregister_targets.call_count == 3
 
-    def test_skips_when_target_group_missing(self, mock_env_vars_premium):
+    def test_heals_missing_tg(self, mock_env_vars_premium):
+        """A missing TG for an active row is a permanent strand, so reconcile
+        drops the row (heal) instead of skipping — the next assign reprovisions
+        the rule/TG."""
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "premium_manager.get_db_connection"
         ) as mock_db, patch("boto3.client") as mock_boto3, patch(
             "premium_manager.target_group_exists", return_value=False
         ), patch(
+            "premium_manager.remove_user_assignment"
+        ) as mock_remove, patch(
             "premium_manager.get_host_port_for_instance"
         ) as mock_host_port:
             mock_db.return_value = setup_db_mock(
@@ -4347,8 +4410,10 @@ class TestReconcilePremiumTargetGroupPorts:
 
             summary = reconcile_premium_target_group_ports()
 
-            assert summary["skipped_missing_tg"] == 1
+            # Healed, not skipped: row dropped and no port work attempted.
+            assert summary["healed_missing_tg"] == 1
             assert summary["drift_detected"] == 0
+            mock_remove.assert_called_once_with(12)
             mock_host_port.assert_not_called()
             mock_elbv2.register_targets.assert_not_called()
 

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -693,9 +693,7 @@ class TestEarlyCheckAndCleanup:
             # reached the fresh path rather than 500ing.
             mock_remove.assert_called_once_with(12)
 
-    def test_reuse_drop_reraises_unexpected_removal_error(
-        self, mock_env_vars_premium
-    ):
+    def test_reuse_drop_reraises_unexpected_removal_error(self, mock_env_vars_premium):
         """A real DB error during the guard's removal (not "No assignment
         found") must still propagate to the outer except and 500 — fail fast,
         as before, rather than masquerading as a heal."""

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -637,6 +637,114 @@ class TestEarlyCheckAndCleanup:
             mock_tg_exists.assert_not_called()
             mock_remove.assert_not_called()
 
+    def test_reuse_drop_survives_concurrent_removal(self, mock_env_vars_premium):
+        """A concurrent reconcile heal (or second /assign) may drop the row
+        before this guard's own remove runs. The resulting "No assignment
+        found" must be treated as already-healed — fall through to the fresh
+        assignment path, not 500 on the outer except."""
+        import premium_manager
+
+        existing = {
+            "user_id": 12,
+            "instance_id": "i-dedicated",
+            "target_group_arn": "arn:aws:tg/premium-12-gone",
+            "alb_rule_arn": "arn:aws:rule/premium-12-gone",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment", return_value=existing
+        ), patch(
+            "premium_manager.target_group_exists", return_value=False
+        ), patch(
+            # Row already dropped by a concurrent heal: removal raises the
+            # same "No assignment found" the transaction raises on an empty row.
+            "premium_manager.remove_user_assignment",
+            side_effect=Exception("No assignment found for user 12"),
+        ) as mock_remove, patch(
+            # Sentinel proves control fell through to fresh provisioning
+            # instead of returning a 500 from the outer except.
+            "premium_manager.register_orphaned_stopped_instances",
+            side_effect=RuntimeError("reached fresh assignment path"),
+        ):
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+            }
+            mock_elbv2 = MagicMock()
+
+            with pytest.raises(RuntimeError, match="reached fresh assignment path"):
+                premium_manager._assign_premium_user_impl(
+                    12,
+                    {"tier": "premium"},
+                    "uid_12",
+                    mock_ec2,
+                    mock_elbv2,
+                    8000,
+                    "vpc-123",
+                    "arn:aws:listener/test",
+                )
+
+            # The concurrent removal was swallowed as already-healed; control
+            # reached the fresh path rather than 500ing.
+            mock_remove.assert_called_once_with(12)
+
+    def test_reuse_drop_reraises_unexpected_removal_error(
+        self, mock_env_vars_premium
+    ):
+        """A real DB error during the guard's removal (not "No assignment
+        found") must still propagate to the outer except and 500 — fail fast,
+        as before, rather than masquerading as a heal."""
+        import premium_manager
+
+        existing = {
+            "user_id": 12,
+            "instance_id": "i-dedicated",
+            "target_group_arn": "arn:aws:tg/premium-12-gone",
+            "alb_rule_arn": "arn:aws:rule/premium-12-gone",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment", return_value=existing
+        ), patch(
+            "premium_manager.target_group_exists", return_value=False
+        ), patch(
+            "premium_manager.remove_user_assignment",
+            side_effect=Exception("Deadlock found when trying to get lock"),
+        ), patch(
+            # Must never be reached — the unexpected error fails fast first.
+            "premium_manager.register_orphaned_stopped_instances",
+            side_effect=RuntimeError("must not reach fresh assignment path"),
+        ):
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+            }
+            mock_elbv2 = MagicMock()
+
+            result = premium_manager._assign_premium_user_impl(
+                12,
+                {"tier": "premium"},
+                "uid_12",
+                mock_ec2,
+                mock_elbv2,
+                8000,
+                "vpc-123",
+                "arn:aws:listener/test",
+            )
+
+            # Unexpected removal error fails fast on the outer except → 500.
+            assert result["statusCode"] == 500
+
     def test_exception_handler_cleans_up_alb_rule(self, mock_env_vars_premium):
         """Exception handler cleans up ALB rule."""
         print("Testing Exception Handler ALB Rule Cleanup")
@@ -4524,6 +4632,34 @@ class TestReconcilePremiumTargetGroupPorts:
             mock_remove.assert_called_once_with(12)
             mock_host_port.assert_not_called()
             mock_elbv2.register_targets.assert_not_called()
+
+    def test_missing_tg_removal_failure_counts_error_not_heal(
+        self, mock_env_vars_premium
+    ):
+        """The heal counter is incremented only after remove_user_assignment
+        succeeds. If removal raises (concurrent removal / DB error) the outer
+        except records an error and the row is NOT counted as healed."""
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists", return_value=False
+        ), patch(
+            "premium_manager.remove_user_assignment",
+            side_effect=Exception("No assignment found for user 12"),
+        ) as mock_remove:
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[[self._make_row(12, "i-aaa", "arn:tg/gone")]]
+            )
+            mock_boto3.return_value = MagicMock()
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            # Removal raised → error counted, heal not counted.
+            assert summary["healed_missing_tg"] == 0
+            assert summary["errors"] == 1
+            mock_remove.assert_called_once_with(12)
 
     def test_heals_only_stranded_row_in_mixed_batch(self, mock_env_vars_premium):
         """In a batch of one missing-TG row and one healthy row, only the

--- a/studio/tests/infrastructure/test_premium_manager.py
+++ b/studio/tests/infrastructure/test_premium_manager.py
@@ -529,6 +529,114 @@ class TestEarlyCheckAndCleanup:
             mock_tg_exists.assert_called_once_with("arn:aws:tg/premium-12-gone")
             mock_remove.assert_called_once_with(12)
 
+    def test_reuse_kept_when_target_group_probe_fails_transiently(
+        self, mock_env_vars_premium
+    ):
+        """Fail-open (N1): a transient (non-NotFound) target-group probe error
+        must NOT drop the row or 500 — the guard keeps reusing the existing
+        assignment. Only an authoritative not-found drops it."""
+        import premium_manager
+
+        existing = {
+            "user_id": 12,
+            "instance_id": "i-dedicated",
+            "target_group_arn": "arn:aws:tg/premium-12",
+            "alb_rule_arn": "arn:aws:rule/premium-12",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 0,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment", return_value=existing
+        ), patch(
+            "premium_manager.target_group_exists",
+            side_effect=Exception("Throttling: Rate exceeded"),
+        ), patch(
+            "premium_manager.remove_user_assignment"
+        ) as mock_remove, patch(
+            # Must never be reached — a kept reuse returns before this path.
+            "premium_manager.register_orphaned_stopped_instances",
+            side_effect=RuntimeError("must not reach fresh assignment path"),
+        ):
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+            }
+            mock_elbv2 = MagicMock()
+
+            result = premium_manager._assign_premium_user_impl(
+                12,
+                {"tier": "premium"},
+                "uid_12",
+                mock_ec2,
+                mock_elbv2,
+                8000,
+                "vpc-123",
+                "arn:aws:listener/test",
+            )
+
+            # Reused, not dropped: row survives the probe hiccup.
+            assert result["statusCode"] == 200
+            assert json.loads(result["body"])["assignment_source"] == "existing"
+            mock_remove.assert_not_called()
+
+    def test_shared_assignment_missing_tg_guard_skipped(self, mock_env_vars_premium):
+        """Scope lock: the missing-TG guard only applies to dedicated rows. A
+        shared row uses the shared TG, so it must never be probed or dropped by
+        the guard — the ``not is_shared`` short-circuit keeps reuse intact."""
+        import premium_manager
+
+        existing = {
+            "user_id": 12,
+            "instance_id": "i-shared",
+            "target_group_arn": "arn:aws:tg/shared-autoscaling",
+            "alb_rule_arn": "arn:aws:rule/shared",
+            "status": "active",
+            "instance_state": "running",
+            "is_shared": 1,
+        }
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.restore_pending_release", return_value=None
+        ), patch(
+            "premium_manager.get_existing_user_assignment", return_value=existing
+        ), patch(
+            # No dedicated instance available → inline migration finds nothing.
+            "premium_manager.get_all_premium_instances_with_states",
+            return_value=[],
+        ), patch(
+            "premium_manager.invoke_migration_async", return_value=None
+        ), patch(
+            "premium_manager.target_group_exists"
+        ) as mock_tg_exists, patch(
+            "premium_manager.remove_user_assignment"
+        ) as mock_remove:
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"State": {"Name": "running"}}]}]
+            }
+            mock_elbv2 = MagicMock()
+
+            result = premium_manager._assign_premium_user_impl(
+                12,
+                {"tier": "premium"},
+                "uid_12",
+                mock_ec2,
+                mock_elbv2,
+                8000,
+                "vpc-123",
+                "arn:aws:listener/test",
+            )
+
+            # Shared row reused; the guard never probed or dropped it.
+            assert result["statusCode"] == 200
+            assert json.loads(result["body"])["assignment_source"] == "existing"
+            mock_tg_exists.assert_not_called()
+            mock_remove.assert_not_called()
+
     def test_exception_handler_cleans_up_alb_rule(self, mock_env_vars_premium):
         """Exception handler cleans up ALB rule."""
         print("Testing Exception Handler ALB Rule Cleanup")
@@ -4417,6 +4525,48 @@ class TestReconcilePremiumTargetGroupPorts:
             mock_host_port.assert_not_called()
             mock_elbv2.register_targets.assert_not_called()
 
+    def test_heals_only_stranded_row_in_mixed_batch(self, mock_env_vars_premium):
+        """In a batch of one missing-TG row and one healthy row, only the
+        stranded row is dropped (``continue``); the healthy row is still
+        reconciled in the same scan."""
+        gone_tg = "arn:tg/premium-12-gone"
+
+        def tg_exists_side_effect(tg_arn):
+            return tg_arn != gone_tg
+
+        with patch.dict("os.environ", mock_env_vars_premium), patch(
+            "premium_manager.get_db_connection"
+        ) as mock_db, patch("boto3.client") as mock_boto3, patch(
+            "premium_manager.target_group_exists",
+            side_effect=tg_exists_side_effect,
+        ), patch(
+            "premium_manager.remove_user_assignment"
+        ) as mock_remove, patch(
+            "premium_manager.get_host_port_for_instance", return_value=None
+        ) as mock_host_port:
+            mock_db.return_value = setup_db_mock(
+                fetchall_values=[
+                    [
+                        self._make_row(12, "i-aaa", gone_tg),
+                        self._make_row(13, "i-bbb", "arn:tg/premium-13-tg"),
+                    ]
+                ]
+            )
+            mock_elbv2 = MagicMock()
+            mock_boto3.return_value = mock_elbv2
+
+            from premium_manager import reconcile_premium_target_group_ports
+
+            summary = reconcile_premium_target_group_ports()
+
+            # Stranded row healed; healthy row reached port reconciliation
+            # (which no-ops here on an unresolved host port).
+            assert summary["assignments_scanned"] == 2
+            assert summary["healed_missing_tg"] == 1
+            assert summary["skipped_no_host_port"] == 1
+            mock_remove.assert_called_once_with(12)
+            mock_host_port.assert_called_once_with("i-bbb")
+
     def test_skips_when_host_port_unresolved(self, mock_env_vars_premium):
         with patch.dict("os.environ", mock_env_vars_premium), patch(
             "premium_manager.get_db_connection"
@@ -4603,7 +4753,7 @@ class TestHandleScheduledMonitoringReconcile:
         self._run(
             mock_env_vars_premium,
             call_order,
-            {"drift_detected": 3, "drift_fixed": 2},
+            {"drift_detected": 3, "drift_fixed": 2, "healed_missing_tg": 1},
         )
 
         publish_calls = [c for c in call_order if isinstance(c, tuple)]
@@ -4611,6 +4761,7 @@ class TestHandleScheduledMonitoringReconcile:
         kwargs = publish_calls[0][1]
         assert kwargs["tg_port_drift_detected"] == 3
         assert kwargs["tg_port_drift_fixed"] == 2
+        assert kwargs["tg_healed_missing"] == 1
 
         reconcile_idx = call_order.index("reconcile")
         publish_idx = call_order.index(publish_calls[0])
@@ -4782,6 +4933,7 @@ class TestPublishPremiumMetricsDriftKwargs:
                 idle_instances=4,
                 tg_port_drift_detected=5,
                 tg_port_drift_fixed=6,
+                tg_healed_missing=7,
             )
 
             args, kwargs = mock_cw.put_metric_data.call_args
@@ -4789,6 +4941,7 @@ class TestPublishPremiumMetricsDriftKwargs:
             metric_by_name = {m["MetricName"]: m["Value"] for m in metric_data}
             assert metric_by_name["TargetGroupPortDriftDetected"] == 5
             assert metric_by_name["TargetGroupPortDriftFixed"] == 6
+            assert metric_by_name["HealedMissingTargetGroup"] == 7
 
     def test_drift_metrics_default_to_zero(self, mock_env_vars_premium):
         with patch.dict("os.environ", mock_env_vars_premium), patch(
@@ -4810,6 +4963,7 @@ class TestPublishPremiumMetricsDriftKwargs:
             metric_by_name = {m["MetricName"]: m["Value"] for m in kwargs["MetricData"]}
             assert metric_by_name["TargetGroupPortDriftDetected"] == 0
             assert metric_by_name["TargetGroupPortDriftFixed"] == 0
+            assert metric_by_name["HealedMissingTargetGroup"] == 0
 
 
 class TestPremiumTgUnhealthyAlarm:


### PR DESCRIPTION
## Summary

When a dedicated premium user's ALB listener rule and target group are deleted while
their assignment row still says `active` (the incident in #766, where orphan cleanup
reaped a live rule/TG mid-grace), the divergence becomes **permanent**: the DB says
"active, dedicated" but the per-user route is gone, and nothing recreates it. The user
cannot self-recover — reload and sign-out/sign-in keep round-tripping the same dead
ARNs.

PR A (#767) stops the *deletion*. PR B is the **defense-in-depth** follow-up in the
`premium_manager` Lambda: it makes a missing target group **self-heal** instead of
persisting, so any future divergence — regardless of cause — cannot deadlock the user.

---

## Root Cause (why the strand persists)

Two code paths in `premium_manager.py` observe the missing TG but neither repairs it:

1. **Assign reuse returns dead ARNs without validating the ALB.**
   `_assign_premium_user_impl` early-returns an existing `active` assignment and hands
   back its stored `target_group_arn` / `alb_rule_arn` **as-is** — it never checks that
   the target group still exists. It only falls through to a fresh assignment when the
   **EC2 instance** is gone. With the instance still running, every `/assign` (including
   after sign-out/sign-in) takes the reuse path and returns the deleted TG's ARN.

2. **Reconcile detects the missing TG but only skips it.**
   `reconcile_premium_target_group_ports` (the 15-minute port-drift reconciler)
   short-circuited with `"… gone — skipping"` (`skipped_missing_tg`) when a row's TG no
   longer existed, so it never healed the strand.

---

## The Fix

`infrastructure/terraform/premium_manager_package/premium_manager.py`. Both changes
reuse existing helpers — `target_group_exists` (already deployed) and
`remove_user_assignment` — and the well-exercised fresh-assignment provisioning path.

### (a) Assign reuse path guard — `_assign_premium_user_impl`

Before reusing a **dedicated** existing assignment, verify its target group still
exists. If it is gone, the stored ARNs are dead — drop the row and fall through to the
fresh-assignment path, which recreates the rule/TG. This mirrors the idiom the same
function already uses when the assigned instance is terminated
(`existing_assignment = None; remove_user_assignment(user_id)`).

```python
# before the existing-assignment reuse return — dedicated rows only
if (
    existing_assignment
    and not existing_assignment.get("is_shared")
    and existing_instance_id != PremiumAssignment.AUTOSCALING_POOL
):
    existing_tg_arn = existing_assignment.get("target_group_arn")
    try:
        tg_confirmed_missing = not target_group_exists(existing_tg_arn)
    except Exception as tg_probe_error:
        # Fail-open: a transient probe error (throttle/5xx) is not a
        # confirmed miss — keep reusing rather than 500 or drop the row.
        tg_confirmed_missing = False
    if tg_confirmed_missing:
        remove_user_assignment(user_id)   # DB row only; cleanup reaps any rule
        existing_assignment = None

if existing_assignment:
    return { ... "assignment_source": "existing" ... }   # unchanged
```

Scope is **dedicated rows only** — shared / autoscaling-pool rows forward to the shared
TG (which legitimately exists) and are handled by the migration branch above. The
existence check is **TG-only**: in the incident the rule and TG are deleted together, so
TG absence is the reliable signal, and this keeps the change minimal. `remove_user_assignment`
drops the **DB row only**; any orphaned ALB rule is reaped by `premium_cleanup`.

**Fail-open on a transient probe error.** `target_group_exists` re-raises anything that is
not an authoritative *not-found* (e.g. ELB throttling). Previously that raise would
propagate to the outer handler and turn a valid reuse into an **HTTP 500**. The guard now
catches it and treats a non-definitive result as "keep and reuse", so only an authoritative
not-found drops the row — a probe hiccup degrades to "reuse as before".

### (b) Reconcile heals instead of skips — `reconcile_premium_target_group_ports`

When a scanned row's TG no longer exists, drop the stranded row so the user's next
`/assign` reprovisions routing via guard (a). The summary counter is renamed
`skipped_missing_tg → healed_missing_tg` to reflect the new behavior.

```python
if not target_group_exists(tg_arn):
    summary["healed_missing_tg"] += 1
    remove_user_assignment(user_id)   # DB row only; cleanup reaps any rule
    continue
```

The reconcile query already filters `last_state_check < NOW() - INTERVAL 30s`, so it
will not race a just-written row. A **transient** `target_group_exists` raise here is
caught by the existing per-row `try/except` as an `errors += 1` and `continue` — it is
counted as an error, never healed — so this path is already fail-safe.

The `healed_missing_tg` counter is also **published to CloudWatch** as
`HealedMissingTargetGroup` (via `publish_premium_metrics`). A non-zero value means a
#766-class strand actually occurred and was repaired in production, so recurrence is
alarmable without log-grepping.

---

## Design Rationale

### Why "drop the row and reprovision" instead of recreating the TG/rule in place

Dropping the stale row and letting the fresh-assignment path rebuild routing reuses one
well-tested provisioning code path (create TG → register target → create rule → store),
rather than duplicating that logic in two more places. It is the same self-heal idiom
`_assign_premium_user_impl` already applies to a terminated instance. In-place
recreation inside the reconciler would additionally need to resolve `user_uid`,
`backend_port`, `vpc_id`, and the listener ARN and re-run priority allocation — more
surface area and more risk for a background job, with no functional gain: guard (a)
already rebuilds routing on the very next assign.

### Why guard (a) and reconcile (b) together

Guard (a) closes the reuse hole so recovery needs only a normal `/assign` — which the
frontend already issues on its poll cycle. Reconcile (b) is the proactive net that
un-sticks a stranded row even before the user acts (the incident row's
`last_state_check` is frozen, so the reconciler always picks it up). Either alone
recovers the user; together they cover both the on-demand and the background path.

### Relationship to PR A (#767)

PR A prevents the deletion (broadened keep-set + recency guard in `premium_cleanup`).
PR B makes any divergence that still occurs heal instead of persisting. The two touch
disjoint files (`premium_cleanup.py` vs `premium_manager.py`) with no code dependency,
so they can merge in any order.

---

## Changed Files

| File | Change |
|------|--------|
| `infrastructure/terraform/premium_manager_package/premium_manager.py` | `_assign_premium_user_impl`: TG-existence guard drops a dedicated assignment with a missing TG before the reuse return, **failing open on a transient probe error**. `reconcile_premium_target_group_ports`: heals a missing TG by dropping the row (`skipped_missing_tg → healed_missing_tg`) instead of skipping. `publish_premium_metrics`: emits the new `HealedMissingTargetGroup` CloudWatch metric. |
| `studio/tests/infrastructure/test_premium_manager.py` | Rewrote `test_skips_when_target_group_missing → test_heals_missing_tg`; added `test_reuse_drops_assignment_when_target_group_missing`, `test_reuse_kept_when_target_group_probe_fails_transiently`, `test_shared_assignment_missing_tg_guard_skipped`, `test_heals_only_stranded_row_in_mixed_batch`; extended the metric/publish tests for `HealedMissingTargetGroup`. |

---

## Test

- **`test_heals_missing_tg`** (reconcile) — with `target_group_exists` False, asserts
  `summary["healed_missing_tg"] == 1`, `remove_user_assignment(user_id)` called once,
  and no port work attempted (`get_host_port_for_instance` / `register_targets` never
  called).
  - Verified **red** before the fix (still counted `skipped_missing_tg`, no removal).
- **`test_heals_only_stranded_row_in_mixed_batch`** (reconcile) — a batch of one
  missing-TG row and one healthy row: asserts only the stranded row is dropped
  (`healed_missing_tg == 1`, `remove_user_assignment(12)`) while the healthy row still
  reaches port reconciliation (`get_host_port_for_instance("i-bbb")`), proving `continue`
  skips only the stranded row.
- **`test_reuse_drops_assignment_when_target_group_missing`** (assign reuse) — drives
  `_assign_premium_user_impl` with a dedicated `active` row whose instance is running
  but whose `target_group_exists` returns False. Asserts the missing TG triggered a
  `remove_user_assignment(user_id)` and that control fell through to the
  fresh-assignment path (a sentinel raised on its first call) — i.e. it did **not**
  return `assignment_source == "existing"`.
  - Verified **red** before the fix (reuse returned the dead assignment; no removal).
- **`test_reuse_kept_when_target_group_probe_fails_transiently`** (assign reuse, fail-open)
  — `target_group_exists` raises a transient throttling error; asserts the row is **kept**
  (`assignment_source == "existing"`, `remove_user_assignment` not called) and no 500.
  - Verified **red** on the pre-fail-open guard (the raise propagated → HTTP 500).
- **`test_shared_assignment_missing_tg_guard_skipped`** (scope lock) — a shared row is
  reused without the guard ever probing or dropping it (`target_group_exists` /
  `remove_user_assignment` never called), pinning the `not is_shared` short-circuit.
- The positive dedicated counterpart (TG exists → reuse still returns `"existing"`)
  remains covered by `test_early_check_returns_existing_assignment`.
- Metric propagation: `test_publish_metrics_runs_after_reconcile_with_drift_kwargs` and
  the `publish_premium_metrics` emission tests extended to assert
  `HealedMissingTargetGroup` / the `tg_healed_missing` kwarg.
- Full `test_premium_manager.py` suite: **132 passed**.
- `flake8` clean on both changed files.

### Manual test — not required

Both edits reuse already-deployed helpers (`target_group_exists`,
`remove_user_assignment`) and the well-exercised fresh-assignment path; no new AWS
control flow is introduced. The unit tests reproduce the strand and its healing
deterministically. A full end-to-end reproduction (reap a live TG → assert the next
assign rebuilds routing) requires staging ALB + RDS and is disproportionate to the
change.

---

## Relationship to other work

- **#766 (issue):** PR B of a staged set — PR A (#767, keep-set + recency guard) →
  **PR B (#768, this — auto-heal)** → PR C (status de-alias) → PR D (frontend recovery).
  PR A + PR B together fully resolve the backend deadlock; C and D are hardening.
- **#730 (parent):** structural premium-routing follow-up.
