### PR TITLE
Fix/free cleanup instance id mismatch

### DIFF
--- a/infrastructure/documentation/BACKGROUND_JOB_ARCHITECTURE.md
+++ b/infrastructure/documentation/BACKGROUND_JOB_ARCHITECTURE.md
@@ -213,6 +213,13 @@ Safety checks before deletion:
 | `PersistentSyncFailure` | `PublishedExperimentSyncJob` | Count |
 | `DataCleanupCount` | `DataCleanupJob` | Count |
 | `CleanupErrors` | `DataCleanupJob` | Count |
+| `CleanupKept` | `DataCleanupJob` | Count |
+
+> `CleanupErrors` = actionable failures (unexpected exception, or data retained
+> because its S3 backup could not be verified). `CleanupKept` = benign
+> keep-the-record outcomes (no local data on this instance, or the user returned)
+> — deliberately **not** counted as errors. No CloudWatch alarm is wired to this
+> namespace yet; these metrics are the intended signals for such alarms.
 
 ### Logs
 

--- a/infrastructure/documentation/EBS_STORAGE_ARCHITECTURE.md
+++ b/infrastructure/documentation/EBS_STORAGE_ARCHITECTURE.md
@@ -285,7 +285,11 @@ All metrics published to CloudWatch namespace `OptiNiSt/BackgroundJobs`.
 | Metric Name | Description | Unit | Trigger |
 |-------------|-------------|------|---------|
 | `DataCleanupCount` | Users whose data was successfully cleaned | Count | Each cleanup run |
-| `CleanupErrors` | Users whose cleanup failed | Count | Each cleanup run |
+| `CleanupErrors` | Users whose cleanup could not complete safely — unexpected exception, or data retained because its S3 backup could not be verified | Count | Each cleanup run |
+| `CleanupKept` | Users deliberately kept (no local data on this instance, or user returned) — not an error | Count | Each cleanup run |
+
+> No CloudWatch alarm currently references the `OptiNiSt/BackgroundJobs` namespace;
+> these metrics are the intended signals for future alarms.
 
 ---
 
@@ -338,7 +342,7 @@ All metrics published to CloudWatch namespace `OptiNiSt/BackgroundJobs`.
 | `_check_user_relogin()` | Detects re-login to abort cleanup for that user |
 | `_verify_no_active_workflows()` | Double-checks no workflows started during cleanup |
 | `_handle_orphaned_data()` | Cleans DB assignments for terminated instances |
-| `_publish_metrics()` | Publishes `DataCleanupCount`, `CleanupErrors` to CloudWatch |
+| `_publish_metrics()` | Publishes `DataCleanupCount`, `CleanupErrors`, `CleanupKept` to CloudWatch |
 
 ### Workflow Tracking (`studio/app/common/core/workflow/workflow_tracking.py`)
 

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -560,29 +560,25 @@ class DataCleanupJob:
                 f"{total_experiments_kept} experiments kept (S3 backup not verified)"
             )
 
+        # Check errors first so a genuine failure is never classified as KEPT.
+        if had_error:
+            return CleanupOutcome.ERROR
+
         if not data_found:
-            # No local data on this instance → keep the DB record; do NOT
-            # treat "no local data" as a completed cleanup.
-            #
-            # instance_id is refreshed to the serving instance on each request
-            # (see user_activity_middleware), so "this instance == instance_id"
-            # does not guarantee this instance is where the data was written: a
-            # stray cross-instance request can point instance_id here. Deleting
-            # the record on that basis would orphan the real data on the
-            # instance that actually holds it. Retaining the record instead
-            # leaves at most reclaimable local disk on the true owner. That disk
-            # is cleaned only if the user is active again on the owning instance
-            # *before logout* (activity stops rewriting instance_id after
-            # logout); otherwise it is reclaimed when the instance is recycled.
-            # Data is also backed up to S3, so nothing is lost.
+            # No local data here → keep the DB record; do NOT treat it as
+            # cleaned. instance_id is activity-driven, so "this instance ==
+            # instance_id" doesn't prove the data was written here (a stray
+            # cross-instance request can point it here); closing the record
+            # then would orphan the real data on the owning instance. Worst
+            # case of keeping is reclaimable local disk on the owner —
+            # reclaimed on instance recycle, or earlier if the user is active
+            # there again before logout; data is in S3, so nothing is lost.
             logger.info(
                 f"No local data for user {user_id} on this instance; "
                 f"keeping DB record (data may live on the owning instance)."
             )
             return CleanupOutcome.KEPT
 
-        if had_error:
-            return CleanupOutcome.ERROR
         return CleanupOutcome.CLEANED if fully_cleaned else CleanupOutcome.KEPT
 
     @classmethod

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -50,9 +50,10 @@ class CleanupOutcome(Enum):
 
     - ``CLEANED``: local data was removed; the assignment may be closed.
     - ``KEPT``: nothing was closed on purpose — no local data on this instance,
-      data intentionally retained pending S3 verification, or the user logged
-      back in. This is a routine, expected outcome, NOT an error.
-    - ``ERROR``: an unexpected failure occurred while cleaning.
+      or the user logged back in. A routine, expected outcome, NOT an error.
+    - ``ERROR``: cleanup could not complete safely — an unexpected exception, or
+      data retained because its S3 backup could not be verified (an actionable
+      condition worth alerting on; the local disk is not being reclaimed).
     """
 
     CLEANED = "cleaned"
@@ -132,11 +133,14 @@ class DataCleanupJob:
                         # Re-check workflow count and re-login before marking cleaned
                         # Prevents race condition where workflow/login during cleanup
                         if cls._check_user_relogin(user_id):
-                            logger.warning(
+                            # User returned during cleanup — a routine event, not
+                            # an error (same bucket as the relogin abort inside
+                            # _cleanup_user_data).
+                            logger.info(
                                 f"Skipping cleanup completion for user {user_id}: "
                                 f"user logged back in during cleanup"
                             )
-                            error_count += 1
+                            kept_count += 1
                         elif cls._verify_no_active_workflows(user_id):
                             cls._mark_cleaned(user_id)
                             cleaned_count += 1
@@ -147,9 +151,8 @@ class DataCleanupJob:
                             )
                             error_count += 1
                     elif outcome == CleanupOutcome.KEPT:
-                        # Nothing closed on purpose (no local data here, data
-                        # retained pending S3 verification, or user returned).
-                        # Expected, not an error.
+                        # Nothing closed on purpose (no local data here, or the
+                        # user returned). Expected, not an error.
                         kept_count += 1
                     else:
                         error_count += 1
@@ -565,21 +568,21 @@ class DataCleanupJob:
             return CleanupOutcome.ERROR
 
         if not data_found:
-            # No local data here → keep the DB record; do NOT treat it as
-            # cleaned. instance_id is activity-driven, so "this instance ==
-            # instance_id" doesn't prove the data was written here (a stray
-            # cross-instance request can point it here); closing the record
-            # then would orphan the real data on the owning instance. Worst
-            # case of keeping is reclaimable local disk on the owner —
-            # reclaimed on instance recycle, or earlier if the user is active
-            # there again before logout; data is in S3, so nothing is lost.
+            # No local data here → KEEP the record (never treat as cleaned):
+            # instance_id is activity-driven, so a match doesn't prove the data
+            # was written here; closing would orphan real data on the owner.
+            # Worst case: reclaimable local disk (freed on recycle, or earlier
+            # if the user is active there before logout); S3 keeps a backup.
             logger.info(
                 f"No local data for user {user_id} on this instance; "
                 f"keeping DB record (data may live on the owning instance)."
             )
             return CleanupOutcome.KEPT
 
-        return CleanupOutcome.CLEANED if fully_cleaned else CleanupOutcome.KEPT
+        # Data present: fully removed → CLEANED; otherwise some was retained
+        # (S3 backup unverified) → ERROR, not KEPT — an S3 outage / missing
+        # backup is actionable and the local disk is not reclaimed.
+        return CleanupOutcome.CLEANED if fully_cleaned else CleanupOutcome.ERROR
 
     @classmethod
     def _verify_no_active_workflows(cls, user_id: str) -> bool:
@@ -790,15 +793,14 @@ class DataCleanupJob:
             logger.error(f"Error handling orphaned data: {e}", exc_info=True)
 
     @classmethod
-    def _publish_metrics(
-        cls, cleaned_count: int, error_count: int, kept_count: int = 0
-    ):
+    def _publish_metrics(cls, cleaned_count: int, error_count: int, kept_count: int):
         """Publish cleanup job metrics to CloudWatch.
 
-        ``CleanupKept`` counts deliberate "keep the record" outcomes (no local
-        data here, data retained pending S3 verification, user returned) so
-        they are not conflated with ``CleanupErrors``, which stays a signal of
-        genuine failures for alarms.
+        ``CleanupKept`` counts benign "keep the record" outcomes (no local data
+        on this instance, or the user returned) so they are not conflated with
+        ``CleanupErrors``. ``CleanupErrors`` stays the actionable-failure signal
+        and still includes S3-backup-unverified retention (data that could not
+        be safely deleted).
         """
         try:
             import boto3

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -7,8 +7,9 @@ COMPREHENSIVE SAFETY CHECKS:
 1. Only processes users with active_workflow_count = 0 (no running workflows)
 2. Verifies S3 backup exists before deleting experiment outputs AND input data
 3. Keeps local data if S3 verification fails (prevents data loss)
-4. Only the owning instance (matching FreeUserAssignment.instance_id) may
-   close an assignment, so cleanup on another instance can never orphan data
+4. Deletes an assignment only after this instance actually removed its local
+   data; "no local data on this instance" never closes a record, so cleanup
+   on another instance can never orphan data
 
 This ensures:
 - No data deletion while workflows are running (even long 2+ hour workflows)
@@ -531,55 +532,25 @@ class DataCleanupJob:
             )
 
         if not data_found:
-            # No local data on disk:
-            # - filtered run → this worker owns the assignment, nothing to
-            #   delete → success (let _mark_cleaned close assignment/usage log)
-            # - unfiltered run → data may be on another instance → keep guard
-            current_instance_id = cls._get_current_instance_id()
-            if current_instance_id != "local":
-                # Defense-in-depth: only treat "no local data" as a completed
-                # cleanup when this instance actually owns the assignment.
-                # The selection query already filters on instance_id, but a
-                # stray mid-run reassignment must never let a non-owning
-                # instance delete the DB record and orphan another instance's
-                # data. If ownership can't be confirmed, keep the record.
-                if not cls._owns_assignment(user_id, current_instance_id):
-                    logger.warning(
-                        f"No local data for user {user_id}, but this instance "
-                        f"({current_instance_id}) no longer owns the assignment. "
-                        f"Keeping DB record to avoid orphaning data elsewhere."
-                    )
-                    return False
-                logger.info(f"No local data for user {user_id}; nothing to clean.")
-                return True
-            logger.warning(
-                f"No local data found for user {user_id} (unfiltered run). "
-                f"Returning False to prevent premature DB record deletion."
+            # No local data on this instance → keep the DB record; do NOT
+            # treat "no local data" as a completed cleanup.
+            #
+            # instance_id is refreshed to the serving instance on each request
+            # (see user_activity_middleware), so "this instance == instance_id"
+            # does not guarantee this instance is where the data was written: a
+            # stray cross-instance request can point instance_id here. Deleting
+            # the record on that basis would orphan the real data on the
+            # instance that actually holds it. Retaining the record instead
+            # leaves at most reclaimable local disk on the true owner, which is
+            # cleaned once instance_id settles back to it. Data is also backed
+            # up to S3, so nothing is lost.
+            logger.info(
+                f"No local data for user {user_id} on this instance; "
+                f"keeping DB record (data may live on the owning instance)."
             )
             return False
 
         return fully_cleaned
-
-    @classmethod
-    def _owns_assignment(cls, user_id: str, current_instance_id: str) -> bool:
-        """Return True if the assignment is pinned to ``current_instance_id``.
-
-        ``FreeUserAssignment.instance_id`` is the authoritative "which
-        instance owns this user's local EBS data" marker (pinned at INSERT by
-        the middleware and never rewritten). A worker may only close an
-        assignment for which it is the owning instance; otherwise "no local
-        data" would delete a record whose data lives on another instance.
-        """
-        with session_scope() as db:
-            result_row = db.execute(
-                select(FreeUserAssignment.instance_id).where(
-                    FreeUserAssignment.user_id == user_id
-                )
-            ).first()
-            if not result_row:
-                # Assignment already gone — nothing to orphan.
-                return True
-            return result_row[0] == current_instance_id
 
     @classmethod
     def _verify_no_active_workflows(cls, user_id: str) -> bool:

--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -20,6 +20,7 @@ This ensures:
 import os
 import shutil
 from datetime import timedelta
+from enum import Enum
 from typing import List, Optional, Tuple
 
 from sqlalchemy import func, update
@@ -42,6 +43,21 @@ from studio.app.common.models.instance_usage import UsageTier
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
+
+
+class CleanupOutcome(Enum):
+    """Outcome of attempting to clean up one user's local data.
+
+    - ``CLEANED``: local data was removed; the assignment may be closed.
+    - ``KEPT``: nothing was closed on purpose — no local data on this instance,
+      data intentionally retained pending S3 verification, or the user logged
+      back in. This is a routine, expected outcome, NOT an error.
+    - ``ERROR``: an unexpected failure occurred while cleaning.
+    """
+
+    CLEANED = "cleaned"
+    KEPT = "kept"
+    ERROR = "error"
 
 
 class DataCleanupJob:
@@ -99,6 +115,7 @@ class DataCleanupJob:
             # Clean up each user
             cleaned_count = 0
             error_count = 0
+            kept_count = 0
 
             for user_id, workspace_ids in users_to_cleanup:
                 try:
@@ -109,9 +126,9 @@ class DataCleanupJob:
                         )
                         continue
 
-                    success = cls._cleanup_user_data(user_id, workspace_ids)
+                    outcome = cls._cleanup_user_data(user_id, workspace_ids)
 
-                    if success:
+                    if outcome == CleanupOutcome.CLEANED:
                         # Re-check workflow count and re-login before marking cleaned
                         # Prevents race condition where workflow/login during cleanup
                         if cls._check_user_relogin(user_id):
@@ -129,6 +146,11 @@ class DataCleanupJob:
                                 f"workflow started during cleanup"
                             )
                             error_count += 1
+                    elif outcome == CleanupOutcome.KEPT:
+                        # Nothing closed on purpose (no local data here, data
+                        # retained pending S3 verification, or user returned).
+                        # Expected, not an error.
+                        kept_count += 1
                     else:
                         error_count += 1
 
@@ -140,11 +162,11 @@ class DataCleanupJob:
 
             logger.info(
                 f"Cleanup job completed: {cleaned_count} users cleaned, "
-                f"{error_count} errors"
+                f"{kept_count} kept, {error_count} errors"
             )
 
             # Publish CloudWatch metrics
-            cls._publish_metrics(cleaned_count, error_count)
+            cls._publish_metrics(cleaned_count, error_count, kept_count)
 
         except Exception as e:
             logger.error(f"Fatal error in cleanup job: {e}", exc_info=True)
@@ -398,7 +420,9 @@ class DataCleanupJob:
             return False
 
     @classmethod
-    def _cleanup_user_data(cls, user_id: str, workspace_ids: List[str]) -> bool:
+    def _cleanup_user_data(
+        cls, user_id: str, workspace_ids: List[str]
+    ) -> CleanupOutcome:
         """
         Delete user's workspace data from local storage.
 
@@ -412,13 +436,17 @@ class DataCleanupJob:
             workspace_ids: List of workspace IDs to clean
 
         Returns:
-            True if ALL data was successfully cleaned, False if any data remains
-            or errors occurred
+            CleanupOutcome.CLEANED if all local data was removed (assignment may
+            be closed); CleanupOutcome.KEPT if nothing was closed on purpose (no
+            local data here, data intentionally retained pending S3
+            verification, or the user logged back in); CleanupOutcome.ERROR on
+            an unexpected failure. KEPT is a routine outcome, not an error.
         """
         logger.info(f"Cleaning up data for user {user_id}, workspaces: {workspace_ids}")
 
         fully_cleaned = True
         data_found = False
+        had_error = False
         total_experiments_kept = 0
 
         # Experiment outputs live in the user's own bucket, not the shared
@@ -431,7 +459,7 @@ class DataCleanupJob:
             # Check if user logged back in before processing workspace
             if cls._check_user_relogin(user_id):
                 logger.info(f"Aborting cleanup for user {user_id}: user logged back in")
-                return False
+                return CleanupOutcome.KEPT
             try:
                 # Clean input data. Uploads are pushed to S3 synchronously on
                 # the free-tier upload path, but verify the backup before
@@ -524,6 +552,7 @@ class DataCleanupJob:
                     exc_info=True,
                 )
                 fully_cleaned = False
+                had_error = True
 
         if total_experiments_kept > 0:
             logger.warning(
@@ -541,16 +570,20 @@ class DataCleanupJob:
             # stray cross-instance request can point instance_id here. Deleting
             # the record on that basis would orphan the real data on the
             # instance that actually holds it. Retaining the record instead
-            # leaves at most reclaimable local disk on the true owner, which is
-            # cleaned once instance_id settles back to it. Data is also backed
-            # up to S3, so nothing is lost.
+            # leaves at most reclaimable local disk on the true owner. That disk
+            # is cleaned only if the user is active again on the owning instance
+            # *before logout* (activity stops rewriting instance_id after
+            # logout); otherwise it is reclaimed when the instance is recycled.
+            # Data is also backed up to S3, so nothing is lost.
             logger.info(
                 f"No local data for user {user_id} on this instance; "
                 f"keeping DB record (data may live on the owning instance)."
             )
-            return False
+            return CleanupOutcome.KEPT
 
-        return fully_cleaned
+        if had_error:
+            return CleanupOutcome.ERROR
+        return CleanupOutcome.CLEANED if fully_cleaned else CleanupOutcome.KEPT
 
     @classmethod
     def _verify_no_active_workflows(cls, user_id: str) -> bool:
@@ -761,14 +794,23 @@ class DataCleanupJob:
             logger.error(f"Error handling orphaned data: {e}", exc_info=True)
 
     @classmethod
-    def _publish_metrics(cls, cleaned_count: int, error_count: int):
-        """Publish cleanup job metrics to CloudWatch"""
+    def _publish_metrics(
+        cls, cleaned_count: int, error_count: int, kept_count: int = 0
+    ):
+        """Publish cleanup job metrics to CloudWatch.
+
+        ``CleanupKept`` counts deliberate "keep the record" outcomes (no local
+        data here, data retained pending S3 verification, user returned) so
+        they are not conflated with ``CleanupErrors``, which stays a signal of
+        genuine failures for alarms.
+        """
         try:
             import boto3
 
             cloudwatch = boto3.client("cloudwatch")
 
             env_prefix = os.environ.get("ENV_PREFIX", "default")
+            now = get_current_datetime()
             cloudwatch.put_metric_data(
                 Namespace=f"OptiNiSt/BackgroundJobs/{env_prefix}",
                 MetricData=[
@@ -776,19 +818,25 @@ class DataCleanupJob:
                         "MetricName": "DataCleanupCount",
                         "Value": cleaned_count,
                         "Unit": "Count",
-                        "Timestamp": get_current_datetime(),
+                        "Timestamp": now,
                     },
                     {
                         "MetricName": "CleanupErrors",
                         "Value": error_count,
                         "Unit": "Count",
-                        "Timestamp": get_current_datetime(),
+                        "Timestamp": now,
+                    },
+                    {
+                        "MetricName": "CleanupKept",
+                        "Value": kept_count,
+                        "Unit": "Count",
+                        "Timestamp": now,
                     },
                 ],
             )
             logger.debug(
                 f"Published CloudWatch metrics: {cleaned_count} cleaned, "
-                f"{error_count} errors"
+                f"{kept_count} kept, {error_count} errors"
             )
         except Exception as e:
             logger.warning(f"Failed to publish metrics: {e}")

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -426,15 +426,18 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
         with session_scope() as session:
             now = get_current_datetime()
 
-            # Try UPDATE first (common path for existing users).
-            #
-            # instance_id is refreshed to the serving instance so it tracks
-            # where the user is currently active. Reworking instance_id write
-            # ownership (single authoritative writer) is deferred to a separate
-            # follow-up issue.
+            # UPDATE first (common path); instance_id is refreshed to the
+            # serving instance. The ``logged_out_at IS NULL`` guard stops a
+            # stray still-authenticated request (in-flight call after logout, a
+            # second tab) from resurrecting a logged-out assignment — a
+            # cross-process guard, unlike the short-lived in-memory logout map.
+            # (instance_id write-ownership rework: separate follow-up.)
+            from sqlalchemy import select
+
             stmt = (
                 update(FreeUserAssignment)
                 .where(FreeUserAssignment.user_id == user_id)
+                .where(FreeUserAssignment.logged_out_at.is_(None))
                 .values(
                     last_activity=now,
                     instance_id=instance_id,
@@ -442,6 +445,17 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
             )
             result = session.execute(stmt)
             if result.rowcount == 0:
+                # UPDATE matched nothing: either no assignment exists yet (new
+                # user → INSERT below) or one exists but is logged out (excluded
+                # by the guard). Never resurrect a logged-out assignment.
+                existing = session.execute(
+                    select(FreeUserAssignment.user_id).where(
+                        FreeUserAssignment.user_id == user_id
+                    )
+                ).first()
+                if existing is not None:
+                    return False
+
                 # No existing row — insert new record
                 assignment = FreeUserAssignment(
                     user_id=user_id,
@@ -464,8 +478,6 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
                 # session exists.  After a logout/re-login cycle the
                 # previous InstanceUsageLog has ended_at set, so we
                 # need to start a new one for the current session.
-                from sqlalchemy import select
-
                 open_session = session.execute(
                     select(InstanceUsageLog.id)
                     .where(

--- a/studio/app/common/core/middleware/user_activity_middleware.py
+++ b/studio/app/common/core/middleware/user_activity_middleware.py
@@ -428,23 +428,16 @@ def _update_free_user_activity_sync(user_id: int) -> bool:
 
             # Try UPDATE first (common path for existing users).
             #
-            # IMPORTANT: do NOT overwrite ``instance_id`` here. The column is
-            # the authoritative "which instance owns this user's local EBS
-            # data" marker that the cleanup worker filters on. Sticky-session
-            # drift (cookie expiry, ASG rebalance, deregistration) can route a
-            # request to a different instance than the one holding the data;
-            # rewriting ``instance_id`` on that stray request would re-point
-            # the assignment to an instance with no local data, and the
-            # cleanup worker there would then treat "no local data" as a
-            # completed cleanup and delete the assignment — orphaning the real
-            # data on the original instance (the exact leak this PR fixes).
-            # ``instance_id`` is pinned at INSERT and only changes when the
-            # assignment is removed and recreated on the next login.
+            # instance_id is refreshed to the serving instance so it tracks
+            # where the user is currently active. Reworking instance_id write
+            # ownership (single authoritative writer) is deferred to a separate
+            # follow-up issue.
             stmt = (
                 update(FreeUserAssignment)
                 .where(FreeUserAssignment.user_id == user_id)
                 .values(
                     last_activity=now,
+                    instance_id=instance_id,
                 )
             )
             result = session.execute(stmt)

--- a/studio/tests/app/common/core/background/test_cleanup_job.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from studio.app.common.core.background.cleanup_job import DataCleanupJob
+from studio.app.common.core.background.cleanup_job import CleanupOutcome, DataCleanupJob
 
 
 @pytest.fixture(autouse=True)
@@ -139,7 +139,7 @@ class TestCleanupUserData:
                                 "123", ["workspace1"]
                             )
 
-        assert result is True
+        assert result == CleanupOutcome.CLEANED
         assert mock_rmtree.call_count >= 1
 
     @patch.object(DataCleanupJob, "_verify_s3_input_backup_exists", return_value=True)
@@ -162,7 +162,7 @@ class TestCleanupUserData:
                                 "123", ["workspace1"]
                             )
 
-        assert result is False
+        assert result == CleanupOutcome.KEPT
         # Input directory is deleted (backup verified, 1 call); experiments kept
         assert mock_rmtree.call_count == 1
         # Verify it was the input directory that was deleted
@@ -187,7 +187,7 @@ class TestCleanupUserData:
                 with patch("shutil.rmtree") as mock_rmtree:
                     result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
 
-        assert result is False
+        assert result == CleanupOutcome.KEPT
         mock_rmtree.assert_not_called()
 
 
@@ -441,39 +441,29 @@ class TestGetUsersForCleanupInstanceFilter:
 class TestCleanupUserDataNotFound:
     """Test _cleanup_user_data no-data behavior (finding #1)"""
 
-    @patch.object(DataCleanupJob, "_get_current_instance_id", return_value="local")
     @patch.object(DataCleanupJob, "_check_user_relogin", return_value=False)
-    def test_returns_false_when_no_data_unfiltered(self, mock_relogin, mock_instance):
-        """Unfiltered run (local / background service): no data → False,
-        because the user's data may live on another instance."""
-        with patch("os.path.exists", return_value=False):
-            result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
-
-        assert result is False
-
-    @patch.object(DataCleanupJob, "_get_current_instance_id", return_value="i-abc12345")
-    @patch.object(DataCleanupJob, "_check_user_relogin", return_value=False)
-    def test_returns_false_when_no_local_data(self, mock_relogin, mock_instance):
-        """No local data on this instance → keep the DB record (return False).
+    def test_returns_kept_when_no_local_data(self, mock_relogin):
+        """No local data on this instance → KEPT (keep the DB record).
 
         instance_id is refreshed to the serving instance, so "no local data"
         must never close a record: a stray cross-instance request could point
-        instance_id here while the real data lives on another instance.
+        instance_id here while the real data lives on another instance. KEPT is
+        a routine outcome, not an error.
         """
         with patch("os.path.exists", return_value=False):
             result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
 
-        assert result is False
+        assert result == CleanupOutcome.KEPT
 
     @patch.object(DataCleanupJob, "_verify_s3_input_backup_exists", return_value=True)
     @patch.object(
         DataCleanupJob, "_resolve_user_bucket_name", return_value="user-bucket"
     )
     @patch.object(DataCleanupJob, "_check_user_relogin", return_value=False)
-    def test_returns_true_when_data_exists_and_cleaned(
+    def test_returns_cleaned_when_data_exists_and_cleaned(
         self, mock_relogin, mock_bucket, mock_input_verify
     ):
-        """When data exists and is fully cleaned, returns True"""
+        """When data exists and is fully cleaned, returns CLEANED"""
         with patch.object(
             DataCleanupJob, "_verify_s3_backup_exists", return_value=True
         ):
@@ -485,7 +475,71 @@ class TestCleanupUserDataNotFound:
                                 "123", ["workspace1"]
                             )
 
-        assert result is True
+        assert result == CleanupOutcome.CLEANED
+
+
+class TestRunOutcomeAccounting:
+    """run() buckets each _cleanup_user_data outcome correctly (finding: metrics)."""
+
+    def _run_with_outcome(self, outcome):
+        import asyncio
+
+        with patch.dict(
+            "os.environ",
+            {"INSTANCE_ID": "i-current", "ENABLE_LOCAL_CLEANUP": "1"},
+        ):
+            with patch.object(DataCleanupJob, "_handle_orphaned_data"):
+                with patch.object(
+                    DataCleanupJob,
+                    "_get_users_for_cleanup",
+                    return_value=[("123", ["ws1"])],
+                ):
+                    with patch.object(
+                        DataCleanupJob, "_check_user_relogin", return_value=False
+                    ):
+                        with patch.object(
+                            DataCleanupJob,
+                            "_verify_no_active_workflows",
+                            return_value=True,
+                        ):
+                            with patch.object(
+                                DataCleanupJob,
+                                "_cleanup_user_data",
+                                return_value=outcome,
+                            ):
+                                with patch.object(
+                                    DataCleanupJob, "_mark_cleaned"
+                                ) as mock_mark:
+                                    with patch.object(
+                                        DataCleanupJob, "_publish_metrics"
+                                    ) as mock_metrics:
+                                        asyncio.run(DataCleanupJob.run())
+        return mock_mark, mock_metrics
+
+    def test_kept_is_not_cleaned_nor_error(self):
+        """A KEPT user must not be closed, and must count as kept — not error."""
+        mock_mark, mock_metrics = self._run_with_outcome(CleanupOutcome.KEPT)
+
+        mock_mark.assert_not_called()
+        mock_metrics.assert_called_once()
+        cleaned, errors, kept = mock_metrics.call_args.args
+        assert (cleaned, errors, kept) == (0, 0, 1)
+
+    def test_cleaned_marks_and_counts_cleaned(self):
+        """A CLEANED user is marked cleaned and counted as cleaned."""
+        mock_mark, mock_metrics = self._run_with_outcome(CleanupOutcome.CLEANED)
+
+        mock_mark.assert_called_once()
+        cleaned, errors, kept = mock_metrics.call_args.args
+        assert (cleaned, errors, kept) == (1, 0, 0)
+
+    def test_error_counts_error_only(self):
+        """An ERROR user is not closed and counts only as an error."""
+        mock_mark, mock_metrics = self._run_with_outcome(CleanupOutcome.ERROR)
+
+        mock_mark.assert_not_called()
+        cleaned, errors, kept = mock_metrics.call_args.args
+        assert (cleaned, errors, kept) == (0, 1, 0)
 
 
 class TestVerifyS3InputBackup:

--- a/studio/tests/app/common/core/background/test_cleanup_job.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job.py
@@ -150,7 +150,8 @@ class TestCleanupUserData:
     def test_cleanup_user_data_keeps_unverified(
         self, mock_relogin, mock_bucket, mock_input_verify
     ):
-        """Test cleanup keeps unverified experiment outputs (input backed up)"""
+        """Unverified experiment outputs are kept locally → ERROR (data could
+        not be safely deleted; an S3-backup failure must stay visible)."""
         with patch.object(
             DataCleanupJob, "_verify_s3_backup_exists", return_value=False
         ):
@@ -162,7 +163,7 @@ class TestCleanupUserData:
                                 "123", ["workspace1"]
                             )
 
-        assert result == CleanupOutcome.KEPT
+        assert result == CleanupOutcome.ERROR
         # Input directory is deleted (backup verified, 1 call); experiments kept
         assert mock_rmtree.call_count == 1
         # Verify it was the input directory that was deleted
@@ -175,7 +176,8 @@ class TestCleanupUserData:
     def test_cleanup_keeps_input_when_backup_unverified(
         self, mock_relogin, mock_bucket
     ):
-        """Input with no verified S3 backup is kept, not deleted (data safety)."""
+        """Input with no verified S3 backup is kept, not deleted (data safety);
+        the unsafe-to-delete retention is classified ERROR, not KEPT."""
         with patch.object(
             DataCleanupJob, "_verify_s3_input_backup_exists", return_value=False
         ):
@@ -187,7 +189,7 @@ class TestCleanupUserData:
                 with patch("shutil.rmtree") as mock_rmtree:
                     result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
 
-        assert result == CleanupOutcome.KEPT
+        assert result == CleanupOutcome.ERROR
         mock_rmtree.assert_not_called()
 
 
@@ -481,39 +483,51 @@ class TestCleanupUserDataNotFound:
 class TestRunOutcomeAccounting:
     """run() buckets each _cleanup_user_data outcome correctly (finding: metrics)."""
 
-    def _run_with_outcome(self, outcome):
+    def _run_with_outcome(self, outcome, relogin=False):
         import asyncio
+        from contextlib import ExitStack
 
-        with patch.dict(
-            "os.environ",
-            {"INSTANCE_ID": "i-current", "ENABLE_LOCAL_CLEANUP": "1"},
-        ):
-            with patch.object(DataCleanupJob, "_handle_orphaned_data"):
-                with patch.object(
+        with ExitStack() as stack:
+            enter = stack.enter_context
+            enter(
+                patch.dict(
+                    "os.environ",
+                    {"INSTANCE_ID": "i-current", "ENABLE_LOCAL_CLEANUP": "1"},
+                )
+            )
+            enter(patch.object(DataCleanupJob, "_handle_orphaned_data"))
+            enter(
+                patch.object(
                     DataCleanupJob,
                     "_get_users_for_cleanup",
                     return_value=[("123", ["ws1"])],
-                ):
-                    with patch.object(
-                        DataCleanupJob, "_check_user_relogin", return_value=False
-                    ):
-                        with patch.object(
-                            DataCleanupJob,
-                            "_verify_no_active_workflows",
-                            return_value=True,
-                        ):
-                            with patch.object(
-                                DataCleanupJob,
-                                "_cleanup_user_data",
-                                return_value=outcome,
-                            ):
-                                with patch.object(
-                                    DataCleanupJob, "_mark_cleaned"
-                                ) as mock_mark:
-                                    with patch.object(
-                                        DataCleanupJob, "_publish_metrics"
-                                    ) as mock_metrics:
-                                        asyncio.run(DataCleanupJob.run())
+                )
+            )
+            if isinstance(relogin, (list, tuple)):
+                enter(
+                    patch.object(
+                        DataCleanupJob,
+                        "_check_user_relogin",
+                        side_effect=list(relogin),
+                    )
+                )
+            else:
+                enter(
+                    patch.object(
+                        DataCleanupJob, "_check_user_relogin", return_value=relogin
+                    )
+                )
+            enter(
+                patch.object(
+                    DataCleanupJob, "_verify_no_active_workflows", return_value=True
+                )
+            )
+            enter(
+                patch.object(DataCleanupJob, "_cleanup_user_data", return_value=outcome)
+            )
+            mock_mark = enter(patch.object(DataCleanupJob, "_mark_cleaned"))
+            mock_metrics = enter(patch.object(DataCleanupJob, "_publish_metrics"))
+            asyncio.run(DataCleanupJob.run())
         return mock_mark, mock_metrics
 
     def test_kept_is_not_cleaned_nor_error(self):
@@ -540,6 +554,19 @@ class TestRunOutcomeAccounting:
         mock_mark.assert_not_called()
         cleaned, errors, kept = mock_metrics.call_args.args
         assert (cleaned, errors, kept) == (0, 1, 0)
+
+    def test_relogin_during_cleanup_counts_as_kept(self):
+        """A user who returns *during* cleanup is kept, not errored — same
+        bucket as the relogin abort inside _cleanup_user_data."""
+        # 1st relogin check (pre-cleanup) False → proceed; 2nd (post-CLEANED)
+        # True → the user came back mid-cleanup.
+        mock_mark, mock_metrics = self._run_with_outcome(
+            CleanupOutcome.CLEANED, relogin=[False, True]
+        )
+
+        mock_mark.assert_not_called()
+        cleaned, errors, kept = mock_metrics.call_args.args
+        assert (cleaned, errors, kept) == (0, 0, 1)
 
 
 class TestVerifyS3InputBackup:

--- a/studio/tests/app/common/core/background/test_cleanup_job.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job.py
@@ -451,29 +451,15 @@ class TestCleanupUserDataNotFound:
 
         assert result is False
 
-    @patch.object(DataCleanupJob, "_owns_assignment", return_value=True)
     @patch.object(DataCleanupJob, "_get_current_instance_id", return_value="i-abc12345")
     @patch.object(DataCleanupJob, "_check_user_relogin", return_value=False)
-    def test_returns_true_when_no_data_on_owning_instance(
-        self, mock_relogin, mock_instance, mock_owns
-    ):
-        """Instance-filtered run where this instance owns the assignment: an
-        empty user is genuinely clean → True, letting _mark_cleaned close
-        the assignment / usage log (prevents the leak in finding #1)."""
-        with patch("os.path.exists", return_value=False):
-            result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
+    def test_returns_false_when_no_local_data(self, mock_relogin, mock_instance):
+        """No local data on this instance → keep the DB record (return False).
 
-        assert result is True
-
-    @patch.object(DataCleanupJob, "_owns_assignment", return_value=False)
-    @patch.object(DataCleanupJob, "_get_current_instance_id", return_value="i-abc12345")
-    @patch.object(DataCleanupJob, "_check_user_relogin", return_value=False)
-    def test_returns_false_when_no_data_but_not_owner(
-        self, mock_relogin, mock_instance, mock_owns
-    ):
-        """Defense-in-depth: even on a filtered run, if this instance no
-        longer owns the assignment (mid-run reassignment), "no local data"
-        must NOT delete the record — data may live on the real owner."""
+        instance_id is refreshed to the serving instance, so "no local data"
+        must never close a record: a stray cross-instance request could point
+        instance_id here while the real data lives on another instance.
+        """
         with patch("os.path.exists", return_value=False):
             result = DataCleanupJob._cleanup_user_data("123", ["workspace1"])
 
@@ -500,44 +486,6 @@ class TestCleanupUserDataNotFound:
                             )
 
         assert result is True
-
-
-class TestOwnsAssignment:
-    """Test _owns_assignment ownership guard (finding: HIGH orphaning)."""
-
-    def _session_returning(self, first_value):
-        mock_db = MagicMock()
-        mock_db.execute.return_value.first.return_value = first_value
-        cm = MagicMock()
-        cm.__enter__.return_value = mock_db
-        cm.__exit__.return_value = False
-        return cm
-
-    def test_true_when_instance_matches(self):
-        cm = self._session_returning(("i-abc12345",))
-        with patch(
-            "studio.app.common.core.background.cleanup_job.session_scope",
-            return_value=cm,
-        ):
-            assert DataCleanupJob._owns_assignment("7", "i-abc12345") is True
-
-    def test_false_when_instance_differs(self):
-        """Assignment pinned to another instance → this worker is not owner."""
-        cm = self._session_returning(("i-other",))
-        with patch(
-            "studio.app.common.core.background.cleanup_job.session_scope",
-            return_value=cm,
-        ):
-            assert DataCleanupJob._owns_assignment("7", "i-abc12345") is False
-
-    def test_true_when_assignment_already_gone(self):
-        """No row → nothing left to orphan → safe to proceed."""
-        cm = self._session_returning(None)
-        with patch(
-            "studio.app.common.core.background.cleanup_job.session_scope",
-            return_value=cm,
-        ):
-            assert DataCleanupJob._owns_assignment("7", "i-abc12345") is True
 
 
 class TestVerifyS3InputBackup:

--- a/studio/tests/app/common/core/background/test_cleanup_job_relogin.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job_relogin.py
@@ -106,7 +106,10 @@ class TestCleanupUserDataReloginCheck:
         self, mock_exists, mock_check_relogin
     ):
         """Should abort cleanup if user logs back in during processing."""
-        from studio.app.common.core.background.cleanup_job import DataCleanupJob
+        from studio.app.common.core.background.cleanup_job import (
+            CleanupOutcome,
+            DataCleanupJob,
+        )
 
         # User logs back in after first check
         mock_check_relogin.side_effect = [False, True]
@@ -117,8 +120,8 @@ class TestCleanupUserDataReloginCheck:
             workspace_ids=["ws1", "ws2", "ws3"],
         )
 
-        # Should return False (cleanup aborted)
-        assert result is False
+        # Cleanup aborted because the user returned → KEPT (not an error)
+        assert result == CleanupOutcome.KEPT
 
 
 class TestVerifyNoActiveWorkflows:

--- a/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
@@ -888,13 +888,12 @@ class TestPremiumActivityRestoresPendingRelease:
         assert result is False
 
 
-class TestFreeUserActivityInstanceIdPinning:
-    """instance_id must be pinned at INSERT and NOT overwritten on UPDATE.
+class TestFreeUserActivityInstanceIdWrite:
+    """instance_id is refreshed to the serving instance on UPDATE and set on
+    INSERT, so it tracks where the user is currently active.
 
-    Rewriting instance_id on a stray cross-instance request would re-point the
-    assignment to an instance holding no local data; the cleanup worker there
-    would then treat "no local data" as done and orphan the real data (the
-    exact leak this PR fixes).
+    (Reworking instance_id write ownership to a single authoritative writer is
+    deferred to a separate follow-up issue.)
     """
 
     def _run_sync_update(self, rowcount):
@@ -927,17 +926,17 @@ class TestFreeUserActivityInstanceIdPinning:
 
         return mock_session
 
-    def test_update_does_not_overwrite_instance_id(self):
-        """Existing-row UPDATE sets last_activity only, never instance_id."""
+    def test_update_refreshes_instance_id(self):
+        """Existing-row UPDATE sets both last_activity and instance_id."""
         mock_session = self._run_sync_update(rowcount=1)
 
         update_stmt = mock_session.execute.call_args_list[0][0][0]
         compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
         assert "last_activity" in compiled
-        assert "instance_id" not in compiled
+        assert "instance_id" in compiled
 
-    def test_insert_still_sets_instance_id(self):
-        """New-row INSERT path still pins instance_id via session.add()."""
+    def test_insert_sets_instance_id(self):
+        """New-row INSERT path sets instance_id via session.add()."""
         mock_session = self._run_sync_update(rowcount=0)
 
         added = [c.args[0] for c in mock_session.add.call_args_list]

--- a/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
+++ b/studio/tests/app/common/core/middleware/test_user_activity_middleware.py
@@ -907,6 +907,9 @@ class TestFreeUserActivityInstanceIdWrite:
         exec_result = MagicMock()
         exec_result.rowcount = rowcount
         exec_result.scalar.return_value = 1  # open usage session already exists
+        # rowcount==0 path does an existence SELECT; None → treat as a new user
+        # and take the INSERT branch (a returned row would mean "logged out").
+        exec_result.first.return_value = None
         mock_session.execute.return_value = exec_result
 
         with patch(
@@ -943,3 +946,39 @@ class TestFreeUserActivityInstanceIdWrite:
         assignments = [a for a in added if hasattr(a, "instance_id")]
         assert assignments, "expected a FreeUserAssignment to be added"
         assert any(a.instance_id == "i-current" for a in assignments)
+
+    def test_logged_out_user_is_not_resurrected(self):
+        """The logged_out_at IS NULL guard makes the UPDATE match nothing; with
+        an existing (logged-out) row present, the write must NOT INSERT/resurrect
+        — it returns without adding anything. Cross-process, no reliance on the
+        short-lived in-memory logout map."""
+        from unittest.mock import MagicMock, patch
+
+        from studio.app.common.core.middleware.user_activity_middleware import (
+            _update_free_user_activity_sync,
+        )
+
+        mock_session = MagicMock()
+        update_result = MagicMock()
+        update_result.rowcount = 0  # guarded UPDATE matched no row (logged out)
+        select_result = MagicMock()
+        select_result.first.return_value = (TEST_USER_ID,)  # assignment exists
+        mock_session.execute.side_effect = [update_result, select_result]
+
+        with patch(
+            "studio.app.common.core.middleware.user_activity_middleware."
+            "is_user_logged_out",
+            return_value=False,  # in-memory map already expired (10s TTL)
+        ), patch(
+            "studio.app.common.core.middleware.user_activity_middleware."
+            "_get_instance_id",
+            return_value="i-current",
+        ), patch(
+            "studio.app.common.core.middleware."
+            "user_activity_middleware.session_scope"
+        ) as mock_scope:
+            mock_scope.return_value.__enter__.return_value = mock_session
+            result = _update_free_user_activity_sync(TEST_USER_ID)
+
+        assert result is False
+        mock_session.add.assert_not_called()  # no INSERT / no usage-log resurrect


### PR DESCRIPTION
## Summary

Follow-up to PR #620. After #620's review changes, the free-tier data cleanup stopped deleting a
logged-out user's data (manual **[Test 1 / 620-01]** failed): the user's
`free_user_assignments.instance_id` held a **public-tier** instance id, so the per-instance cleanup
filter on the free-tier instance never matched and the data was never cleaned.

This PR fixes **[Test 1 / 620-01]** **without changing the `instance_id` write logic's scope**:

1. **Reverts the `instance_id` pin** (`2a17e7be`) so `instance_id` is refreshed to the serving
   instance again and self-heals to the free-tier instance that actually holds the data.
2. **Makes cleanup conservative on "no local data"** so the reverted (activity-driven) `instance_id`
   can never cause data orphaning — the risk is downgraded to a reclaimable, S3-backed local-disk leak.

## Problem

The deployment routes sign-in / SPA delivery through a **public** ASG, then routes the authenticated
free user to the **free** ASG (which holds the user's local EBS data and runs the cleanup worker).

`UserActivityMiddleware` writes `instance_id` from whatever instance serves the request. #620 pinned
`instance_id` at INSERT to stop overwrites, but a free user's early authenticated request can be
served by a **public** instance — so the pin froze `instance_id` to the public instance:

- Cleanup on the free-tier instance filters `WHERE instance_id = <free instance>` → the user (pinned
  to a public instance) is never selected → data is never cleaned (manual and hourly runs both no-op).

Root cause detail: `instance_id` is a shared, multi-writer column (the `free_manager` autoscaling
lambda is the authoritative placement writer; the middleware also writes it per request). Reworking
that write ownership is broader than this cleanup fix and is deferred to a separate follow-up issue
(see **Follow-up**).

## Changes

| Area | Change |
|---|---|
| `user_activity_middleware.py` | The activity `UPDATE` refreshes `instance_id` to the serving instance again (reverts the `2a17e7be` pin), so it self-heals to the free-tier instance holding the data. |
| `cleanup_job.py` | When this instance has **no local data** for the user, keep the DB record (never mark cleaned); the pin-premised `_owns_assignment` guard is removed, since with an activity-driven `instance_id` "this instance == `assignment.instance_id`" no longer proves the data was written here. `_cleanup_user_data` returns `CleanupOutcome` (CLEANED / KEPT / ERROR): a benign "keep" is counted as `CleanupKept`, while S3-backup-unverified retention stays `CleanupErrors`. |

Delivered as three independently-green commits (`4e5223f0`, `4eb22d46`, `01f8eea0`); no `instance_id`
write-ownership redesign and no infrastructure change are included.

## Behavior / safety after this PR

- **[Test 1 / 620-01] passes:** `instance_id` tracks the free-tier instance the user worked on, so
  that instance's cleanup worker selects the user and deletes local data + DB row (S3 preserved).
- **No orphaning:** an instance never closes an assignment while it has no local data, so a transient
  `instance_id` mismatch can no longer delete a DB record whose data lives elsewhere. Worst case is a
  reclaimable local-disk leak on the true owner: it is cleaned if the user is active again on the owning
  instance **before logout** (activity stops rewriting `instance_id` after logout); otherwise it is
  reclaimed when the instance is recycled. Data is also backed up to S3, so nothing is lost.
- **Metrics stay meaningful:** `_cleanup_user_data` returns a tri-state (`CleanupOutcome.CLEANED /
  KEPT / ERROR`). Only **benign** keeps — no local data on this instance, or the user returned — are
  counted as `CleanupKept`. **S3-backup-unverified retention** (data present but not safely deletable) is
  classified `ERROR`, so an S3 outage stays visible on `CleanupErrors` instead of hiding among benign
  keeps. A new `CleanupKept` metric separates the benign outcomes from errors. Note: no CloudWatch alarm
  currently references the `OptiNiSt/BackgroundJobs` namespace — these metrics are the intended signals
  for such alarms, which are not yet wired.

## Known limitations (this fix is a correct-but-timing-dependent interim)

This PR makes the cleanup side **safe** (never orphans by deleting a record whose data lives elsewhere)
and fixes 620-01 in the single-free-instance topology, but it is **not a structural fix**. With the
`instance_id` refresh restored, the following remain and are deferred to the write-ownership follow-up:

- **Free→free drift (HIGH).** The free target group's stickiness cookie is 300s; with ≥2 free instances,
  a user whose cookie expires or is rebalanced is served by instance B while their data sits on A.
  `instance_id` follows to B; B keeps the record (no local data); A's filter never selects the user.
  Result: the data is **never cleaned by the job** — the 620-01 symptom, now probabilistic — and A's
  disk holds it until the instance recycles (data is safe in S3; no loss). **Test 10 / 620-10 is the
  test for this class and is now treated as important, not optional.**
- **Migration flapping (MEDIUM).** `migrate_user_to_instance` (`free_manager`) is the authoritative
  placement writer; with the refresh restored, one request served by the old instance inside the 300s
  window rewrites `instance_id` back, undoing the recorded placement and churning `migration_count` /
  `trigger_experiment_sync`. This is a **live** consequence of reverting the pin, not only a deferred
  design note.
- **Partial-ownership (LOW).** `data_found` is per-user, not per-workspace: a user with `ws1` on A and
  `ws2` on B (`instance_id = B`) gets `CLEANED` on B (it cleaned `ws2`), the row is deleted, and `ws1`
  on A is orphaned with no row to drive its cleanup.

The structural resolution is the same for all three: **consolidate `instance_id` to a single
authoritative writer** (stop the activity middleware from writing it). Tracked as a separate follow-up
issue targeting `develop-main`, with its own (broader) test scope (routing, migration, autoscaling).

Also tracked there: the row-reaper (`common_user_manager`, `last_activity`-based) deletes
`free_user_assignments` rows **without** triggering local-data cleanup, so in the drift / abnormal-
termination case the local disk is reclaimed only on instance recycle (data stays safe in S3). A
pre-existing gap in the assignment/data lifecycle, not introduced by this PR.

## Test Plan

### Automated
`studio/` unit tests — **all passing** (cleanup_job, cleanup_job_relogin, cleanup_worker, middleware);
`flake8` / `black` / `isort` clean. Test changes:
- middleware: assert the activity UPDATE **refreshes** `instance_id` (was: asserts it is not overwritten);
  assert a **logged-out** assignment is **not resurrected** by a stray post-logout request.
- cleanup: "no local data" **keeps the DB record** regardless of ownership (was: marked cleaned when
  it owned the assignment); removed the `_owns_assignment` unit tests.
- cleanup: `_cleanup_user_data` returns a tri-state (`CleanupOutcome.CLEANED/KEPT/ERROR`); `run()`-level
  tests assert a KEPT user is not marked cleaned and is bucketed as `CleanupKept`, an S3-unverified
  retention is `CleanupErrors`, and relogin-during-cleanup counts as kept, not error.

### Manual

The manual procedure reuses **PR #620's plan** (see PR #620, *Manual Test Plan (Tester)* — its
Prerequisites and Common helpers apply unchanged). Run those tests **as written**, applying only the
deltas below; do **not** re-transcribe the #620 steps. It also adds one new test,
**[Test 10 / 620-10]**, summarized and linked below — its full step-by-step spec lives in the #620 v3
plan.

> **Note — this maps to the #620 plan's v3 revision.** The deltas below are already
> folded into PR #620's test plan as its **v3** update (the `_v3` document): the
> steps for **620-01 / 620-07 / 620-09** are re-annotated with the v3 expectations
> and **620-10** is added, all tagged **[v3]** under the v1→v3 version legend
> (v1 = initial PR, v2 = #620 review-fix pins/guards, **v3 = this PR #782**).
> A tester can therefore run the #620 **v3** plan directly; the table below is the
> summary of what v3 changed relative to v2.

#### Deltas to existing #620 tests

Only the tests whose expected behavior this PR changes are listed. **[Test 2 / 620-02],
[Test 3 / 620-03], [Test 4 / 620-04], [Test 5 / 620-05], [Test 6 / 620-06], and [Test 8 / 620-08] are
unaffected** — this PR's changes do not reach their code paths (the instance_id filter excludes them, or
they exercise the data-present / orphaned-assignment paths) — so run them as written per #620 with no
delta.

| #620 test | Status in this PR | Delta to apply |
|---|---|---|
| **[Test 1 / 620-01]** (data deleted on the free instance) | **Now passes** (was failing) | The regression this PR fixes. Explicitly exercise the **public → free** path: sign in (served by the public tier), then run a workflow on the free tier. Confirm `free_user_assignments.instance_id` = the **free** instance (self-healed), not a public instance, and that the free instance's cleanup deletes the data + DB row. |
| **[Test 7 / 620-07]** (empty-but-valid user cleaned up, gated by `_owns_assignment`) | **Changed — pass criteria reversed** | The ownership gate is removed and "no local data" no longer closes a record. New expectation: the empty user's assignment row is **KEPT, not cleaned** (log: `keeping DB record`; no `Marked user ... as cleaned`). Verify the `free_user_assignments` row **remains** after the run. (The open `instance_usage_log` is already closed at logout, independently of cleanup — see *Known trade-off*.) |
| **[Test 9 / 620-09]** (`instance_id` pinned, not overwritten) | **Reverted — pass criteria reversed** | `instance_id` **is refreshed** to the serving instance on activity again. New expectation: after several authenticated requests served by a given instance (enough to exceed the throttle TTL), `free_user_assignments.instance_id` equals that serving instance and updates if a request is served elsewhere (opposite of #620's "unchanged" expectation). |

#### Known trade-off (minor; documented)

Because "no local data" now always keeps the record (**[Test 7 / 620-07]** delta), a genuinely empty
free user (logged in, never generated data, logged out) has its `free_user_assignments` **row retained**
by this job instead of auto-closed. The net leak is negligible:

- **Billing/analytics is NOT affected**: the `instance_usage_log` session is closed at **logout**
  (`users_me` logout handler sets `ended_at`), independently of cleanup.
- **The retained row is short-lived**: the existing `common_user_manager` lambda (runs every 10 min)
  hard-deletes any `free_user_assignments` row whose `last_activity` exceeds the free idle timeout
  (`FREE_IDLE_TIMEOUT_HOURS`, default 2h). So a data-less row is reaped ≲2h after the user's last
  activity regardless of this PR — the net effect is only a short delay in row removal, not a leak.

This is the deliberate, low-cost trade-off for orphan-safety under activity-driven `instance_id`.
Proactive empty-user row closure at cleanup time (e.g. distinguish "no data anywhere, incl. S3" from
"data on another instance") is deferred to the write-ownership follow-up.

#### New test — Test 10 / 620-10 (full spec lives in the #620 v3 plan)

**Summary:** a cleanup worker running on an instance that holds **no local data** for the user **keeps**
the DB record instead of closing it, so a transient `instance_id` mismatch (possible again under
activity-driven `instance_id`) can never orphan data that lives on another instance. Set up a user with
data on instance **A**, point the assignment at a data-less instance **B**, run cleanup on **B**, and
confirm B keeps the row, A's data is untouched, and the owning instance later cleans up (self-heal).

**Priority: important (needs 2 free-tier instances).** This is the **only** test that exercises the
multi-free-instance drift class (see *Known limitations → free→free drift*): it confirms the cleanup
side stays safe (no orphaning) in the topology where the symptom can recur. It needs two running
free-tier instances, so it was not run in the single-instance dev pass — run it before relying on the
fix in a multi-instance environment.

**Full step-by-step spec:** see **PR #620's test plan, v3 revision — "Test 10 [v3] (620-10)"** (its
Objective / Why / Scope / Steps 1–4 / Pass criteria).
