### PR TITLE
Sync assignment/usage models with migrations (#723 — PR1 of series) (follow-up)

### DIFF
--- a/studio/app/common/models/experiment.py
+++ b/studio/app/common/models/experiment.py
@@ -173,7 +173,7 @@ class BackgroundTask(Base, TimestampMixin, table=True):
             index=True,
             comment="User who initiated the task",
         ),
-        description="User who initiated the deletion",
+        description="User who initiated the task",
     )
     task_type: str = Field(
         sa_column=Column(
@@ -202,7 +202,7 @@ class BackgroundTask(Base, TimestampMixin, table=True):
             comment="Workspace ID for experiment tasks",
         ),
         default=None,
-        description="Workspace ID for experiment deletions",
+        description="Workspace ID for experiment tasks",
     )
     status: str = Field(
         sa_column=Column(
@@ -246,7 +246,7 @@ class BackgroundTask(Base, TimestampMixin, table=True):
             comment="Error message if task failed",
         ),
         default=None,
-        description="Error message if deletion failed",
+        description="Error message if task failed",
     )
     started_at: Optional[datetime] = Field(
         sa_column=Column(

--- a/studio/app/common/models/premium_user.py
+++ b/studio/app/common/models/premium_user.py
@@ -31,13 +31,14 @@ class PremiumUserAssignment(SQLModel, table=True):
         ),
         default=None,
     )
-    user_id: int = Field(
+    user_id: Optional[int] = Field(
         sa_column=Column(
             BIGINT(unsigned=True),
-            ForeignKey("users.id"),
+            ForeignKey("users.id", name="fk_premium_user"),
             unique=True,
-            nullable=False,
-        )
+            nullable=True,
+        ),
+        default=None,
     )
     instance_id: str = Field(sa_column=Column(VARCHAR(20), nullable=False))
     target_group_arn: str = Field(sa_column=Column(VARCHAR(512), nullable=False))


### PR DESCRIPTION
## Content

This PR contains the same content as #761 and serves as a follow-up.
Since the previous PR was merged by mistake, the remaining tasks are being addressed here.