### PR TITLE
Sync misc models with migrations (#723 — PR3 of series) (follow-up)

### DIFF
--- a/studio/app/common/models/subscription.py
+++ b/studio/app/common/models/subscription.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -678,13 +679,13 @@ class Taxes(SQLModel, table=True):
     )
     tax_type: str = Field(sa_column=Column(String(50), nullable=False))
     tax_name: str = Field(sa_column=Column(String(100), nullable=False))
-    tax_rate: float = Field(
+    tax_rate: Decimal = Field(
         sa_column=Column(DECIMAL(precision=5, scale=4), nullable=False)
     )
     is_active: bool = Field(
         sa_column=Column(Boolean, nullable=False, server_default="1"), default=True
     )
-    effective_date: datetime = Field(sa_column=Column(Date, nullable=False))
+    effective_date: date = Field(sa_column=Column(Date, nullable=False))
     created_at: Optional[datetime] = Field(
         sa_column=Column(
             TIMESTAMP, nullable=False, server_default=func.current_timestamp()

--- a/studio/app/common/models/user_preferences.py
+++ b/studio/app/common/models/user_preferences.py
@@ -14,9 +14,6 @@ from studio.app.common.core.subscription.constants import DeletionPriority  # no
 
 class UserPreferences(SQLModel, table=True):
     __tablename__ = "user_preferences"
-    # Migration created two objects on user_id: an unnamed UniqueConstraint
-    # (reflected as index "user_id") plus a separate non-unique index
-    # "ix_user_preferences_user_id". Declare both to match the DB exactly.
     __table_args__ = (
         UniqueConstraint("user_id"),
         Index("ix_user_preferences_user_id", "user_id"),

--- a/studio/app/common/models/workspace.py
+++ b/studio/app/common/models/workspace.py
@@ -39,10 +39,9 @@ class Workspace(Base, TimestampMixin, table=True):
         ),
     )
     deleted: bool = Field(nullable=False)
-    # Reserved column added ahead of PR #393 (arayabrain/araya-optinist#393).
-    # Not yet used by any code; added early so alembic autogenerate stays
-    # conflict-free until #393 merges. No SQL comment — the migration that
-    # created the column set none, and adding one here would create drift.
+    # NOTE: Reserved column for the pending PR #393. Not yet used by any code;
+    # kept in sync with the migration so alembic autogenerate stays
+    # conflict-free until #393 merges.
     type: int = Field(
         sa_column=Column(Integer, nullable=False, server_default="0"),
         default=0,


### PR DESCRIPTION
## Content

This PR contains the same content as #763 and serves as a follow-up.
Since the previous PR was merged by mistake, the remaining tasks are being addressed here.