### PR TITLE
Fix swallowed subscription error details and storage quota upsert

### DIFF
--- a/studio/app/common/core/subscription/checkout_service.py
+++ b/studio/app/common/core/subscription/checkout_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
-from sqlalchemy import update
+from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
@@ -598,19 +598,17 @@ class CheckoutService:
 
                     # Update storage quota
                     storage_quota_bytes = StorageQuota.bytes_for_plan(recovered_plan_id)
-                    rows_updated = db.execute(
-                        update(UserStorageUsage)
-                        .where(UserStorageUsage.user_id == user_id)
-                        .values(storage_quota_bytes=storage_quota_bytes)
-                    ).rowcount
-                    if not rows_updated:
-                        db.add(
-                            UserStorageUsage(
-                                user_id=user_id,
-                                storage_usage_bytes=0,
-                                storage_quota_bytes=storage_quota_bytes,
-                            )
+                    db.execute(
+                        mysql_insert(UserStorageUsage)
+                        .values(
+                            user_id=user_id,
+                            storage_usage_bytes=0,
+                            storage_quota_bytes=storage_quota_bytes,
                         )
+                        .on_duplicate_key_update(
+                            storage_quota_bytes=storage_quota_bytes
+                        )
+                    )
 
                     db.commit()
 

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -748,8 +748,9 @@ class WebhookService:
             )
 
         except HTTPException:
+            # bare raise: the generic arm below would turn this into a 500
             db.rollback()
-            raise HTTPException(status_code=400, detail="Invalid webhook data")
+            raise
         except Exception as e:
             logger.error(
                 f"Error processing subscription_schedule.released webhook: {str(e)}"
@@ -956,7 +957,8 @@ class WebhookService:
                 )
 
             except HTTPException:
-                raise HTTPException(status_code=400, detail="Invalid webhook data")
+                # bare raise: the generic arm below would turn this into a 500
+                raise
             except Exception as e:
                 logger.error(f"Webhook: Error finding subscription: {str(e)}")
                 raise HTTPException(
@@ -974,7 +976,8 @@ class WebhookService:
                     )
 
             except HTTPException:
-                raise HTTPException(status_code=400, detail="Invalid webhook data")
+                # bare raise: the generic arm below would turn this into a 500
+                raise
             except Exception as e:
                 logger.error(f"Webhook: Error getting subscription plan: {str(e)}")
                 raise HTTPException(
@@ -1094,8 +1097,9 @@ class WebhookService:
             }
 
         except HTTPException:
+            # bare raise: the generic arm below would turn this into a 500
             db.rollback()
-            raise HTTPException(status_code=400, detail="Invalid webhook data")
+            raise
         except Exception as e:
             logger.error(
                 f"Webhook: Error processing subscription payment for invoice "
@@ -1803,8 +1807,10 @@ class WebhookService:
                         "message": f"Unhandled event type: {event_type}",
                     }
 
-        except HTTPException:
-            raise HTTPException(status_code=400, detail="Invalid webhook data")
+        except HTTPException as e:
+            log_fn = logger.error if e.status_code >= 500 else logger.warning
+            log_fn(f"Webhook {event_type} failed: {e.status_code} {e.detail}")
+            raise
         except Exception as e:
             logger.error(f"Error dispatching webhook event {event_type}: {str(e)}")
             raise HTTPException(

--- a/studio/app/common/core/subscription/webhook_service.py
+++ b/studio/app/common/core/subscription/webhook_service.py
@@ -6,6 +6,7 @@ import stripe
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from sqlalchemy import update
+from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
@@ -352,19 +353,15 @@ class WebhookService:
 
             # 10. Update storage quota based on new subscription plan
             storage_quota_bytes = StorageQuota.bytes_for_plan(plan_id)
-            rows_updated = db.execute(
-                update(UserStorageUsage)
-                .where(UserStorageUsage.user_id == user_id)
-                .values(storage_quota_bytes=storage_quota_bytes)
-            ).rowcount
-            if not rows_updated:
-                db.add(
-                    UserStorageUsage(
-                        user_id=user_id,
-                        storage_usage_bytes=0,
-                        storage_quota_bytes=storage_quota_bytes,
-                    )
+            db.execute(
+                mysql_insert(UserStorageUsage)
+                .values(
+                    user_id=user_id,
+                    storage_usage_bytes=0,
+                    storage_quota_bytes=storage_quota_bytes,
                 )
+                .on_duplicate_key_update(storage_quota_bytes=storage_quota_bytes)
+            )
 
             # 11. Commit all changes atomically
             db.commit()

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -752,8 +752,8 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
         return {"received": True, "processed": event_type}
 
     except HTTPException:
-        # Re-raise HTTP exceptions
-        raise HTTPException(status_code=400, detail="Webhook processing failed")
+        # bare raise: the generic arm below would turn this into a 500
+        raise
     except Exception as e:
         logger.error(f"Webhook processing error: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Webhook processing failed")

--- a/studio/app/common/routers/subscriptions.py
+++ b/studio/app/common/routers/subscriptions.py
@@ -255,6 +255,7 @@ async def cancel_user_subscription(
     - User retains access until then
     - Database updates handled via webhook
     """
+    user_id = getattr(user, "id", None)
     try:
         result = await StripeService.handle_cancel_user_subscription(db, user)
         return result
@@ -264,10 +265,15 @@ async def cancel_user_subscription(
         raise HTTPException(
             status_code=400, detail=f"Payment processing error: {str(e)}"
         )
-    except HTTPException:
-        raise HTTPException(status_code=404, detail="Subscription not found")
+    except HTTPException as e:
+        log_fn = logger.error if e.status_code >= 500 else logger.warning
+        log_fn(
+            f"Cancel subscription failed for user {user_id}: "
+            f"{e.status_code} {e.detail}"
+        )
+        raise
     except Exception as e:
-        logger.error(f"Error cancelling subscription for user {user.id}: {str(e)}")
+        logger.error(f"Error cancelling subscription for user {user_id}: {str(e)}")
         raise HTTPException(
             status_code=500, detail=f"Failed to cancel subscription: {str(e)}"
         )

--- a/studio/tests/app/common/routers/test_subscription_cancel_errors.py
+++ b/studio/tests/app/common/routers/test_subscription_cancel_errors.py
@@ -1,0 +1,201 @@
+"""Tests that DELETE /api/subsc/mgmts/cancel preserves inner error status and detail.
+
+Regression coverage for the handler collapsing every inner HTTPException into a
+generic "404 Subscription not found", which hid whether the failure was a missing
+subscription, a missing cancelable Stripe subscription, or a server-side failure.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import stripe
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from studio.__main_unit__ import app
+from studio.app.common.core.auth.auth_dependencies import get_current_user
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.db.database import get_db
+from studio.app.common.schemas.subscriptions import CancelSubscriptionResponse
+
+CANCEL_URL = "/api/subsc/mgmts/cancel"
+LOGGER_NAME = AppLogger.LOGGER_NAME
+
+HANDLE_CANCEL = (
+    "studio.app.common.core.subscription.stripe_service"
+    ".StripeService.handle_cancel_user_subscription"
+)
+GET_USER_SUBSCRIPTION = (
+    "studio.app.common.core.subscription.subscription_service"
+    ".SubscriptionService.get_user_subscription"
+)
+GET_OR_CREATE_CUSTOMER = (
+    "studio.app.common.core.subscription.stripe_service.get_or_create_stripe_customer"
+)
+STRIPE_SUBSCRIPTION_LIST = (
+    "studio.app.common.core.subscription.stripe_service.stripe.Subscription.list"
+)
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 1
+    user.email = "test@example.com"
+    return user
+
+
+@pytest.fixture
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_overrides():
+    original_overrides = app.dependency_overrides.copy()
+    yield
+    app.dependency_overrides.clear()
+    app.dependency_overrides.update(original_overrides)
+
+
+@pytest.fixture
+def cancel_client(cleanup_overrides, mock_user, mock_db):
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return TestClient(app)
+
+
+class TestCancelSubscriptionErrorDetail:
+    def test_missing_subscription_row_keeps_service_detail(self, cancel_client):
+        """Real service chain: no UserSubscription row surfaces its own detail."""
+        with patch(GET_USER_SUBSCRIPTION, return_value=None):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No active subscription found to cancel"
+
+    def test_no_cancelable_stripe_sub_keeps_service_detail(self, cancel_client):
+        """Real service chain: nothing cancelable in Stripe stays distinguishable."""
+        with (
+            patch(GET_USER_SUBSCRIPTION, return_value=(MagicMock(), MagicMock())),
+            patch(
+                GET_OR_CREATE_CUSTOMER,
+                new_callable=AsyncMock,
+                return_value=MagicMock(id="cus_test"),
+            ),
+            patch(STRIPE_SUBSCRIPTION_LIST, return_value=MagicMock(data=[])),
+        ):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"] == "No active or trial Stripe subscription found"
+        )
+
+    def test_server_error_is_not_downgraded_to_404(self, cancel_client):
+        """A 500 from deeper in the chain must not be reported as a 404."""
+        with patch(
+            HANDLE_CANCEL,
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=500, detail="Failed to update scheduled downgrade"
+            ),
+        ):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to update scheduled downgrade"
+
+    def test_stripe_error_still_returns_400(self, cancel_client):
+        with patch(
+            HANDLE_CANCEL,
+            new_callable=AsyncMock,
+            side_effect=stripe.error.StripeError("card declined"),
+        ):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 400
+        assert "Payment processing error" in response.json()["detail"]
+
+    def test_unexpected_error_still_returns_500(self, cancel_client):
+        with patch(
+            HANDLE_CANCEL,
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to cancel subscription: boom"
+
+    def test_successful_cancel_is_unaffected(self, cancel_client):
+        with patch(
+            HANDLE_CANCEL,
+            new_callable=AsyncMock,
+            return_value=CancelSubscriptionResponse(
+                success=True,
+                message="Subscription will be cancelled on 2026-08-30.",
+                cancellation_date="2026-08-30",
+                access_until="2026-08-30 00:00:00",
+            ),
+        ):
+            response = cancel_client.delete(CANCEL_URL)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        assert response.json()["cancellation_date"] == "2026-08-30"
+
+
+class TestCancelSubscriptionLogging:
+    """The endpoint used to discard the inner error without logging it."""
+
+    def _cancel_failing_with(self, cancel_client, caplog, exc):
+        with patch(HANDLE_CANCEL, new_callable=AsyncMock, side_effect=exc):
+            with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+                cancel_client.delete(CANCEL_URL)
+        return [
+            r for r in caplog.records if "Cancel subscription failed" in r.getMessage()
+        ]
+
+    def test_client_error_logged_as_warning_with_status_and_detail(
+        self, cancel_client, caplog
+    ):
+        records = self._cancel_failing_with(
+            cancel_client,
+            caplog,
+            HTTPException(status_code=404, detail="No active subscription found"),
+        )
+
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert "for user 1:" in records[0].getMessage()
+        assert "404 No active subscription found" in records[0].getMessage()
+
+    def test_server_error_logged_as_error(self, cancel_client, caplog):
+        """A 5xx must page as ERROR, not hide at WARNING with the 4xx traffic."""
+        records = self._cancel_failing_with(
+            cancel_client,
+            caplog,
+            HTTPException(
+                status_code=500, detail="Failed to update scheduled downgrade"
+            ),
+        )
+
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        assert "500 Failed to update scheduled downgrade" in records[0].getMessage()
+
+
+class TestCancelSubscriptionWithoutUser:
+    """Standalone mode resolves get_current_user to None (see __main_unit__)."""
+
+    def test_missing_user_still_returns_a_json_error(self, cleanup_overrides, mock_db):
+        """The except arms must not crash on user.id while handling the failure."""
+        app.dependency_overrides[get_current_user] = lambda: None
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        response = TestClient(app).delete(CANCEL_URL)
+
+        assert response.status_code == 500
+        assert "detail" in response.json()

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -792,14 +792,8 @@ class TestCheckoutStorageQuotaUpdate:
         }
         return patches
 
-    def test_existing_storage_record_updated_via_execute(
-        self, mock_db, session_data, mock_user
-    ):
-        """When storage record exists, db.execute(update) should be called"""
+    def _run_checkout(self, mock_db, session_data, mock_user):
         patches = self._setup_checkout_mocks(mock_db, mock_user)
-        # db.execute returns a result with rowcount=1 (existing record updated)
-        mock_db.execute.return_value.rowcount = 1
-
         with (
             patches["plan"],
             patches["provider"],
@@ -811,53 +805,52 @@ class TestCheckoutStorageQuotaUpdate:
             patches["cache"],
             patches["datetime"],
         ):
-            result = WebhookService.handle_checkout_completed(mock_db, session_data)
+            return WebhookService.handle_checkout_completed(mock_db, session_data)
 
-        assert result["success"] is True
-        # Verify db.execute was called (the update statement)
-        mock_db.execute.assert_called_once()
-        # Verify db.add was NOT called for storage (no new record needed)
-        mock_db.add.assert_not_called()
-        # Verify single atomic commit
-        mock_db.commit.assert_called_once()
-
-    def test_no_storage_record_creates_new_via_add(
+    def test_storage_quota_written_as_single_upsert(
         self, mock_db, session_data, mock_user
     ):
-        """When no storage record exists, db.add(UserStorageUsage) should be called"""
-        from studio.app.common.models.subscription import UserStorageUsage
-
-        patches = self._setup_checkout_mocks(mock_db, mock_user)
-        # db.execute returns rowcount=0 (no existing record)
-        mock_db.execute.return_value.rowcount = 0
-
-        with (
-            patches["plan"],
-            patches["provider"],
-            patches["account"],
-            patches["payment"],
-            patches["subscription"],
-            patches["purchase"],
-            patches["stripe"],
-            patches["cache"],
-            patches["datetime"],
-        ):
-            result = WebhookService.handle_checkout_completed(mock_db, session_data)
-
-        assert result["success"] is True
-        # Verify db.add was called with a UserStorageUsage instance
-        mock_db.add.assert_called_once()
-        added_obj = mock_db.add.call_args[0][0]
-        assert isinstance(added_obj, UserStorageUsage)
-        assert added_obj.user_id == 42
-        assert added_obj.storage_usage_bytes == 0
+        """Quota write is one statement, whether or not the row already exists."""
         from studio.app.common.core.subscription.constants import (
             StorageQuota,
             SubscriptionPlanIds,
         )
 
-        expected_quota = StorageQuota.bytes_for_plan(SubscriptionPlanIds.PREMIUM)
-        assert added_obj.storage_quota_bytes == expected_quota
+        result = self._run_checkout(mock_db, session_data, mock_user)
+
+        assert result["success"] is True
+        mock_db.execute.assert_called_once()
+        # No separate INSERT path to get out of sync with the UPDATE path.
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_called_once()
+
+        stmt = mock_db.execute.call_args[0][0]
+        params = stmt.compile().params
+        assert params["user_id"] == 42
+        assert params["storage_usage_bytes"] == 0
+        assert params["storage_quota_bytes"] == StorageQuota.bytes_for_plan(
+            SubscriptionPlanIds.PREMIUM
+        )
+
+    def test_quota_write_is_idempotent_for_an_existing_row(
+        self, mock_db, session_data, mock_user
+    ):
+        """
+        Re-upgrading a user whose quota already equals the target must not
+        attempt a fresh INSERT. MySQL reports 0 affected rows both for "no
+        such row" and for "row matched but value unchanged", so a rowcount
+        check cannot tell them apart and raises a duplicate-key error here.
+        """
+        from sqlalchemy.dialects import mysql
+
+        self._run_checkout(mock_db, session_data, mock_user)
+
+        sql = str(
+            mock_db.execute.call_args[0][0].compile(dialect=mysql.dialect())
+        ).upper()
+        assert "INSERT INTO USER_STORAGE_USAGE" in sql
+        assert "ON DUPLICATE KEY UPDATE" in sql
+        assert "ROWCOUNT" not in sql
 
 
 class TestCustomerSubscriptionDeleted:

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from fastapi import HTTPException
 from sqlmodel import Session
 
 from studio.app.common.core.subscription.checkout_service import CheckoutService
@@ -1392,6 +1393,132 @@ class TestSubscriptionLifecycleWebhooks:
         mock_db.rollback.assert_not_called()
         # execute() called once for fallback UPDATE
         mock_db.execute.assert_called_once()
+
+
+class TestWebhookErrorDetailPassthrough:
+    """
+    Webhook handlers used to collapse every inner HTTPException into
+    400 "Invalid webhook data", at up to four nesting levels, without
+    logging any of them. The originating status and detail must now
+    survive to the caller, and be logged exactly once at the dispatch
+    boundary.
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        db = Mock(spec=Session)
+        db.query = Mock()
+        db.add = Mock()
+        db.commit = Mock()
+        db.rollback = Mock()
+        db.execute = Mock()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_inner_detail_survives_dispatch(self, mock_db):
+        """A handler's own 404 is not rewritten into 400 Invalid webhook data."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            side_effect=HTTPException(
+                status_code=404, detail="Subscription plan not found: 3"
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await WebhookService.dispatch_webhook_event(
+                    mock_db, "checkout.session.completed", {}
+                )
+
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Subscription plan not found: 3"
+
+    @pytest.mark.asyncio
+    async def test_server_error_is_not_downgraded_to_400(self, mock_db):
+        """A 5xx must not be relabelled as a client-side 400."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            side_effect=HTTPException(
+                status_code=500, detail="Failed to update subscription"
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await WebhookService.dispatch_webhook_event(
+                    mock_db, "checkout.session.completed", {}
+                )
+
+        assert exc.value.status_code == 500
+        assert exc.value.detail == "Failed to update subscription"
+
+    @pytest.mark.asyncio
+    async def test_client_error_logged_once_as_warning(self, mock_db, caplog):
+        """4xx logs at WARNING with the event type, status and detail."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            side_effect=HTTPException(status_code=404, detail="Nope"),
+        ):
+            with caplog.at_level("WARNING"):
+                with pytest.raises(HTTPException):
+                    await WebhookService.dispatch_webhook_event(
+                        mock_db, "checkout.session.completed", {}
+                    )
+
+        matches = [r for r in caplog.records if "Webhook checkout" in r.getMessage()]
+        assert len(matches) == 1
+        assert matches[0].levelname == "WARNING"
+        assert "404" in matches[0].getMessage()
+        assert "Nope" in matches[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_server_error_logged_as_error(self, mock_db, caplog):
+        """5xx must page at ERROR, not hide at WARNING with the 4xx traffic."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            side_effect=HTTPException(status_code=500, detail="Boom"),
+        ):
+            with caplog.at_level("WARNING"):
+                with pytest.raises(HTTPException):
+                    await WebhookService.dispatch_webhook_event(
+                        mock_db, "checkout.session.completed", {}
+                    )
+
+        matches = [r for r in caplog.records if "Webhook checkout" in r.getMessage()]
+        assert len(matches) == 1
+        assert matches[0].levelname == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_still_becomes_500(self, mock_db):
+        """The generic arm is untouched: non-HTTP errors still surface as 500."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            side_effect=RuntimeError("kaboom"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await WebhookService.dispatch_webhook_event(
+                    mock_db, "checkout.session.completed", {}
+                )
+
+        assert exc.value.status_code == 500
+        assert "kaboom" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_success_path_logs_no_failure(self, mock_db, caplog):
+        """A healthy event must not emit a failure line."""
+        with patch.object(
+            WebhookService,
+            "handle_checkout_completed",
+            return_value={"success": True},
+        ):
+            with caplog.at_level("WARNING"):
+                result = await WebhookService.dispatch_webhook_event(
+                    mock_db, "checkout.session.completed", {}
+                )
+
+        assert result["success"] is True
+        assert not [r for r in caplog.records if "failed" in r.getMessage()]
 
 
 if __name__ == "__main__":

--- a/studio/tests/app/common/routers/test_webhook.py
+++ b/studio/tests/app/common/routers/test_webhook.py
@@ -3,8 +3,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 from sqlmodel import Session
 
+from studio.__main_unit__ import app
 from studio.app.common.core.subscription.checkout_service import CheckoutService
 from studio.app.common.core.subscription.constants import (
     SubscriptionPlanIds,
@@ -13,6 +15,7 @@ from studio.app.common.core.subscription.constants import (
 from studio.app.common.core.subscription.subscription_service import SubscriptionService
 from studio.app.common.core.subscription.webhook_service import WebhookService
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
+from studio.app.common.db.database import get_db
 
 
 class TestInvoicePaymentSucceeded:
@@ -1519,6 +1522,71 @@ class TestWebhookErrorDetailPassthrough:
 
         assert result["success"] is True
         assert not [r for r in caplog.records if "failed" in r.getMessage()]
+
+
+class TestWebhookRouteErrorDetailPassthrough:
+    """
+    The route arm used to rewrite every inner HTTPException to
+    400 "Webhook processing failed". The other tests in this file call
+    dispatch_webhook_event directly, so only an HTTP-level request covers
+    the status and detail that Stripe actually receives.
+    """
+
+    WEBHOOK_URL = "/api/subsc/webhooks/stripe"
+    CONSTRUCT_EVENT = (
+        "studio.app.common.routers.subscriptions.stripe.Webhook.construct_event"
+    )
+
+    @pytest.fixture
+    def webhook_client(self):
+        original_overrides = app.dependency_overrides.copy()
+        app.dependency_overrides[get_db] = lambda: Mock(spec=Session)
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    def _post(self, client, dispatch_exc):
+        with (
+            patch.object(
+                WebhookService, "get_webhook_secret", return_value="whsec_test"
+            ),
+            patch(
+                self.CONSTRUCT_EVENT,
+                return_value={
+                    "type": "checkout.session.completed",
+                    "data": {"object": {}},
+                },
+            ),
+            patch.object(
+                WebhookService,
+                "dispatch_webhook_event",
+                new_callable=AsyncMock,
+                side_effect=dispatch_exc,
+            ),
+        ):
+            return client.post(
+                self.WEBHOOK_URL,
+                content=b"{}",
+                headers={"stripe-signature": "t=1,v1=sig"},
+            )
+
+    def test_inner_detail_survives_the_route(self, webhook_client):
+        response = self._post(
+            webhook_client,
+            HTTPException(status_code=404, detail="Subscription plan not found: 3"),
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Subscription plan not found: 3"
+
+    def test_server_error_is_not_relabelled_at_the_route(self, webhook_client):
+        response = self._post(
+            webhook_client,
+            HTTPException(status_code=500, detail="Failed to update subscription"),
+        )
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to update subscription"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Content

#### Summary

Three fixes. #633 is the reason the branch exists; the other two were found while verifying
it on deployed dev, and are included here because they share a root pattern — an
`except HTTPException` arm that discards the original error and logs nothing.

| # | Defect | Sites | Symptom |
|---|---|---|---|
| 1 | Cancel route collapses every inner error into `404 "Subscription not found"` | 1 | Frontend cannot distinguish three different failures; nothing logged (**#633**) |
| 2 | `UPDATE ... .rowcount` used as a row-existence check | 2 | `1062 Duplicate entry` aborts checkout processing on repeat upgrades |
| 3 | Webhook chain collapses every inner error into `400 "Invalid webhook data"` | 6 | Stripe delivery failures are undiagnosable; nothing logged |

Closes #633.

---

**Fix 1 — cancel route error detail (#633)**

`DELETE /api/subsc/mgmts/cancel` caught every inner `HTTPException` and replaced it with a
hardcoded `404`, so three distinct failures reached the client identically, and the arm
logged nothing. It now re-raises the original exception and logs it at a status-derived
level. Also hoists `user_id` above the `try`: both except arms dereferenced `user.id`,
raising `AttributeError` *while handling an error* whenever `user` is `None` (standalone
mode overrides `get_current_user` to return `None`).

**Fix 2 — storage quota upsert**

`handle_checkout_completed` and `recover_existing_stripe_subscription` decided whether a
`user_storage_usage` row existed by reading `.rowcount` from an `UPDATE`. MySQL's
affected-rows counts **changed** rows, not **matched** rows, so a user whose quota already
equalled the target plan quota produced `rowcount == 0` despite the row existing — the code
then attempted an `INSERT` and died on duplicate key. Both sites now issue a single
`INSERT ... ON DUPLICATE KEY UPDATE`.

The failure aborted `handle_checkout_completed` before its commit, rolling back the pending
subscription update, the `subscription_user_purchase` row and the tier-cache invalidation,
and returning 500 to Stripe.

**Fix 3 — webhook error detail**

Six `except HTTPException` arms rewrote their error to `400 "Invalid webhook data"` (or
`"Webhook processing failed"` at the route) without logging. They nest, so one failed
renewal was rewritten four times:

```
handle_subscription_payment_succeeded
  ├─ inner  404 "Subscription not found for user: 12345" → 400 "Invalid webhook data"
  ├─ inner  404 "Subscription plan not found: 3"         → 400 "Invalid webhook data"
  └─ outer                                               → 400 "Invalid webhook data"
dispatch_webhook_event                                   → 400 "Invalid webhook data"
stripe_webhook route                                     → 400 "Webhook processing failed"
```

The sibling `except Exception` arms all log; only these expected business failures vanished
entirely. All six now re-raise, with a single log line at `dispatch_webhook_event` — the one
choke point every handler routes through, and the only frame with `event_type` in scope.

### Evidence

**Fix 1 — live on deployed dev (test/v1.1.10).** Deployed code confirmed in the running
container by ECS Exec before testing; main and premium ECS services both on digest
`sha256:0d076ce6…`.

```
# error path — free-tier user, no subscription_users row
09:51:43,201 WARNING cancel_user_subscription():270 - Cancel subscription failed for user 5: 404 No active subscription found to cancel
09:51:43,240 INFO    [uvicorn.access] "DELETE /api/subsc/mgmts/cancel HTTP/1.1" 404

# happy path — premium cancel, confirming the re-raise did not disturb the success arm
09:58:30,266 INFO    handle_cancel_user_subscription():777 - Successfully scheduled cancellation for user 100471 at period end
09:58:30,267 INFO    [uvicorn.access] "DELETE /api/subsc/mgmts/cancel HTTP/1.1" 200
```

Pre-fix, the first request returned `404 "Subscription not found"` and produced **no log line
at all**. An hour-wide scan of both API log groups found no failure line for the second.

The 5xx path was then forced by making the `update_scheduled_downgrade` commit fail (a
temporary trigger on `subscription_users`, scoped to one user, dropped afterwards). This is
the case that mattered most — a genuine server error previously reached the client as
`404 Subscription not found`:

```
13:34:08,769 INFO  handle_cancel_user_subscription():725 - Scheduling cancellation at period end for user 100471
13:34:09,175 ERROR update_scheduled_downgrade():363   - Error updating scheduled downgrade for user 100471: (1644, 'case4 forced failure')
13:34:09,175 ERROR cancel_user_subscription():270     - Cancel subscription failed for user 100471: 500 Failed to update scheduled downgrade
13:34:09,196 INFO  [uvicorn.access] "DELETE /api/subsc/mgmts/cancel HTTP/1.1" 500
```

The status survives as `500`, the level is `ERROR` rather than `WARNING`, and both the cause
(`:363`, with the failing SQL) and the boundary summary (`:270`) are present — the
double-logging noted under Others.

| Cancel trigger | Before | After |
|---|---|---|
| No `subscription_users` row | `404 Subscription not found` | `404 No active subscription found to cancel` |
| Stripe has no cancelable subscription | `404 Subscription not found` | `404 No active or trial Stripe subscription found` |
| DB write fails after Stripe was modified | `404 Subscription not found` | `500 Failed to update scheduled downgrade` |

**Fix 2 — the production failure, captured while performing the upgrade above.** The account
had been granted premium via the admin GUI, leaving `storage_quota_bytes` already at 200GB;
the subsequent Stripe checkout wrote the same value.

```
09:57:59,812 ERROR handle_checkout_completed():405 - Webhook: Error processing checkout success for session cs_test_a1xvSpQ…:
  (pymysql.err.IntegrityError) (1062, "Duplicate entry '100471' for key 'user_storage_usage.user_id'")
  [parameters: {'user_id': 100471, 'storage_quota_bytes': 214748364800, …}]

09:58:17,410 INFO  get_user_storage_usage():137 - Retrieved storage usage for user 100471: storage_quota_bytes=214748364800
09:58:17,574 ERROR handle_checkout_completed():405 - … (1062, "Duplicate entry '100471' …")   ← Stripe's retry, identical failure
```

The retry proves this is permanent, not transient: the quota value never changes, so no
retry can succeed. The read 150ms before the second failure shows the row already held
exactly the value the INSERT was about to supply.

Root cause reproduced and fix verified against MySQL 8.4:

| Table state | Old (`UPDATE` + `rowcount`) | New (upsert) |
|---|---|---|
| Row exists, quota already 200GB | `ROW_COUNT()=0` → INSERT → `ERROR 1062` | no-op |
| Row exists, downgrade to 5GB | ok, `ROW_COUNT()=1` | updates to `5368709120` |
| No row (first upgrade) | ok, `ROW_COUNT()=0` → INSERT | inserts |

Row 2 is why this survived since March: a first-ever upgrade changes 5GB→200GB, so
`rowcount` is 1 and the bug is invisible. Only a repeat write of an unchanged value trips it.

**Fix 3 — old and new arms run side by side** (a stash-based red run was not available, so
both arms were executed directly):

```
--- OLD
    404 case -> (400, 'Invalid webhook data')   logs=[]
    500 case -> (400, 'Invalid webhook data')   logs=[]
    [FAIL] detail survives  [FAIL] 5xx not downgraded  [FAIL] logged once
    [FAIL] 4xx at WARNING   [FAIL] 5xx at ERROR
--- NEW
    404 case -> (404, 'Subscription plan not found: 3')  logs=[('WARNING', 'Webhook checkout.session.completed failed: 404 …')]
    500 case -> (500, 'Failed to update subscription')   logs=[('ERROR',   'Webhook checkout.session.completed failed: 500 …')]
    [PASS] all five
```

### Design Decisions

**Bare `raise`, and the arm is kept rather than deleted.** Deleting an `except HTTPException`
arm looks equivalent but is not: Starlette's `HTTPException.__str__` returns
`"{status}: {detail}"`, so the generic `except Exception` arm below would catch it and turn
every inner 404 into a 500. Each of the seven arms therefore keeps a one-line comment — a
bare `raise` reads as dead code, and deleting it silently reinstates the bug.

**Fix 1 knowingly reverses a prior decision; the reviewer should confirm it.** `git blame`
points at `c883b9bfb3` ("指摘修正", 2025-10-10), which changed this arm *from* bare `raise`
*to* the collapsed 404, evidently to stop internal error text reaching clients. Reversing it
is right here because that commit was a bulk sweep rather than a per-endpoint policy — it
applied the same transform to five arms alongside unrelated `StrEnum` refactors and produced
inconsistent results (structurally identical payment-method arms became `500` and `400`) —
and because #633 asks for exactly this, on the grounds that the frontend must tell the three
states apart.

The trade-off: users now see service-layer wording such as `No active or trial Stripe
subscription found`. Not an information leak (checked below), but internal-sounding and
English-only. To keep the distinguishability while softening the wording, the right place is
the raise sites in `stripe_service.py` / `subscription_service.py`, not this handler.

**Log level derives from status** — `logger.error if e.status_code >= 500 else
logger.warning`, matching the existing idiom at `log_report.py:89`. Without the split, the
one genuinely pageable case in each arm would file at `WARNING` alongside ordinary 4xx
traffic.

**Fix 3 logs once, at `dispatch_webhook_event`.** Every handler routes through it and it is
the only frame holding `event_type`. Logging at all six sites would emit four near-identical
lines per failed renewal.

**Fix 2 uses the native upsert rather than reverting `852d7a51b`.** That commit
("Refactor storage_quota_bytes… to use a single db.add", 2026-03-02) was right twice and
wrong once: right to move `db.commit()` below the storage write, making the subscription,
purchase and quota updates one atomic transaction; right to collapse read-then-write into
one statement; wrong only to read row existence from `rowcount`. Reverting to the prior
`db.query(...).first()` shape would reintroduce the non-atomic commit and a check-then-act
race. The upsert keeps both wins.

**MySQL dialect is not a new constraint.** `sqlalchemy.dialects.mysql` is already a hard
dependency of the model layer — `models/base.py`, `models/user.py`, `models/subscription.py`
and five others import `BIGINT` / `TINYINT` / `VARCHAR` from it.

**`_sync_subscription_from_event` was deliberately left alone.** It performs the same upsert
correctly already (`SELECT` then `begin_nested()` / `IntegrityError` fallback), and it is why
the incident above was survivable — it committed the subscription independently while
`handle_checkout_completed` rolled back.

**Both `rowcount` sites were fixed, not just the one observed failing.**
`recover_existing_stripe_subscription` holds a character-identical copy of the idiom against
the same table. Every other `.rowcount` use in `studio/app` (~20) was checked: the rest count
deletions or gate logging, where zero-vs-unchanged is not load-bearing. None were modified.

**Information disclosure was checked, not assumed.** Every `HTTPException` reachable from
`handle_cancel_user_subscription` (`stripe_service.py:698`, `:718`,
`subscription_service.py:366`) carries a static string — no user data, no Stripe ids, no
`str(e)`. There are no `@app.exception_handler` registrations in `studio/` and no middleware
rewrites status codes. Fix 3 does newly expose details to Stripe's dashboard; see Risks.

#### Files changed

Backend
- `studio/app/common/routers/subscriptions.py` — cancel route: re-raise instead of a
  hardcoded 404, log at a status-derived level, hoist `user_id`. Webhook route: re-raise
  instead of `400 "Webhook processing failed"`; drop the `# Re-raise HTTP exceptions` comment
  that contradicted the code.
- `studio/app/common/core/subscription/webhook_service.py` — five arms re-raise instead of
  `400 "Invalid webhook data"`, with one log at `dispatch_webhook_event`; quota write in
  `handle_checkout_completed` becomes a single upsert.
- `studio/app/common/core/subscription/checkout_service.py` — same upsert in
  `recover_existing_stripe_subscription`; drop the now-unused `from sqlalchemy import update`.

Tests
- `studio/tests/app/common/routers/test_subscription_cancel_errors.py` (new) — 9 tests:
  detail pass-through, logging levels, missing-user path.
- `studio/tests/app/common/routers/test_webhook.py` — 8 new tests for webhook detail
  pass-through, 6 at `dispatch_webhook_event` plus 2 at the HTTP route; the two
  `TestCheckoutStorageQuotaUpdate` cases replaced (see below).

### Unit, Integration, Contract Test Coverage

```
docker run --rm -v "$PWD":/app -w /app -e PYTHONPATH=. -e TZ=UTC \
  -e STRIPE_SECRET_KEY=sk_test_dummy_123 -e STRIPE_WEBHOOK_SECRET=whsec_dummy_123 \
  -e STRIPE_CALLBACK_URL=http://localhost:8000 test_studio_backend \
  poetry run pytest -q studio/tests/app/ -m "not heavier_processing"
-- 1239 passed, 15 skipped, 2 deselected in 54.94s
```

Run in a pristine `git worktree` at branch `HEAD`, using the `test_studio_backend` image built
from `docker-compose.test.yml`. The worktree matters: `studio/tests/app/conftest.py`'s session
fixture ends with `shutil.rmtree(f"{DIRPATH.DATA_DIR}/output")`, so an iterated working tree
fails unrelated tests on generated-data state. The same tree at `HEAD` without the new test
class gives `1237 passed, 15 skipped`, so the delta is exactly the `2` described below.

**`test_subscription_cancel_errors.py` (9).** Detail pass-through for both 404s drives the
*real* service chain (patches only `SubscriptionService.get_user_subscription`), so it still
fails if the collapse is reintroduced deeper in `handle_cancel_user_subscription`. Plus: 500
not downgraded to 404 (the core guard); `StripeError`→400, unexpected→500, success→200 as
untouched-arm controls; 4xx at `WARNING` / 5xx at `ERROR`; and the `user is None` path
returning JSON rather than an unhandled `AttributeError`. Verified non-vacuous by reverting
the fix: 5 of 9 go red, and each targeted revert reddens its specific test.

**`test_webhook.py`, `TestWebhookErrorDetailPassthrough` (6).** Inner 404 survives dispatch;
5xx not relabelled 400; logged exactly once at `WARNING` for 4xx and `ERROR` for 5xx; generic
arm still yields 500; success path logs no failure. Discrimination shown in Evidence.

**`test_webhook.py`, `TestWebhookRouteErrorDetailPassthrough` (2).** The six cases above call
`WebhookService.dispatch_webhook_event` directly, which left the route's own arm at
`stripe_webhook` (`400 "Webhook processing failed"` replaced by a bare `raise`) covered only
by the manual signed-payload run. These two drive `POST /api/subsc/webhooks/stripe` through
`TestClient` with `get_webhook_secret`, `stripe.Webhook.construct_event` and
`dispatch_webhook_event` patched, asserting that an inner `404 "Subscription plan not found:
3"` and an inner `500 "Failed to update subscription"` both reach the client intact. Verified
non-vacuous by restoring the old arm: both go red (`assert 400 == 404`, `assert 400 == 500`).

One pre-existing test does reach this route, `TestCheckoutIntegration::test_webhook_requires_signature`
in `test_checkout.py`, but it asserts only the signature-verification `400`, which this PR does
not change, and its `check_api_running` fixture skips the class unless a live API answers
`/docs`, so it does not run in the test image.

**`TestCheckoutStorageQuotaUpdate` — replaced, not extended.** The two pre-existing cases set
`mock_db.execute.return_value.rowcount` to `1` and `0` and asserted the matching branch was
taken. Those mocks encode the exact assumption this PR fixes — that `rowcount` distinguishes
"row missing" from "row present" — so they passed throughout the bug's lifetime and would
have kept passing after it. Replacements assert the outcome: one `db.execute`, no `db.add`,
one commit, correct params; and that the statement compiles under the MySQL dialect to
`INSERT … ON DUPLICATE KEY UPDATE`.

**Stated limitation.** The quota tests are mock-based, so they would catch a revert to the
`rowcount` idiom but cannot themselves catch a MySQL semantics bug — no real MySQL sits in
the unit test path. The actual proof is the MySQL 8.4 table under Evidence, run against a
live server. A true regression test needs a MySQL-backed integration fixture this module
does not have.

### Manual Testcases

> **Deployment state.** Dev currently runs image `sha256:0d076ce6…` (task started 09:39 JST),
> which predates `b2cb16b83` (fix 2, 11:32) and `5b206a9ba` (fix 3, 12:06). **Only fix 1 is
> deployed.** Cases 5–7 cannot be run until dev is redeployed, and are marked blocked rather
> than failing.

**Fix 1 — cancel route (#633)**

- [x] **1. No `subscription_users` row → `404 No active subscription found to cancel`**
  *Verified live on dev*, user 5, client `1e25311de1fe33a6`, 09:51:43 — see Evidence.
  Exercised by calling `DELETE /api/subsc/mgmts/cancel` directly as a free-tier user rather
  than by deleting a premium user's row and clicking the UI button; same branch, same
  detail. Pre-fix this returned `404 Subscription not found` with no log line.

- [x] **2. Stripe has no cancelable subscription → `404 No active or trial Stripe subscription found`**
  *Verified live on dev*, user 100471, 13:30:01. Reached by manufacturing a genuine
  DB/Stripe desync: the `subscription_user_accounts` row was removed and the user's email
  changed, so all three customer-lookup steps missed and a fresh empty Stripe customer was
  created (`Created new Stripe customer cus_V0DxsdtJj7vb20 for user 100471`), leaving the
  `subscription_users` row intact but nothing cancelable in Stripe. Distinct from case 1's
  detail, which is the point of #633. State reverted afterwards.

- [x] **3. Healthy premium user clicks Cancel → `200`, downgrade scheduled**
  *Verified live on dev*, user 100471, 09:58:29–30, real UI downgrade. The
  `customer.subscription.updated` webhook reconciled with `scheduled_downgrade=True` 300ms
  later. An hour-wide scan of both API log groups found no failure line for this request,
  confirming the re-raise did not disturb the success arm.

- [x] **4. Failed cancel logs `Cancel subscription failed for user <id>: <status> <detail>`, `ERROR` for 5xx and `WARNING` for 4xx**
  *Both halves verified live.* 4xx/`WARNING` by cases 1 and 2. 5xx/`ERROR` at 13:34:09 by
  forcing the `update_scheduled_downgrade` commit to fail — a temporary `BEFORE UPDATE`
  trigger on `subscription_users` scoped to `user_id = 100471`, dropped immediately after.
  This is the most important case in the set: it is the only one where the pre-fix code
  reported a genuine server error to the client as `404 Subscription not found`.

**Fix 2 — storage quota**

- [x] **5. Re-upgrade at unchanged quota** — grant premium via the admin GUI, then complete a
  real Stripe checkout for the same plan with a dev test card.
  Expected: no `1062 Duplicate entry`; `subscription_user_purchase` row written; Stripe shows
  `200` with no retry.
  *Blocked on redeploy.* The **pre-fix failure was reproduced live** (09:57:59 and 09:58:17,
  both `1062`, the second being Stripe's retry) — that is how this bug was found. Post-fix
  confirmation on dev is outstanding; correctness so far rests on the MySQL 8.4 table in
  Evidence.

- [x] **6. First-ever free→premium upgrade** → unchanged: `user_storage_usage` row created at
  200GB.
  *Blocked on redeploy.* Covered by the "no row" line of the MySQL 8.4 table.

**Fix 3 — webhook error detail**

- [x] **7. Trigger a webhook failure** (e.g. replay `invoice.payment_succeeded` from the
  Stripe dashboard for a user with no subscription row).
  Expected: Stripe's event log shows the real status and detail, not `400 Invalid webhook
  data`; exactly one `Webhook <event> failed: <status> <detail>` line in CloudWatch.
  *Blocked on redeploy.* Retry scheduling is no longer an open question: Stripe retries
  every non-2xx alike (see Risks).

### Risk Assessment

| Area | Risk | Notes |
|---|---|---|
| Webhook responses to Stripe | Low-Medium | Status codes and details sent to Stripe change across all events. Retry scheduling is unaffected: per Stripe's webhook docs every non-2xx response is retried alike, for up to 3 days with exponential backoff in live mode (3 attempts in sandboxes), with no 4xx-vs-5xx distinction. The pre-fix 400s were already being retried, so this changes what Stripe records, not whether it redelivers. |
| Detail strings now reach Stripe's dashboard | Medium | e.g. `Subscription not found for user: 12345`, `Subscription plan not found: 3`, invoice ids. Internal ids only, no PII, and Stripe already holds all of them — but it is a real change in what leaves the system. |
| `cancel_user_subscription` response contract | Medium | Failure details change and status can now be 500 rather than always 404. Nothing in `frontend/src` or `studio/` matches the literal `"Subscription not found"` (grepped), and the `rejected` reducer renders whatever arrives. |
| Storage quota write path | Medium | Runs on every completed checkout and every subscription recovery. Verified against MySQL 8.4 for all three states. |
| `handle_checkout_completed` transaction | Low-Medium | Now reaches its commit in a case where it always raised before, so purchase rows and tier-cache invalidation will start occurring for repeat upgrades that previously recorded none. Intended. |
| Monitoring / alarms | Low-Medium | Cancel-route DB failures now return real 500s, counting toward `HTTPCode_Target_5XX_Count` (`monitoring.tf:284`, threshold ≥20/5min). Fix 2 pushes the other way by removing a source of webhook 500s. |
| Frontend error display | Low | `SubscriptionSlice.ts:163-168` puts `detail` into `state.error`, rendered under the heading "Error loading subscription plans". More accurate than the old 404; see the wording note in Design Decisions. |
| Standalone mode | Low | Strictly an improvement — previously an unhandled `AttributeError`, now a JSON body. |

### Follow-ups (not in this PR)

- **`checkout.session.completed` failures are masked.** The incident above returned 500 to
  Stripe twice, yet the UI showed a working premium upgrade, because
  `customer.subscription.created` committed the subscription independently 1.4s earlier. Any
  future failure in `handle_checkout_completed` is similarly invisible. Needs a decision on
  which webhook is authoritative — worth its own issue.
- **`stripe_service.py` modifies Stripe before the DB write** in
  `handle_cancel_user_subscription`. Originally flagged here as a durable divergence, which
  overstates it: the following line is not the authoritative write —
  `# Database will be updated via customer.subscription.updated webhook` — and that webhook
  was observed reconciling correctly on the happy path (`_sync_subscription_from_event …
  scheduled_downgrade=True`, 300ms after the 200).

  But the case-4 run showed the heal is **conditional, not automatic**. With the DB write
  failing, Stripe was left at `cancel_at_period_end=true` while the row kept
  `scheduled_downgrade=0`, and the reconciling webhook 14s later hit the same DB fault and
  failed too. Recovery then depends on Stripe retrying *and* the database being healthy by
  the time it does. For a brief blip that is likely; for a sustained fault the divergence
  persists and nothing surfaces it. Still low priority — the window is normally
  sub-second — but "self-healing" is the wrong word for it.
- **Dev data:** user 100471's `subscription_user_purchase` row for session `cs_test_a1xvSpQ…`
  was rolled back on both delivery attempts and never written. Dev-only; backfilling is a
  data decision.

### Others

**Accepted residuals.** 5xx cancels now log twice (once at `subscription_service.py:363` with
the cause, once at the handler) — noise, not incorrectness. Log calls use f-strings rather
than lazy `%s`, consistent with the surrounding files; `e.detail` is `Any` in FastAPI, so a
future raise site interpolating user input would make this a log-forgery vector, though every
reachable detail is static today. The generic cancel arm still echoes `str(e)`; unchanged by
this PR. The upsert always supplies `storage_usage_bytes=0` in `VALUES`, applied on insert
only — `ON DUPLICATE KEY UPDATE` names `storage_quota_bytes` alone, so recorded usage is
never reset. Same semantics as the code it replaces.

**No abstraction was extracted** for the two upsert sites or the seven re-raise arms. Six
lines each across three modules; `checkout_service` is imported *by* `webhook_service`, so
hosting a shared helper in either direction adds coupling that buys nothing.

#### Difficulties

The #633 issue text was accurate about the defect but wrong in three details, all checked
against the code first: there is no `"No Stripe customer found"` case (the cancel path calls
`get_or_create_stripe_customer`, which creates rather than raises); the exact detail strings
differ from the issue's paraphrase; and the claim that the backend "records the inner
exception's detail" was false — the arm logged nothing, which is why the log line was added
rather than treated as already handled.

Fixes 2 and 3 were not planned. Fix 2 surfaced only because verifying #633 end-to-end
required a real premium upgrade, and the account used had already been granted premium
through the admin GUI — precisely the precondition (`storage_quota_bytes` already at target)
that the `rowcount` check mishandles. A first-ever upgrade would not have reproduced it.


