### PR TITLE
fix: allow clock skew when verifying firebase id tokens

### DIFF
--- a/studio/app/common/core/auth/auth_helper.py
+++ b/studio/app/common/core/auth/auth_helper.py
@@ -48,6 +48,10 @@ _token_cache: Dict[str, Dict[str, any]] = {}
 # Cache TTL in seconds (5 minutes)
 _CACHE_TTL_SECONDS = 300
 
+# Google stamps `iat` from its own clock, so a host running even a second
+# behind rejects a token the client just received. Firebase allows 0-60.
+_CLOCK_SKEW_SECONDS = 10
+
 
 def _compute_token_hash(token: str) -> str:
     """
@@ -116,7 +120,9 @@ def _verify_firebase_token_sync(token: str) -> Optional[str]:
         User ID if verification succeeds, None otherwise
     """
     try:
-        user = firebase_auth.verify_id_token(token)
+        user = firebase_auth.verify_id_token(
+            token, clock_skew_seconds=_CLOCK_SKEW_SECONDS
+        )
         return user.get("uid")
     except Exception:
         return None
@@ -160,7 +166,9 @@ def extract_uid_from_firebase_credential(
         Tuple of (uid, error_message). If successful, error_message is None.
     """
     try:
-        user = firebase_auth.verify_id_token(credential.credentials)
+        user = firebase_auth.verify_id_token(
+            credential.credentials, clock_skew_seconds=_CLOCK_SKEW_SECONDS
+        )
         uid = user.get("uid")
         return uid, None
     except Exception as e:
@@ -281,7 +289,9 @@ def extract_uid_from_request(request: Request) -> Optional[str]:
 
             # Verify token and cache result
             try:
-                user = firebase_auth.verify_id_token(token)
+                user = firebase_auth.verify_id_token(
+                    token, clock_skew_seconds=_CLOCK_SKEW_SECONDS
+                )
                 uid = user.get("uid")
                 _cache_uid(token, uid)
                 return uid

--- a/studio/tests/app/common/core/auth/test_token_clock_skew.py
+++ b/studio/tests/app/common/core/auth/test_token_clock_skew.py
@@ -1,6 +1,6 @@
 """A host clock running behind Google's rejects a token the client just got.
 
-The failure is `Token used too early, <iat> < <now>` on the request that
+The failure is `Token used too early, <now> < <iat>` on the request that
 immediately follows a successful login, so every path that verifies a Firebase
 token has to allow the same tolerance - one path without it is enough to 401 a
 freshly signed-in user.

--- a/studio/tests/app/common/core/auth/test_token_clock_skew.py
+++ b/studio/tests/app/common/core/auth/test_token_clock_skew.py
@@ -1,0 +1,54 @@
+"""A host clock running behind Google's rejects a token the client just got.
+
+The failure is `Token used too early, <iat> < <now>` on the request that
+immediately follows a successful login, so every path that verifies a Firebase
+token has to allow the same tolerance - one path without it is enough to 401 a
+freshly signed-in user.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from studio.app.common.core.auth import auth_helper
+
+MODULE = "studio.app.common.core.auth.auth_helper"
+
+
+@pytest.fixture
+def verifier():
+    with patch(f"{MODULE}.firebase_auth.verify_id_token") as mock:
+        mock.return_value = {"uid": "uid-1"}
+        yield mock
+
+
+def skew_of(mock) -> int:
+    assert mock.call_count == 1, f"expected one verification, got {mock.call_count}"
+    return mock.call_args.kwargs.get("clock_skew_seconds", 0)
+
+
+class TestEveryVerificationPathAllowsSkew:
+    def test_the_sync_path_allows_skew(self, verifier):
+        assert auth_helper._verify_firebase_token_sync("t") == "uid-1"
+        assert skew_of(verifier) > 0
+
+    def test_the_credential_path_allows_skew(self, verifier):
+        credential = MagicMock(credentials="t")
+        uid, err = auth_helper.extract_uid_from_firebase_credential(credential)
+        assert (uid, err) == ("uid-1", None)
+        assert skew_of(verifier) > 0
+
+    def test_the_request_path_allows_skew(self, verifier):
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer t"}
+        request.cookies = {}
+        with patch(f"{MODULE}.AUTH_CONFIG") as config:
+            config.USE_FIREBASE_TOKEN = True
+            assert auth_helper.extract_uid_from_request(request) == "uid-1"
+        assert skew_of(verifier) > 0
+
+
+def test_the_tolerance_is_within_the_range_firebase_accepts():
+    # Pinned separately: a test deriving its bound from the constant would
+    # still pass if the constant went to 0 or past Firebase's ceiling of 60.
+    assert 1 <= auth_helper._CLOCK_SKEW_SECONDS <= 60

--- a/studio/tests/app/common/core/auth/test_token_clock_skew.py
+++ b/studio/tests/app/common/core/auth/test_token_clock_skew.py
@@ -17,9 +17,13 @@ MODULE = "studio.app.common.core.auth.auth_helper"
 
 @pytest.fixture
 def verifier():
+    """A cached uid short-circuits verification entirely, so a stale entry from
+    another test would leave the verifier uncalled and this fixture blind."""
+    auth_helper._token_cache.clear()
     with patch(f"{MODULE}.firebase_auth.verify_id_token") as mock:
         mock.return_value = {"uid": "uid-1"}
         yield mock
+    auth_helper._token_cache.clear()
 
 
 def skew_of(mock) -> int:
@@ -30,13 +34,13 @@ def skew_of(mock) -> int:
 class TestEveryVerificationPathAllowsSkew:
     def test_the_sync_path_allows_skew(self, verifier):
         assert auth_helper._verify_firebase_token_sync("t") == "uid-1"
-        assert skew_of(verifier) > 0
+        assert skew_of(verifier) == auth_helper._CLOCK_SKEW_SECONDS
 
     def test_the_credential_path_allows_skew(self, verifier):
         credential = MagicMock(credentials="t")
         uid, err = auth_helper.extract_uid_from_firebase_credential(credential)
         assert (uid, err) == ("uid-1", None)
-        assert skew_of(verifier) > 0
+        assert skew_of(verifier) == auth_helper._CLOCK_SKEW_SECONDS
 
     def test_the_request_path_allows_skew(self, verifier):
         request = MagicMock()
@@ -45,7 +49,7 @@ class TestEveryVerificationPathAllowsSkew:
         with patch(f"{MODULE}.AUTH_CONFIG") as config:
             config.USE_FIREBASE_TOKEN = True
             assert auth_helper.extract_uid_from_request(request) == "uid-1"
-        assert skew_of(verifier) > 0
+        assert skew_of(verifier) == auth_helper._CLOCK_SKEW_SECONDS
 
 
 def test_the_tolerance_is_within_the_range_firebase_accepts():


### PR DESCRIPTION
### Content

#### Summary

Firebase ID tokens were being rejected with `401` whenever the host clock ran
behind Google's, because `verify_id_token` defaults to zero clock-skew
tolerance on the `iat` and `exp` claims. A host one second slow rejects a token
the client received moments earlier: `Firebase token validation failed:
Token used too early,
1785918276 < 1785918277`. This adds a 10 second allowance at all three
`verify_id_token` call sites and pins the behaviour with a new test.

The failure is intermittent and looks like a broken login rather than a clock
problem, which is what made it expensive to diagnose.

#### Design Decisions

- **10 seconds, not 60.** Firebase permits `0` to `60`. Ten covers ordinary NTP
  drift and VM suspend and resume, while keeping the accepted window small.
  The value is a module constant (`_CLOCK_SKEW_SECONDS`) rather than three
  literals so the three call sites cannot drift apart.
- **All three call sites, not just the failing one.** `_verify_firebase_token_sync`,
  `extract_uid_from_firebase_credential` and `extract_uid_from_request` each
  verify tokens independently. Fixing only the one that surfaced in testing
  would leave the same defect on the other two paths.
- **The tolerance is symmetric: it moves `iat` and `exp`.** `google-auth` applies
  `clock_skew_seconds` to both ends of the window in `_verify_iat_and_exp`
  (`earliest = iat - skew`, `latest = exp + skew`), so a token is also accepted
  for up to 10 seconds past its `exp`. On a 3600 second Firebase ID token that is
  a 0.3% lifetime extension. Signature, audience and issuer checking are
  untouched, and a forged token is still rejected. Note that this path validates
  `iat` and `exp` only; `nbf` is not read at all.

### Evidence

Before, from a local Playwright run, every spec performing an interactive
login failed while every spec reusing the storage state saved in global setup
passed:

```
401 /users/me: "Firebase token validation failed:
Token used too early, 1785918276 < 1785918277"
```

Ten specs failed on this (AUTH-01/06/08, SUB-04/05, STO-01/02/03). After the
change, the same specs pass against the same stack with no other edits.

### References

- Related PR: #801 (test suite work that surfaced this)

### Files changed

- `studio/app/common/core/auth/auth_helper.py` -- adds `_CLOCK_SKEW_SECONDS = 10`
  and passes `clock_skew_seconds` at the three `verify_id_token` call sites.
- `studio/tests/app/common/core/auth/test_token_clock_skew.py` -- new: asserts the
  argument is passed on every path and that the constant stays inside Firebase's
  permitted `0` to `60` range. The bound is pinned as `1` to `60`, so a future
  drop back to `0` (which would silently reintroduce the bug) also fails.

### Manual Testcases

1. Set the backend host clock one to two seconds behind real time
   (or run the docker VM after a suspend, which reproduces it naturally).
2. Log in through the UI as any user.
3. Expected before: the first authenticated request returns `401` with
   `Token used too early`. Expected after: login completes normally.
4. Restore the clock and confirm login still works, so the change is not
   masking a genuine expiry failure.

`pytest studio/tests/app/common/core/auth/` — all tests pass.

### Unit, Integration, Contract Test Coverage

`test_token_clock_skew.py` covers all three call sites. Mutation-verified:
removing `clock_skew_seconds` from any one of the three turns the suite red,
so a future refactor that drops it on one path cannot pass silently.

### Others

#### Difficulties (if any)

The symptom presents as an authentication failure, not a clock failure, and it
is intermittent by nature: it only appears when the drift exceeds the gap
between minting a token and using it. Specs that reused a saved storage state
passed throughout, which initially pointed the investigation at the login flow
rather than at the host clock.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| Authentication | Low | Widens the accepted `iat`/`exp` window by 10s at all three call sites. Signature, audience and issuer checking are untouched, and 10s is well inside Firebase's own allowance. All three sites already use the default `check_revoked=False`, so revocation was not enforced before this change and is not enforced after it. |
| Token replay | Low | Effective token lifetime grows by 10s: rejection now happens at `exp + 10` rather than at `exp`. On a 3600s ID token that is a 0.3% extension, and the token is still rejected past that point. |
| Blast radius | Medium | All three verification paths change together, so every authenticated request is affected. This is deliberate: a partial fix would leave two paths broken. |
