### PR TITLE
Force-new-deployment on every ECS service

### DIFF
--- a/infrastructure/scripts/ecr_build_push.sh
+++ b/infrastructure/scripts/ecr_build_push.sh
@@ -3,6 +3,7 @@ set -e
 
 # Common Configuration
 REGION="ap-northeast-1"
+TERRAFORM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../terraform" && pwd)"
 
 # ===========================================
 # Parse arguments
@@ -56,8 +57,8 @@ fi
 # Detect environment and ECR target
 # ===========================================
 echo "Reading Terraform outputs..."
-ENVIRONMENT=$(terraform -chdir=../terraform output -raw environment 2>/dev/null || echo "")
-ECR_URI=$(terraform -chdir=../terraform output -raw ecr_repository_url 2>/dev/null || echo "")
+ENVIRONMENT=$(terraform -chdir="$TERRAFORM_DIR" output -raw environment 2>/dev/null || echo "")
+ECR_URI=$(terraform -chdir="$TERRAFORM_DIR" output -raw ecr_repository_url 2>/dev/null || echo "")
 
 if [ -z "$ENVIRONMENT" ]; then
     echo "ERROR: Could not read environment from Terraform output."
@@ -121,9 +122,9 @@ fi
 # ===========================================
 # Get configuration from Terraform outputs
 # ===========================================
-AUTOSCALING_HOST=$(terraform -chdir=../terraform output -raw domain_name)
-AUTOSCALING_PORT=$(terraform -chdir=../terraform output -raw domain_port)
-AUTOSCALING_PROTO=$(terraform -chdir=../terraform output -raw domain_protocol)
+AUTOSCALING_HOST=$(terraform -chdir="$TERRAFORM_DIR" output -raw domain_name)
+AUTOSCALING_PORT=$(terraform -chdir="$TERRAFORM_DIR" output -raw domain_port)
+AUTOSCALING_PROTO=$(terraform -chdir="$TERRAFORM_DIR" output -raw domain_protocol)
 
 echo "Autoscaling Host: $AUTOSCALING_HOST"
 echo "Autoscaling Protocol: $AUTOSCALING_PROTO"
@@ -190,7 +191,7 @@ echo "============================================"
 # Runs AFTER the push, so the force always resolves the digest we just pushed.
 # Cycles all tiers (main/premium/public/background), not just the main service.
 if [ "$DEPLOY" = true ]; then
-    CLUSTER=$(terraform -chdir=../terraform output -raw ecs_cluster_name)
+    CLUSTER=$(terraform -chdir="$TERRAFORM_DIR" output -raw ecs_cluster_name)
     echo ""
     echo "Forcing new deployment on all services in ${CLUSTER}..."
     SERVICES=$(aws ecs list-services --cluster "$CLUSTER" --region "$REGION" \

--- a/infrastructure/scripts/ecr_build_push.sh
+++ b/infrastructure/scripts/ecr_build_push.sh
@@ -7,11 +7,14 @@ REGION="ap-northeast-1"
 # ===========================================
 # Parse arguments
 # ===========================================
-# Usage: ./ecr_build_push.sh [--tag <version-tag>] [--yes]
+# Usage: ./ecr_build_push.sh [--tag <version-tag>] [--yes] [--deploy]
 #   --tag <tag>  : Custom version tag (default: auto-generated YYYYMMDD-HHMMSS-<git-sha>)
 #   --yes        : Skip confirmation prompt
+#   --deploy     : After push, force-new-deployment on EVERY service in the
+#                  cluster so all tiers re-pull the just-pushed :latest
 CUSTOM_TAG=""
 SKIP_CONFIRM=false
+DEPLOY=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -23,9 +26,13 @@ while [[ $# -gt 0 ]]; do
             SKIP_CONFIRM=true
             shift
             ;;
+        --deploy)
+            DEPLOY=true
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: ./ecr_build_push.sh [--tag <version-tag>] [--yes]"
+            echo "Usage: ./ecr_build_push.sh [--tag <version-tag>] [--yes] [--deploy]"
             exit 1
             ;;
     esac
@@ -176,3 +183,22 @@ echo "  Environment : ${ENVIRONMENT}"
 echo "  latest      : ${ECR_URI}:latest"
 echo "  Version     : ${ECR_URI}:${VERSION_TAG}"
 echo "============================================"
+
+# ===========================================
+# Optional: force every service to re-pull :latest
+# ===========================================
+# Runs AFTER the push, so the force always resolves the digest we just pushed.
+# Cycles all tiers (main/premium/public/background), not just the main service.
+if [ "$DEPLOY" = true ]; then
+    CLUSTER=$(terraform -chdir=../terraform output -raw ecs_cluster_name)
+    echo ""
+    echo "Forcing new deployment on all services in ${CLUSTER}..."
+    for svc in $(aws ecs list-services --cluster "$CLUSTER" --region "$REGION" \
+        --query 'serviceArns[]' --output text); do
+        echo "  -> ${svc##*/}"
+        aws ecs update-service --cluster "$CLUSTER" --service "$svc" \
+            --force-new-deployment --region "$REGION" >/dev/null
+    done
+    echo "Force-new-deployment issued for all services (${ECR_URI}:${VERSION_TAG})."
+    echo "Standby (desiredCount 0) services will re-pull on next scale-up."
+fi

--- a/infrastructure/scripts/ecr_build_push.sh
+++ b/infrastructure/scripts/ecr_build_push.sh
@@ -4,6 +4,7 @@ set -e
 # Common Configuration
 REGION="ap-northeast-1"
 TERRAFORM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../terraform" && pwd)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # ===========================================
 # Parse arguments
@@ -150,7 +151,7 @@ fi
 
 # Build frontend with custom domain for autoscaling
 echo "Building frontend for autoscaling with ${AUTOSCALING_PROTO}://${AUTOSCALING_HOST}:${AUTOSCALING_PORT}"
-cd ../../frontend
+cd "$REPO_ROOT/frontend"
 cat > .env.production << ENV_EOF
 REACT_APP_SERVER_HOST=${AUTOSCALING_HOST}
 REACT_APP_SERVER_PORT=${AUTOSCALING_PORT}
@@ -160,7 +161,7 @@ ENV_EOF
 
 yarn install
 yarn build
-cd ..
+cd "$REPO_ROOT"
 
 # Build the Docker image with embedded build metadata
 echo "Building autoscaling Docker image..."
@@ -202,5 +203,5 @@ if [ "$DEPLOY" = true ]; then
             --force-new-deployment --region "$REGION" >/dev/null
     done
     echo "Force-new-deployment issued for all services (re-pulling ${ECR_URI}:latest)."
-    echo "Standby (desiredCount 0) services will re-pull on next scale-up."
+    echo "Running services restart now; any service at desiredCount 0 re-pulls on next scale-up."
 fi

--- a/infrastructure/scripts/ecr_build_push.sh
+++ b/infrastructure/scripts/ecr_build_push.sh
@@ -193,12 +193,13 @@ if [ "$DEPLOY" = true ]; then
     CLUSTER=$(terraform -chdir=../terraform output -raw ecs_cluster_name)
     echo ""
     echo "Forcing new deployment on all services in ${CLUSTER}..."
-    for svc in $(aws ecs list-services --cluster "$CLUSTER" --region "$REGION" \
-        --query 'serviceArns[]' --output text); do
+    SERVICES=$(aws ecs list-services --cluster "$CLUSTER" --region "$REGION" \
+        --query 'serviceArns[]' --output text)
+    for svc in $SERVICES; do
         echo "  -> ${svc##*/}"
         aws ecs update-service --cluster "$CLUSTER" --service "$svc" \
             --force-new-deployment --region "$REGION" >/dev/null
     done
-    echo "Force-new-deployment issued for all services (${ECR_URI}:${VERSION_TAG})."
+    echo "Force-new-deployment issued for all services (re-pulling ${ECR_URI}:latest)."
     echo "Standby (desiredCount 0) services will re-pull on next scale-up."
 fi

--- a/infrastructure/terraform/deployment.tf
+++ b/infrastructure/terraform/deployment.tf
@@ -133,6 +133,11 @@ resource "aws_ssm_association" "app_setup" {
 resource "null_resource" "deploy_to_ecs" {
   depends_on = [null_resource.build_and_deploy]
 
+  triggers = {
+    git_branch = var.git_branch
+    ecr_repo   = local.ecr_repository_url
+  }
+
   provisioner "local-exec" {
     command = <<-EOT
       set -e

--- a/infrastructure/terraform/deployment.tf
+++ b/infrastructure/terraform/deployment.tf
@@ -138,13 +138,21 @@ resource "null_resource" "deploy_to_ecs" {
       set -e
       echo "=== Starting ECS deployment ==="
 
-      # Force ECS deployment
-      echo "Forcing ECS service deployment..."
-      aws ecs update-service \
+      # Force a new deployment on EVERY service in the cluster (main, premium,
+      # public, background) so all tiers re-pull the just-pushed :latest, not
+      # only the main service.
+      echo "Forcing ECS deployment on all services in ${aws_ecs_cluster.main.name}..."
+      for svc in $(aws ecs list-services \
         --cluster ${aws_ecs_cluster.main.name} \
-        --service ${aws_ecs_service.autoscaling.name} \
-        --force-new-deployment \
-        --region ${var.aws_region}
+        --region ${var.aws_region} \
+        --query 'serviceArns[]' --output text); do
+        echo "  -> $${svc##*/}"
+        aws ecs update-service \
+          --cluster ${aws_ecs_cluster.main.name} \
+          --service "$svc" \
+          --force-new-deployment \
+          --region ${var.aws_region} >/dev/null
+      done
 
       echo "Waiting for ECS service to stabilize..."
             # Check if service is already running first

--- a/infrastructure/terraform/deployment.tf
+++ b/infrastructure/terraform/deployment.tf
@@ -142,10 +142,11 @@ resource "null_resource" "deploy_to_ecs" {
       # public, background) so all tiers re-pull the just-pushed :latest, not
       # only the main service.
       echo "Forcing ECS deployment on all services in ${aws_ecs_cluster.main.name}..."
-      for svc in $(aws ecs list-services \
+      SERVICES=$(aws ecs list-services \
         --cluster ${aws_ecs_cluster.main.name} \
         --region ${var.aws_region} \
-        --query 'serviceArns[]' --output text); do
+        --query 'serviceArns[]' --output text)
+      for svc in $SERVICES; do
         echo "  -> $${svc##*/}"
         aws ecs update-service \
           --cluster ${aws_ecs_cluster.main.name} \
@@ -154,42 +155,13 @@ resource "null_resource" "deploy_to_ecs" {
           --region ${var.aws_region} >/dev/null
       done
 
-      echo "Waiting for ECS service to stabilize..."
-            # Check if service is already running first
-            SERVICE_STATUS=$(aws ecs describe-services \
-              --cluster ${aws_ecs_cluster.main.name} \
-              --services ${aws_ecs_service.autoscaling.name} \
-              --region ${var.aws_region} \
-              --query 'services[0].status' --output text)
-
-            if [ "$SERVICE_STATUS" = "ACTIVE" ]; then
-              echo "Service is already active, checking running count..."
-              RUNNING_COUNT=$(aws ecs describe-services \
-                --cluster ${aws_ecs_cluster.main.name} \
-                --services ${aws_ecs_service.autoscaling.name} \
-                --region ${var.aws_region} \
-                --query 'services[0].runningCount' --output text)
-
-              if [ "$RUNNING_COUNT" -gt "0" ]; then
-                echo "Service already has $RUNNING_COUNT running tasks"
-              else
-                echo "Waiting for service to stabilize..."
-                timeout 1800 aws ecs wait services-stable \
-                  --cluster ${aws_ecs_cluster.main.name} \
-                  --services ${aws_ecs_service.autoscaling.name} \
-                  --region ${var.aws_region} \
-                  --cli-read-timeout 1800 \
-                  --cli-connect-timeout 120 || echo "Warning: Service stabilization timed out, but continuing..."
-              fi
-            else
-              echo "Service not active, waiting..."
-              timeout 1800 aws ecs wait services-stable \
-                --cluster ${aws_ecs_cluster.main.name} \
-                --services ${aws_ecs_service.autoscaling.name} \
-                --region ${var.aws_region} \
-                --cli-read-timeout 1800 \
-                --cli-connect-timeout 120 || echo "Warning: Service stabilization timed out, but continuing..."
-            fi
+      echo "Waiting for all services to stabilize..."
+      timeout 1800 aws ecs wait services-stable \
+        --cluster ${aws_ecs_cluster.main.name} \
+        --services $SERVICES \
+        --region ${var.aws_region} \
+        --cli-read-timeout 1800 \
+        --cli-connect-timeout 120 || echo "Warning: service stabilization timed out, but continuing..."
 
       echo "=== DEPLOYMENT COMPLETE ==="
       echo "Application is ready at: http://${aws_lb.autoscaling.dns_name}"


### PR DESCRIPTION
### Content

#### Summary
- The Terraform deploy step and the manual `ecr_build_push.sh` script only forced a new deployment on the main autoscaling service. ECS pins the `:latest` tag to a digest at deployment-creation time, so premium/public/background tiers kept running stale code after a release.
- Both paths now loop over every service in the cluster and issue `--force-new-deployment` for each, so all tiers re-pull the just-pushed `:latest`.
- `ecr_build_push.sh` also gains an opt-in `--deploy` flag to trigger that cycle right after a push.

#### Design Decisions
- **Enumerate services with `aws ecs list-services` instead of hardcoding names.** New tiers get picked up automatically and there is no name list to drift out of sync.
- **Force runs strictly after the image push** in the script, so the deployment always resolves the digest we just pushed.
- **`--deploy` is opt-in, not default.** The push and the cluster-wide restart stay separable; a plain `--yes` push does not disturb running services.
- Standby services (desiredCount 0) are cycled harmlessly and re-pull on their next scale-up; noted in the script output rather than special-cased.

### References
- Memory: deploy must cycle all four ECS services (main/premium/public/background)

#### Files changed
- `infrastructure/terraform/deployment.tf` -- `null_resource.deploy_to_ecs` now loops over all `list-services` ARNs and force-deploys each, replacing the single main-service update.
- `infrastructure/scripts/ecr_build_push.sh` -- add `--deploy` flag that, after push, force-new-deployments every service in the cluster.

### Manual Testcases
- Operator runs `./ecr_build_push.sh --yes` -> image builds and pushes, no service is restarted (unchanged behaviour).
- Operator runs `./ecr_build_push.sh --yes --deploy` -> after push, each service ARN prints and receives a force-new-deployment; verify each running task's image digest matches the new `:latest` post-deploy.
- `terraform apply` triggers `deploy_to_ecs` -> all cluster services cycle, not only the main service.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| ECS deploy (terraform) | Medium | Now restarts every tier on each apply; intended, but a wider blast radius than before. Standby services (count 0) are no-ops. |
| ecr_build_push.sh | Low | `--deploy` is opt-in; default push behaviour is unchanged. |
