### PR TITLE
Sync experiment config from S3 before publish validation

### DIFF
--- a/frontend/src/components/Dataview/DataviewRecords.tsx
+++ b/frontend/src/components/Dataview/DataviewRecords.tsx
@@ -890,6 +890,7 @@ const DataviewRecords = ({
         ?.response?.data?.detail
       enqueueSnackbar(detail ?? "Failed to publish experiment", {
         variant: "error",
+        style: { whiteSpace: "pre-line" },
       })
     }
   }
@@ -1030,6 +1031,7 @@ const DataviewRecords = ({
         ?.response?.data?.detail
       enqueueSnackbar(detail ?? "Failed to publish experiments", {
         variant: "error",
+        style: { whiteSpace: "pre-line" },
       })
     }
   }

--- a/frontend/src/components/Dataview/DataviewRecords.tsx
+++ b/frontend/src/components/Dataview/DataviewRecords.tsx
@@ -888,7 +888,8 @@ const DataviewRecords = ({
     } catch (e) {
       const detail = (e as { response?: { data?: { detail?: string } } })
         ?.response?.data?.detail
-      enqueueSnackbar(detail ?? "Failed to publish experiment", {
+      const action = status === "on" ? "publish" : "unpublish"
+      enqueueSnackbar(detail ?? `Failed to ${action} experiment`, {
         variant: "error",
         style: { whiteSpace: "pre-line" },
       })
@@ -1029,7 +1030,8 @@ const DataviewRecords = ({
     } catch (e) {
       const detail = (e as { response?: { data?: { detail?: string } } })
         ?.response?.data?.detail
-      enqueueSnackbar(detail ?? "Failed to publish experiments", {
+      const action = openPublishAll.type === "on" ? "publish" : "unpublish"
+      enqueueSnackbar(detail ?? `Failed to ${action} experiments`, {
         variant: "error",
         style: { whiteSpace: "pre-line" },
       })

--- a/frontend/src/components/Dataview/DataviewRecords.tsx
+++ b/frontend/src/components/Dataview/DataviewRecords.tsx
@@ -873,17 +873,25 @@ const DataviewRecords = ({
 
   const handlePublish = async (id: number, status: "on" | "off") => {
     const newPublish = getPublishStatusValue(dataParamsFilter.publish_status)
-    await dispatch(
-      postPublish({
-        id,
-        status,
-        params: {
-          ...dataParamsFilter,
-          publish_status: newPublish,
-          ...dataParams,
-        },
-      }),
-    )
+    try {
+      await dispatch(
+        postPublish({
+          id,
+          status,
+          params: {
+            ...dataParamsFilter,
+            publish_status: newPublish,
+            ...dataParams,
+          },
+        }),
+      ).unwrap()
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail
+      enqueueSnackbar(detail ?? "Failed to publish experiment", {
+        variant: "error",
+      })
+    }
   }
 
   const handleSort = useCallback(
@@ -1001,21 +1009,29 @@ const DataviewRecords = ({
     })
   }
 
-  const handlePublishOk = () => {
+  const handlePublishOk = async () => {
     setOpenPublishAll({
       ...openPublishAll,
       open: false,
     })
-    dispatch(
-      postPublishAll({
-        status: openPublishAll.type,
-        params: {
-          ...dataParamsFilter,
-          ...dataParams,
-        },
-        listCheck,
-      }),
-    )
+    try {
+      await dispatch(
+        postPublishAll({
+          status: openPublishAll.type,
+          params: {
+            ...dataParamsFilter,
+            ...dataParams,
+          },
+          listCheck,
+        }),
+      ).unwrap()
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail
+      enqueueSnackbar(detail ?? "Failed to publish experiments", {
+        variant: "error",
+      })
+    }
   }
 
   const ColumnPrivate = () => {

--- a/frontend/src/components/Dataview/__tests__/DataviewRecords.test.tsx
+++ b/frontend/src/components/Dataview/__tests__/DataviewRecords.test.tsx
@@ -781,6 +781,33 @@ describe("DataviewRecords Component", () => {
       await waitFor(() =>
         expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
           "Some experiments cannot be published:\n- exp: corrupted",
+          expect.objectContaining({
+            variant: "error",
+            // multi-line backend detail must keep its line breaks
+            style: { whiteSpace: "pre-line" },
+          }),
+        ),
+      )
+    })
+
+    it("uses an action-aware fallback message when bulk unpublish is rejected without detail", async () => {
+      mockEnqueueSnackbar.mockClear()
+      // Reject without a `detail` -> the fallback message is used
+      store.dispatch = jest.fn().mockReturnValue({
+        unwrap: () => Promise.reject({ message: "network error" }),
+      }) as unknown as typeof store.dispatch
+
+      renderWithProviders(<DataviewRecords user={mockUser} readonly={false} />)
+
+      fireEvent.click(screen.getAllByRole("checkbox")[0])
+
+      const bulkUnpublish = screen.getAllByLabelText(/bulk unpublish/i)[0]
+      fireEvent.click(bulkUnpublish.querySelector("button") ?? bulkUnpublish)
+      fireEvent.click(screen.getByTestId("confirm-button"))
+
+      await waitFor(() =>
+        expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+          "Failed to unpublish experiments",
           expect.objectContaining({ variant: "error" }),
         ),
       )

--- a/frontend/src/components/Dataview/__tests__/DataviewRecords.test.tsx
+++ b/frontend/src/components/Dataview/__tests__/DataviewRecords.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store"
 import thunk from "redux-thunk"
 
 import { describe, it, expect, jest, beforeEach } from "@jest/globals"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 
 import { UserDTO } from "api/users/UsersApiDTO"
 import DataviewRecords from "components/Dataview/DataviewRecords"
@@ -14,10 +14,19 @@ import { DataviewType } from "store/slice/Dataview/DataviewType"
 
 const mockStore = configureStore([thunk])
 
+// Mock notistack so snackbar calls can be asserted.
+// (mock-prefixed name is required to reference it inside the jest.mock factory)
+const mockEnqueueSnackbar = jest.fn()
+jest.mock("notistack", () => ({
+  enqueueSnackbar: (...args: unknown[]) => mockEnqueueSnackbar(...args),
+}))
+
 // Mock Dataview Actions
 jest.mock("store/slice/Dataview/DataviewActions", () => ({
   getDataviewRecords: () => ({ type: "GET_DATAVIEW_RECORDS" }),
   getPublicDataviewRecords: () => ({ type: "GET_PUBLIC_DATAVIEW_RECORDS" }),
+  postPublish: () => ({ type: "POST_PUBLISH" }),
+  postPublishAll: () => ({ type: "POST_PUBLISH_ALL" }),
 }))
 
 // Mock react-plotlyjs-ts to avoid d3-interpolate issues
@@ -740,6 +749,41 @@ describe("DataviewRecords Component", () => {
       // Legacy TIFF/JSON thumbnails should NOT render as img tags with these alt texts
       expect(screen.queryByAltText("Input thumbnail")).toBeNull()
       expect(screen.queryByAltText("ROI thumbnail")).toBeNull()
+    })
+  })
+
+  describe("Publish error handling", () => {
+    it("shows an error snackbar with the backend detail when bulk publish is rejected", async () => {
+      mockEnqueueSnackbar.mockClear()
+      // dispatch(...).unwrap() rejects with a FastAPI-shaped error body
+      store.dispatch = jest.fn().mockReturnValue({
+        unwrap: () =>
+          Promise.reject({
+            response: {
+              data: {
+                detail: "Some experiments cannot be published:\n- exp: corrupted",
+              },
+            },
+          }),
+      }) as unknown as typeof store.dispatch
+
+      renderWithProviders(<DataviewRecords user={mockUser} readonly={false} />)
+
+      // Select records (header select-all checkbox is always rendered)
+      fireEvent.click(screen.getAllByRole("checkbox")[0])
+
+      // Open the bulk-publish confirm dialog (label is on the Tooltip wrapper;
+      // click the inner button), then confirm.
+      const bulkPublish = screen.getAllByLabelText(/bulk publish/i)[0]
+      fireEvent.click(bulkPublish.querySelector("button") ?? bulkPublish)
+      fireEvent.click(screen.getByTestId("confirm-button"))
+
+      await waitFor(() =>
+        expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+          "Some experiments cannot be published:\n- exp: corrupted",
+          expect.objectContaining({ variant: "error" }),
+        ),
+      )
     })
   })
 })

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -51,6 +51,10 @@ public_router = APIRouter(tags=["Dataview"], prefix="/api/public/dataview")
 
 logger = AppLogger.get_logger()
 
+# Max concurrent S3 pre-sync operations during bulk publish (bounds the
+# per-request fan-out of RemoteStorageReader clients on one uvicorn process).
+PUBLISH_PRESYNC_CONCURRENCY = 8
+
 
 RECORDS_SORT_MAPPING = {
     "user_name": models.User.name,
@@ -375,44 +379,76 @@ def _resolve_workspace_remote_bucket_name(db: Session, workspace_id: str) -> str
     return owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
 
 
+def _local_config_can_publish(workspace_id: str, unique_id: str) -> bool:
+    """Whether the local experiment.yaml already passes publish validation.
+
+    Uses the same PublishValidator the handler uses, so the pre-sync skip
+    condition matches the validator's notion of "valid" (a config that merely
+    parses may still be missing required fields or be stale).
+    """
+    return PublishValidator.validate(
+        workspace_id=workspace_id,
+        unique_id=unique_id,
+        user_has_s3_bucket=True,
+        check_files_on_disk=True,
+    ).can_publish
+
+
 async def _sync_experiment_config_for_publish(
     workspace_id: str, unique_id: str, remote_bucket_name: str
 ) -> None:
     """
     Sync metadata from S3 so publish validation reads a valid experiment.yaml.
 
-    Repairs a local config that is missing or a corrupt/empty stub:
-    - missing      -> download metadata
-    - invalid stub -> remove, then download (download_experiment_meta skips
-                      existing files, so the stub must be removed first)
+    Repairs a local config that is missing or fails validation (empty stub,
+    missing required fields, stale success state) by downloading fresh metadata
+    from S3. An existing invalid config is moved aside first (the download skips
+    files that already exist) and restored if the download produces nothing, so
+    the only local copy is never lost when S3 has no replacement.
 
-    Best-effort: any failure is logged and swallowed. If the experiment is
-    absent from S3 the config stays missing and PublishValidator.validate
-    returns 400. The caller resolves the bucket, so this helper does no DB
-    access (safe to run concurrently over one Session via asyncio.gather).
+    Best-effort: any failure is logged and swallowed. If the experiment cannot
+    be synced the local config is left as-is and PublishValidator.validate
+    reports the real 400. The caller resolves the bucket, so this helper does no
+    DB access (safe to run concurrently over one Session via asyncio.gather).
     """
-    if not RemoteStorageController.is_available():
+    if not RemoteStorageController.is_available() or not remote_bucket_name:
         return
 
     try:
         config_path = ExptConfigReader.get_config_yaml_path(workspace_id, unique_id)
 
-        # Skip sync when the local config is already valid.
-        if os.path.exists(config_path):
-            try:
-                ExptConfigReader.read(workspace_id, unique_id)
-                return
-            except Exception:
-                # Invalid stub: remove so the download re-fetches it.
-                os.remove(config_path)
+        # Skip when the local config already passes publish validation.
+        if os.path.exists(config_path) and _local_config_can_publish(
+            workspace_id, unique_id
+        ):
+            return
 
-        async with RemoteStorageReader(
-            remote_bucket_name,
-            workspace_id,
-            unique_id,
-            sync_mode=RemoteExperimentSyncMode.METADATA_ONLY,
-        ) as controller:
-            await controller.download_experiment_meta(workspace_id, unique_id)
+        # Move an existing (invalid) config aside so the download re-fetches it,
+        # keeping a backup to restore if the download yields no replacement.
+        backup_path = None
+        if os.path.exists(config_path):
+            backup_path = f"{config_path}.bak"
+            try:
+                os.replace(config_path, backup_path)
+            except FileNotFoundError:
+                # Raced with another remover; nothing to move.
+                backup_path = None
+
+        try:
+            async with RemoteStorageReader(
+                remote_bucket_name,
+                workspace_id,
+                unique_id,
+                sync_mode=RemoteExperimentSyncMode.METADATA_ONLY,
+            ) as controller:
+                await controller.download_experiment_meta(workspace_id, unique_id)
+        finally:
+            # Discard the backup on a successful download; restore it otherwise.
+            if backup_path and os.path.exists(backup_path):
+                if os.path.exists(config_path):
+                    os.remove(backup_path)
+                else:
+                    os.replace(backup_path, config_path)
     except Exception as e:
         logger.warning(
             f"Publish pre-sync failed for {workspace_id}/{unique_id}: {e}",
@@ -561,11 +597,16 @@ async def publish_dataview_records(
             # Validate publish eligibility when publishing
             if flag == PublishFlags.on:
                 # Repair missing/stub local config from S3 before validating.
-                await _sync_experiment_config_for_publish(
-                    str(record.workspace_id),
-                    record.uid,
-                    _resolve_workspace_remote_bucket_name(db, str(record.workspace_id)),
-                )
+                # Guard on is_available() so the bucket lookup (a DB join) is
+                # skipped when remote storage is off.
+                if RemoteStorageController.is_available():
+                    await _sync_experiment_config_for_publish(
+                        str(record.workspace_id),
+                        record.uid,
+                        _resolve_workspace_remote_bucket_name(
+                            db, str(record.workspace_id)
+                        ),
+                    )
 
                 validation = PublishValidator.validate(
                     workspace_id=str(record.workspace_id),
@@ -715,39 +756,50 @@ async def multiple_publish_dataview_records(
                 "for your account. Please contact support to enable publishing.",
             )
 
-        # Resolve owned records once (records not owned by the user are skipped)
+        # Resolve owned records once, de-duplicating ids (select-all across
+        # pages can repeat ids; duplicates would collide on the sync lock file).
         owned_records = []
+        seen_ids = set()
         for record_id in ids:
+            if record_id in seen_ids:
+                continue
+            seen_ids.add(record_id)
             record = DataviewService.find_user_owned_dataview_record(
                 db, record_id, current_user.id
             )
             if record:
                 owned_records.append((record_id, record))
 
-        # Resolve the owner bucket once per workspace (bulk is typically a single
-        # workspace) to avoid redundant queries and keep DB access out of the
-        # gathered coroutines below.
-        bucket_by_workspace = {}
-        for _, record in owned_records:
-            ws_id = str(record.workspace_id)
-            if ws_id not in bucket_by_workspace:
-                bucket_by_workspace[ws_id] = _resolve_workspace_remote_bucket_name(
-                    db, ws_id
-                )
+        # Repair missing/stub local config from S3 before validating.
+        # Guarded on is_available() so bucket lookups (DB joins) are skipped when
+        # remote storage is off.
+        if RemoteStorageController.is_available():
+            # Resolve the owner bucket once per workspace (bulk is typically a
+            # single workspace) and keep DB access out of the gathered coroutines.
+            bucket_by_workspace = {}
+            for _, record in owned_records:
+                ws_id = str(record.workspace_id)
+                if ws_id not in bucket_by_workspace:
+                    bucket_by_workspace[ws_id] = _resolve_workspace_remote_bucket_name(
+                        db, ws_id
+                    )
 
-        # Repair missing/stub local config from S3 (concurrently) before validating.
-        # return_exceptions keeps one record's failure from aborting the batch.
-        await asyncio.gather(
-            *(
-                _sync_experiment_config_for_publish(
-                    str(record.workspace_id),
-                    record.uid,
-                    bucket_by_workspace[str(record.workspace_id)],
-                )
-                for _, record in owned_records
-            ),
-            return_exceptions=True,
-        )
+            # Bound the fan-out of concurrent RemoteStorageReader clients.
+            semaphore = asyncio.Semaphore(PUBLISH_PRESYNC_CONCURRENCY)
+
+            async def _bounded_sync(record):
+                async with semaphore:
+                    await _sync_experiment_config_for_publish(
+                        str(record.workspace_id),
+                        record.uid,
+                        bucket_by_workspace[str(record.workspace_id)],
+                    )
+
+            # return_exceptions keeps one record's failure from aborting the batch.
+            await asyncio.gather(
+                *(_bounded_sync(record) for _, record in owned_records),
+                return_exceptions=True,
+            )
 
         # Validate each record
         failed_records = []

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -564,9 +564,7 @@ async def publish_dataview_records(
                 await _sync_experiment_config_for_publish(
                     str(record.workspace_id),
                     record.uid,
-                    _resolve_workspace_remote_bucket_name(
-                        db, str(record.workspace_id)
-                    ),
+                    _resolve_workspace_remote_bucket_name(db, str(record.workspace_id)),
                 )
 
                 validation = PublishValidator.validate(

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import List, Optional, Sequence, Tuple
 
@@ -14,9 +15,11 @@ from studio.app.common.core.dataview.dataview_services import (
     DataviewService,
     PublishValidator,
 )
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.storage.remote_storage_controller import (
     RemoteExperimentNotFoundError,
+    RemoteExperimentSyncMode,
     RemoteStorageController,
     RemoteStorageDownloadUtils,
     RemoteStorageLockError,
@@ -372,6 +375,57 @@ def _resolve_workspace_remote_bucket_name(db: Session, workspace_id: str) -> str
     return owner_bucket or os.environ.get("S3_DEFAULT_BUCKET_NAME")
 
 
+async def _sync_experiment_config_for_publish(
+    db: Session, workspace_id: str, unique_id: str
+) -> None:
+    """
+    Sync metadata from S3 so publish validation reads a valid experiment.yaml.
+
+    Repairs a local config that is missing or a corrupt/empty stub:
+    - missing      -> download metadata
+    - invalid stub -> remove, then download (download_experiment_meta skips
+                      existing files, so the stub must be removed first)
+
+    Best-effort (failures logged, swallowed). If the experiment is absent from
+    S3 the config stays missing and PublishValidator.validate returns 400.
+    """
+    if not RemoteStorageController.is_available():
+        return
+
+    config_path = ExptConfigReader.get_config_yaml_path(workspace_id, unique_id)
+
+    # Skip sync when the local config is already valid.
+    if os.path.exists(config_path):
+        try:
+            ExptConfigReader.read(workspace_id, unique_id)
+            return
+        except Exception:
+            # Invalid stub: remove so the download re-fetches it.
+            try:
+                os.remove(config_path)
+            except OSError as e:
+                logger.warning(
+                    f"Failed to remove stub experiment.yaml for "
+                    f"{workspace_id}/{unique_id}: {e}"
+                )
+                return
+
+    remote_bucket_name = _resolve_workspace_remote_bucket_name(db, workspace_id)
+    try:
+        async with RemoteStorageReader(
+            remote_bucket_name,
+            workspace_id,
+            unique_id,
+            sync_mode=RemoteExperimentSyncMode.METADATA_ONLY,
+        ) as controller:
+            await controller.download_experiment_meta(workspace_id, unique_id)
+    except Exception as e:
+        logger.warning(
+            f"Publish pre-sync failed for {workspace_id}/{unique_id}: {e}",
+            exc_info=True,
+        )
+
+
 async def _ensure_experiment_downloaded(
     db: Session, workspace_id: str, unique_id: str
 ) -> Optional[JSONResponse]:
@@ -512,6 +566,11 @@ async def publish_dataview_records(
 
             # Validate publish eligibility when publishing
             if flag == PublishFlags.on:
+                # Repair missing/stub local config from S3 before validating.
+                await _sync_experiment_config_for_publish(
+                    db, str(record.workspace_id), record.uid
+                )
+
                 validation = PublishValidator.validate(
                     workspace_id=str(record.workspace_id),
                     unique_id=record.uid,
@@ -519,6 +578,11 @@ async def publish_dataview_records(
                     check_files_on_disk=True,
                 )
                 if not validation.can_publish:
+                    logger.warning(
+                        f"Publish rejected for experiment {record.id} "
+                        f"({record.workspace_id}/{record.uid}, name={record.name}): "
+                        f"{validation.reason}"
+                    )
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail=validation.reason,
@@ -636,7 +700,7 @@ async def publish_dataview_records(
 - Validates each record before publishing; fails if any record cannot be published
 """,
 )
-def multiple_publish_dataview_records(
+async def multiple_publish_dataview_records(
     ids: List[int],
     flag: PublishFlags,
     db: Session = Depends(get_db),
@@ -652,15 +716,28 @@ def multiple_publish_dataview_records(
                 "for your account. Please contact support to enable publishing.",
             )
 
-        # Validate each record
-        failed_records = []
+        # Resolve owned records once (records not owned by the user are skipped)
+        owned_records = []
         for record_id in ids:
             record = DataviewService.find_user_owned_dataview_record(
                 db, record_id, current_user.id
             )
-            if not record:
-                continue  # Skip records not owned by user
+            if record:
+                owned_records.append((record_id, record))
 
+        # Repair missing/stub local config from S3 (concurrently) before validating.
+        await asyncio.gather(
+            *(
+                _sync_experiment_config_for_publish(
+                    db, str(record.workspace_id), record.uid
+                )
+                for _, record in owned_records
+            )
+        )
+
+        # Validate each record
+        failed_records = []
+        for record_id, record in owned_records:
             validation = PublishValidator.validate(
                 workspace_id=str(record.workspace_id),
                 unique_id=record.uid,
@@ -677,6 +754,14 @@ def multiple_publish_dataview_records(
                 )
 
         if failed_records:
+            logger.warning(
+                "Bulk publish rejected %d record(s): %s",
+                len(failed_records),
+                "; ".join(
+                    f"{rec['name']} ({rec['id']}): {rec['reason']}"
+                    for rec in failed_records
+                ),
+            )
             # Return error with details about which records failed
             detail = "Some experiments cannot be published:\n"
             for rec in failed_records[:5]:  # Limit to first 5

--- a/studio/app/common/routers/dataview.py
+++ b/studio/app/common/routers/dataview.py
@@ -376,7 +376,7 @@ def _resolve_workspace_remote_bucket_name(db: Session, workspace_id: str) -> str
 
 
 async def _sync_experiment_config_for_publish(
-    db: Session, workspace_id: str, unique_id: str
+    workspace_id: str, unique_id: str, remote_bucket_name: str
 ) -> None:
     """
     Sync metadata from S3 so publish validation reads a valid experiment.yaml.
@@ -386,32 +386,26 @@ async def _sync_experiment_config_for_publish(
     - invalid stub -> remove, then download (download_experiment_meta skips
                       existing files, so the stub must be removed first)
 
-    Best-effort (failures logged, swallowed). If the experiment is absent from
-    S3 the config stays missing and PublishValidator.validate returns 400.
+    Best-effort: any failure is logged and swallowed. If the experiment is
+    absent from S3 the config stays missing and PublishValidator.validate
+    returns 400. The caller resolves the bucket, so this helper does no DB
+    access (safe to run concurrently over one Session via asyncio.gather).
     """
     if not RemoteStorageController.is_available():
         return
 
-    config_path = ExptConfigReader.get_config_yaml_path(workspace_id, unique_id)
-
-    # Skip sync when the local config is already valid.
-    if os.path.exists(config_path):
-        try:
-            ExptConfigReader.read(workspace_id, unique_id)
-            return
-        except Exception:
-            # Invalid stub: remove so the download re-fetches it.
-            try:
-                os.remove(config_path)
-            except OSError as e:
-                logger.warning(
-                    f"Failed to remove stub experiment.yaml for "
-                    f"{workspace_id}/{unique_id}: {e}"
-                )
-                return
-
-    remote_bucket_name = _resolve_workspace_remote_bucket_name(db, workspace_id)
     try:
+        config_path = ExptConfigReader.get_config_yaml_path(workspace_id, unique_id)
+
+        # Skip sync when the local config is already valid.
+        if os.path.exists(config_path):
+            try:
+                ExptConfigReader.read(workspace_id, unique_id)
+                return
+            except Exception:
+                # Invalid stub: remove so the download re-fetches it.
+                os.remove(config_path)
+
         async with RemoteStorageReader(
             remote_bucket_name,
             workspace_id,
@@ -568,7 +562,11 @@ async def publish_dataview_records(
             if flag == PublishFlags.on:
                 # Repair missing/stub local config from S3 before validating.
                 await _sync_experiment_config_for_publish(
-                    db, str(record.workspace_id), record.uid
+                    str(record.workspace_id),
+                    record.uid,
+                    _resolve_workspace_remote_bucket_name(
+                        db, str(record.workspace_id)
+                    ),
                 )
 
                 validation = PublishValidator.validate(
@@ -579,9 +577,12 @@ async def publish_dataview_records(
                 )
                 if not validation.can_publish:
                     logger.warning(
-                        f"Publish rejected for experiment {record.id} "
-                        f"({record.workspace_id}/{record.uid}, name={record.name}): "
-                        f"{validation.reason}"
+                        "Publish rejected for experiment %s (%s/%s, name=%s): %s",
+                        record.id,
+                        record.workspace_id,
+                        record.uid,
+                        record.name,
+                        validation.reason,
                     )
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
@@ -725,14 +726,29 @@ async def multiple_publish_dataview_records(
             if record:
                 owned_records.append((record_id, record))
 
+        # Resolve the owner bucket once per workspace (bulk is typically a single
+        # workspace) to avoid redundant queries and keep DB access out of the
+        # gathered coroutines below.
+        bucket_by_workspace = {}
+        for _, record in owned_records:
+            ws_id = str(record.workspace_id)
+            if ws_id not in bucket_by_workspace:
+                bucket_by_workspace[ws_id] = _resolve_workspace_remote_bucket_name(
+                    db, ws_id
+                )
+
         # Repair missing/stub local config from S3 (concurrently) before validating.
+        # return_exceptions keeps one record's failure from aborting the batch.
         await asyncio.gather(
             *(
                 _sync_experiment_config_for_publish(
-                    db, str(record.workspace_id), record.uid
+                    str(record.workspace_id),
+                    record.uid,
+                    bucket_by_workspace[str(record.workspace_id)],
                 )
                 for _, record in owned_records
-            )
+            ),
+            return_exceptions=True,
         )
 
         # Validate each record

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -723,3 +723,227 @@ class TestValidateExperimentExistsInS3:
         )
         assert exists is None
         assert error is not None
+
+
+class TestSyncExperimentConfigForPublish:
+    """Publish pre-sync helper: repair missing/stub local config from S3."""
+
+    @staticmethod
+    def _reader_ctx(controller):
+        """Build an async-context-manager mock yielding `controller`."""
+        from unittest.mock import AsyncMock
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=controller)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_noop_when_remote_unavailable(self):
+        """No sync attempt when remote storage is not configured."""
+        from studio.app.common.routers.dataview import (
+            _sync_experiment_config_for_publish,
+        )
+
+        mock_reader = MagicMock()
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=False,
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
+        ):
+            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+
+        mock_reader.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_downloads_when_config_missing(self):
+        """Missing local config triggers a metadata download."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            _sync_experiment_config_for_publish,
+        )
+
+        controller = AsyncMock()
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview.os.path.exists", return_value=False
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageReader",
+            return_value=self._reader_ctx(controller),
+        ):
+            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+
+        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
+
+    @pytest.mark.asyncio
+    async def test_repairs_stub_then_downloads(self):
+        """A present-but-invalid stub is removed, then re-downloaded."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            _sync_experiment_config_for_publish,
+        )
+
+        controller = AsyncMock()
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview.os.path.exists", return_value=True
+        ), patch(
+            "studio.app.common.routers.dataview.ExptConfigReader.read",
+            side_effect=AssertionError("Invalid config yaml file"),
+        ), patch(
+            "studio.app.common.routers.dataview.os.remove"
+        ) as mock_remove, patch(
+            "studio.app.common.routers.dataview."
+            "_resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageReader",
+            return_value=self._reader_ctx(controller),
+        ):
+            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+
+        mock_remove.assert_called_once()
+        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
+
+    @pytest.mark.asyncio
+    async def test_skips_when_config_valid(self):
+        """A valid local config is left untouched (no sync)."""
+        from studio.app.common.routers.dataview import (
+            _sync_experiment_config_for_publish,
+        )
+
+        mock_reader = MagicMock()
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview.os.path.exists", return_value=True
+        ), patch(
+            "studio.app.common.routers.dataview.ExptConfigReader.read",
+            return_value=MagicMock(),
+        ), patch(
+            "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
+        ):
+            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+
+        mock_reader.assert_not_called()
+
+
+class TestMultiplePublishDataviewRecords:
+    """Bulk publish: pre-sync + all-or-nothing validation."""
+
+    @staticmethod
+    def _make_record(record_id):
+        record = MagicMock()
+        record.id = record_id
+        record.workspace_id = "1"
+        record.uid = f"uid{record_id}"
+        record.name = f"exp{record_id}"
+        return record
+
+    @pytest.mark.asyncio
+    async def test_bulk_publish_success_presyncs_each_record(self):
+        """All valid: pre-sync runs per record and the service is invoked."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            PublishFlags,
+            multiple_publish_dataview_records,
+        )
+
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = 123
+        mock_user.remote_bucket_name = "test-bucket"
+
+        records = {1: self._make_record(1), 2: self._make_record(2)}
+
+        mock_validation = MagicMock()
+        mock_validation.can_publish = True
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_user_owned_dataview_record",
+            side_effect=lambda db, rid, uid: records.get(rid),
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_sync_experiment_config_for_publish",
+            new=AsyncMock(),
+        ) as mock_sync, patch(
+            "studio.app.common.routers.dataview.PublishValidator.validate",
+            return_value=mock_validation,
+        ), patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "multiple_publish_dataview_records"
+        ) as mock_service:
+            result = await multiple_publish_dataview_records(
+                ids=[1, 2], flag=PublishFlags.on, db=mock_db, current_user=mock_user
+            )
+
+        assert result is True
+        assert mock_sync.await_count == 2
+        mock_service.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bulk_publish_blocks_when_a_record_invalid(self):
+        """One invalid record blocks the whole batch with 400; no publish."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            PublishFlags,
+            multiple_publish_dataview_records,
+        )
+
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = 123
+        mock_user.remote_bucket_name = "test-bucket"
+
+        records = {1: self._make_record(1), 2: self._make_record(2)}
+
+        def validate(workspace_id, unique_id, **kwargs):
+            result = MagicMock()
+            result.can_publish = unique_id != "uid2"
+            result.reason = None if result.can_publish else "corrupted"
+            return result
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_user_owned_dataview_record",
+            side_effect=lambda db, rid, uid: records.get(rid),
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_sync_experiment_config_for_publish",
+            new=AsyncMock(),
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator.validate",
+            side_effect=validate,
+        ), patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "multiple_publish_dataview_records"
+        ) as mock_service:
+            with pytest.raises(HTTPException) as exc_info:
+                await multiple_publish_dataview_records(
+                    ids=[1, 2],
+                    flag=PublishFlags.on,
+                    db=mock_db,
+                    current_user=mock_user,
+                )
+
+        assert exc_info.value.status_code == 400
+        mock_service.assert_not_called()

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -753,7 +753,7 @@ class TestSyncExperimentConfigForPublish:
         ), patch(
             "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
         ):
-            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
 
         mock_reader.assert_not_called()
 
@@ -774,20 +774,48 @@ class TestSyncExperimentConfigForPublish:
         ), patch(
             "studio.app.common.routers.dataview.os.path.exists", return_value=False
         ), patch(
-            "studio.app.common.routers.dataview."
-            "_resolve_workspace_remote_bucket_name",
-            return_value="test-bucket",
-        ), patch(
             "studio.app.common.routers.dataview.RemoteStorageReader",
             return_value=self._reader_ctx(controller),
         ):
-            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
 
         controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
 
     @pytest.mark.asyncio
     async def test_repairs_stub_then_downloads(self):
-        """A present-but-invalid stub is removed, then re-downloaded."""
+        """A present-but-invalid stub is removed (by path), then re-downloaded."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            ExptConfigReader,
+            _sync_experiment_config_for_publish,
+        )
+
+        expected_path = ExptConfigReader.get_config_yaml_path("1", "uid")
+        controller = AsyncMock()
+        with patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview.os.path.exists", return_value=True
+        ), patch(
+            "studio.app.common.routers.dataview.ExptConfigReader.read",
+            side_effect=AssertionError("Invalid config yaml file"),
+        ), patch(
+            "studio.app.common.routers.dataview.os.remove"
+        ) as mock_remove, patch(
+            "studio.app.common.routers.dataview.RemoteStorageReader",
+            return_value=self._reader_ctx(controller),
+        ):
+            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
+
+        mock_remove.assert_called_once_with(expected_path)
+        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
+
+    @pytest.mark.asyncio
+    async def test_stub_removal_failure_is_swallowed(self):
+        """If removing the stub fails, no download runs and no error escapes."""
         from unittest.mock import AsyncMock
 
         from studio.app.common.routers.dataview import (
@@ -805,19 +833,16 @@ class TestSyncExperimentConfigForPublish:
             "studio.app.common.routers.dataview.ExptConfigReader.read",
             side_effect=AssertionError("Invalid config yaml file"),
         ), patch(
-            "studio.app.common.routers.dataview.os.remove"
-        ) as mock_remove, patch(
-            "studio.app.common.routers.dataview."
-            "_resolve_workspace_remote_bucket_name",
-            return_value="test-bucket",
+            "studio.app.common.routers.dataview.os.remove",
+            side_effect=OSError("permission denied"),
         ), patch(
             "studio.app.common.routers.dataview.RemoteStorageReader",
             return_value=self._reader_ctx(controller),
         ):
-            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+            # Must not raise.
+            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
 
-        mock_remove.assert_called_once()
-        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
+        controller.download_experiment_meta.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_skips_when_config_valid(self):
@@ -839,7 +864,7 @@ class TestSyncExperimentConfigForPublish:
         ), patch(
             "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
         ):
-            await _sync_experiment_config_for_publish(MagicMock(), "1", "uid")
+            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
 
         mock_reader.assert_not_called()
 
@@ -947,3 +972,73 @@ class TestMultiplePublishDataviewRecords:
 
         assert exc_info.value.status_code == 400
         mock_service.assert_not_called()
+
+
+class TestSinglePublishPreSync:
+    """Single publish wires the pre-sync helper before validation."""
+
+    @pytest.mark.asyncio
+    async def test_single_publish_presyncs_before_validate(self):
+        """publish_dataview_records calls the sync helper before validating."""
+        from unittest.mock import AsyncMock
+
+        from studio.app.common.routers.dataview import (
+            PublishFlags,
+            publish_dataview_records,
+        )
+
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_db.execute.return_value = mock_result
+
+        mock_user = MagicMock()
+        mock_user.id = 123
+        mock_user.remote_bucket_name = "test-bucket"
+
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.workspace_id = "1"
+        mock_record.uid = "test_uid"
+        mock_record.publish_status = 0
+        mock_record.local_sync_status = LocalSyncStatus.synced.value
+        mock_record.version = 0
+
+        mock_validation = MagicMock()
+        mock_validation.can_publish = True
+
+        order = []
+
+        async def sync_side(*args, **kwargs):
+            order.append("sync")
+
+        def validate_side(*args, **kwargs):
+            order.append("validate")
+            return mock_validation
+
+        with patch(
+            "studio.app.common.routers.dataview.DataviewService."
+            "find_user_owned_dataview_record",
+            return_value=mock_record,
+        ), patch(
+            "studio.app.common.routers.dataview."
+            "_sync_experiment_config_for_publish",
+            new=AsyncMock(side_effect=sync_side),
+        ) as mock_sync, patch(
+            "studio.app.common.routers.dataview._resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
+            "studio.app.common.routers.dataview.PublishValidator.validate",
+            side_effect=validate_side,
+        ), patch(
+            "studio.app.common.routers.dataview._validate_experiment_exists_in_s3",
+            new=AsyncMock(return_value=(True, None)),
+        ):
+            result = await publish_dataview_records(
+                id=1, flag=PublishFlags.on, db=mock_db, current_user=mock_user
+            )
+
+        assert result is True
+        mock_sync.assert_awaited_once_with("1", "test_uid", "test-bucket")
+        # Sync must be ordered before validation.
+        assert order == ["sync", "validate"]

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -750,9 +750,7 @@ class TestSyncExperimentConfigForPublish:
             "studio.app.common.routers.dataview.RemoteStorageController."
             "is_available",
             return_value=False,
-        ), patch(
-            "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
-        ):
+        ), patch("studio.app.common.routers.dataview.RemoteStorageReader", mock_reader):
             await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
 
         mock_reader.assert_not_called()
@@ -906,8 +904,7 @@ class TestMultiplePublishDataviewRecords:
             "find_user_owned_dataview_record",
             side_effect=lambda db, rid, uid: records.get(rid),
         ), patch(
-            "studio.app.common.routers.dataview."
-            "_sync_experiment_config_for_publish",
+            "studio.app.common.routers.dataview." "_sync_experiment_config_for_publish",
             new=AsyncMock(),
         ) as mock_sync, patch(
             "studio.app.common.routers.dataview.PublishValidator.validate",
@@ -952,8 +949,7 @@ class TestMultiplePublishDataviewRecords:
             "find_user_owned_dataview_record",
             side_effect=lambda db, rid, uid: records.get(rid),
         ), patch(
-            "studio.app.common.routers.dataview."
-            "_sync_experiment_config_for_publish",
+            "studio.app.common.routers.dataview." "_sync_experiment_config_for_publish",
             new=AsyncMock(),
         ), patch(
             "studio.app.common.routers.dataview.PublishValidator.validate",
@@ -1021,8 +1017,7 @@ class TestSinglePublishPreSync:
             "find_user_owned_dataview_record",
             return_value=mock_record,
         ), patch(
-            "studio.app.common.routers.dataview."
-            "_sync_experiment_config_for_publish",
+            "studio.app.common.routers.dataview." "_sync_experiment_config_for_publish",
             new=AsyncMock(side_effect=sync_side),
         ) as mock_sync, patch(
             "studio.app.common.routers.dataview._resolve_workspace_remote_bucket_name",

--- a/studio/tests/app/common/routers/test_dataview_publish.py
+++ b/studio/tests/app/common/routers/test_dataview_publish.py
@@ -4,13 +4,60 @@ Integration tests for dataview publish endpoint with optimistic locking.
 Tests concurrent publish/unpublish operations.
 """
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from fastapi import HTTPException
 
 from studio.app.common.routers.dataview import publish_dataview_records
 from studio.app.common.schemas.dataview import LocalSyncStatus
+
+# A minimal experiment.yaml that passes PublishValidator (all required fields,
+# success == SUCCESS).
+_VALID_CONFIG = {
+    "workspace_id": "1",
+    "unique_id": "uid",
+    "name": "exp",
+    "started_at": "2025-01-01 00:00:00",
+    "finished_at": "2025-01-01 00:01:00",
+    "success": "success",
+    "hasNWB": True,
+    "function": {},
+    "nwb": {"session_description": "optinist"},
+    "snakemake": {"use_conda": True},
+}
+
+# Parses (read() succeeds) but fails validation: nwb/snakemake are required but
+# read via .get(), so their absence does not raise.
+_INCOMPLETE_CONFIG = {
+    "workspace_id": "1",
+    "unique_id": "uid",
+    "name": "exp",
+    "started_at": "2025-01-01 00:00:00",
+    "success": "success",
+    "hasNWB": True,
+    "function": {},
+}
+
+
+def _config_path(workspace_id, unique_id):
+    from studio.app.common.routers.dataview import ExptConfigReader
+
+    return ExptConfigReader.get_config_yaml_path(workspace_id, unique_id)
+
+
+def _write_config(path, config):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.safe_dump(config, f)
+
+
+def _can_publish(workspace_id, unique_id):
+    from studio.app.common.routers.dataview import _local_config_can_publish
+
+    return _local_config_can_publish(workspace_id, unique_id)
 
 
 class TestPublishDataviewRecords:
@@ -726,145 +773,148 @@ class TestValidateExperimentExistsInS3:
 
 
 class TestSyncExperimentConfigForPublish:
-    """Publish pre-sync helper: repair missing/stub local config from S3."""
+    """Behaviour of the publish pre-sync helper on a real filesystem.
 
-    @staticmethod
-    def _reader_ctx(controller):
-        """Build an async-context-manager mock yielding `controller`."""
-        from unittest.mock import AsyncMock
+    Only the S3 download is faked; validation runs against the real
+    PublishValidator and real files, so the tests pin the repaired behaviour
+    (not just that the code calls a mock).
+    """
 
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=controller)
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        return ctx
+    class _FakeReader:
+        """Stands in for RemoteStorageReader.
 
-    @pytest.mark.asyncio
-    async def test_noop_when_remote_unavailable(self):
-        """No sync attempt when remote storage is not configured."""
+        Records constructor args, and on ``download_experiment_meta`` writes
+        ``s3_config`` to the local config path (``None`` => S3 has nothing).
+        """
+
+        def __init__(self, s3_config):
+            self._s3_config = s3_config
+            self.calls = []
+
+        def __call__(self, bucket, workspace_id, unique_id, sync_mode=None):
+            self.calls.append((bucket, workspace_id, unique_id, sync_mode))
+            outer = self
+
+            class _Ctx:
+                async def __aenter__(self_ctx):
+                    return self_ctx
+
+                async def __aexit__(self_ctx, *exc):
+                    return False
+
+                async def download_experiment_meta(self_ctx, ws, uid):
+                    if outer._s3_config is not None:
+                        _write_config(_config_path(ws, uid), outer._s3_config)
+                    return True
+
+            return _Ctx()
+
+    async def _run(self, tmp_path, monkeypatch, *, local, s3, bucket="test-bucket"):
+        """Seed ``local`` config (or None), fake S3 to yield ``s3``, run the
+        helper, and return (fake_reader, config_path)."""
         from studio.app.common.routers.dataview import (
             _sync_experiment_config_for_publish,
         )
+        from studio.app.dir_path import DIRPATH
 
-        mock_reader = MagicMock()
-        with patch(
-            "studio.app.common.routers.dataview.RemoteStorageController."
-            "is_available",
-            return_value=False,
-        ), patch("studio.app.common.routers.dataview.RemoteStorageReader", mock_reader):
-            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
+        monkeypatch.setattr(DIRPATH, "OUTPUT_DIR", str(tmp_path))
+        config_path = _config_path("1", "uid")
+        if local is not None:
+            _write_config(config_path, local)
 
-        mock_reader.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_downloads_when_config_missing(self):
-        """Missing local config triggers a metadata download."""
-        from unittest.mock import AsyncMock
-
-        from studio.app.common.routers.dataview import (
-            _sync_experiment_config_for_publish,
-        )
-
-        controller = AsyncMock()
-        with patch(
-            "studio.app.common.routers.dataview.RemoteStorageController."
-            "is_available",
-            return_value=True,
-        ), patch(
-            "studio.app.common.routers.dataview.os.path.exists", return_value=False
-        ), patch(
-            "studio.app.common.routers.dataview.RemoteStorageReader",
-            return_value=self._reader_ctx(controller),
-        ):
-            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
-
-        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
-
-    @pytest.mark.asyncio
-    async def test_repairs_stub_then_downloads(self):
-        """A present-but-invalid stub is removed (by path), then re-downloaded."""
-        from unittest.mock import AsyncMock
-
-        from studio.app.common.routers.dataview import (
-            ExptConfigReader,
-            _sync_experiment_config_for_publish,
-        )
-
-        expected_path = ExptConfigReader.get_config_yaml_path("1", "uid")
-        controller = AsyncMock()
+        fake = self._FakeReader(s3)
         with patch(
             "studio.app.common.routers.dataview.RemoteStorageController."
             "is_available",
             return_value=True,
-        ), patch(
-            "studio.app.common.routers.dataview.os.path.exists", return_value=True
-        ), patch(
-            "studio.app.common.routers.dataview.ExptConfigReader.read",
-            side_effect=AssertionError("Invalid config yaml file"),
-        ), patch(
-            "studio.app.common.routers.dataview.os.remove"
-        ) as mock_remove, patch(
-            "studio.app.common.routers.dataview.RemoteStorageReader",
-            return_value=self._reader_ctx(controller),
-        ):
-            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
-
-        mock_remove.assert_called_once_with(expected_path)
-        controller.download_experiment_meta.assert_awaited_once_with("1", "uid")
+        ), patch("studio.app.common.routers.dataview.RemoteStorageReader", fake):
+            await _sync_experiment_config_for_publish("1", "uid", bucket)
+        return fake, config_path
 
     @pytest.mark.asyncio
-    async def test_stub_removal_failure_is_swallowed(self):
-        """If removing the stub fails, no download runs and no error escapes."""
-        from unittest.mock import AsyncMock
-
-        from studio.app.common.routers.dataview import (
-            _sync_experiment_config_for_publish,
+    async def test_absent_local_valid_in_s3_becomes_publishable(
+        self, tmp_path, monkeypatch
+    ):
+        """Probe A: no local config, valid in S3 -> downloaded and publishable."""
+        fake, config_path = await self._run(
+            tmp_path, monkeypatch, local=None, s3=_VALID_CONFIG
         )
-
-        controller = AsyncMock()
-        with patch(
-            "studio.app.common.routers.dataview.RemoteStorageController."
-            "is_available",
-            return_value=True,
-        ), patch(
-            "studio.app.common.routers.dataview.os.path.exists", return_value=True
-        ), patch(
-            "studio.app.common.routers.dataview.ExptConfigReader.read",
-            side_effect=AssertionError("Invalid config yaml file"),
-        ), patch(
-            "studio.app.common.routers.dataview.os.remove",
-            side_effect=OSError("permission denied"),
-        ), patch(
-            "studio.app.common.routers.dataview.RemoteStorageReader",
-            return_value=self._reader_ctx(controller),
-        ):
-            # Must not raise.
-            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
-
-        controller.download_experiment_meta.assert_not_awaited()
+        assert os.path.exists(config_path)
+        assert _can_publish("1", "uid") is True
 
     @pytest.mark.asyncio
-    async def test_skips_when_config_valid(self):
-        """A valid local config is left untouched (no sync)."""
-        from studio.app.common.routers.dataview import (
-            _sync_experiment_config_for_publish,
+    async def test_stub_local_valid_in_s3_is_repaired(self, tmp_path, monkeypatch):
+        """Probe B: `{}` stub, valid in S3 -> repaired, backup discarded."""
+        fake, config_path = await self._run(
+            tmp_path, monkeypatch, local={}, s3=_VALID_CONFIG
+        )
+        assert _can_publish("1", "uid") is True
+        assert not os.path.exists(f"{config_path}.bak")
+
+    @pytest.mark.asyncio
+    async def test_incomplete_local_valid_in_s3_is_repaired(
+        self, tmp_path, monkeypatch
+    ):
+        """Probe C: parses but missing required fields -> re-synced from S3.
+
+        This is the case the previous read()-based skip did NOT repair.
+        """
+        # Sanity: the seeded local config is not publishable to begin with.
+        from studio.app.dir_path import DIRPATH
+
+        monkeypatch.setattr(DIRPATH, "OUTPUT_DIR", str(tmp_path))
+        _write_config(_config_path("1", "uid"), _INCOMPLETE_CONFIG)
+        assert _can_publish("1", "uid") is False
+
+        await self._run(
+            tmp_path, monkeypatch, local=_INCOMPLETE_CONFIG, s3=_VALID_CONFIG
+        )
+        assert _can_publish("1", "uid") is True
+
+    @pytest.mark.asyncio
+    async def test_stub_local_absent_in_s3_preserves_original(
+        self, tmp_path, monkeypatch
+    ):
+        """Probe E: `{}` stub, absent in S3 -> file is NOT destroyed."""
+        fake, config_path = await self._run(tmp_path, monkeypatch, local={}, s3=None)
+        # The only local copy must survive (restored from backup).
+        assert os.path.exists(config_path)
+        with open(config_path) as f:
+            assert yaml.safe_load(f) == {}
+        assert not os.path.exists(f"{config_path}.bak")
+        assert _can_publish("1", "uid") is False
+
+    @pytest.mark.asyncio
+    async def test_valid_local_skips_download(self, tmp_path, monkeypatch):
+        """A valid local config is left untouched (no S3 call)."""
+        fake, _ = await self._run(
+            tmp_path, monkeypatch, local=_VALID_CONFIG, s3=_VALID_CONFIG
+        )
+        assert fake.calls == []
+
+    @pytest.mark.asyncio
+    async def test_download_uses_metadata_only_and_correct_args(
+        self, tmp_path, monkeypatch
+    ):
+        """The reader is constructed with (bucket, ws, uid, METADATA_ONLY)."""
+        from studio.app.common.core.storage.remote_storage_controller import (
+            RemoteExperimentSyncMode,
         )
 
-        mock_reader = MagicMock()
-        with patch(
-            "studio.app.common.routers.dataview.RemoteStorageController."
-            "is_available",
-            return_value=True,
-        ), patch(
-            "studio.app.common.routers.dataview.os.path.exists", return_value=True
-        ), patch(
-            "studio.app.common.routers.dataview.ExptConfigReader.read",
-            return_value=MagicMock(),
-        ), patch(
-            "studio.app.common.routers.dataview.RemoteStorageReader", mock_reader
-        ):
-            await _sync_experiment_config_for_publish("1", "uid", "test-bucket")
+        fake, _ = await self._run(
+            tmp_path, monkeypatch, local=None, s3=_VALID_CONFIG, bucket="b1"
+        )
+        assert fake.calls == [
+            ("b1", "1", "uid", RemoteExperimentSyncMode.METADATA_ONLY)
+        ]
 
-        mock_reader.assert_not_called()
+    @pytest.mark.asyncio
+    async def test_noop_without_bucket(self, tmp_path, monkeypatch):
+        """No bucket -> return early, do not construct the reader."""
+        fake, _ = await self._run(
+            tmp_path, monkeypatch, local=None, s3=_VALID_CONFIG, bucket=""
+        )
+        assert fake.calls == []
 
 
 class TestMultiplePublishDataviewRecords:
@@ -907,6 +957,13 @@ class TestMultiplePublishDataviewRecords:
             "studio.app.common.routers.dataview." "_sync_experiment_config_for_publish",
             new=AsyncMock(),
         ) as mock_sync, patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
+            "studio.app.common.routers.dataview._resolve_workspace_remote_bucket_name",
+            return_value="test-bucket",
+        ), patch(
             "studio.app.common.routers.dataview.PublishValidator.validate",
             return_value=mock_validation,
         ), patch(
@@ -1020,6 +1077,10 @@ class TestSinglePublishPreSync:
             "studio.app.common.routers.dataview." "_sync_experiment_config_for_publish",
             new=AsyncMock(side_effect=sync_side),
         ) as mock_sync, patch(
+            "studio.app.common.routers.dataview.RemoteStorageController."
+            "is_available",
+            return_value=True,
+        ), patch(
             "studio.app.common.routers.dataview._resolve_workspace_remote_bucket_name",
             return_value="test-bucket",
         ), patch(


### PR DESCRIPTION
## Summary

Publishing an experiment validates it by reading the **local** `experiment.yaml`,
but never syncs it from S3 first. On a lazily-synced instance (free-tier shared or
a freshly-migrated premium instance) that file may be missing or an empty/`{}`
stub, so a perfectly valid experiment is rejected with **HTTP 400**
("configuration is incomplete/corrupted") purely because of which instance served
the request. The rejection is also silent — no user feedback and no app-level log.

This PR:

- makes the publish path (single + bulk) **sync experiment metadata on demand**
  before validation, mirroring what every read/view endpoint already does;
- **repairs corrupt/empty `{}` stubs** (not just missing files) so validation sees
  the same data that exists in S3;
- **surfaces the failure** — logs the rejected records/reasons (backend) and shows
  the backend error message in a snackbar (frontend).

A record whose `experiment.yaml` is genuinely absent from S3 still returns 400
(the intended "cannot publish"), so bulk all-or-nothing semantics are preserved.

## Root Cause

`PublishValidator.validate` runs against the **local** path from
`ExptConfigReader.get_config_yaml_path` and checks, in order: the file exists, it
parses, it has the required fields, `config.success == SUCCESS`. It never triggers
a download. On a lazily-synced instance the local file is missing or a `{}` stub,
so step 1–3 fails → `can_publish = False` → the router raises 400.

Every read/view endpoint already syncs-on-demand before reading the config; only
the publish path did not:

| Path | Syncs from S3 first? |
|------|----------------------|
| `workflow.py` reproduce / `run.py` / `experiment.py` (view) | Yes |
| `dataview.py` public reproduce / view | Yes |
| `publish_dataview_records` (single) | **No** (before this PR) |
| `multiple_publish_dataview_records` (bulk) | **No** (before this PR) |

Note the existing `ExptConfigReader.ensure_synced_async` skips when the file
already exists, so it repairs a *missing* config but **not** a present-but-invalid
one. This PR uses a dedicated repair path that re-downloads such configs
non-destructively.

## Changed Files

### Backend — `studio/app/common/routers/dataview.py`

New helper `_sync_experiment_config_for_publish(workspace_id, unique_id, remote_bucket_name)`
(the caller resolves the bucket, so the helper does no DB access and is safe to run
concurrently over one Session):

- no-op when remote storage is off or the bucket is empty;
- **skip when the local config already passes `PublishValidator.validate`** — a
  config that merely *parses* may still be missing required fields (`nwb`/`snakemake`
  are read via `.get()`) or be stale (`success: running`), so the skip uses the same
  validator the handler does, not just "`read()` didn't throw";
- otherwise download fresh metadata (`METADATA_ONLY`, `download_experiment_meta`).
  An existing invalid config is **moved to `.bak` first** (the download skips files
  that already exist) and **restored if the download yields no replacement**, so the
  only local copy is never lost when S3 has nothing — the `exists→move` race is
  absorbed with `os.replace` + benign `FileNotFoundError`;
- best-effort: failures are logged and swallowed. If the experiment cannot be synced
  the config is left as-is and `PublishValidator.validate` returns the real 400.

Wired into both publish handlers before validation, guarded on `is_available()` so the
bucket lookup (a DB join) is skipped when remote storage is off:

- `publish_dataview_records` (single): `await` the helper before `validate`.
- `multiple_publish_dataview_records` (bulk): made `async`; de-duplicates `ids`,
  resolves the bucket once per workspace, and syncs concurrently under an
  `asyncio.Semaphore(8)` to bound the fan-out of `RemoteStorageReader` clients.

Both handlers now `logger.warning` the rejected record(s) + reason where the 400
is raised (previously CloudWatch showed only the bare `... 400` access line).

### Frontend — `frontend/src/components/Dataview/DataviewRecords.tsx`

`handlePublish` (single) and `handlePublishOk` (bulk) now `.unwrap()` the dispatch,
catch the rejection, and `enqueueSnackbar` the backend's `detail`
(e.g. "Some experiments cannot be published: - {name}: {reason}"). Previously the
human-readable detail was discarded and no snackbar appeared.

## Automated Test Cases

`studio/tests/app/common/routers/test_dataview_publish.py` — the helper tests run
against a **real filesystem** and the real `PublishValidator`, faking only the S3
download, so they pin the repaired behaviour (not just that the code calls a mock):

| Test | Probe | Expected |
|---|---|---|
| `test_absent_local_valid_in_s3_becomes_publishable` | A | no local config, valid in S3 → downloaded, publishable |
| `test_stub_local_valid_in_s3_is_repaired` | B | `{}` stub, valid in S3 → repaired, backup discarded |
| `test_incomplete_local_valid_in_s3_is_repaired` | C | parses but missing fields → re-synced (old skip did **not** repair) |
| `test_stub_local_absent_in_s3_preserves_original` | E | `{}` stub, absent in S3 → file **not** destroyed (restored) |
| `test_valid_local_skips_download` | — | valid config → no S3 call |
| `test_download_uses_metadata_only_and_correct_args` | — | reader built with `(bucket, ws, uid, METADATA_ONLY)` |
| `test_noop_without_bucket` | — | empty bucket → reader not constructed |
| `test_bulk_publish_success_presyncs_each_record` | — | all valid → pre-sync per record, service invoked |
| `test_bulk_publish_blocks_when_a_record_invalid` | — | one invalid → 400, nothing published |
| `test_single_publish_presyncs_before_validate` | — | single publish syncs before validating |

Frontend covers the snackbar path for bulk publish (backend `detail` shown, `pre-line`
style) and bulk unpublish (action-aware fallback message).

```
docker compose -f docker-compose.test.yml run --rm test_studio_backend \
  python -m pytest studio/tests/app/common/routers/test_dataview_publish.py -q
# 27 passed

cd frontend && CI=true node_modules/.bin/react-app-rewired test \
  --testPathPattern="DataviewRecords" --watchAll=false
# 19 passed
```

## Manual Test Plan

### Prerequisites

- **Focus:** the publish **operation** (owner publishing their own experiment), not the
  viewing of published data — the public instance / viewer download-on-view path is out
  of scope.
- **Which container:** publish (`POST /api/dataview/publish/...`, authenticated) is
  served by the **owner's** free-shared or premium instance, **never the public
  instance** (`INSTANCE_MODE=public` skips `dataview.router`; see
  `studio/__main_unit__.py`). "The container" below = that owner-serving backend (reach
  it via `aws ecs execute-command`, or use a local dev container).
- **Data in S3:** `experiment.yaml` is uploaded to S3 at **workflow completion**, so
  "valid in S3" needs only a completed run — **no prior publish** (the
  "publish-then-syncs" behaviour is the public instance's viewer path).
- A user that **can publish** (`remote_bucket_name` set) on an instance with
  `REMOTE_STORAGE_TYPE=2`, plus one **owned, unpublished** experiment intact in S3
  (e.g. tutorial1 run to completion). Shell access to that container + browser DevTools.

> These tests **simulate** the lazily-synced state (fresh premium migration / free-shared
> instance that hasn't pulled the workspace) by editing the **local** `experiment.yaml`
> while leaving the S3 copy intact — runnable on any single S3-configured instance; no
> second instance or public service needed.

**Inspection reference** (used by the steps below). On the serving container the config
is at `EXP=/app/studio_data/output/{workspace_id}/{unique_id}/experiment.yaml` and app
logs are in CloudWatch or at `/app/studio_data/logs/studio.log` (`LOG` below).
Grep these exact markers:

| What | Command |
|---|---|
| Publish accepted | `grep "Published experiment {id}, sync_status=pending" $LOG` |
| Single publish rejected | `grep "Publish rejected for experiment {id}" $LOG` |
| Bulk publish rejected | `grep "Bulk publish rejected" $LOG` |
| Pre-sync error (should be absent) | `grep "Publish pre-sync failed for {ws}/{uid}" $LOG` |
| Local config contents / backup | `cat $EXP` &nbsp;·&nbsp; `ls $EXP.bak` |
| S3 download — **only at `LOG_LEVEL=DEBUG`** | `grep "metadata files for \[{ws}/{uid}\]" $LOG` |

The S3 metadata download logs at **DEBUG**, so at the default `INFO` level the primary
proof of a sync is the **file contents** (a real config replacing the deleted/`{}` one
can only have come from S3). To see the download explicitly, run with `LOG_LEVEL=DEBUG`
and grep `Downloading experiment metadata from S3` / `Downloaded N metadata files for`.

### Test 1: Missing local config — single publish (core fix)

**Objective**: A record whose local config is absent (but valid in S3) publishes.

1. Pick an owned, unpublished record. On the container, **delete** its local
   `experiment.yaml` (keep the S3 object). Confirm it is gone: `ls $EXP` → not found.
2. In the UI, toggle **Publish** on for that record.
3. **Verify** (Network tab): the `POST /api/dataview/publish/{id}/on` request returns
   **200**; the row switches to **Published**.
4. **Verify** the S3 sync happened: `cat $EXP` now shows a real config (e.g.
   `grep "success: success" $EXP` prints the line) — since you deleted it in step 1,
   this can only have been restored from S3 — and `grep "Published experiment {id}" $LOG`
   matches. *(Optional explicit download log: with `LOG_LEVEL=DEBUG`,
   `grep "metadata files for \[{ws}/{uid}\]" $LOG`.)*

### Test 2: `{}` stub local config — single publish

**Objective**: A present-but-empty `{}` stub is repaired, not rejected.

1. For another owned, unpublished record, overwrite its local config with exactly
   `{}` (keep the S3 object): `echo '{}' > $EXP`. Confirm: `cat $EXP` → `{}`.
2. Toggle **Publish** on.
3. **Verify** (Network tab): the publish request returns **200**; the row shows
   **Published**.
4. **Verify the re-download**: `cat $EXP` no longer prints `{}` but the real config
   (`grep "workspace_id" $EXP` prints the line) — the `{}` can only have been replaced
   from S3 — and no backup is left behind (`ls $EXP.bak` → not found).
   *(Optional explicit download log: with `LOG_LEVEL=DEBUG`,
   `grep "metadata files for \[{ws}/{uid}\]" $LOG`.)*

### Test 3: Bulk publish with unsynced records

**Objective**: Bulk publish succeeds when all selected records are valid in S3,
even if some are missing/`{}` locally.

1. Select several owned, unpublished records; for two of them delete or `{}`-stub
   the local `experiment.yaml` (all still intact in S3).
2. Trigger **bulk Publish** (Publish all selected).
3. **Verify** (Network tab): `POST /api/dataview/multiple/publish/on` returns **200**;
   **all** selected records show **Published** (the previously-unsynced ones included),
   and `grep "Bulk publish rejected" $LOG` has **no** new match.

### Test 4: Genuinely absent in S3 — 400 + feedback

**Objective**: A record that truly cannot be published is still blocked, and the
failure is now visible.

1. Pick an owned, unpublished record. Make its local config missing/`{}` **and**
   rename/remove its `experiment.yaml` in the **S3** bucket so it cannot be synced.
2. Try to publish it — both **single** and as part of a **bulk** selection.
3. **Verify** (Network tab): the publish request (`.../publish/{id}/on` or
   `.../multiple/publish/on`) returns **400**; nothing is published (for bulk, the
   whole batch is blocked — all-or-nothing).
4. **Verify** (frontend): an **error snackbar** appears showing the backend detail
   (e.g. "Some experiments cannot be published: - {name}: {reason}").
5. **Verify** (logs): a `Publish rejected ...` (single) or `Bulk publish rejected
   N record(s): ...` (bulk) warning with the record name + reason.
6. **Verify the only local copy is not destroyed** (the non-destructive guarantee).
   Check both files with explicit output:
   - `test -e $EXP && echo PRESENT || echo ABSENT`
   - `test -e $EXP.bak && echo "LEFTOVER BAK" || echo "no bak"`

   Expected — **no leftover `.bak`** in every case (`no bak`), plus, by how you set up
   step 1:
   - **`{}`-stub variant:** `$EXP` is **PRESENT** and unchanged (`cat $EXP` → `{}`) —
     it was restored from the backup after the failed sync. *(This is the case that
     proves B1; prefer it here.)*
   - **deleted variant:** `$EXP` stays **ABSENT** — there was nothing to preserve
     (expected; the record is simply un-syncable and 400s).

### Test 5: Regression — already-synced record is not re-synced

**Objective**: A record whose local config is already valid takes the skip fast-path —
publish/unpublish still work and no S3 sync is triggered.

1. Pick an owned record whose local `experiment.yaml` is present **and** valid (leave
   it untouched). Record its mtime: `MTIME=$(stat -c %Y $EXP)`.
2. **Verify the skip (no spurious sync)**: toggle **Publish** on, then **off**.
   - Both requests return **200**; no error snackbar.
   - The local config was **not** rewritten (the helper skipped the download):
     `stat -c %Y $EXP` still equals `$MTIME`, and `ls $EXP.bak` → not found.
   - `grep "Publish pre-sync failed for {ws}/{uid}" $LOG` has **no** match.

## Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Pre-sync helper | Low | Best-effort, wrapped in try/except; no-op when remote storage is off or the bucket is empty; skips entirely when the local config already validates. |
| Non-destructive repair | Low | An invalid config is moved to `.bak` and restored if the download yields no replacement, so the only local copy is never lost; verified by probe E. |
| Bulk handler made async | Low | Validation/service logic unchanged; ids de-duplicated and pre-sync bounded by a semaphore. |
| Frontend snackbar | Low | Additive; happy path unchanged. Action-aware fallback when no `detail` is present. |

## Relationship to the #787 trend analysis

This fix is scoped as a compact instance of the
[Dataview bug-trend analysis in #787](https://github.com/arayabrain/araya-optinist/issues/787#issuecomment-5174823355):

- **Trend 1 (sync-first not enforced per path):** #714 is the publish path missing
  the sync-on-demand guard the read paths already have — the fix restores that
  existing discipline rather than inventing a new pattern.
- **Trend 2 (absent vs unsynced/transient):** "genuinely absent in S3 → keep 400"
  aligns with the tri-state direction from #748 instead of a new state model.
- **Trend 3 (branch proliferation):** the repair logic lives in one helper shared
  by single + bulk, not duplicated inline; the failure is surfaced (log + snackbar)
  so the next occurrence is diagnosable.

The larger "materialization gateway" consolidation (the permanent fix for Trend 1)
is intentionally left out — see below.

## Out of Scope (follow-up)

- Surfacing a concurrent sync lock (`RemoteStorageLockError`) as **423** on the publish
  path, mirroring the read paths, instead of letting it fall through to a 400. The clean
  fix also touches the bulk `gather` error handling, so it is better as its own change.
- Adding a "re-sync when the local config is invalid" option to
  `ExptConfigReader.ensure_synced_async` so this helper and `ensure_synced_async` share
  one implementation (removes the near-duplication).
- Unifying all read/validate/publish paths through a single "ensure the experiment
  is materialized and valid locally" gateway (the permanent fix for the recurring
  "read local, assume valid" class of bugs tracked in #787).
