### PR TITLE
Run interval jobs shortly after startup instead of one full interval later

### DIFF
--- a/studio/app/common/core/background/cleanup_job.py
+++ b/studio/app/common/core/background/cleanup_job.py
@@ -68,6 +68,12 @@ class DataCleanupJob:
     # avoid repeating IMDS round-trips when INSTANCE_ID is unset.
     _instance_id_cache = None
 
+    # Whether the grace-less orphan sweep has been skipped once at startup.
+    # The first run now fires ~10s after boot (INITIAL_RUN_DELAY_SECONDS),
+    # inside the deploy window; skip orphan detection on that first run so a
+    # rolling deploy's instance handoff can complete before we sweep.
+    _orphan_sweep_warmup_done = False
+
     @classmethod
     def _get_current_instance_id(cls) -> str:
         """Return the EC2 instance ID for the current host (cached).
@@ -102,7 +108,16 @@ class DataCleanupJob:
             # run orphan detection — that responsibility stays with the
             # background service which has EC2 describe permissions.
             if os.environ.get("ENABLE_LOCAL_CLEANUP") != "1":
-                cls._handle_orphaned_data()
+                # Defer the grace-less sweep past the first (startup) run so it
+                # does not delete assignments for an instance still handing off
+                # during a rolling deploy. Resumes on the next interval.
+                if cls._orphan_sweep_warmup_done:
+                    cls._handle_orphaned_data()
+                else:
+                    cls._orphan_sweep_warmup_done = True
+                    logger.info(
+                        "Skipping orphaned-data sweep on first run (startup warm-up)"
+                    )
 
             # Get users eligible for cleanup
             users_to_cleanup = cls._get_users_for_cleanup()

--- a/studio/app/common/core/background/scheduler.py
+++ b/studio/app/common/core/background/scheduler.py
@@ -11,6 +11,7 @@ API services disable their schedulers via DISABLE_BACKGROUND_SCHEDULER=1.
 """
 
 import os
+from datetime import datetime, timedelta
 from typing import Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -19,6 +20,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
+from studio.app.common.core.subscription.constants import SyncStatusConstants
 
 logger = AppLogger.get_logger()
 
@@ -143,10 +145,19 @@ class BackgroundScheduler:
 
         NOTE: AsyncIOScheduler automatically detects if func is an async function
         and handles it correctly. No special configuration needed for async jobs.
+
+        First run defaults to now + INITIAL_RUN_DELAY_SECONDS (shortly after
+        startup) instead of now + interval. Pass next_run_time to override.
         """
         if cls._scheduler is None:
             logger.warning("Scheduler not initialized, cannot add job")
             return
+
+        kwargs.setdefault(
+            "next_run_time",
+            datetime.now()
+            + timedelta(seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS),
+        )
 
         cls._scheduler.add_job(
             func,

--- a/studio/app/common/core/background/scheduler.py
+++ b/studio/app/common/core/background/scheduler.py
@@ -11,7 +11,7 @@ API services disable their schedulers via DISABLE_BACKGROUND_SCHEDULER=1.
 """
 
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -21,6 +21,7 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.storage.remote_storage_controller import RemoteStorageType
 from studio.app.common.core.subscription.constants import SyncStatusConstants
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
 logger = AppLogger.get_logger()
 
@@ -155,7 +156,7 @@ class BackgroundScheduler:
 
         kwargs.setdefault(
             "next_run_time",
-            datetime.now()
+            get_current_datetime()
             + timedelta(seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS),
         )
 

--- a/studio/app/common/core/background/scheduler.py
+++ b/studio/app/common/core/background/scheduler.py
@@ -154,11 +154,13 @@ class BackgroundScheduler:
             logger.warning("Scheduler not initialized, cannot add job")
             return
 
-        kwargs.setdefault(
-            "next_run_time",
-            get_current_datetime()
-            + timedelta(seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS),
-        )
+        # Apply the default when next_run_time is absent OR explicitly None:
+        # APScheduler treats next_run_time=None as "paused" (never fires), so
+        # setdefault alone would let a None slip through. get()-check covers both.
+        if kwargs.get("next_run_time") is None:
+            kwargs["next_run_time"] = get_current_datetime() + timedelta(
+                seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+            )
 
         cls._scheduler.add_job(
             func,

--- a/studio/app/common/core/subscription/constants.py
+++ b/studio/app/common/core/subscription/constants.py
@@ -356,6 +356,12 @@ class SyncStatusConstants:
         tempfile.gettempdir(), "optinist_sync_job.lock"
     )  # Lock file to prevent concurrent runs (cross-platform)
 
+    # Interval jobs' first run: next_run_time = now + this delay.
+    # Without it, IntervalTrigger first fires at now+interval (delaying the
+    # first run a full interval after each restart).
+    # Non-zero to avoid racing container/DB startup; kept under a minute.
+    INITIAL_RUN_DELAY_SECONDS = 10
+
     # Cleanup job configuration
     CLEANUP_INTERVAL_MINUTES = 60  # How often to run cleanup job
     LOGOUT_GRACE_PERIOD_MINUTES = 60  # Wait time after logout before cleanup

--- a/studio/cleanup_worker.py
+++ b/studio/cleanup_worker.py
@@ -16,7 +16,7 @@ SIGTERM / SIGINT (ECS sends SIGTERM on task stop).
 
 import asyncio
 import signal
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -24,6 +24,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from studio.app.common.core.background.cleanup_job import DataCleanupJob
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.subscription.constants import SyncStatusConstants
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
 from studio.app.common.core.utils.instance_utils import resolve_instance_id
 
 logger = AppLogger.get_logger()
@@ -44,7 +45,7 @@ def main() -> None:
 
     scheduler = AsyncIOScheduler(event_loop=loop)
     # First cleanup shortly after startup, not now+interval.
-    first_run = datetime.now() + timedelta(
+    first_run = get_current_datetime() + timedelta(
         seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
     )
     scheduler.add_job(

--- a/studio/cleanup_worker.py
+++ b/studio/cleanup_worker.py
@@ -16,6 +16,7 @@ SIGTERM / SIGINT (ECS sends SIGTERM on task stop).
 
 import asyncio
 import signal
+from datetime import datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -42,11 +43,16 @@ def main() -> None:
     asyncio.set_event_loop(loop)
 
     scheduler = AsyncIOScheduler(event_loop=loop)
+    # First cleanup shortly after startup, not now+interval.
+    first_run = datetime.now() + timedelta(
+        seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+    )
     scheduler.add_job(
         DataCleanupJob.run,
         trigger=IntervalTrigger(minutes=SyncStatusConstants.CLEANUP_INTERVAL_MINUTES),
         id="local_data_cleanup",
         replace_existing=True,
+        next_run_time=first_run,
     )
     scheduler.start()
 

--- a/studio/tests/app/common/core/background/test_cleanup_job.py
+++ b/studio/tests/app/common/core/background/test_cleanup_job.py
@@ -340,7 +340,10 @@ class TestHandleOrphanedData:
                     mock_orphan.assert_not_called()
 
     def test_handle_orphaned_data_runs_on_background_service(self):
-        """Test _handle_orphaned_data runs when ENABLE_LOCAL_CLEANUP is not set"""
+        """Test _handle_orphaned_data runs when ENABLE_LOCAL_CLEANUP is not set
+
+        (after the first, startup run — see the warm-up skip test below).
+        """
         import asyncio
 
         with patch.dict("os.environ", {"INSTANCE_ID": "i-bg"}, clear=False):
@@ -350,14 +353,41 @@ class TestHandleOrphanedData:
 
                 _os.environ.pop("ENABLE_LOCAL_CLEANUP", None)
 
-                with patch.object(
-                    DataCleanupJob, "_handle_orphaned_data"
-                ) as mock_orphan:
+                # Simulate a process past its startup warm-up run.
+                with patch.object(DataCleanupJob, "_orphan_sweep_warmup_done", True):
                     with patch.object(
-                        DataCleanupJob, "_get_users_for_cleanup", return_value=[]
-                    ):
-                        asyncio.run(DataCleanupJob.run())
-                    mock_orphan.assert_called_once()
+                        DataCleanupJob, "_handle_orphaned_data"
+                    ) as mock_orphan:
+                        with patch.object(
+                            DataCleanupJob, "_get_users_for_cleanup", return_value=[]
+                        ):
+                            asyncio.run(DataCleanupJob.run())
+                        mock_orphan.assert_called_once()
+
+    def test_handle_orphaned_data_skipped_on_first_run(self):
+        """First run after startup skips the grace-less orphan sweep.
+
+        Deferring it past the deploy window avoids deleting assignments for an
+        instance that is still handing off during a rolling deploy.
+        """
+        import asyncio
+
+        with patch.dict("os.environ", {"INSTANCE_ID": "i-bg"}, clear=False):
+            with patch.dict("os.environ", {}, clear=False):
+                import os as _os
+
+                _os.environ.pop("ENABLE_LOCAL_CLEANUP", None)
+
+                # Fresh process: warm-up run not yet done.
+                with patch.object(DataCleanupJob, "_orphan_sweep_warmup_done", False):
+                    with patch.object(
+                        DataCleanupJob, "_handle_orphaned_data"
+                    ) as mock_orphan:
+                        with patch.object(
+                            DataCleanupJob, "_get_users_for_cleanup", return_value=[]
+                        ):
+                            asyncio.run(DataCleanupJob.run())
+                        mock_orphan.assert_not_called()
 
 
 class TestGetCurrentInstanceId:

--- a/studio/tests/app/common/core/background/test_scheduler.py
+++ b/studio/tests/app/common/core/background/test_scheduler.py
@@ -11,12 +11,20 @@ from studio.app.common.core.background.scheduler import BackgroundScheduler
 from studio.app.common.core.subscription.constants import SyncStatusConstants
 from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
+DELAY = timedelta(seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS)
+
 
 def _add_job_and_capture(**extra_kwargs):
-    """Call add_job against a mocked scheduler; return the forwarded kwargs."""
+    """Call add_job against a mocked scheduler; return (before, kwargs, after).
+
+    `before`/`after` bracket the moment add_job computed next_run_time, so callers
+    can assert the value falls in a precise window without a flaky bare
+    wall-clock subtraction.
+    """
     mock_scheduler = MagicMock()
     original = BackgroundScheduler._scheduler
     BackgroundScheduler._scheduler = mock_scheduler
+    before = get_current_datetime()
     try:
         BackgroundScheduler.add_job(
             func=lambda: None,
@@ -25,40 +33,57 @@ def _add_job_and_capture(**extra_kwargs):
             **extra_kwargs,
         )
     finally:
+        after = get_current_datetime()
         BackgroundScheduler._scheduler = original
 
     mock_scheduler.add_job.assert_called_once()
-    return mock_scheduler.add_job.call_args.kwargs
+    return before, mock_scheduler.add_job.call_args.kwargs, after
 
 
 def test_add_job_defaults_next_run_time_shortly_after_startup():
-    """Default first run is a small, bounded delay from now, not a full interval."""
-    kwargs = _add_job_and_capture()
+    """Default first run lands just after startup and within a literal ~minute."""
+    before, kwargs, after = _add_job_and_capture()
 
     next_run_time = kwargs["next_run_time"]
-    delay = (next_run_time - get_current_datetime()).total_seconds()
-    assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+    # Exact window: next_run_time == (now during add_job) + DELAY.
+    assert before + DELAY <= next_run_time <= after + DELAY
+    # Literal upper bound, independent of the constant: catches an over-large
+    # INITIAL_RUN_DELAY_SECONDS (e.g. 3600) that would no longer be "shortly".
+    assert (next_run_time - before).total_seconds() <= 60
+
+
+def test_add_job_pins_misfire_grace_time():
+    """misfire_grace_time stays 60s (the 3d3710d9b sweepjob fix)."""
+    _, kwargs, _ = _add_job_and_capture()
+    assert kwargs["misfire_grace_time"] == 60
 
 
 def test_add_job_preserves_caller_next_run_time():
-    """A caller-supplied next_run_time is not overridden."""
+    """A caller-supplied (non-None) next_run_time is not overridden."""
     explicit = get_current_datetime() + timedelta(minutes=30)
-    kwargs = _add_job_and_capture(next_run_time=explicit)
+    _, kwargs, _ = _add_job_and_capture(next_run_time=explicit)
 
     assert kwargs["next_run_time"] == explicit
 
 
-def test_initial_run_delay_is_bounded():
-    """First run lands within ~a minute of startup, not a full interval."""
-    assert 0 < SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
+def test_add_job_replaces_explicit_none_next_run_time():
+    """An explicit next_run_time=None is replaced (None would pause the job)."""
+    before, kwargs, after = _add_job_and_capture(next_run_time=None)
+
+    next_run_time = kwargs["next_run_time"]
+    assert next_run_time is not None
+    assert before + DELAY <= next_run_time <= after + DELAY
 
 
 def test_add_job_noop_when_not_initialized():
-    """add_job is a safe no-op if the scheduler was never initialized."""
+    """add_job is a safe no-op when the scheduler was never initialized."""
     original = BackgroundScheduler._scheduler
     BackgroundScheduler._scheduler = None
     try:
-        # Should not raise.
-        BackgroundScheduler.add_job(func=lambda: None, interval_minutes=5, job_id="x")
+        result = BackgroundScheduler.add_job(
+            func=lambda: None, interval_minutes=5, job_id="x"
+        )
+        assert result is None
+        assert BackgroundScheduler._scheduler is None
     finally:
         BackgroundScheduler._scheduler = original

--- a/studio/tests/app/common/core/background/test_scheduler.py
+++ b/studio/tests/app/common/core/background/test_scheduler.py
@@ -1,0 +1,60 @@
+"""Tests for BackgroundScheduler.add_job first-run scheduling.
+
+add_job defaults next_run_time to now + a small delay so interval jobs run
+shortly after startup (not now+interval), and lets callers override it.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from studio.app.common.core.background.scheduler import BackgroundScheduler
+from studio.app.common.core.subscription.constants import SyncStatusConstants
+
+
+def _add_job_and_capture(**extra_kwargs):
+    """Call add_job against a mocked scheduler; return the forwarded kwargs."""
+    mock_scheduler = MagicMock()
+    original = BackgroundScheduler._scheduler
+    BackgroundScheduler._scheduler = mock_scheduler
+    try:
+        BackgroundScheduler.add_job(
+            func=lambda: None,
+            interval_minutes=60,
+            job_id="test_job",
+            **extra_kwargs,
+        )
+    finally:
+        BackgroundScheduler._scheduler = original
+
+    mock_scheduler.add_job.assert_called_once()
+    return mock_scheduler.add_job.call_args.kwargs
+
+
+def test_add_job_defaults_next_run_time_shortly_after_startup():
+    """Default first run is a small, bounded delay from now, not a full interval."""
+    kwargs = _add_job_and_capture()
+
+    next_run_time = kwargs["next_run_time"]
+    delay = (next_run_time - datetime.now()).total_seconds()
+    assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+    # First run within ~a minute, not a full interval.
+    assert SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
+
+
+def test_add_job_preserves_caller_next_run_time():
+    """A caller-supplied next_run_time is not overridden."""
+    explicit = datetime.now() + timedelta(minutes=30)
+    kwargs = _add_job_and_capture(next_run_time=explicit)
+
+    assert kwargs["next_run_time"] == explicit
+
+
+def test_add_job_noop_when_not_initialized():
+    """add_job is a safe no-op if the scheduler was never initialized."""
+    original = BackgroundScheduler._scheduler
+    BackgroundScheduler._scheduler = None
+    try:
+        # Should not raise.
+        BackgroundScheduler.add_job(func=lambda: None, interval_minutes=5, job_id="x")
+    finally:
+        BackgroundScheduler._scheduler = original

--- a/studio/tests/app/common/core/background/test_scheduler.py
+++ b/studio/tests/app/common/core/background/test_scheduler.py
@@ -4,11 +4,12 @@ add_job defaults next_run_time to now + a small delay so interval jobs run
 shortly after startup (not now+interval), and lets callers override it.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from studio.app.common.core.background.scheduler import BackgroundScheduler
 from studio.app.common.core.subscription.constants import SyncStatusConstants
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
 
 def _add_job_and_capture(**extra_kwargs):
@@ -35,18 +36,21 @@ def test_add_job_defaults_next_run_time_shortly_after_startup():
     kwargs = _add_job_and_capture()
 
     next_run_time = kwargs["next_run_time"]
-    delay = (next_run_time - datetime.now()).total_seconds()
+    delay = (next_run_time - get_current_datetime()).total_seconds()
     assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
-    # First run within ~a minute, not a full interval.
-    assert SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
 
 
 def test_add_job_preserves_caller_next_run_time():
     """A caller-supplied next_run_time is not overridden."""
-    explicit = datetime.now() + timedelta(minutes=30)
+    explicit = get_current_datetime() + timedelta(minutes=30)
     kwargs = _add_job_and_capture(next_run_time=explicit)
 
     assert kwargs["next_run_time"] == explicit
+
+
+def test_initial_run_delay_is_bounded():
+    """First run lands within ~a minute of startup, not a full interval."""
+    assert 0 < SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
 
 
 def test_add_job_noop_when_not_initialized():

--- a/studio/tests/test_cleanup_worker.py
+++ b/studio/tests/test_cleanup_worker.py
@@ -5,6 +5,7 @@ verify the scheduler is registered with the expected job id / interval and
 that SIGTERM / SIGINT handlers are installed.
 """
 
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from studio.app.common.core.background.cleanup_job import DataCleanupJob
@@ -37,6 +38,13 @@ def test_main_registers_cleanup_job():
             trigger.interval.total_seconds()
             == SyncStatusConstants.CLEANUP_INTERVAL_MINUTES * 60
         )
+
+        # First run shortly after startup: next_run_time is a small, bounded
+        # delay from now, not a full interval later.
+        next_run_time = kwargs["next_run_time"]
+        delay = (next_run_time - datetime.now()).total_seconds()
+        assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+        assert SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
 
         mock_sched.start.assert_called_once()
         mock_loop.run_forever.assert_called_once()

--- a/studio/tests/test_cleanup_worker.py
+++ b/studio/tests/test_cleanup_worker.py
@@ -5,6 +5,7 @@ verify the scheduler is registered with the expected job id / interval and
 that SIGTERM / SIGINT handlers are installed.
 """
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from studio.app.common.core.background.cleanup_job import DataCleanupJob
@@ -26,7 +27,9 @@ def test_main_registers_cleanup_job():
         mock_loop = MagicMock()
         mock_asyncio.new_event_loop.return_value = mock_loop
 
+        before = get_current_datetime()
         worker.main()
+        after = get_current_datetime()
 
         # Job registered with correct target, id and interval
         mock_sched.add_job.assert_called_once()
@@ -39,11 +42,12 @@ def test_main_registers_cleanup_job():
             == SyncStatusConstants.CLEANUP_INTERVAL_MINUTES * 60
         )
 
-        # First run shortly after startup: next_run_time is a small, bounded
-        # delay from now, not a full interval later.
+        # First run shortly after startup: next_run_time falls in the window
+        # [before, after] + delay, not a full interval later. Window bounds
+        # (not a bare wall-clock subtraction) keep this non-flaky under load.
+        delay = timedelta(seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS)
         next_run_time = kwargs["next_run_time"]
-        delay = (next_run_time - get_current_datetime()).total_seconds()
-        assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
+        assert before + delay <= next_run_time <= after + delay
 
         mock_sched.start.assert_called_once()
         mock_loop.run_forever.assert_called_once()

--- a/studio/tests/test_cleanup_worker.py
+++ b/studio/tests/test_cleanup_worker.py
@@ -5,11 +5,11 @@ verify the scheduler is registered with the expected job id / interval and
 that SIGTERM / SIGINT handlers are installed.
 """
 
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from studio.app.common.core.background.cleanup_job import DataCleanupJob
 from studio.app.common.core.subscription.constants import SyncStatusConstants
+from studio.app.common.core.utils.datetime_utils import get_current_datetime
 
 
 def test_main_registers_cleanup_job():
@@ -42,9 +42,8 @@ def test_main_registers_cleanup_job():
         # First run shortly after startup: next_run_time is a small, bounded
         # delay from now, not a full interval later.
         next_run_time = kwargs["next_run_time"]
-        delay = (next_run_time - datetime.now()).total_seconds()
+        delay = (next_run_time - get_current_datetime()).total_seconds()
         assert 0 < delay <= SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
-        assert SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS <= 60
 
         mock_sched.start.assert_called_once()
         mock_loop.run_forever.assert_called_once()


### PR DESCRIPTION
## Summary

Interval-triggered background jobs register an APScheduler `IntervalTrigger`
with **no `start_date` / `next_run_time`**, so APScheduler schedules the **first**
fire at `now + interval`. The first run is therefore delayed a full interval
after the process starts, and every deploy / task restart resets the clock — so
frequent restarts keep pushing the first run out.

This affects:

- `studio/cleanup_worker.py` (the free-tier standalone cleanup worker) — first
  `DataCleanupJob.run` up to **60 min** after boot.
- Every job registered through `BackgroundScheduler.add_job` (sync,
  cleanup, storage-reconciliation, expiration, premium-expiration-sweep) — all
  skip their first interval after deploy too. Same root cause, so this is a
  **shared scheduling gap**, not only a cleanup-worker one.

This PR makes the first run fire **shortly after startup** by passing an explicit
`next_run_time = now + INITIAL_RUN_DELAY_SECONDS` (10 s). The delay is non-zero to
avoid racing container/DB startup and is kept well under a minute.

**Severity:** Low. Data is still cleaned/synced eventually; only the first pass
after a deploy/restart was delayed. No data loss. Worth fixing because it slows
the feedback loop on a fresh deploy and, combined with frequent restarts, can
extend the effective time-to-first-run well beyond one interval.

## Root Cause

An `IntervalTrigger` with no anchor computes its first fire time relative to when
it is added:

```python
# studio/cleanup_worker.py (before)
scheduler.add_job(
    DataCleanupJob.run,
    trigger=IntervalTrigger(minutes=CLEANUP_INTERVAL_MINUTES),  # 60
    id="local_data_cleanup",
    replace_existing=True,
)  # first fire = startup + 60min
```

```python
# BackgroundScheduler.add_job (before)
cls._scheduler.add_job(
    func,
    trigger=IntervalTrigger(minutes=interval_minutes),
    id=job_id,
    replace_existing=True,
    misfire_grace_time=60,
    **kwargs,
)  # first fire = startup + interval, for every registered job
```

Passing `next_run_time` overrides the first fire time only; the recurring cadence
is unchanged. The value is a **timezone-aware UTC** datetime (via the project's
`get_current_datetime()` helper). This is a **policy alignment, not a correctness
fix** — the naive `datetime.now()` variant also yields exactly the same 10 s first
fire in every timezone, because APScheduler localizes a naive `next_run_time` to
the scheduler's own tz. Using the aware helper simply matches the datetime_utils
convention and removes a latent footgun if the scheduler tz is ever set explicitly.

To avoid the grace-less orphaned-data sweep running inside a rolling-deploy window,
`DataCleanupJob` **defers `_handle_orphaned_data()` past the first run after
startup** (it resumes on the next interval). The first, early run does local
cleanup only. This affects the background service only; free-tier `cleanup_worker`
processes already skip orphan detection (`ENABLE_LOCAL_CLEANUP=1`).

## Scope decision

Fixed **centrally** in `BackgroundScheduler.add_job` **and** in the standalone
`cleanup_worker.py`, rather than the cleanup worker alone. The gap is shared by
all interval jobs, so a central fix is cleaner and gives every job a run shortly
after startup. This changes the first-run timing of the sync / reconciliation /
expiration / premium-sweep jobs too (they now also run ~10 s after startup);
their recurring interval is unchanged. Callers can still override or opt out by
passing their own `next_run_time`.

**Startup load note:** as a consequence, all five background-service jobs
(`published_experiment_sync`, `data_cleanup`, `storage_reconciliation`,
`ExpirationLifecycleJob`, `PremiumExpirationSweepJob`) now fire their **first**
run within the same ~10 s window after startup, instead of being spread across
their respective intervals. This is a brief, one-time concurrent I/O touch on a
single background service (each job is `max_instances=1`), so the spike is minor.
If startup DB/S3 contention ever becomes a concern, a small per-job offset
(`INITIAL_RUN_DELAY_SECONDS + i * few_seconds`) can stagger them; not done here as
the current load is negligible.

## Changed Files

| File | Change |
|------|--------|
| `studio/app/common/core/subscription/constants.py` | Add `SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS = 10`. |
| `studio/cleanup_worker.py` | Pass `next_run_time = get_current_datetime() + delay` so the first cleanup runs at startup+delay. |
| `studio/app/common/core/background/scheduler.py` | `add_job` sets `next_run_time` to `get_current_datetime() + delay` when absent **or explicitly None** (None would pause the job); callers may still override with a real value — applies to all interval jobs. |
| `studio/app/common/core/background/cleanup_job.py` | Defer `_handle_orphaned_data()` past the first run after startup (background service only); resumes on the next interval. |
| `studio/tests/test_cleanup_worker.py` | Assert `next_run_time` falls in a captured `[before, after] + delay` window (non-flaky). |
| `studio/tests/app/common/core/background/test_scheduler.py` | default (literal 60s bound) / misfire-grace pin / caller-override / explicit-None / uninitialized-no-op. |
| `studio/tests/app/common/core/background/test_cleanup_job.py` | First-run orphan-sweep skip + warmed-up run. |

### `add_job` (after)

```python
# Apply the default when next_run_time is absent OR explicitly None
# (APScheduler treats None as "paused"). A real caller value is preserved.
if kwargs.get("next_run_time") is None:
    kwargs["next_run_time"] = get_current_datetime() + timedelta(
        seconds=SyncStatusConstants.INITIAL_RUN_DELAY_SECONDS
    )
cls._scheduler.add_job(
    func,
    trigger=IntervalTrigger(minutes=interval_minutes),
    id=job_id,
    replace_existing=True,
    misfire_grace_time=60,
    **kwargs,
)
```

## Automated Tests

| # | Test | Asserts |
|---|------|---------|
| 1 | `test_cleanup_worker.py::test_main_registers_cleanup_job` | Job id/interval **plus** `next_run_time` in a captured `[before, after] + delay` window (non-flaky). |
| 2 | `test_scheduler.py::test_add_job_defaults_next_run_time_shortly_after_startup` | Window bound **and** a literal `≤ 60 s` bound (independent of the constant). |
| 3 | `test_scheduler.py::test_add_job_pins_misfire_grace_time` | `misfire_grace_time == 60` (pins the sweepjob fix). |
| 4 | `test_scheduler.py::test_add_job_preserves_caller_next_run_time` | A caller-supplied (non-None) `next_run_time` is not overridden. |
| 5 | `test_scheduler.py::test_add_job_replaces_explicit_none_next_run_time` | An explicit `next_run_time=None` is replaced (would otherwise pause the job). |
| 6 | `test_scheduler.py::test_add_job_noop_when_not_initialized` | Safe no-op (returns None, scheduler stays None) when uninitialized. |
| 7 | `test_cleanup_job.py::test_handle_orphaned_data_skipped_on_first_run` | First run after startup skips the orphan sweep. |
| 8 | `test_cleanup_job.py::test_handle_orphaned_data_runs_on_background_service` | A warmed-up run does run the orphan sweep. |

```
studio/tests/app/common/core/background/ + test_cleanup_worker : 133 passed
flake8 (changed files) : clean
```

## Manual Test Plan

The recurring behavior is unchanged; the only observable change is **when the
first run fires after startup**. Both tests confirm the first run appears within a
few seconds, not a full interval later.

### Prerequisites

- Local dev / staging checkout of this branch.
- A shell that can tail the app logs (CloudWatch Logs group for the relevant ECS
  task in staging, or stdout locally).
- Ability to note wall-clock timestamps of log lines.

### Test 1: Standalone cleanup worker first run (free tier)

**Objective:** The first `DataCleanupJob.run` fires ~10 s after the worker starts,
not 60 min later.

#### Steps

1. Start the worker (the same command `cloud-startup.sh` uses):
   ```bash
   python -m studio.cleanup_worker
   ```
2. In the logs, note the timestamp of the startup line:
   ```
   cleanup_worker starting (instance: <id>, interval: 60min)
   ```
3. Watch for the first cleanup-run line:
   ```
   Starting data cleanup job for logged-out free users (instance: <id>)
   ```
4. **Verify:** the cleanup-run line appears **~10 seconds** after the startup line
   (bounded by `INITIAL_RUN_DELAY_SECONDS`), **not** ~60 minutes later.
5. **Verify (regression):** leave the worker running; the next cleanup-run line
   appears ~60 minutes after the first — the recurring interval is unchanged.

**Checkpoint:** first run is bounded to a few seconds after startup; cadence is
still 60 min.

### Test 2: Background scheduler jobs first run (background service)

**Objective:** Every job registered via `BackgroundScheduler.add_job` fires its
first run shortly after startup.

#### Steps

1. Start the background service (scheduler enabled — i.e. **not** standalone and
   `DISABLE_BACKGROUND_SCHEDULER` unset), e.g. a normal non-standalone app start.
2. In the logs, note the **scheduler-start timestamp** `T0` (the anchor for every
   check below):
   ```
   Background job scheduler started
   ```
   Immediately before it, all **five** jobs register (this is the full set — none
   are omitted):
   ```
   Added background job: published_experiment_sync (runs every 5 minutes)
   Added background job: data_cleanup (runs every 60 minutes)
   Added background job: storage_reconciliation (runs every 60 minutes)
   Added background job: expiration_lifecycle (runs every 1440 minutes)
   Added background job: premium_expiration_sweep (runs every 60 minutes)
   ```
3. **Verify (this is the core check):** each job emits an `INFO` line at the top of
   its `run()`. All five must appear **within ~10 s of `T0`** — i.e.
   `(first-run line timestamp) − T0 ≈ 10 s` (a few seconds up to ~10 s, always
   `< 60 s`), **not** after the job's full interval. The exact lines to grep for:

   | job_id | first-run log line (`run()` opening `INFO`) | interval (old wait) |
   |--------|---------------------------------------------|---------------------|
   | `published_experiment_sync` | `Starting published experiment validation job` | 5 min |
   | `data_cleanup` | `Starting data cleanup job for logged-out free users (instance: <id>)` | 60 min |
   | `storage_reconciliation` | `Starting storage reconciliation job` | 60 min |
   | `expiration_lifecycle` | `Starting expiration lifecycle job` | **1440 min (24 h)** |
   | `premium_expiration_sweep` | `Starting premium expiration sweep job` | 60 min |

   The clearest signal is `expiration_lifecycle`: previously it would not run for
   **24 h**, so seeing `Starting expiration lifecycle job` ~10 s after `T0`
   directly demonstrates the fix.

   Grep helper (local run — the app writes to `studio.log`):
   ```bash
   grep -nE "Background job scheduler started|Starting published experiment validation job|Starting data cleanup job|Starting storage reconciliation job|Starting expiration lifecycle job|Starting premium expiration sweep job" studio.log
   ```
   CloudWatch (staging ECS task log group):
   ```bash
   aws logs filter-log-events \
     --log-group-name <ECS-task-log-group> \
     --filter-pattern '"Starting" "job"' \
     --start-time <T0 epoch ms>
   ```
   Note: `storage_reconciliation` early-returns *before* logging its start line when
   `MODE.IS_STANDALONE`; Step 1 already requires a non-standalone start, so it will
   log normally here.
4. **Verify (regression):** subsequent runs still follow each job's configured
   interval (sync every 5 min, cleanup/reconciliation every 60 min).

**Checkpoint:** all interval jobs run once shortly after startup; recurring
intervals are unchanged.

### Test 3: Startup-race safety (no zero-delay)

**Objective:** Confirm the initial delay is non-zero so the first run does not
race container/DB startup.

There is **no log line that prints `next_run_time` directly.**

**Already covered by automated tests — no pytest run needed here.** The non-zero,
bounded delay is asserted by the CI suite (see **Automated Tests** above):
`test_scheduler.py::test_add_job_defaults_next_run_time_shortly_after_startup`
(#2 — window **and** literal `≤ 60 s` bound) and
`test_cleanup_worker.py::test_main_registers_cleanup_job` (#1 — worker path). If
those pass in CI, the delay is `> 0` and `≤ 10 s` by construction. The steps below
are only a manual cross-check on a running instance; skip them if you are relying
on CI.

#### Manual cross-check (optional — from a running instance)

The app writes to **`studio.log`**. Reuse the same run as Test 1
or Test 2 — no separate startup is needed.

1. Extract the startup line and the first job-run line, with their timestamps:
   ```bash
   # Background service (Test 2): scheduler start vs. the earliest job first-run
   grep -E "Background job scheduler started|Starting (published experiment validation|data cleanup|storage reconciliation|expiration lifecycle|premium expiration sweep)" studio.log | head

   # OR standalone worker (Test 1):
   grep -E "cleanup_worker starting|Starting data cleanup job for logged-out free users" studio.log | head
   ```
   Each line begins with a `YYYY-MM-DD HH:MM:SS,mmm` timestamp, e.g.:
   ```
   2026-08-06 13:14:19,604 INFO:  ... cleanup_worker starting (instance: i-worker, interval: 60min)
   2026-08-06 13:14:29,610 INFO:  ... Starting data cleanup job for logged-out free users (instance: i-worker)
   ```
2. Subtract the startup timestamp from the first-run timestamp
   (`13:14:29 − 13:14:19 = 10 s` in the example above).
3. **Verify:** the difference is **strictly greater than 0** (the two lines are
   never in the same second) **and ≈ 10 s** (`INITIAL_RUN_DELAY_SECONDS`, always
   `< 60 s`). This shows the first run is deferred a few seconds past startup, not
   fired at `t=0`, giving the container/DB time to initialize.

## Acceptance Criteria

- [x] After a fresh `cleanup_worker` start, the first `DataCleanupJob.run` executes
      within a short bounded delay (≤ 10 s), not after a full 60-min interval.
- [x] The initial delay is non-zero (10 s) to avoid racing container/DB startup.
- [x] Decision recorded (central fix in `BackgroundScheduler.add_job` + the
      cleanup worker; see **Scope decision**).

## References

- Issue #792. Follow-up originally noted in the PR #782 manual test plan
  ("First-run delay").
- Code: `studio/cleanup_worker.py`; `BackgroundScheduler.add_job` in
  `studio/app/common/core/background/scheduler.py`; job registration in
  `studio/__main_unit__.py`.
