### PR TITLE
Reduce user-identifier exposure in API responses

### DIFF
--- a/frontend/src/api/premium/PremiumAssignmentApi.ts
+++ b/frontend/src/api/premium/PremiumAssignmentApi.ts
@@ -8,7 +8,6 @@ import { UserTier } from "const/Subscription"
 import axios from "utils/axios"
 
 export interface RoutingInfo {
-  user_id: string
   user_tier: UserTier
   requires_premium_routing: boolean
   routing_headers: Record<string, string>
@@ -41,7 +40,6 @@ export interface PremiumAssignment {
 }
 
 export interface PremiumStatusResult {
-  user_id: number
   subscription_type: UserTier
   is_premium: boolean
   assignment: PremiumAssignment | null
@@ -53,7 +51,6 @@ export interface PremiumStatusResult {
 export interface PremiumHeartbeatResult {
   message: string
   updated: boolean
-  user_id: number
   user_tier: UserTier
   assignment_active: boolean
   activity_update?: boolean

--- a/frontend/src/api/storage/StorageAlerts.ts
+++ b/frontend/src/api/storage/StorageAlerts.ts
@@ -83,7 +83,6 @@ export interface LimitAlertStatus {
   has_alert: boolean
   alert_type: string | null
   days_remaining: number | null
-  user_id: number
 }
 
 // Limit Alert API Functions

--- a/frontend/src/api/storage/StorageAlerts.ts
+++ b/frontend/src/api/storage/StorageAlerts.ts
@@ -2,7 +2,6 @@ import { LimitAlertType } from "const/Subscription"
 import axios from "utils/axios"
 
 export interface StorageAlert {
-  user_id: number
   user_name: string
   user_email: string
   alert_level: "critical" | "danger"

--- a/frontend/src/components/Workspace/__tests__/FlowChart/Buttons/RunButtons.test.tsx
+++ b/frontend/src/components/Workspace/__tests__/FlowChart/Buttons/RunButtons.test.tsx
@@ -32,7 +32,6 @@ const mockStore = configureStore([])
 const createMockStorageAlert = (
   overrides: Partial<StorageAlertsApi.StorageAlert> = {},
 ): StorageAlertsApi.StorageAlert => ({
-  user_id: 1,
   user_name: "Test User",
   user_email: "test@example.com",
   alert_level: "critical",

--- a/frontend/src/contexts/__tests__/PremiumInactivityActivity.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityActivity.test.tsx
@@ -159,7 +159,6 @@ const renderProvider = () => {
 }
 
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {

--- a/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumInactivityReassign.test.tsx
@@ -169,7 +169,6 @@ const dedicatedAssignment: PremiumAssignmentResult = {
 }
 
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {
@@ -323,7 +322,6 @@ describe("PremiumAssignmentProvider — inactivity re-assignment", () => {
     // This test guards against the PR #603 regression: DOM listeners must
     // NOT bump autoAssignGeneration during initial mount.
     mockGetPremiumStatus.mockResolvedValue({
-      user_id: 1,
       subscription_type: UserTier.PREMIUM,
       is_premium: true,
       assignment: null,

--- a/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumPollingRoutingRestore.test.tsx
@@ -184,7 +184,6 @@ const dedicatedAssignment: PremiumAssignmentResult = {
 }
 
 const sharedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {
@@ -196,7 +195,6 @@ const sharedStatus: PremiumStatusResult = {
 }
 
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {

--- a/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumRetriggerAssign.test.tsx
@@ -209,7 +209,6 @@ const dedicatedAssignment: PremiumAssignmentResult = {
 
 /** Status endpoint returning null assignment (no assignment exists). */
 const nullAssignmentStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: null,
@@ -217,7 +216,6 @@ const nullAssignmentStatus: PremiumStatusResult = {
 
 /** Status endpoint returning a dedicated assignment. */
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {
@@ -578,7 +576,6 @@ describe("PremiumAssignmentProvider — re-trigger assign during polling", () =>
 
     // Set up mocks for recovery: status returns a new dedicated instance.
     const newDedicatedStatus: PremiumStatusResult = {
-      user_id: 1,
       subscription_type: UserTier.PREMIUM,
       is_premium: true,
       assignment: {

--- a/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumSubscriptionExpiry.test.tsx
@@ -158,7 +158,6 @@ const tree = (ctxRef: { current: Ctx | null }) => (
 )
 
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {
@@ -295,7 +294,6 @@ describe("PremiumAssignmentProvider — subscription expiry auto-logout", () => 
   test("does NOT auto-logout when there is no active assignment", async () => {
     // Status with no assignment → goes through the assign path.
     mockGetPremiumStatus.mockResolvedValue({
-      user_id: 1,
       subscription_type: UserTier.PREMIUM,
       is_premium: true,
     } as PremiumStatusResult)

--- a/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
+++ b/frontend/src/contexts/__tests__/PremiumUnreachableIntegration.test.tsx
@@ -195,7 +195,6 @@ const mockedAssign = mockAssignPremiumInstance
 const mockedLog = mockLogPremiumUiEvent
 
 const dedicatedStatus: PremiumStatusResult = {
-  user_id: 1,
   subscription_type: UserTier.PREMIUM,
   is_premium: true,
   assignment: {

--- a/frontend/src/store/slice/User/UserSelector.ts
+++ b/frontend/src/store/slice/User/UserSelector.ts
@@ -6,8 +6,6 @@ export const selectCurrentUserId = (state: RootState) =>
   selectCurrentUser(state)?.id
 export const selectListUser = (state: RootState) => state.user.listUser
 export const selectLoading = (state: RootState) => state.user.loading
-export const selectCurrentUserUid = (state: RootState) =>
-  selectCurrentUser(state)?.uid
 export const selectCurrentUserEmail = (state: RootState) =>
   selectCurrentUser(state)?.email
 export const selectListUserSearch = (state: RootState) =>

--- a/frontend/src/utils/routing/RoutingService.ts
+++ b/frontend/src/utils/routing/RoutingService.ts
@@ -24,7 +24,6 @@ import {
 } from "const/Subscription"
 
 export interface RoutingInfo {
-  user_id: string
   user_tier: UserTier
   requires_premium_routing: boolean
   routing_headers: Record<string, string>
@@ -152,7 +151,6 @@ export class RoutingService {
     const userTier = isPremium ? UserTier.PREMIUM : UserTier.FREE
 
     this.routingInfo = {
-      user_id: user.uid || "",
       user_tier: userTier,
       requires_premium_routing: isPremium,
       routing_headers: {}, // No longer client-controlled

--- a/studio/app/common/routers/storage_limit_alerts.py
+++ b/studio/app/common/routers/storage_limit_alerts.py
@@ -70,7 +70,6 @@ async def get_my_storage_alert(
 
             if alert_level:
                 alert = {
-                    "user_id": current_user.id,
                     "alert_level": alert_level,
                     "storage_usage_bytes": current_usage,
                     "storage_quota_bytes": storage_quota,

--- a/studio/app/common/routers/storage_limit_alerts.py
+++ b/studio/app/common/routers/storage_limit_alerts.py
@@ -18,7 +18,11 @@ from studio.app.common.core.cloud.s3_storage_monitor import (
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.db.database import get_db
-from studio.app.common.schemas.storage import LimitWarning, LimitWarningStatus
+from studio.app.common.schemas.storage import (
+    LimitWarning,
+    LimitWarningStatus,
+    StorageAlertResponse,
+)
 from studio.app.common.schemas.users import User
 
 router = APIRouter(prefix="/storage-limit-alerts", tags=["storage-limit-alerts"])
@@ -35,7 +39,11 @@ def _get_storage_utilities():
     return S3StorageMonitor("dummy")  # Bucket name not used for utilities
 
 
-@router.get("/me", response_model=Dict)
+@router.get(
+    "/me",
+    response_model=StorageAlertResponse,
+    response_model_exclude_unset=True,
+)
 async def get_my_storage_alert(
     current_user: User = Depends(get_current_user),
 ):

--- a/studio/app/common/routers/storage_limit_alerts.py
+++ b/studio/app/common/routers/storage_limit_alerts.py
@@ -325,7 +325,6 @@ async def check_limit_warning_status(
             has_alert=warning is not None,
             alert_type=warning.alert_type if warning else None,
             days_remaining=warning.days_remaining if warning else None,
-            user_id=current_user.uid,
         )
 
     except Exception as e:

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -92,7 +92,11 @@ async def get_routing_info(current_user: User = Depends(get_current_user)):
     return routing_info
 
 
-@router.post("/premium/assign", response_model=PremiumAssignResponse)
+@router.post(
+    "/premium/assign",
+    response_model=PremiumAssignResponse,
+    response_model_exclude_unset=True,
+)
 async def assign_premium_instance(current_user: User = Depends(get_current_user)):
     """
     Assign current user to a premium instance if they have an active subscription.
@@ -169,7 +173,11 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
         )
 
 
-@router.delete("/premium/assign", response_model=PremiumReleaseResponse)
+@router.delete(
+    "/premium/assign",
+    response_model=PremiumReleaseResponse,
+    response_model_exclude_unset=True,
+)
 async def release_premium_instance(current_user: User = Depends(get_current_user)):
     """
     Release current user from their assigned premium instance.
@@ -270,7 +278,11 @@ async def release_premium_beacon(request: Request, db: Session = Depends(get_db)
         return {"success": False, "message": str(e)}
 
 
-@router.post("/free/logout", response_model=FreeLogoutResponse)
+@router.post(
+    "/free/logout",
+    response_model=FreeLogoutResponse,
+    response_model_exclude_unset=True,
+)
 async def logout_free_user(
     current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
 ):
@@ -343,7 +355,11 @@ async def logout_free_user(
         }
 
 
-@router.get("/premium/status", response_model=PremiumStatusResponse)
+@router.get(
+    "/premium/status",
+    response_model=PremiumStatusResponse,
+    response_model_exclude_unset=True,
+)
 async def get_premium_assignment_status(current_user: User = Depends(get_current_user)):
     """
     Get the current premium instance assignment status for the user.
@@ -389,7 +405,11 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
         }
 
 
-@router.post("/premium/heartbeat", response_model=PremiumHeartbeatResponse)
+@router.post(
+    "/premium/heartbeat",
+    response_model=PremiumHeartbeatResponse,
+    response_model_exclude_unset=True,
+)
 async def send_premium_heartbeat(current_user: User = Depends(get_current_user)):
     """
     Send heartbeat to update activity timestamp for premium users.
@@ -500,7 +520,11 @@ async def delete_me(
     )
 
 
-@router.get("/cloud-details", response_model=CloudDetailsResponse)
+@router.get(
+    "/cloud-details",
+    response_model=CloudDetailsResponse,
+    response_model_exclude_unset=True,
+)
 async def get_my_cloud_details(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -33,7 +33,20 @@ from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.db.database import get_db
 from studio.app.common.models import FreeUserAssignment
 from studio.app.common.models.instance_usage import InstanceUsageLog, UsageTier
-from studio.app.common.schemas.users import SelfUserUpdate, User, UserPasswordUpdate
+from studio.app.common.schemas.premium import (
+    FreeLogoutResponse,
+    PremiumAssignResponse,
+    PremiumHeartbeatResponse,
+    PremiumReleaseResponse,
+    PremiumStatusResponse,
+    RoutingInfoResponse,
+)
+from studio.app.common.schemas.users import (
+    CloudDetailsResponse,
+    SelfUserUpdate,
+    User,
+    UserPasswordUpdate,
+)
 
 router = APIRouter(prefix="/users/me", tags=["users/me"])
 
@@ -52,7 +65,7 @@ async def me(current_user: User = Depends(get_current_user)):
     return current_user
 
 
-@router.get("/routing-info", response_model=Dict)
+@router.get("/routing-info", response_model=RoutingInfoResponse)
 async def get_routing_info(current_user: User = Depends(get_current_user)):
     """
     Get routing information for ALB header-based routing.
@@ -79,7 +92,7 @@ async def get_routing_info(current_user: User = Depends(get_current_user)):
     return routing_info
 
 
-@router.post("/premium/assign", response_model=Dict)
+@router.post("/premium/assign", response_model=PremiumAssignResponse)
 async def assign_premium_instance(current_user: User = Depends(get_current_user)):
     """
     Assign current user to a premium instance if they have an active subscription.
@@ -156,7 +169,7 @@ async def assign_premium_instance(current_user: User = Depends(get_current_user)
         )
 
 
-@router.delete("/premium/assign", response_model=Dict)
+@router.delete("/premium/assign", response_model=PremiumReleaseResponse)
 async def release_premium_instance(current_user: User = Depends(get_current_user)):
     """
     Release current user from their assigned premium instance.
@@ -257,7 +270,7 @@ async def release_premium_beacon(request: Request, db: Session = Depends(get_db)
         return {"success": False, "message": str(e)}
 
 
-@router.post("/free/logout", response_model=Dict)
+@router.post("/free/logout", response_model=FreeLogoutResponse)
 async def logout_free_user(
     current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
 ):
@@ -330,7 +343,7 @@ async def logout_free_user(
         }
 
 
-@router.get("/premium/status", response_model=Dict)
+@router.get("/premium/status", response_model=PremiumStatusResponse)
 async def get_premium_assignment_status(current_user: User = Depends(get_current_user)):
     """
     Get the current premium instance assignment status for the user.
@@ -376,7 +389,7 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
         }
 
 
-@router.post("/premium/heartbeat", response_model=Dict)
+@router.post("/premium/heartbeat", response_model=PremiumHeartbeatResponse)
 async def send_premium_heartbeat(current_user: User = Depends(get_current_user)):
     """
     Send heartbeat to update activity timestamp for premium users.
@@ -487,7 +500,7 @@ async def delete_me(
     )
 
 
-@router.get("/cloud-details", response_model=Dict)
+@router.get("/cloud-details", response_model=CloudDetailsResponse)
 async def get_my_cloud_details(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),

--- a/studio/app/common/routers/users_me.py
+++ b/studio/app/common/routers/users_me.py
@@ -61,7 +61,6 @@ async def get_routing_info(current_user: User = Depends(get_current_user)):
     is_premium = current_user.subscription_type == SubscriptionType.PREMIUM.value
 
     routing_info = {
-        "user_id": current_user.uid,
         "user_tier": current_user.subscription_type,
         "requires_premium_routing": is_premium,
         "routing_headers": {},
@@ -317,7 +316,6 @@ async def logout_free_user(
 
         return {
             "message": "Logout recorded successfully",
-            "user_id": current_user.uid,
             "user_tier": SubscriptionType.FREE.value,
             "logged_out": True,
             "cleanup_after_minutes": 60,  # Data cleanup occurs after 1 hour
@@ -327,7 +325,6 @@ async def logout_free_user(
         logger.error(f"Error logging out free user {current_user.id}: {e}")
         return {
             "message": f"Logout processed with warnings: {str(e)}",
-            "user_id": current_user.uid,
             "logged_out": False,
             "error": str(e),
         }
@@ -362,7 +359,6 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
             )
 
         return {
-            "user_id": current_user.uid,
             "subscription_type": current_user.subscription_type,
             "is_premium": current_user.subscription_type
             == SubscriptionType.PREMIUM.value,
@@ -372,7 +368,6 @@ async def get_premium_assignment_status(current_user: User = Depends(get_current
     except Exception as e:
         logger.error(f"Error getting premium status for user {current_user.id}: {e}")
         return {
-            "user_id": current_user.uid,
             "subscription_type": current_user.subscription_type,
             "is_premium": current_user.subscription_type
             == SubscriptionType.PREMIUM.value,
@@ -393,7 +388,6 @@ async def send_premium_heartbeat(current_user: User = Depends(get_current_user))
     if not is_premium:
         return {
             "message": "Heartbeat received (non-premium user)",
-            "user_id": current_user.uid,
             "user_tier": SubscriptionType.FREE.value,
             "assignment_active": False,
             "updated": False,
@@ -409,7 +403,6 @@ async def send_premium_heartbeat(current_user: User = Depends(get_current_user))
             return {
                 "message": "Activity updated successfully",
                 "updated": True,
-                "user_id": current_user.uid,
                 "user_tier": SubscriptionType.PREMIUM.value,
                 "assignment_active": True,
                 "activity_update": result.get("timestamp"),
@@ -419,7 +412,6 @@ async def send_premium_heartbeat(current_user: User = Depends(get_current_user))
             return {
                 "message": "No active assignment found",
                 "updated": False,
-                "user_id": current_user.uid,
                 "user_tier": SubscriptionType.PREMIUM.value,
                 "assignment_active": False,
                 "heartbeat_failures": failure_count,
@@ -431,7 +423,6 @@ async def send_premium_heartbeat(current_user: User = Depends(get_current_user))
         return {
             "message": f"Heartbeat processed with warnings: {str(e)}",
             "updated": False,
-            "user_id": current_user.uid,
             "user_tier": SubscriptionType.PREMIUM.value,
             "assignment_active": False,
             "heartbeat_failures": failure_count,
@@ -514,7 +505,6 @@ async def get_my_cloud_details(
         await CloudDebug.print_user_details(user_id=current_user.id)
 
         result = {
-            "user_id": current_user.uid,
             "user_name": current_user.name,
             "user_email": current_user.email,
         }
@@ -557,5 +547,4 @@ async def get_my_cloud_details(
         logger.error(f"Failed to get cloud details for user {current_user.id}: {e}")
         return {
             "error": str(e),
-            "user_id": current_user.uid,
         }

--- a/studio/app/common/schemas/premium.py
+++ b/studio/app/common/schemas/premium.py
@@ -8,6 +8,20 @@ from pydantic import BaseModel
 # (success / retry / error) stays valid.
 
 
+class PremiumAssignmentDetail(BaseModel):
+    """Whitelisted `/premium/status` assignment body (mirrors the frontend
+    `PremiumAssignment`). Typed so undeclared keys from the passthrough Lambda
+    payload are dropped on serialization. All Optional: any branch stays valid.
+    """
+
+    instance_id: Optional[str] = None
+    instance_id_hash: Optional[str] = None
+    assigned_at: Optional[str] = None
+    status: Optional[str] = None
+    is_shared: Optional[bool] = None
+    assignment_source: Optional[str] = None
+
+
 class RoutingInfoResponse(BaseModel):
     user_tier: str
     requires_premium_routing: bool
@@ -34,7 +48,7 @@ class PremiumReleaseResponse(BaseModel):
 class PremiumStatusResponse(BaseModel):
     subscription_type: str
     is_premium: bool
-    assignment: Optional[dict] = None
+    assignment: Optional[PremiumAssignmentDetail] = None
     migration_ready: Optional[bool] = None
     health_status: Optional[str] = None
     error: Optional[str] = None

--- a/studio/app/common/schemas/premium.py
+++ b/studio/app/common/schemas/premium.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+# Response models for the premium instance-assignment / routing endpoints
+# (studio/app/common/routers/users_me.py).
+# Branch-divergent fields are Optional so every return path
+# (success / retry / error) stays valid.
+
+
+class RoutingInfoResponse(BaseModel):
+    user_tier: str
+    requires_premium_routing: bool
+    routing_headers: Dict[str, str]
+
+
+class PremiumAssignResponse(BaseModel):
+    message: str
+    assigned: bool
+    instance_id: Optional[str] = None
+    instance_id_hash: Optional[str] = None
+    is_shared: Optional[bool] = None
+    assignment_source: Optional[str] = None
+    retry_after: Optional[int] = None
+    scaling_in_progress: Optional[bool] = None
+
+
+class PremiumReleaseResponse(BaseModel):
+    message: str
+    released: bool
+    released_instance: Optional[str] = None
+
+
+class PremiumStatusResponse(BaseModel):
+    subscription_type: str
+    is_premium: bool
+    assignment: Optional[dict] = None
+    migration_ready: Optional[bool] = None
+    health_status: Optional[str] = None
+    error: Optional[str] = None
+
+
+class PremiumHeartbeatResponse(BaseModel):
+    message: str
+    updated: bool
+    user_tier: str
+    assignment_active: bool
+    activity_update: Optional[Any] = None
+    heartbeat_failures: Optional[int] = None
+    error: Optional[str] = None
+
+
+class FreeLogoutResponse(BaseModel):
+    message: str
+    logged_out: bool
+    user_tier: Optional[str] = None
+    cleanup_after_minutes: Optional[int] = None
+    error: Optional[str] = None

--- a/studio/app/common/schemas/storage.py
+++ b/studio/app/common/schemas/storage.py
@@ -122,7 +122,6 @@ class LimitWarningStatus(BaseModel):
         None,
         description="Days remaining if alert is present",
     )
-    user_id: str = Field(..., description="User UID")
 
     class Config:
         schema_extra = {
@@ -130,6 +129,5 @@ class LimitWarningStatus(BaseModel):
                 "has_alert": True,
                 "alert_type": "grace",
                 "days_remaining": 15,
-                "user_id": "abc123",
             }
         }

--- a/studio/app/common/schemas/storage.py
+++ b/studio/app/common/schemas/storage.py
@@ -106,6 +106,36 @@ class LimitWarning(BaseModel):
         }
 
 
+class StorageAlertDetail(BaseModel):
+    """Nested alert object for GET /storage-limit-alerts/me.
+
+    Typed so undeclared keys are dropped on serialization. user_name /
+    user_email are the owner's own PII (frontend-unused; removal deferred).
+    """
+
+    alert_level: Optional[str] = None
+    storage_usage_bytes: Optional[int] = None
+    storage_quota_bytes: Optional[int] = None
+    storage_usage_percent: Optional[float] = None
+    timestamp: Optional[str] = None
+    user_name: Optional[str] = None
+    user_email: Optional[str] = None
+    message: Optional[str] = None
+
+
+class StorageAlertResponse(BaseModel):
+    """Response for GET /storage-limit-alerts/me. Covers both branches:
+    alert present (has_alert=True, alert set) and none (has_alert=False,
+    storage_usage_bytes / _formatted set). Served with exclude_unset so only
+    each branch's keys are emitted.
+    """
+
+    has_alert: bool
+    alert: Optional[StorageAlertDetail] = None
+    storage_usage_bytes: Optional[int] = None
+    storage_usage_formatted: Optional[str] = None
+
+
 class LimitWarningStatus(BaseModel):
     """
     Quick status check response for limit warnings.

--- a/studio/app/common/schemas/users.py
+++ b/studio/app/common/schemas/users.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field
@@ -135,3 +135,12 @@ class UserInfo(BaseModel):
 
 class UserCreateResponse(BaseModel):
     user: User
+
+
+class CloudDetailsResponse(BaseModel):
+    user_name: Optional[str] = None
+    user_email: Optional[str] = None
+    user_context: Optional[dict] = None
+    subscription_details: Optional[dict] = None
+    storage_usage: Optional[Any] = None
+    error: Optional[str] = None

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -28,7 +28,6 @@ from studio.app.common.core.subscription.constants import SubscriptionType
 
 # RoutingInfo interface
 ROUTING_INFO_REQUIRED_FIELDS = {
-    "user_id": str,
     "user_tier": str,
     "requires_premium_routing": bool,
     "routing_headers": dict,
@@ -61,7 +60,6 @@ PREMIUM_RELEASE_OPTIONAL_FIELDS = {
 
 # PremiumStatusResult interface
 PREMIUM_STATUS_REQUIRED_FIELDS = {
-    "user_id": (str, int),  # Backend returns string uid
     "subscription_type": str,
     "is_premium": bool,
 }
@@ -90,7 +88,6 @@ PREMIUM_ASSIGNMENT_NESTED_OPTIONAL_FIELDS = {
 PREMIUM_HEARTBEAT_REQUIRED_FIELDS = {
     "message": str,
     "updated": bool,
-    "user_id": (str, int),
     "user_tier": str,
     "assignment_active": bool,
 }

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -823,3 +823,40 @@ def test_response_model_drops_identifier_fields(model_cls, payload):
     serialized = model_cls(**leaked).dict()
     assert "uid" not in serialized
     assert "user_id" not in serialized
+
+
+# ============================================================================
+# Guard Test (end-to-end): real FastAPI serialization strips identifiers
+# ============================================================================
+# The parametrized guard above exercises the model layer directly
+# (Model(**...).dict()). This one drives the actual response_model
+# serialization via TestClient, so it also catches a future config change
+# (e.g. Config.extra = "allow") or a serialization-path regression.
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from studio.__main_unit__ import app  # noqa: E402
+from studio.app.common.core.auth.auth_dependencies import (  # noqa: E402
+    get_current_user,
+)
+
+
+def test_routing_info_response_omits_identifiers_end_to_end():
+    mock_user = Mock()
+    mock_user.id = 1
+    mock_user.subscription_type = SubscriptionType.FREE.value
+
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        response = TestClient(app).get("/users/me/routing-info")
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) == {
+            "user_tier",
+            "requires_premium_routing",
+            "routing_headers",
+        }
+        assert "user_id" not in body
+        assert "uid" not in body
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -844,6 +844,9 @@ def test_routing_info_response_omits_identifiers_end_to_end():
     mock_user.id = 1
     mock_user.subscription_type = SubscriptionType.FREE.value
 
+    # Save/restore rather than pop: conftest sets a session-scoped
+    # get_current_user override that later TestClient tests rely on.
+    previous_override = app.dependency_overrides.get(get_current_user)
     app.dependency_overrides[get_current_user] = lambda: mock_user
     try:
         response = TestClient(app).get("/users/me/routing-info")
@@ -857,4 +860,7 @@ def test_routing_info_response_omits_identifiers_end_to_end():
         assert "user_id" not in body
         assert "uid" not in body
     finally:
-        app.dependency_overrides.pop(get_current_user, None)
+        if previous_override is not None:
+            app.dependency_overrides[get_current_user] = previous_override
+        else:
+            app.dependency_overrides.pop(get_current_user, None)

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -825,6 +825,33 @@ def test_response_model_drops_identifier_fields(model_cls, payload):
     assert "user_id" not in serialized
 
 
+def test_premium_status_nested_assignment_drops_identifier_fields():
+    """The nested `assignment` model must strip identifiers the passthrough
+    Lambda body might echo, while keeping the whitelisted fields."""
+    leaked_assignment = {
+        "instance_id": "i-123456",
+        "instance_id_hash": "hash-abc",
+        "assigned_at": "2024-01-15T10:30:00Z",
+        "status": "active",
+        "is_shared": False,
+        "assignment_source": "existing",
+        "uid": "leak-uid",
+        "user_id": "leak-id",
+    }
+    serialized = PremiumStatusResponse(
+        subscription_type="premium",
+        is_premium=True,
+        assignment=leaked_assignment,
+    ).dict()
+
+    assignment = serialized["assignment"]
+    assert "uid" not in assignment
+    assert "user_id" not in assignment
+    # Whitelisted fields survive.
+    assert assignment["instance_id"] == "i-123456"
+    assert assignment["assignment_source"] == "existing"
+
+
 # ============================================================================
 # Guard Test (end-to-end): real FastAPI serialization strips identifiers
 # ============================================================================

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -836,9 +836,7 @@ def test_response_model_drops_identifier_fields(model_cls, payload):
 from fastapi.testclient import TestClient  # noqa: E402
 
 from studio.__main_unit__ import app  # noqa: E402
-from studio.app.common.core.auth.auth_dependencies import (  # noqa: E402
-    get_current_user,
-)
+from studio.app.common.core.auth.auth_dependencies import get_current_user  # noqa: E402
 
 
 def test_routing_info_response_omits_identifiers_end_to_end():

--- a/studio/tests/app/common/routers/test_premium_api_contract.py
+++ b/studio/tests/app/common/routers/test_premium_api_contract.py
@@ -768,3 +768,58 @@ async def test_contract_beacon_release_missing_uid():
     )
 
     assert result["success"] is False
+
+
+# ============================================================================
+# Guard Tests: typed response models must not leak identifier fields
+# ============================================================================
+# These verify the response_model layer strips undeclared keys, so an internal
+# identifier (e.g. uid / user_id) cannot be re-exposed by adding it to a
+# response dict. Each sample is the minimal valid payload for that model, which
+# also confirms every required-field set constructs without error.
+
+from studio.app.common.schemas.premium import (  # noqa: E402
+    FreeLogoutResponse,
+    PremiumAssignResponse,
+    PremiumHeartbeatResponse,
+    PremiumReleaseResponse,
+    PremiumStatusResponse,
+    RoutingInfoResponse,
+)
+from studio.app.common.schemas.users import CloudDetailsResponse  # noqa: E402
+
+RESPONSE_MODEL_SAMPLES = [
+    (
+        RoutingInfoResponse,
+        {
+            "user_tier": "free",
+            "requires_premium_routing": False,
+            "routing_headers": {},
+        },
+    ),
+    (PremiumAssignResponse, {"message": "ok", "assigned": True}),
+    (PremiumReleaseResponse, {"message": "ok", "released": True}),
+    (
+        PremiumStatusResponse,
+        {"subscription_type": "premium", "is_premium": True},
+    ),
+    (
+        PremiumHeartbeatResponse,
+        {
+            "message": "ok",
+            "updated": True,
+            "user_tier": "premium",
+            "assignment_active": True,
+        },
+    ),
+    (FreeLogoutResponse, {"message": "ok", "logged_out": True}),
+    (CloudDetailsResponse, {"user_name": "n", "user_email": "e"}),
+]
+
+
+@pytest.mark.parametrize("model_cls,payload", RESPONSE_MODEL_SAMPLES)
+def test_response_model_drops_identifier_fields(model_cls, payload):
+    leaked = {**payload, "uid": "leak-uid", "user_id": "leak-id"}
+    serialized = model_cls(**leaked).dict()
+    assert "uid" not in serialized
+    assert "user_id" not in serialized

--- a/studio/tests/app/common/routers/test_storage_alerts_api_contract.py
+++ b/studio/tests/app/common/routers/test_storage_alerts_api_contract.py
@@ -24,7 +24,6 @@ import pytest
 
 # StorageAlert interface (nested in StorageAlertResponse)
 STORAGE_ALERT_REQUIRED_FIELDS = {
-    "user_id": int,
     "user_name": str,
     "user_email": str,
     "alert_level": str,  # "critical" | "danger"

--- a/studio/tests/app/common/routers/test_storage_alerts_api_contract.py
+++ b/studio/tests/app/common/routers/test_storage_alerts_api_contract.py
@@ -223,6 +223,8 @@ async def test_contract_storage_alert_response_with_alert(
                     )
                     # Validate alert_level is valid enum
                     assert result["alert"]["alert_level"] in VALID_ALERT_LEVELS
+                    # The internal user id must not be echoed back to the client.
+                    assert "user_id" not in result["alert"]
 
 
 @pytest.mark.asyncio

--- a/studio/tests/app/common/routers/test_storage_limit_alerts.py
+++ b/studio/tests/app/common/routers/test_storage_limit_alerts.py
@@ -587,7 +587,6 @@ async def test_check_limit_warning_has_alert(mock_current_user):
         assert result.has_alert is True
         assert result.alert_type == "grace"
         assert result.days_remaining == 5
-        assert result.user_id == "test-user-123"
 
 
 @pytest.mark.asyncio
@@ -607,7 +606,6 @@ async def test_check_limit_warning_no_warning(mock_current_user):
         assert result.has_alert is False
         assert result.alert_type is None
         assert result.days_remaining is None
-        assert result.user_id == "test-user-123"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Several `/users/me` and storage-alert API responses echoed internal user
identifiers — the Firebase UID (`users.uid`) and the integer primary key
(`users.id`) — as `user_id` fields that the frontend never reads. This PR
removes those unused exposures and adds a structural guard so they cannot be
reintroduced, without changing any user-facing behavior.

Two identifiers are treated differently by design:

- **Firebase UID** — a core internal identifier (JWT subject, source of the
  routing HMAC). Unused by the client → **removed**.
- **Integer `users.id`** — actively used by the sharing / subscription / admin
  flows → **kept where consumed**, removed only from the one response that
  echoed it unused.

This aligns with the existing policy of not exposing raw identifiers (routing
headers already use the `X-Routing-ID` HMAC hash instead of the raw UID).

## Background

- The UID was returned as `user_id` in `routing-info`, `premium/status`,
  `premium/heartbeat`, `free/logout`, `cloud-details`, and
  `storage/limit-warning/check`. The frontend interfaces declared it as
  `number` while the backend sent the string UID (a type mismatch), and no
  consumer ever read it.
- The integer id was echoed as `user_id` in the `/me` storage alert, also
  unread by the frontend.
- No cross-user leak was involved — each field was returned only to the
  authenticated owner (or, for admin endpoints, to an admin) — so severity is
  low; this is a least-exposure / defense-in-depth cleanup.

## Changes

Delivered as four commits:

### 1. Stop exposing Firebase UID in API responses (Stage A)
- Remove `user_id: current_user.uid` from `routing-info`, `free/logout`,
  `premium/status`, `premium/heartbeat`, and `cloud-details` responses
  (`studio/app/common/routers/users_me.py`).
- Remove the unused `user_id` field from the `RoutingInfo`,
  `PremiumStatusResult`, and `PremiumHeartbeatResult` frontend interfaces;
  stop populating `routingInfo.user_id`; delete the dead
  `selectCurrentUserUid` selector.
- Update the premium API contract test and premium context test mocks.

### 2. Type premium/routing responses to prevent re-exposure (Stage A-guard)
- Replace `response_model=Dict` on the premium / routing / free-logout /
  cloud-details endpoints with explicit Pydantic models
  (`studio/app/common/schemas/premium.py`, plus `CloudDetailsResponse` in
  `schemas/users.py`). FastAPI now drops any undeclared key on serialization,
  so re-adding an identifier to a response dict cannot reach the client.
- Branch-divergent fields are `Optional` so every success / retry / error
  return path stays valid.
- Add a guard test asserting each model strips injected `uid` / `user_id`.

### 3. Stop exposing Firebase UID via limit-warning/check (Stage A follow-up)
- Remove the `user_id` (UID) field from `LimitWarningStatus`
  (`schemas/storage.py`) and its endpoint; remove the unused
  `LimitAlertStatus.user_id` frontend field; drop the related test assertions.
- (This exposure was missed by the initial Stage A inventory, which was scoped
  to `users_me.py`.)

### 4. Stop echoing integer user id in /me storage alert (Stage B)
- Remove `user_id: current_user.id` from the `/me` storage alert
  (`storage_limit_alerts.py`); remove the unused `StorageAlert.user_id`
  frontend field; update the contract test and the mock in `RunButtons.test`.

## Design decisions

- **UID kept in the shared `User` schema** (`GET /users/me`, `/admin/users`):
  the admin-only proxy-login flow requires it.
- **Admin `/all` storage endpoint keeps `user_id`**: it is admin-only and the
  integer id is needed to identify users; the monitor also uses user
  name/email server-side for admin notifications.
- **Integer id kept** in subscription responses, workspace sharing, and admin
  endpoints, where the frontend genuinely consumes it.
- **`user_name` / `user_email` on the `/me` storage alert left as-is** for now
  (unused but the owner's own PII; deferred as an optional cleanup).

## Security / IDOR notes

- Endpoints that accept a `{user_id}` path parameter remain protected:
  `POST /subsc/mgmts/reactivate/{user_id}` and `GET /subsc/invoices/{user_id}`
  enforce `current_user.id != user_id → 403`; `/admin/users/{user_id}` is
  admin + organization scoped. No IDOR guard was changed.
- Request routing headers were already HMAC-based (`X-Routing-ID`); unchanged.

## Out of scope

- Making the sequential integer primary key non-enumerable (e.g. UUID /
  opaque external ids) — a larger migration.
- Removing unused `user_name` / `user_email` from the `/me` storage alert.

## Known residuals / deferred follow-ups

- **`/storage-limit-alerts/me` still uses `response_model=Dict`.** The
  `user_id` was removed and a negative test now locks its absence, but this
  endpoint is not yet behind the typed-model guard. Pairing a typed model with
  the deferred `user_name`/`user_email` PII cleanup is the natural follow-up.
- **`PremiumStatusResponse.assignment` is an untyped `Optional[dict]`
  passthrough** of the premium-manager Lambda body. The guard strips only
  top-level keys; today the body carries no identifier (only
  `instance_id`/`assigned_at`/`is_shared`/`status`/`assignment_source`), so the
  risk is low, but typing this nested object would make the guard complete.

## Test coverage

- Backend: premium API contract tests, storage alert and limit-warning tests
  pass. All premium/routing return branches were validated against the new
  response models (no serialization errors).
- Guard tests locking the anti-reexposure invariant:
  - `test_response_model_drops_identifier_fields` — injects `uid`/`user_id`
    into every typed model and asserts they are stripped (model layer).
  - `test_routing_info_response_omits_identifiers_end_to_end` — drives the real
    FastAPI serialization path via `TestClient` and asserts the response
    exposes exactly the declared keys (catches a future `Config.extra` /
    serialization change).
  - Negative assertion `"user_id" not in alert` on the `/me` storage alert
    (the un-typed Stage B endpoint).
- Frontend: type-check clean for the affected areas; premium context, storage
  and limit-alert hook tests pass.

---

## Manual test cases (for Tester)

> **What this change does, in plain terms:** it removes some hidden ID values
> from server responses that the screen never showed. So there is **nothing new
> to see in the UI** — the goal of manual testing is only to confirm that the
> normal features still work exactly as before (no regression). No developer
> tools, API tools, or command line are needed for the main cases below; just
> use the app normally.
>
> Each case lists a **Precondition** (what account/state you need), **Steps**,
> and the **Expected result**.

### Case 1 — Premium user: the app keeps working normally
**Precondition:** a premium user account.
1. Log in as the premium user.
2. Wait a few seconds until the app finishes loading and you reach the normal
   workspace screen (the premium instance is assigned automatically).
3. Use the app normally for a couple of minutes (open a workspace, click
   around).
4. Put the computer to sleep (or close the laptop lid) for about one minute,
   then wake it and return to the app.

**Expected:**
- The app loads and works normally; you are **not** unexpectedly logged out or
  shown an error.
- After waking from sleep, the app continues to work normally (no forced
  logout, no error banner).
- *(Optional, technical — see Appendix for how)* In the DevTools Network tab,
  the `premium/status` and `premium/assign` responses (from login) and the
  `premium/heartbeat` response (from wake) contain **no** `user_id`.

### Case 2 — Free user: logout works
**Precondition:** a free-tier user account.
1. Log in as the free user and use the app briefly.
2. Log out.

**Expected:**
- Logout completes normally and returns you to the login screen.
- *(Optional, technical — see Appendix for how)* In the DevTools Network tab,
  the `free/logout` response contains **no** `user_id`.

### Case 3 — Storage alert still shows when running a job
**Precondition:** a user whose storage usage is over the alert level
(near/over quota). If such an account is hard to prepare, this case can be
skipped and left to the automated tests.
1. Log in as that user and open a workspace.
2. Click **Run** on a workflow.

**Expected:**
- The storage warning message appears (e.g. a red/orange snackbar saying
  storage is high / quota exceeded), the same as before this change.
- *(Optional, technical — see Appendix for how)* In the DevTools Network tab,
  the `storage-limit-alerts/me` response contains **no** `user_id`.

### Case 4 — Workspace sharing works
**Precondition:** two user accounts (A and B); a workspace owned by user A.
1. Log in as user A and open the **Share** dialog of the workspace.
2. Search for user B by name/email, add them, and save.
3. Reopen the share status.

**Expected:**
- Sharing succeeds and user B appears in the shared-users list. (This confirms
  the internal numeric user id that sharing relies on still works.)
- *No Network-tab `user_id` check applies here* — this case verifies a
  **retained** identifier keeps working, not a removal.

### Case 5 — Admin proxy-login works
**Precondition:** an admin account that can open the user-management (Account
Manager) screen.
1. Log in as admin and open the user-management screen.
2. Select another user and use **proxy login**.

**Expected:**
- The user list loads and proxy login succeeds (you are signed in as the
  selected user). This confirms the user identifier that admin login relies on
  still works.
- *No Network-tab `user_id` check applies here* — this case verifies a
  **retained** identifier keeps working, not a removal.

### Case 6 (optional) — Subscription reactivate works
> Optional / heavier: only run if a premium account **already** scheduled for
> cancellation is available. It does not need to be set up specially for this
> PR — Case 4 and the automated tests already cover the same "numeric id still
> works" point.
**Precondition:** a user whose subscription is scheduled for cancellation.
1. Log in as that user and open the Subscription screen.
2. Click **Reactivate**.

**Expected:**
- Reactivation succeeds and the scheduled cancellation is cleared.
- *No Network-tab `user_id` check applies here* — this case verifies a
  **retained** identifier keeps working, not a removal.

### Not manually testable (covered by automated tests only)
Two responses that had an ID removed — `routing-info` and
`storage/limit-warning/check` — are **not triggered by any current screen**, so
there is no UI action a tester can take to exercise them. Their behavior is
locked by the automated backend tests in this PR; no manual step is required.

### Regression sweep
- Premium assignment and normal usage behave exactly as before.
- No new error messages appear on any of the flows above.

---

### Appendix (optional, for a technical tester) — confirming the ID is gone
This is **not required**; the functional cases above are enough. If you want to
verify the removal directly in the browser:

1. Press **F12** to open Developer Tools and select the **Network** tab.
2. Do one of the UI actions below and click the matching request in the list.
3. Open its **Response** tab and press **Ctrl+F** / **Cmd+F** to search for
   `user_id`.

**Expected in every case:** `user_id` is **not** found in the response body.

| UI action | Request to inspect (Network tab) |
|---|---|
| Log in as a premium user (wait for assignment) | `premium/status` and `premium/assign` |
| As a premium user, sleep the computer ~1 min then wake it | `premium/heartbeat` |
| Log out as a **premium** user | `premium/assign` (the `DELETE` request) |
| Log out as a **free** user | `free/logout` |
| Click **Run** on a workflow (near/over quota) | `storage-limit-alerts/me` |

> Note: two endpoints that also had the id removed — `routing-info` and
> `storage/limit-warning/check` — are not called by any current screen, so they
> will not appear in the Network tab. They are covered by the automated tests.
