### PR TITLE
Add GTM, GA4 and Consent Mode v2 measurement to the frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,3 +13,8 @@ REACT_APP_SERVER_PROTO=http
 # Url to access stripe billing url
 # STRIPE_MANAGE_BILLING_URL=https://billing.stripe.com/p/login/test_5kQ9ATdaS2TbdknghI2wU00
 
+# Google Tag Manager container ID, e.g. GTM-XXXXXXX.
+# Empty or unset disables GTM, GA4, the consent banner and all event tracking.
+# The ID is baked into index.html at build time, so leave it empty for
+# standalone/local builds (make local_build, make build_frontend).
+REACT_APP_GTM_ID=

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -10,3 +10,9 @@ REACT_APP_SERVER_HOST=
 REACT_APP_SERVER_PORT=
 # (default: location.protocol)
 REACT_APP_SERVER_PROTO=
+
+# Google Tag Manager container ID, e.g. GTM-XXXXXXX.
+# Empty or unset disables GTM, GA4, the consent banner and all event tracking.
+# Do not set it here: the deploy script regenerates this file on every build and
+# takes the per-environment ID from infrastructure/.env.deploy instead.
+REACT_APP_GTM_ID=

--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,4 +1,12 @@
 module.exports = function override(config) {
+  // CRA interpolates this into a JS string literal in index.html, where the runtime guard is already too late to contain a value that breaks out.
+  const gtmId = process.env.REACT_APP_GTM_ID
+  if (gtmId && !/^GTM-[A-Z0-9]+$/.test(gtmId)) {
+    throw new Error(
+      `Malformed REACT_APP_GTM_ID: '${gtmId}'. Expected GTM-XXXXXXX.`,
+    )
+  }
+
   const okv = {
     fallback: {
       stream: require.resolve("stream-browserify"),

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -65,6 +65,11 @@ async function saveLoginState(
         if (attempt >= 3) throw e
       }
     }
+    // Keeps the analytics consent notice from fronting the UI when the build
+    // under test was compiled with a GTM container ID.
+    await page.evaluate(() =>
+      localStorage.setItem("analyticsConsent", "denied"),
+    )
     await page.context().storageState({ path: statePath })
   } finally {
     await browser.close()

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -79,6 +79,37 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
+
+    <!-- Consent Mode v2 defaults. Must run before gtm.js loads, so it stays inline here. -->
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        window.dataLayer.push(arguments)
+      }
+      gtag("consent", "default", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "denied",
+        // A returning visitor's stored grant is re-applied once the bundle runs.
+        wait_for_update: 500,
+      })
+    </script>
+
+    <!-- Google Tag Manager. Skipped unless REACT_APP_GTM_ID was set at build time. -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        if (!/^GTM-[A-Z0-9]+$/.test(i)) return
+        w[l] = w[l] || []
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" })
+        var f = d.getElementsByTagName(s)[0]
+        var j = d.createElement(s)
+        var dl = l !== "dataLayer" ? "&l=" + l : ""
+        j.async = true
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, "script", "dataLayer", "%REACT_APP_GTM_ID%")
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import IconButton from "@mui/material/IconButton"
 import BackendUnavailable from "components/common/BackendUnavailable"
 import ErrorBoundary from "components/common/ErrorBoundary"
 import Loading from "components/common/Loading"
+import RouteChangeTracker from "components/common/RouteChangeTracker"
 import Layout from "components/Layout"
 import { RETRY_MAX_COUNT, RETRY_WAIT, RETRY_WAIT_LONG } from "const/Mode"
 import Account from "pages/Account"
@@ -118,6 +119,7 @@ const App: FC = () => {
         style={{ maxWidth: "600px" }}
       >
         <BrowserRouter>
+          <RouteChangeTracker />
           <Routes>
             {/* Landing page - outside Layout */}
             <Route path="/" element={<LandingPage />} />

--- a/frontend/src/components/common/ConsentBanner.tsx
+++ b/frontend/src/components/common/ConsentBanner.tsx
@@ -1,0 +1,78 @@
+import { FC, useState } from "react"
+import { useSelector } from "react-redux"
+
+import Box from "@mui/material/Box"
+import Button from "@mui/material/Button"
+import Paper from "@mui/material/Paper"
+import Typography from "@mui/material/Typography"
+
+import { Z_INDEX } from "const/Layout"
+import { selectModeStandalone } from "store/slice/Standalone/StandaloneSeclector"
+import {
+  ConsentDecision,
+  getAnalyticsConsent,
+  isGtmEnabled,
+  setAnalyticsConsent,
+} from "utils/analytics"
+
+const ConsentBanner: FC = () => {
+  const isStandalone = useSelector(selectModeStandalone)
+  const [decided, setDecided] = useState(() => getAnalyticsConsent() !== null)
+
+  const decide = (decision: ConsentDecision) => {
+    setAnalyticsConsent(decision)
+    setDecided(true)
+  }
+
+  // Only once the backend has confirmed hosted mode: standalone is a local
+  // install, and an unresolved mode means the app itself is not usable yet.
+  if (!isGtmEnabled() || isStandalone !== false || decided) return null
+
+  return (
+    <Paper
+      elevation={8}
+      role="region"
+      aria-label="Analytics cookie consent"
+      aria-live="polite"
+      data-testid="consent-banner"
+      sx={{
+        position: "fixed",
+        // Bottom-right, one line tall: keeps the notice clear of the fixed
+        // controls and toasts that sit in the bottom-left corner.
+        bottom: 16,
+        right: 16,
+        maxWidth: "calc(100vw - 32px)",
+        zIndex: Z_INDEX.CONSENT_BANNER,
+        px: 2,
+        py: 1.5,
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      <Typography variant="body2">
+        We use analytics cookies to measure site usage.
+      </Typography>
+      <Box sx={{ display: "flex", gap: 1, ml: "auto" }}>
+        <Button
+          size="small"
+          onClick={() => decide("denied")}
+          data-testid="consent-decline"
+        >
+          Decline
+        </Button>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => decide("granted")}
+          data-testid="consent-accept"
+        >
+          Accept
+        </Button>
+      </Box>
+    </Paper>
+  )
+}
+
+export default ConsentBanner

--- a/frontend/src/components/common/ConsentBanner.tsx
+++ b/frontend/src/components/common/ConsentBanner.tsx
@@ -55,8 +55,10 @@ const ConsentBanner: FC = () => {
         We use analytics cookies to measure site usage.
       </Typography>
       <Box sx={{ display: "flex", gap: 1, ml: "auto" }}>
+        {/* Identical styling on both: a de-emphasised Decline is a dark pattern. */}
         <Button
           size="small"
+          variant="outlined"
           onClick={() => decide("denied")}
           data-testid="consent-decline"
         >
@@ -64,7 +66,7 @@ const ConsentBanner: FC = () => {
         </Button>
         <Button
           size="small"
-          variant="contained"
+          variant="outlined"
           onClick={() => decide("granted")}
           data-testid="consent-accept"
         >

--- a/frontend/src/components/common/RouteChangeTracker.tsx
+++ b/frontend/src/components/common/RouteChangeTracker.tsx
@@ -1,0 +1,31 @@
+import { FC, useEffect, useRef } from "react"
+import { useSelector } from "react-redux"
+import { useLocation } from "react-router-dom"
+
+import { selectModeStandalone } from "store/slice/Standalone/StandaloneSeclector"
+import { normalizePath, trackEvent } from "utils/analytics"
+
+const RouteChangeTracker: FC = () => {
+  const { pathname } = useLocation()
+  const isStandalone = useSelector(selectModeStandalone)
+  // Raw pathname, so /workspaces/12 -> /workspaces/13 still counts as a change.
+  const trackedPathname = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (isStandalone) return
+    if (trackedPathname.current === pathname) return
+    trackedPathname.current = pathname
+
+    // page_location is supplied sanitized so the GA4 tag never has to fall back
+    // to document.location.href, which carries emails and Stripe session ids.
+    const pagePath = normalizePath(pathname)
+    trackEvent("route_change", {
+      page_path: pagePath,
+      page_location: `${window.location.origin}${pagePath}`,
+    })
+  }, [pathname, isStandalone])
+
+  return null
+}
+
+export default RouteChangeTracker

--- a/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
+++ b/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
@@ -1,0 +1,117 @@
+import { Provider } from "react-redux"
+
+import configureMockStore from "redux-mock-store"
+
+// expect is left global so the jest-dom matchers stay typed.
+import { beforeEach, afterEach, describe, it } from "@jest/globals"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import ConsentBanner from "components/common/ConsentBanner"
+import { ModeType } from "store/slice/Standalone/StandaloneType"
+import { CONSENT_STORAGE_KEY, trackEvent } from "utils/analytics"
+import {
+  disableGtm,
+  setUpAnalyticsTest,
+  tearDownAnalyticsTest,
+} from "utils/analyticsTestUtils"
+
+const mockStore = configureMockStore()
+
+// Takes the whole slice state: a destructuring default would silently turn an
+// explicitly passed `undefined` mode back into `false`.
+const renderBanner = (mode: ModeType = { mode: false, loading: false }) =>
+  render(
+    <Provider store={mockStore({ mode })}>
+      <ConsentBanner />
+    </Provider>,
+  )
+
+describe("ConsentBanner", () => {
+  let gtag: ReturnType<typeof setUpAnalyticsTest>
+
+  beforeEach(() => {
+    gtag = setUpAnalyticsTest()
+  })
+
+  afterEach(tearDownAnalyticsTest)
+
+  it("renders nothing when GTM is not configured", () => {
+    disableGtm()
+    renderBanner()
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when a decision is already stored", () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "denied")
+    renderBanner()
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing in standalone mode", () => {
+    renderBanner({ mode: true, loading: false })
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing before the backend has confirmed the mode", () => {
+    renderBanner({ loading: false })
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("renders when GTM is configured and no decision is stored", () => {
+    renderBanner()
+    expect(screen.getByTestId("consent-banner")).toBeInTheDocument()
+  })
+
+  it("persists the grant, updates gtag and dismisses", async () => {
+    renderBanner()
+
+    await userEvent.click(screen.getByTestId("consent-accept"))
+
+    expect(localStorage.getItem(CONSENT_STORAGE_KEY)).toBe("granted")
+    expect(gtag).toHaveBeenCalledWith("consent", "update", {
+      analytics_storage: "granted",
+    })
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("persists the denial, updates gtag and dismisses", async () => {
+    renderBanner()
+
+    await userEvent.click(screen.getByTestId("consent-decline"))
+
+    expect(localStorage.getItem(CONSENT_STORAGE_KEY)).toBe("denied")
+    expect(gtag).toHaveBeenCalledWith("consent", "update", {
+      analytics_storage: "denied",
+    })
+    expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
+  })
+
+  it("releases events buffered before the visitor accepted", async () => {
+    trackEvent("route_change", { page_path: "/" })
+    renderBanner()
+
+    await userEvent.click(screen.getByTestId("consent-accept"))
+
+    expect(window.dataLayer).toEqual([
+      { event: "route_change", page_path: "/" },
+    ])
+  })
+
+  it("drops events buffered before the visitor declined", async () => {
+    trackEvent("route_change", { page_path: "/" })
+    renderBanner()
+
+    await userEvent.click(screen.getByTestId("consent-decline"))
+
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it("uses a labelled region rather than role=alert", () => {
+    renderBanner()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("region", { name: "Analytics cookie consent" }),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
+++ b/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
@@ -54,7 +54,9 @@ describe("ConsentBanner", () => {
   })
 
   it("renders nothing before the backend has confirmed the mode", () => {
-    renderBanner({ loading: false })
+    // The slice's own pre-confirmation state: `mode` is only ever set by
+    // `fulfilled`, which also clears `loading`, so an undefined mode implies it.
+    renderBanner({ mode: undefined, loading: true })
     expect(screen.queryByTestId("consent-banner")).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
+++ b/frontend/src/components/common/__tests__/ConsentBanner.test.tsx
@@ -109,6 +109,13 @@ describe("ConsentBanner", () => {
     expect(window.dataLayer).toEqual([])
   })
 
+  it("gives Decline and Accept identical visual weight", () => {
+    renderBanner()
+    expect(screen.getByTestId("consent-decline").className).toBe(
+      screen.getByTestId("consent-accept").className,
+    )
+  })
+
   it("uses a labelled region rather than role=alert", () => {
     renderBanner()
     expect(screen.queryByRole("alert")).not.toBeInTheDocument()

--- a/frontend/src/components/common/__tests__/RouteChangeTracker.test.tsx
+++ b/frontend/src/components/common/__tests__/RouteChangeTracker.test.tsx
@@ -1,0 +1,117 @@
+import { FC } from "react"
+import { Provider } from "react-redux"
+import { MemoryRouter, useNavigate } from "react-router-dom"
+
+import configureMockStore from "redux-mock-store"
+
+import { beforeEach, afterEach, describe, expect, it } from "@jest/globals"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import RouteChangeTracker from "components/common/RouteChangeTracker"
+import { CONSENT_STORAGE_KEY } from "utils/analytics"
+import {
+  disableGtm,
+  setUpAnalyticsTest,
+  tearDownAnalyticsTest,
+} from "utils/analyticsTestUtils"
+
+const mockStore = configureMockStore()
+
+const NavigateButton: FC<{ to: string }> = ({ to }) => {
+  const navigate = useNavigate()
+  return (
+    <button onClick={() => navigate(to)} data-testid={`go-${to}`}>
+      go
+    </button>
+  )
+}
+
+const renderTracker = (
+  { isStandalone = false, initialPath = "/" } = {},
+  targets: string[] = [],
+) =>
+  render(
+    <Provider
+      store={mockStore({ mode: { mode: isStandalone, loading: false } })}
+    >
+      <MemoryRouter initialEntries={[initialPath]}>
+        <RouteChangeTracker />
+        {targets.map((target) => (
+          <NavigateButton key={target} to={target} />
+        ))}
+      </MemoryRouter>
+    </Provider>,
+  )
+
+const navigateTo = (to: string) =>
+  userEvent.click(screen.getByTestId(`go-${to}`))
+
+const pageview = (pagePath: string) => ({
+  event: "route_change",
+  page_path: pagePath,
+  page_location: `${window.location.origin}${pagePath}`,
+})
+
+describe("RouteChangeTracker", () => {
+  beforeEach(() => {
+    setUpAnalyticsTest()
+    localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+  })
+
+  afterEach(tearDownAnalyticsTest)
+
+  it("records the initial location", () => {
+    renderTracker({ initialPath: "/public" })
+    expect(window.dataLayer).toEqual([pageview("/public")])
+  })
+
+  it("records one pageview per navigation", async () => {
+    renderTracker({ initialPath: "/" }, ["/login"])
+
+    await navigateTo("/login")
+
+    expect(window.dataLayer).toEqual([pageview("/"), pageview("/login")])
+  })
+
+  it("distinguishes different ids on the same route", async () => {
+    renderTracker({ initialPath: "/workspaces/12" }, ["/workspaces/13"])
+
+    await navigateTo("/workspaces/13")
+
+    expect(window.dataLayer).toEqual([
+      pageview("/workspaces/:id"),
+      pageview("/workspaces/:id"),
+    ])
+  })
+
+  it("ignores a query-string-only change and never sends the query string", async () => {
+    renderTracker({ initialPath: "/account-manager" }, [
+      "/account-manager?email=someone@example.com",
+    ])
+
+    await navigateTo("/account-manager?email=someone@example.com")
+
+    expect(window.dataLayer).toEqual([pageview("/account-manager")])
+    expect(JSON.stringify(window.dataLayer)).not.toContain(
+      "someone@example.com",
+    )
+  })
+
+  it("records nothing in standalone mode", async () => {
+    renderTracker({ isStandalone: true, initialPath: "/" }, ["/login"])
+
+    await navigateTo("/login")
+
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it("records nothing when GTM is not configured", async () => {
+    disableGtm()
+    renderTracker({ initialPath: "/" }, ["/login"])
+
+    await navigateTo("/login")
+
+    expect(window.dataLayer).toEqual([])
+  })
+})

--- a/frontend/src/const/Layout.ts
+++ b/frontend/src/const/Layout.ts
@@ -25,6 +25,8 @@ export const Z_INDEX = {
   PLOT_OVERLAY: 999,
   /** Header, floating buttons */
   HEADER: 1000,
+  /** Cookie consent notice - below modals and snackbars so both stay clickable */
+  CONSENT_BANNER: 1200,
   /** Loading overlay - high but below MUI modals */
   LOADING_OVERLAY: 1250,
 } as const

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,14 +7,18 @@ import "index.css"
 import { ThemeProvider } from "@mui/material/styles"
 
 import App from "App"
+import ConsentBanner from "components/common/ConsentBanner"
+import ErrorBoundary from "components/common/ErrorBoundary"
 import reportWebVitals from "reportWebVitals"
 import { store } from "store/store"
 import { theme } from "Theme"
+import { initAnalyticsConsent } from "utils/analytics"
 import { initChunkReloadHandler } from "utils/chunkLoadReload"
 import { initErrorReporter } from "utils/errorReporter"
 
 initChunkReloadHandler()
 initErrorReporter()
+initAnalyticsConsent()
 
 const root = createRoot(document.getElementById("root")!)
 
@@ -22,6 +26,9 @@ root.render(
   <Provider store={store}>
     <ThemeProvider theme={theme}>
       <App />
+      <ErrorBoundary fallback={<></>}>
+        <ConsentBanner />
+      </ErrorBoundary>
     </ThemeProvider>
   </Provider>,
 )

--- a/frontend/src/pages/Account/__tests__/AnalyticsConsent.test.tsx
+++ b/frontend/src/pages/Account/__tests__/AnalyticsConsent.test.tsx
@@ -1,0 +1,152 @@
+import { Provider } from "react-redux"
+import { MemoryRouter } from "react-router-dom"
+
+import { SnackbarProvider } from "notistack"
+import configureStore from "redux-mock-store"
+
+// expect is left global so the jest-dom matchers stay typed.
+import { describe, it, beforeEach, jest, afterEach } from "@jest/globals"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { SubscriptionUserStatus } from "const/Subscription"
+import Account from "pages/Account"
+import { CONSENT_STORAGE_KEY, trackEvent } from "utils/analytics"
+import {
+  disableGtm,
+  setUpAnalyticsTest,
+  tearDownAnalyticsTest,
+} from "utils/analyticsTestUtils"
+
+jest.mock("api/subscriptions/Subscriptions")
+
+jest.mock("utils/auth/AuthUtils", () => ({
+  getToken: () => "mock-token",
+}))
+
+jest.mock("store/slice/User/UserActions", () => ({
+  getMe: () => ({ type: "user/getMe/mock" }),
+  updateMe: () => ({ type: "user/updateMe/mock" }),
+  updateMePassword: () => ({ type: "user/updateMePassword/mock" }),
+  deleteMe: () => ({ type: "user/deleteMe/mock" }),
+}))
+
+jest.mock("store/slice/Subscriptions/SubscriptionActions", () => ({
+  getUserSubscription: () => ({
+    type: "subscription/getUserSubscription/mock",
+  }),
+  getDeletionPriority: () => ({
+    type: "subscription/getDeletionPriority/mock",
+  }),
+  updateDeletionPriority: () => ({
+    type: "subscription/updateDeletionPriority/mock",
+  }),
+}))
+
+const mockStoreCreator = configureStore([])
+
+const renderAccount = () =>
+  render(
+    <Provider
+      store={mockStoreCreator({
+        user: {
+          currentUser: {
+            id: 1,
+            name: "Test User",
+            email: "test@example.com",
+            data_usage: 1000,
+            attributes: { remote_bucket_name: "test-bucket" },
+          },
+          loading: false,
+        },
+        subscription: {
+          plans: [],
+          userSubscription: {
+            id: 1,
+            plan_id: 2,
+            user_id: 1,
+            expiration: "2026-12-31",
+            is_expired: false,
+            scheduled_downgrade: false,
+            status: SubscriptionUserStatus.SUBSCRIBED,
+            plan_name: "Premium",
+            plan_price: 10,
+          },
+          loading: false,
+          checkoutLoading: false,
+          error: null,
+          plansLoading: false,
+          userSubscriptionLoading: false,
+          serverTime: null,
+          deletionPriority: "preserve_outputs",
+          deletionPriorityLoading: false,
+        },
+      })}
+    >
+      <MemoryRouter>
+        <SnackbarProvider>
+          <Account />
+        </SnackbarProvider>
+      </MemoryRouter>
+    </Provider>,
+  )
+
+const consentSwitch = () =>
+  screen.queryByRole("checkbox", { name: "Allow analytics cookies" })
+
+describe("Account analytics consent control", () => {
+  let gtag: ReturnType<typeof setUpAnalyticsTest>
+
+  beforeEach(() => {
+    gtag = setUpAnalyticsTest()
+  })
+
+  afterEach(tearDownAnalyticsTest)
+
+  it("is absent when GTM is not configured", () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+    disableGtm()
+    renderAccount()
+    expect(consentSwitch()).not.toBeInTheDocument()
+  })
+
+  it("is absent while the visitor has not answered the notice", () => {
+    renderAccount()
+    expect(consentSwitch()).not.toBeInTheDocument()
+  })
+
+  it("reflects the stored decision", () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+    renderAccount()
+    expect(consentSwitch()).toBeChecked()
+  })
+
+  it("withdraws consent without a reload", async () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+    renderAccount()
+
+    await userEvent.click(consentSwitch() as HTMLElement)
+
+    expect(localStorage.getItem(CONSENT_STORAGE_KEY)).toBe("denied")
+    expect(gtag).toHaveBeenCalledWith("consent", "update", {
+      analytics_storage: "denied",
+    })
+    expect(consentSwitch()).not.toBeChecked()
+
+    trackEvent("route_change", { page_path: "/account" })
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it("re-grants consent from the same control", async () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "denied")
+    renderAccount()
+
+    await userEvent.click(consentSwitch() as HTMLElement)
+
+    expect(localStorage.getItem(CONSENT_STORAGE_KEY)).toBe("granted")
+    trackEvent("route_change", { page_path: "/account" })
+    expect(window.dataLayer).toEqual([
+      { event: "route_change", page_path: "/account" },
+    ])
+  })
+})

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -21,6 +21,7 @@ import {
   MenuItem,
   Select,
   styled,
+  Switch,
   Tooltip,
   Typography,
 } from "@mui/material"
@@ -55,6 +56,11 @@ import {
 import { selectCurrentUser, selectLoading } from "store/slice/User/UserSelector"
 import { AppDispatch } from "store/store"
 import { convertBytes } from "utils"
+import {
+  getAnalyticsConsent,
+  isGtmEnabled,
+  setAnalyticsConsent,
+} from "utils/analytics"
 
 const Account = () => {
   const user = useSelector(selectCurrentUser)
@@ -73,6 +79,8 @@ const Account = () => {
   const [isEditName, setIsEditName] = useState(false)
   const [isEditDeletionPriority, setIsEditDeletionPriority] = useState(false)
   const [isName, setIsName] = useState<string>()
+  const [analyticsConsent, setAnalyticsConsentState] =
+    useState(getAnalyticsConsent)
 
   const ref = useRef<HTMLInputElement>(null)
 
@@ -482,6 +490,21 @@ const Account = () => {
           </>
         )}
       </BoxFlex>
+      {/* ponytail: shown only once a decision exists, so this and the notice cannot disagree without any shared state. */}
+      {isGtmEnabled() && analyticsConsent !== null && (
+        <BoxFlex>
+          <TitleData>Analytics Cookies</TitleData>
+          <Switch
+            checked={analyticsConsent === "granted"}
+            onChange={(e) => {
+              const decision = e.target.checked ? "granted" : "denied"
+              setAnalyticsConsent(decision)
+              setAnalyticsConsentState(decision)
+            }}
+            inputProps={{ "aria-label": "Allow analytics cookies" }}
+          />
+        </BoxFlex>
+      )}
       <BoxFlex sx={{ justifyContent: "space-between", mt: 10, maxWidth: 600 }}>
         <Button variant="contained" color="primary" onClick={onChangePwClick}>
           Change Password

--- a/frontend/src/pages/PublicDataview/index.tsx
+++ b/frontend/src/pages/PublicDataview/index.tsx
@@ -1,10 +1,17 @@
+import { useEffect } from "react"
+
 import { Box, styled } from "@mui/material"
 
 import DataviewRecords from "components/Dataview/DataviewRecords"
 import PublicDataviewWrapper from "components/Dataview/PublicDataviewWrapper"
 import PublicHeader from "components/PublicLayout/PublicHeader"
+import { trackEvent } from "utils/analytics"
 
 const PublicDataview = () => {
+  useEffect(() => {
+    trackEvent("view_public_data")
+  }, [])
+
   return (
     <>
       <PublicHeader />

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="react-scripts" />
+
+interface Window {
+  dataLayer?: unknown[]
+  gtag?: (...args: unknown[]) => void
+}

--- a/frontend/src/store/__tests__/analyticsMiddleware.test.ts
+++ b/frontend/src/store/__tests__/analyticsMiddleware.test.ts
@@ -1,0 +1,142 @@
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals"
+
+import { analyticsMiddleware } from "store/analyticsMiddleware"
+import {
+  run,
+  runApplyFilter,
+  runByCurrentUid,
+} from "store/slice/Pipeline/PipelineActions"
+import { registerUser } from "store/slice/Registration/RegistrationActions"
+import { getMe, login, proxyLogin } from "store/slice/User/UserActions"
+import { CONSENT_STORAGE_KEY } from "utils/analytics"
+import {
+  disableGtm,
+  setUpAnalyticsTest,
+  tearDownAnalyticsTest,
+} from "utils/analyticsTestUtils"
+
+const dispatchThrough = (
+  action: unknown,
+  { isStandalone = false } = {},
+): unknown[] => {
+  const api = {
+    getState: () => ({ mode: { mode: isStandalone, loading: false } }),
+    dispatch: jest.fn(),
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(analyticsMiddleware as any)(api)((a: unknown) => a)(action)
+  return window.dataLayer as unknown[]
+}
+
+describe("analyticsMiddleware", () => {
+  beforeEach(() => {
+    setUpAnalyticsTest()
+    localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+  })
+
+  afterEach(tearDownAnalyticsTest)
+
+  it("passes the action on to the next middleware", () => {
+    const next = jest.fn((a: unknown) => a)
+    const action = { type: "some/other/action" }
+    const api = {
+      getState: () => ({ mode: { mode: false, loading: false } }),
+      dispatch: jest.fn(),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = (analyticsMiddleware as any)(api)(next)(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+    expect(result).toBe(action)
+  })
+
+  it("emits sign_up on a fulfilled registration", () => {
+    expect(dispatchThrough({ type: registerUser.fulfilled.type })).toEqual([
+      { event: "sign_up" },
+    ])
+  })
+
+  it("emits login on a fulfilled user login", () => {
+    expect(
+      dispatchThrough({
+        type: login.fulfilled.type,
+        meta: { arg: { email: "user@example.com", password: "secret" } },
+      }),
+    ).toEqual([{ event: "login" }])
+  })
+
+  it("emits no PII with the login event", () => {
+    const pushed = dispatchThrough({
+      type: login.fulfilled.type,
+      meta: { arg: { email: "user@example.com", password: "secret" } },
+    })
+    expect(JSON.stringify(pushed)).not.toContain("user@example.com")
+    expect(JSON.stringify(pushed)).not.toContain("secret")
+  })
+
+  it("ignores proxyLogin, which shares login's action type", () => {
+    expect(
+      dispatchThrough({
+        type: proxyLogin.fulfilled.type,
+        meta: { arg: "some-firebase-uid" },
+      }),
+    ).toEqual([])
+  })
+
+  it("ignores a login-typed action with no arg", () => {
+    expect(dispatchThrough({ type: login.fulfilled.type })).toEqual([])
+  })
+
+  it("emits run_pipeline for both run thunks", () => {
+    expect(dispatchThrough({ type: run.fulfilled.type })).toEqual([
+      { event: "run_pipeline" },
+    ])
+
+    window.dataLayer = []
+    expect(dispatchThrough({ type: runByCurrentUid.fulfilled.type })).toEqual([
+      { event: "run_pipeline" },
+    ])
+  })
+
+  it("ignores a filter re-run, which shares run's type stem", () => {
+    expect(dispatchThrough({ type: runApplyFilter.fulfilled.type })).toEqual([])
+  })
+
+  it("ignores pending and rejected variants", () => {
+    dispatchThrough({ type: run.pending.type })
+    dispatchThrough({ type: run.rejected.type })
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it("ignores unmapped actions", () => {
+    expect(dispatchThrough({ type: getMe.fulfilled.type })).toEqual([])
+  })
+
+  it("ignores action types that collide with Object prototype members", () => {
+    expect(dispatchThrough({ type: "toString" })).toEqual([])
+    expect(dispatchThrough({ type: "constructor" })).toEqual([])
+  })
+
+  it("emits nothing in standalone mode", () => {
+    expect(
+      dispatchThrough({ type: run.fulfilled.type }, { isStandalone: true }),
+    ).toEqual([])
+  })
+
+  it("emits nothing when GTM is not configured", () => {
+    disableGtm()
+    expect(dispatchThrough({ type: run.fulfilled.type })).toEqual([])
+  })
+
+  it("emits nothing before the visitor has consented", () => {
+    localStorage.clear()
+    expect(dispatchThrough({ type: run.fulfilled.type })).toEqual([])
+  })
+})

--- a/frontend/src/store/analyticsMiddleware.ts
+++ b/frontend/src/store/analyticsMiddleware.ts
@@ -1,0 +1,34 @@
+import { AnyAction, Middleware } from "@reduxjs/toolkit"
+
+import { run, runByCurrentUid } from "store/slice/Pipeline/PipelineActions"
+import { registerUser } from "store/slice/Registration/RegistrationActions"
+import { ModeType } from "store/slice/Standalone/StandaloneType"
+import { login } from "store/slice/User/UserActions"
+import { trackEvent } from "utils/analytics"
+
+const EVENT_BY_ACTION_TYPE = new Map<string, string>([
+  [registerUser.fulfilled.type, "sign_up"],
+  [login.fulfilled.type, "login"],
+  [run.fulfilled.type, "run_pipeline"],
+  [runByCurrentUid.fulfilled.type, "run_pipeline"],
+])
+
+// proxyLogin shares login's action type; only the real login carries a LoginDTO.
+const isUserLogin = (arg: unknown): boolean =>
+  typeof arg === "object" && arg !== null && "email" in arg
+
+export const analyticsMiddleware: Middleware = (api) => (next) => (action) => {
+  const result = next(action)
+
+  const { type, meta } = action as AnyAction
+  const event = EVENT_BY_ACTION_TYPE.get(type)
+  if (!event) return result
+
+  const state = api.getState() as { mode: ModeType }
+  if (state.mode.mode) return result
+
+  if (event === "login" && !isUserLogin(meta?.arg)) return result
+
+  trackEvent(event)
+  return result
+}

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -5,6 +5,7 @@ import {
   combineReducers,
 } from "@reduxjs/toolkit"
 
+import { analyticsMiddleware } from "store/analyticsMiddleware"
 import {
   algorithmListReducer,
   algorithmNodeReducer,
@@ -67,7 +68,7 @@ export const store = configureStore({
       // Ignore serializable checks because serializing fails
       // on rejectedWith value
       serializableCheck: false,
-    }),
+    }).concat(analyticsMiddleware),
 })
 
 export type AppDispatch = typeof store.dispatch

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -1,0 +1,342 @@
+import fs from "fs"
+import path from "path"
+
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals"
+
+import {
+  CONSENT_STORAGE_KEY,
+  getAnalyticsConsent,
+  initAnalyticsConsent,
+  isGtmEnabled,
+  normalizePath,
+  setAnalyticsConsent,
+  trackEvent,
+} from "utils/analytics"
+import {
+  disableGtm,
+  setUpAnalyticsTest,
+  tearDownAnalyticsTest,
+  TEST_GTM_ID,
+} from "utils/analyticsTestUtils"
+
+describe("analytics", () => {
+  let gtag: ReturnType<typeof setUpAnalyticsTest>
+
+  beforeEach(() => {
+    gtag = setUpAnalyticsTest()
+  })
+
+  afterEach(tearDownAnalyticsTest)
+
+  describe("isGtmEnabled", () => {
+    it("is false when unset", () => {
+      disableGtm()
+      expect(isGtmEnabled()).toBe(false)
+    })
+
+    it("is false when empty", () => {
+      process.env.REACT_APP_GTM_ID = ""
+      expect(isGtmEnabled()).toBe(false)
+    })
+
+    it("is false for the un-interpolated CRA placeholder", () => {
+      process.env.REACT_APP_GTM_ID = "%REACT_APP_GTM_ID%"
+      expect(isGtmEnabled()).toBe(false)
+    })
+
+    it("rejects the ids that index.html also rejects", () => {
+      // Diverging from that guard would show a consent notice on a site whose
+      // container never loads.
+      process.env.REACT_APP_GTM_ID = "gtm-lowercase"
+      expect(isGtmEnabled()).toBe(false)
+      process.env.REACT_APP_GTM_ID = "GTM-"
+      expect(isGtmEnabled()).toBe(false)
+      process.env.REACT_APP_GTM_ID = "GTM-ABC123&extra=1"
+      expect(isGtmEnabled()).toBe(false)
+    })
+
+    it("is true for a container ID", () => {
+      expect(isGtmEnabled()).toBe(true)
+    })
+  })
+
+  describe("getAnalyticsConsent", () => {
+    it("returns null with nothing stored", () => {
+      expect(getAnalyticsConsent()).toBeNull()
+    })
+
+    it("returns null for an unrecognised stored value", () => {
+      localStorage.setItem(CONSENT_STORAGE_KEY, "yes-please")
+      expect(getAnalyticsConsent()).toBeNull()
+    })
+
+    it("round-trips both decisions", () => {
+      setAnalyticsConsent("granted")
+      expect(getAnalyticsConsent()).toBe("granted")
+      setAnalyticsConsent("denied")
+      expect(getAnalyticsConsent()).toBe("denied")
+    })
+  })
+
+  describe("trackEvent", () => {
+    it("pushes nothing when GTM is not configured", () => {
+      disableGtm()
+      setAnalyticsConsent("granted")
+      trackEvent("route_change", { page_path: "/" })
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it("pushes the event and params once consent is granted", () => {
+      setAnalyticsConsent("granted")
+      trackEvent("route_change", { page_path: "/public" })
+      expect(window.dataLayer).toEqual([
+        { event: "route_change", page_path: "/public" },
+      ])
+    })
+
+    it("pushes nothing before the visitor has decided", () => {
+      trackEvent("route_change", { page_path: "/" })
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it("pushes nothing after the visitor declined", () => {
+      setAnalyticsConsent("denied")
+      trackEvent("route_change", { page_path: "/" })
+      trackEvent("login")
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it("does not throw when the GTM head snippet never ran", () => {
+      delete window.dataLayer
+      delete window.gtag
+      setAnalyticsConsent("granted")
+      expect(() => trackEvent("login")).not.toThrow()
+    })
+
+    it("does not let params override the event name", () => {
+      setAnalyticsConsent("granted")
+      trackEvent("login", { event: "spoofed" })
+      expect(window.dataLayer).toEqual([{ event: "login" }])
+    })
+  })
+
+  describe("setAnalyticsConsent", () => {
+    it("flushes the event buffered before the decision when granted", () => {
+      trackEvent("route_change", { page_path: "/login" })
+      setAnalyticsConsent("granted")
+      expect(window.dataLayer).toEqual([
+        { event: "route_change", page_path: "/login" },
+      ])
+    })
+
+    it("flushes every buffered event in order", () => {
+      // A first visit to /public buffers the pageview and the page's own event.
+      trackEvent("route_change", { page_path: "/public" })
+      trackEvent("view_public_data")
+      setAnalyticsConsent("granted")
+      expect(window.dataLayer).toEqual([
+        { event: "route_change", page_path: "/public" },
+        { event: "view_public_data" },
+      ])
+    })
+
+    it("caps the buffer instead of growing without bound", () => {
+      for (let i = 0; i < 25; i++) {
+        trackEvent("route_change", { page_path: `/page-${i}` })
+      }
+      setAnalyticsConsent("granted")
+      expect(window.dataLayer).toHaveLength(10)
+      expect(window.dataLayer?.[0]).toEqual({
+        event: "route_change",
+        page_path: "/page-0",
+      })
+    })
+
+    it("discards the buffered event when denied", () => {
+      trackEvent("route_change", { page_path: "/" })
+      setAnalyticsConsent("denied")
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it("does not replay the buffered event on a later grant", () => {
+      trackEvent("route_change", { page_path: "/" })
+      setAnalyticsConsent("denied")
+      setAnalyticsConsent("granted")
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it("updates gtag consent in both directions", () => {
+      setAnalyticsConsent("granted")
+      expect(gtag).toHaveBeenCalledWith("consent", "update", {
+        analytics_storage: "granted",
+      })
+
+      setAnalyticsConsent("denied")
+      expect(gtag).toHaveBeenLastCalledWith("consent", "update", {
+        analytics_storage: "denied",
+      })
+    })
+
+    it("honours the decision for the session when localStorage refuses writes", () => {
+      const setItem = jest
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new Error("Storage disabled")
+        })
+
+      trackEvent("route_change", { page_path: "/" })
+      setAnalyticsConsent("granted")
+
+      expect(getAnalyticsConsent()).toBe("granted")
+      trackEvent("login")
+      expect(window.dataLayer).toEqual([
+        { event: "route_change", page_path: "/" },
+        { event: "login" },
+      ])
+
+      setItem.mockRestore()
+    })
+  })
+
+  describe("initAnalyticsConsent", () => {
+    it("re-applies a stored grant", () => {
+      localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+      initAnalyticsConsent()
+      expect(gtag).toHaveBeenCalledWith("consent", "update", {
+        analytics_storage: "granted",
+      })
+    })
+
+    it("re-applies a stored denial", () => {
+      localStorage.setItem(CONSENT_STORAGE_KEY, "denied")
+      initAnalyticsConsent()
+      expect(gtag).toHaveBeenCalledWith("consent", "update", {
+        analytics_storage: "denied",
+      })
+    })
+
+    it("does nothing with no stored decision", () => {
+      initAnalyticsConsent()
+      expect(gtag).not.toHaveBeenCalled()
+    })
+
+    it("does nothing when GTM is not configured", () => {
+      disableGtm()
+      localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+      initAnalyticsConsent()
+      expect(gtag).not.toHaveBeenCalled()
+    })
+
+    it("does not throw when the GTM head snippet never ran", () => {
+      delete window.gtag
+      localStorage.setItem(CONSENT_STORAGE_KEY, "granted")
+      expect(() => initAnalyticsConsent()).not.toThrow()
+    })
+  })
+
+  describe("index.html head snippet", () => {
+    const inlineScripts = (
+      fs
+        .readFileSync(
+          path.join(__dirname, "../../../public/index.html"),
+          "utf8",
+        )
+        .match(/<script>[\s\S]*?<\/script>/g) ?? []
+    )
+      .map((tag) => tag.replace(/<\/?script>/g, ""))
+      .filter((source) => /consent|gtm\.js/.test(source))
+
+    // window.eval, not eval: only the former makes the gtag declaration a
+    // property of window, which is the browser behaviour utils/analytics.ts
+    // relies on. Returns the src of the container script the loader inserted.
+    const runSnippet = (gtmId: string): string | null => {
+      delete window.dataLayer
+      delete window.gtag
+      // The loader inserts itself before the first existing script tag.
+      document.head.appendChild(document.createElement("script"))
+      inlineScripts.forEach((source) =>
+        window.eval(source.replace("%REACT_APP_GTM_ID%", gtmId)),
+      )
+      return (
+        document.querySelector<HTMLScriptElement>("script[src]")?.src ?? null
+      )
+    }
+
+    afterEach(() => {
+      document.head.innerHTML = ""
+    })
+
+    it("finds both inline scripts", () => {
+      expect(inlineScripts).toHaveLength(2)
+    })
+
+    it("defines the gtag shim that utils/analytics.ts calls through", () => {
+      runSnippet(TEST_GTM_ID)
+      expect(typeof window.gtag).toBe("function")
+    })
+
+    it("defaults every consent signal to denied before the container loads", () => {
+      runSnippet(TEST_GTM_ID)
+      // The shim forwards `arguments`, which is what gtm.js reads back.
+      expect(Array.from(window.dataLayer?.[0] as IArguments)).toEqual([
+        "consent",
+        "default",
+        {
+          ad_storage: "denied",
+          ad_user_data: "denied",
+          ad_personalization: "denied",
+          analytics_storage: "denied",
+          wait_for_update: 500,
+        },
+      ])
+    })
+
+    it("loads the container for a well-formed id", () => {
+      expect(runSnippet(TEST_GTM_ID)).toBe(
+        `https://www.googletagmanager.com/gtm.js?id=${TEST_GTM_ID}`,
+      )
+    })
+
+    it("loads nothing when CRA left the placeholder un-interpolated", () => {
+      expect(runSnippet("%REACT_APP_GTM_ID%")).toBeNull()
+    })
+
+    it("rejects exactly the ids isGtmEnabled rejects", () => {
+      // Divergence between the two guards is a consent notice on a site whose
+      // container never loads, or the reverse.
+      for (const id of ["", "gtm-lowercase", "GTM-", "GTM-ABC123&extra=1"]) {
+        process.env.REACT_APP_GTM_ID = id
+        expect(isGtmEnabled()).toBe(false)
+        expect(runSnippet(id)).toBeNull()
+      }
+    })
+  })
+
+  describe("normalizePath", () => {
+    it("leaves paths without numeric segments alone", () => {
+      expect(normalizePath("/")).toBe("/")
+      expect(normalizePath("/account-manager")).toBe("/account-manager")
+      expect(normalizePath("/subscription/thanks")).toBe("/subscription/thanks")
+    })
+
+    it("collapses numeric segments", () => {
+      expect(normalizePath("/workspaces/12")).toBe("/workspaces/:id")
+      expect(normalizePath("/dataview/12")).toBe("/dataview/:id")
+      expect(normalizePath("/workspaces/12/runs/34")).toBe(
+        "/workspaces/:id/runs/:id",
+      )
+    })
+
+    it("does not collapse segments that merely contain digits", () => {
+      expect(normalizePath("/optinist2")).toBe("/optinist2")
+      expect(normalizePath("/v1beta/thing")).toBe("/v1beta/thing")
+    })
+  })
+})

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,81 @@
+import { safeLocalStorage } from "utils/safeStorage"
+
+export const CONSENT_STORAGE_KEY = "analyticsConsent"
+
+export type ConsentDecision = "granted" | "denied"
+
+type AnalyticsEvent = {
+  event: string
+  params?: Record<string, unknown>
+}
+
+const MAX_PENDING_EVENTS = 10
+
+// Must stay identical to the container loader's own guard: a value accepted by
+// one and rejected by the other means a consent notice with nothing behind it.
+const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/
+
+// Events raised before the visitor answered the banner, so accepting still
+// records the entry pageview instead of losing it.
+let _pending: AnalyticsEvent[] = []
+
+// Survives a localStorage that refuses writes (Safari "block all cookies",
+// private modes), which would otherwise leave GTM granted but nothing pushed.
+let _sessionConsent: ConsentDecision | null = null
+
+export function isGtmEnabled(): boolean {
+  return GTM_ID_PATTERN.test(process.env.REACT_APP_GTM_ID ?? "")
+}
+
+export function getAnalyticsConsent(): ConsentDecision | null {
+  if (_sessionConsent) return _sessionConsent
+  const stored = safeLocalStorage.getItem(CONSENT_STORAGE_KEY)
+  return stored === "granted" || stored === "denied" ? stored : null
+}
+
+function updateGtagConsent(decision: ConsentDecision): void {
+  window.gtag?.("consent", "update", { analytics_storage: decision })
+}
+
+export function trackEvent(
+  event: string,
+  params?: Record<string, unknown>,
+): void {
+  if (!isGtmEnabled()) return
+
+  const consent = getAnalyticsConsent()
+  if (consent === null) {
+    if (_pending.length < MAX_PENDING_EVENTS) _pending.push({ event, params })
+    return
+  }
+  if (consent === "denied") return
+
+  window.dataLayer?.push({ ...params, event })
+}
+
+export function setAnalyticsConsent(decision: ConsentDecision): void {
+  _sessionConsent = decision
+  safeLocalStorage.setItem(CONSENT_STORAGE_KEY, decision)
+  updateGtagConsent(decision)
+
+  const pending = _pending
+  _pending = []
+  if (decision === "granted") {
+    pending.forEach(({ event, params }) => trackEvent(event, params))
+  }
+}
+
+export function initAnalyticsConsent(): void {
+  if (!isGtmEnabled()) return
+  const consent = getAnalyticsConsent()
+  if (consent) updateGtagConsent(consent)
+}
+
+export function normalizePath(pathname: string): string {
+  return pathname.replace(/\/\d+(?=\/|$)/g, "/:id")
+}
+
+export function _resetForTesting(): void {
+  _pending = []
+  _sessionConsent = null
+}

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -11,8 +11,7 @@ type AnalyticsEvent = {
 
 const MAX_PENDING_EVENTS = 10
 
-// Must stay identical to the container loader's own guard: a value accepted by
-// one and rejected by the other means a consent notice with nothing behind it.
+// Must stay identical to the copies in public/index.html, config-overrides.js and ecr_build_push.sh: divergence means a consent notice with nothing behind it.
 const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/
 
 // Events raised before the visitor answered the banner, so accepting still

--- a/frontend/src/utils/analyticsTestUtils.ts
+++ b/frontend/src/utils/analyticsTestUtils.ts
@@ -1,0 +1,33 @@
+import { jest } from "@jest/globals"
+
+import { _resetForTesting } from "utils/analytics"
+
+export const TEST_GTM_ID = "GTM-TESTID"
+
+// A dotenv-provided container ID leaks into the test environment, so every
+// suite must pin and restore this rather than trusting the ambient value.
+const originalGtmId = process.env.REACT_APP_GTM_ID
+
+export function setUpAnalyticsTest() {
+  localStorage.clear()
+  _resetForTesting()
+  process.env.REACT_APP_GTM_ID = TEST_GTM_ID
+  window.dataLayer = []
+  const gtag = jest.fn()
+  window.gtag = gtag as unknown as Window["gtag"]
+  return gtag
+}
+
+export function tearDownAnalyticsTest(): void {
+  if (originalGtmId === undefined) {
+    delete process.env.REACT_APP_GTM_ID
+  } else {
+    process.env.REACT_APP_GTM_ID = originalGtmId
+  }
+  delete window.dataLayer
+  delete window.gtag
+}
+
+export function disableGtm(): void {
+  delete process.env.REACT_APP_GTM_ID
+}

--- a/infrastructure/documentation/ANALYTICS_ARCHITECTURE.md
+++ b/infrastructure/documentation/ANALYTICS_ARCHITECTURE.md
@@ -48,7 +48,8 @@ route_change                pages/PublicDataview -> view_public_data
 | ------------------------------------------ | --------------------------------------------------------------------------------- |
 | `public/index.html`                        | Consent Mode defaults, `gtag` shim, guarded container load                        |
 | `utils/analytics.ts`                       | Guard, consent state, buffering, path sanitization, the single `dataLayer` writer |
-| `components/common/ConsentBanner.tsx`      | Collects and persists the decision                                                |
+| `components/common/ConsentBanner.tsx`      | Collects and persists the first decision                                          |
+| `pages/Account/index.tsx`                  | Analytics Cookies switch: withdraws or re-grants an existing decision             |
 | `components/common/RouteChangeTracker.tsx` | Pageviews on route transitions                                                    |
 | `store/analyticsMiddleware.ts`             | Maps fulfilled thunks to custom events                                            |
 | `infrastructure/scripts/ecr_build_push.sh` | Supplies the per-environment container ID at build time                           |
@@ -60,6 +61,8 @@ route_change                pages/PublicDataview -> view_public_data
 The head snippet runs before the deferred CRA bundle, so `window.dataLayer` and the `gtag` shim always exist by the time application code runs, and the Consent Mode default is always registered before `gtm.js` can load. The loader is a no-op unless the compiled-in container ID matches the guard, which is what makes an un-configured build byte-for-byte inert at runtime.
 
 Inside the bundle, `initAnalyticsConsent()` runs at module scope in `index.tsx`, before `root.render`, so a returning visitor's decision is applied before the first event can be produced. `trackEvent` is the single writer to `dataLayer`; it holds events in a FIFO buffer (max 10) while no decision exists, flushes them in order on a grant, and discards them on a denial. That buffer is why a first-time visitor's entry pageview is still recorded if they accept, and why nothing at all is recorded if they decline.
+
+Withdrawal needs no reload. `trackEvent` calls `getAnalyticsConsent()` on every event and that reads the in-memory session value before `localStorage`, so flipping the `/account` switch off stops the very next event. The switch appears only once a decision exists, which is what keeps it and the notice from ever describing different states without any shared state between them.
 
 `RouteChangeTracker` deduplicates on the raw `location.pathname` but pushes the normalized value, so navigating between two different workspace ids is two pageviews rather than one. `analyticsMiddleware` calls `next(action)` first and never alters the action or the dispatch result; it looks up event names by exact action type, so sibling thunks that merely share a type prefix are not captured.
 
@@ -118,6 +121,37 @@ No event carries parameters other than `route_change`'s sanitized path fields.
 
 ---
 
+## Before setting a container ID
+
+Setting `REACT_APP_GTM_ID` is what activates every risk in this document. Until it is set there is nothing to review: no third-party request, no notice, no `dataLayer` writes. The items below are blocking, and none of them can be satisfied from this repository alone.
+
+### Access and supply chain
+
+1. **Restrict GTM container publish rights to a named, minimal set of people, with 2FA enforced on those Google accounts.** GTM is by design a mechanism for injecting arbitrary JavaScript into the page from a console outside this repository. That page runs authenticated scientific workflows and admin impersonation (`proxyLogin`), so publish rights on the container are equivalent to code execution in an authenticated session. This is the single largest security consideration of the whole feature.
+2. **Prefer a locked-down container.** Avoid Custom HTML tags; if the threat model warrants it, use server-side GTM.
+3. **Decide and record the CSP posture.** There is currently **no Content-Security-Policy anywhere in this repository** - no meta tag in `index.html`, no nginx layer, no CloudFront distribution, and the ALB rules in `infrastructure/terraform/public_alb_rules.tf` only match request headers, they do not add response headers. The absence pre-dates this subsystem (the app already loads `fonts.googleapis.com`), and adding GTM does not preclude a nonce-based CSP later, but GTM materially raises what an injection is worth. Either add one following Google's CSP guidance for GTM, or record the decision to accept the current posture.
+
+### Compliance
+
+4. **Link the privacy policy from the consent notice.** GDPR and ePrivacy expect the notice to link to the policy describing the processing. The Terms of Service and Privacy Policy pages are being added separately; wire the link in once those routes exist.
+5. **Have the notice copy reviewed.** It has had no legal review.
+6. **Confirm the consent controls still meet "withdrawal as easy as granting".** Decline and Accept carry identical styling in the notice, and `/account` offers an Analytics Cookies switch that both withdraws and re-grants, taking effect immediately without a reload. A restyle of either surface can regress this.
+
+### Verification, once a container exists
+
+The client-side test suite stops at `window.dataLayer`. A correct `dataLayer` does **not** prove correct GA4 data: every automated test still passes if the GA4 tag keeps its automatic `page_view`, if the `page_location` override is missing, or if a custom-event trigger was never created. Run these in GTM Preview and GA4 DebugView / Realtime and record the results.
+
+| #   | Case                                          | Expected result                                                                                                                                 |
+| --- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | One client-side route change, GTM Preview     | The GA4 configuration tag fires exactly once and sends `page_view`; `page_location` is the sanitized value with no query string                 |
+| 2   | Exercise all five events, GA4 DebugView       | `route_change` (as `page_view`), `sign_up`, `login`, `run_pipeline` and `view_public_data` all appear, with correct names and no PII parameters |
+| 3   | Two navigations, GA4 Realtime                 | Exactly two pageviews. Three means the automatic `page_view` was left on                                                                        |
+| 4   | Decline at the notice, then navigate          | DebugView receives nothing at all                                                                                                               |
+| 5   | Visit `/account-manager?email=...`, DebugView | `page_location` carries no email and no query string                                                                                            |
+| 6   | Trigger cross-check in the container          | All four custom-event triggers exist and fire                                                                                                   |
+
+---
+
 ## Required GTM container configuration
 
 The code side is inert without these console-side settings. Configure them **before** setting `REACT_APP_GTM_ID`, or measurement will be wrong from the first hit.
@@ -147,7 +181,6 @@ The code side is inert without these console-side settings. Configure them **bef
 
 ## Known gaps
 
-- **No consent-withdrawal UI.** GDPR requires withdrawal to be as easy as granting. This must be added before enabling the container for EEA/UK traffic. The current manual workaround is to clear the `analyticsConsent` localStorage key **and reload** - the in-memory session value takes precedence until the page is reloaded.
 - **The notice does not link to a privacy policy.** Terms and privacy pages are being added separately; link them from the notice once they exist.
 - **Consent does not sync across tabs.** Granting in one tab leaves another tab's notice up until it reloads.
 - **`canonical` and `og:url` in `index.html` are hardcoded to the site root**, so `/login`, `/register` and `/public` in `sitemap.xml` self-canonicalize to `/`. Submitting that sitemap to Search Console will report those URLs as duplicates. Fix the canonical handling before submitting the sitemap.
@@ -161,7 +194,8 @@ The code side is inert without these console-side settings. Configure them **bef
 | Suite                                                                  | Covers                                                                                                                                                                                                                                        |
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `frontend/src/utils/__tests__/analytics.test.ts`                       | Guard, consent storage, buffering and flush, path sanitization. Also reads the inline scripts out of `public/index.html` and evaluates them, so the `gtag` shim, the consent defaults and the loader guard are asserted rather than described |
-| `frontend/src/components/common/__tests__/ConsentBanner.test.tsx`      | Visibility rules, both decisions, accessibility role                                                                                                                                                                                          |
+| `frontend/src/components/common/__tests__/ConsentBanner.test.tsx`      | Visibility rules, both decisions, equal button prominence, accessibility role                                                                                                                                                                 |
+| `frontend/src/pages/Account/__tests__/AnalyticsConsent.test.tsx`       | The withdrawal switch: visibility rules, withdrawal and re-grant, and that withdrawal silences the next event without a reload                                                                                                                |
 | `frontend/src/components/common/__tests__/RouteChangeTracker.test.tsx` | Initial and subsequent pageviews, dedupe, query-string exclusion, standalone suppression                                                                                                                                                      |
 | `frontend/src/store/__tests__/analyticsMiddleware.test.ts`             | Action-to-event mapping, impersonation exclusion, standalone suppression                                                                                                                                                                      |
 

--- a/infrastructure/documentation/ANALYTICS_ARCHITECTURE.md
+++ b/infrastructure/documentation/ANALYTICS_ARCHITECTURE.md
@@ -1,0 +1,168 @@
+# Analytics Architecture: GTM, GA4 and Consent Mode v2
+
+## Executive Summary
+
+- **Google Tag Manager** is the single tag container for the hosted web frontend. Tags are managed in the GTM console, not in code.
+- **GA4 is measured through GTM only.** The frontend contains no GA4 or Firebase Analytics SDK, so there is no second measurement path to double-count.
+- **Consent Mode v2** defaults every signal to `denied`. No application event is pushed to `dataLayer` until the visitor answers the consent notice.
+- **The whole subsystem is inert unless `REACT_APP_GTM_ID` is set at build time.** With it unset, `gtm.js` is never requested, the consent notice never renders, and `trackEvent` is a no-op.
+- **Standalone (local) installs are excluded.** Local builds must leave `REACT_APP_GTM_ID` unset, and the route tracker, event middleware and consent notice all suppress themselves when the backend reports standalone mode.
+
+---
+
+## Key Architectural Principles
+
+1. **The SPA owns 100% of pageviews.** The GA4 configuration tag must have its automatic `page_view` turned OFF. `route_change` is the only pageview signal. Leaving the automatic pageview on double-counts every navigation.
+2. **No personal data leaves the browser.** `page_path` and `page_location` are always sanitized: query strings are dropped and numeric path segments are collapsed to `:id`. The GA4 tag must be configured to use these values rather than its defaults.
+3. **Consent is fail-closed on the signal side.** The consent update is issued through the `gtag` shim defined in `frontend/public/index.html`. If that shim is missing, the signal stays `denied` rather than being assumed granted. Note this governs the Consent Mode signal, not whether `dataLayer` receives application events - those are gated separately on the stored decision.
+4. **Custom events are emitted from one place.** A Redux middleware maps fulfilled thunk action types to event names, so no feature component contains event-tracking code and every present or future dispatcher is covered. Pageviews and the public-repository view are the two exceptions: they are not Redux actions, so they come from their own components.
+5. **The container ID is a build-time value.** It is baked into `index.html` by CRA's HTML interpolation, so it cannot be changed at runtime and cannot be varied per request.
+
+---
+
+## Architecture Overview
+
+```
+public/index.html  (inline, <head>, before the bundle)
+  dataLayer = []  ->  gtag shim  ->  consent default: all denied, wait_for_update 500
+  guarded loader:  /^GTM-[A-Z0-9]+$/  ->  gtm.js   (skipped when the ID is absent)
+        |
+        v
+index.tsx
+  initAnalyticsConsent()   re-applies a stored decision before the first render
+  <ConsentBanner/>         sibling of <App/>, wrapped in ErrorBoundary
+        |
+        v
+utils/analytics.ts   the only writer to dataLayer
+  no decision yet  ->  buffer (FIFO, max 10)
+  granted          ->  push { ...params, event }
+  denied           ->  drop
+        ^                        ^
+        |                        |
+components/common/          store/analyticsMiddleware.ts
+RouteChangeTracker          sign_up / login / run_pipeline
+route_change                pages/PublicDataview -> view_public_data
+```
+
+| Component                                  | Responsibility                                                                    |
+| ------------------------------------------ | --------------------------------------------------------------------------------- |
+| `public/index.html`                        | Consent Mode defaults, `gtag` shim, guarded container load                        |
+| `utils/analytics.ts`                       | Guard, consent state, buffering, path sanitization, the single `dataLayer` writer |
+| `components/common/ConsentBanner.tsx`      | Collects and persists the decision                                                |
+| `components/common/RouteChangeTracker.tsx` | Pageviews on route transitions                                                    |
+| `store/analyticsMiddleware.ts`             | Maps fulfilled thunks to custom events                                            |
+| `infrastructure/scripts/ecr_build_push.sh` | Supplies the per-environment container ID at build time                           |
+
+---
+
+## Implementation Details
+
+The head snippet runs before the deferred CRA bundle, so `window.dataLayer` and the `gtag` shim always exist by the time application code runs, and the Consent Mode default is always registered before `gtm.js` can load. The loader is a no-op unless the compiled-in container ID matches the guard, which is what makes an un-configured build byte-for-byte inert at runtime.
+
+Inside the bundle, `initAnalyticsConsent()` runs at module scope in `index.tsx`, before `root.render`, so a returning visitor's decision is applied before the first event can be produced. `trackEvent` is the single writer to `dataLayer`; it holds events in a FIFO buffer (max 10) while no decision exists, flushes them in order on a grant, and discards them on a denial. That buffer is why a first-time visitor's entry pageview is still recorded if they accept, and why nothing at all is recorded if they decline.
+
+`RouteChangeTracker` deduplicates on the raw `location.pathname` but pushes the normalized value, so navigating between two different workspace ids is two pageviews rather than one. `analyticsMiddleware` calls `next(action)` first and never alters the action or the dispatch result; it looks up event names by exact action type, so sibling thunks that merely share a type prefix are not captured.
+
+---
+
+## Key Functions Reference
+
+| Function                        | Purpose                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `isGtmEnabled()`                | Whether a well-formed container ID was compiled in. Every other entry point returns early when false          |
+| `getAnalyticsConsent()`         | Current decision: in-memory session value first, then localStorage; unrecognised values read as "no decision" |
+| `setAnalyticsConsent(decision)` | Persists, emits the Consent Mode update, and flushes or discards the buffer                                   |
+| `initAnalyticsConsent()`        | Re-applies a stored decision at bundle start, before the first event                                          |
+| `trackEvent(event, params?)`    | The only `dataLayer` writer. Buffers while undecided, drops when denied                                       |
+| `normalizePath(pathname)`       | Collapses numeric segments to `:id` to bound GA4 cardinality and keep internal ids out                        |
+
+---
+
+## Monitoring and Metrics
+
+No CloudWatch metrics or alarms: this subsystem is entirely client-side and emits no backend telemetry. Observability is the GA4 property itself, plus GTM Preview and GA4 DebugView for verification.
+
+---
+
+## Configuration
+
+| Variable                         | Where it is set                           | Effect when unset                                                |
+| -------------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| `REACT_APP_GTM_ID_<ENVIRONMENT>` | `infrastructure/.env.deploy` (gitignored) | GTM, GA4, the consent notice and all event tracking are disabled |
+
+`ecr_build_push.sh` selects the entry matching the Terraform `environment` output, uppercased: production (`subscr`) reads `REACT_APP_GTM_ID_SUBSCR`, development reads `REACT_APP_GTM_ID_DEVELOPMENT`. Per-environment keys prevent a development build from being published with the production container, which would pollute the property permanently. The file is sourced in a subshell, so unrelated assignments in it cannot affect the build.
+
+```
+# infrastructure/.env.deploy
+REACT_APP_GTM_ID_SUBSCR=GTM-XXXXXXX
+REACT_APP_GTM_ID_DEVELOPMENT=GTM-YYYYYYY
+```
+
+The script rewrites `frontend/.env.production` on every build, so editing that file by hand does not survive a deploy.
+
+Format: `GTM-` followed by uppercase letters and digits, enforced identically in three places - the deploy script (hard-fails the build on a malformed value), `isGtmEnabled()` in `frontend/src/utils/analytics.ts`, and the loader guard in `frontend/public/index.html`. The un-interpolated literal `%REACT_APP_GTM_ID%` that CRA leaves behind when the variable is absent fails all three.
+
+---
+
+## Events
+
+| Event              | Emitted by            | Trigger                                                                                                    |
+| ------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `route_change`     | `RouteChangeTracker`  | Initial location and every subsequent distinct pathname. Carries sanitized `page_path` and `page_location` |
+| `sign_up`          | `analyticsMiddleware` | `registerUser.fulfilled`                                                                                   |
+| `login`            | `analyticsMiddleware` | `login.fulfilled`, excluding admin impersonation                                                           |
+| `run_pipeline`     | `analyticsMiddleware` | `run.fulfilled` or `runByCurrentUid.fulfilled`                                                             |
+| `view_public_data` | `PublicDataview`      | Mount of the `/public` page                                                                                |
+
+No event carries parameters other than `route_change`'s sanitized path fields.
+
+---
+
+## Required GTM container configuration
+
+The code side is inert without these console-side settings. Configure them **before** setting `REACT_APP_GTM_ID`, or measurement will be wrong from the first hit.
+
+1. **GA4 configuration tag: automatic `page_view` OFF.** Add a Custom Event trigger on `route_change` and send `page_view` from it. Leaving the built-in pageview on produces two pageviews per navigation.
+2. **Override `page_location` and `page_title` on the GA4 tag** using the `page_location` and `page_path` dataLayer variables. GA4 otherwise defaults `page_location` to `document.location.href`, and two live routes carry personal data in their query strings: `/account-manager?email=...&name=...` and `/subscription/thanks?session_id=...`. The frontend cannot prevent that from the tag's own default.
+3. **Enable GA4 "Redact data"** (IP and query-string redaction) as defence in depth.
+4. **Create Custom Event triggers** for `sign_up`, `login`, `run_pipeline` and `view_public_data`.
+5. **Do not put tags on the Initialization or All Pages triggers.** See the returning-visitor row under Edge Case Handling.
+6. **`sign_up` fires when registration is submitted, not when the email is verified.** Verification is a separate later step, so this metric counts attempted registrations.
+
+---
+
+## Edge Case Handling
+
+| Case                                                                        | Behaviour                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Visitor has not answered the notice                                         | Events are buffered in memory (up to 10, in order) and pushed only if the visitor accepts. Declining discards them and every later event is a no-op.                                                                                                                                                                                                                                                                                                                                                                     |
+| Visitor declines                                                            | No `route_change`, `sign_up`, `login`, `run_pipeline` or `view_public_data` event is ever pushed. The container is still loaded and `analytics_storage` stays `denied`, so whether a tag on an Initialization or All Pages trigger emits a cookieless ping is decided entirely by the container configuration, not by this code.                                                                                                                                                                                         |
+| Returning visitor who accepted                                              | The stored decision is re-applied at bundle start, before any event is pushed. `wait_for_update: 500` only helps a warm cache: the main chunk is ~2 MB gzipped, so on a cold load the wait expires first. Any tag on an Initialization or All Pages trigger will therefore evaluate against `denied` for a returning visitor and produce a cookieless, unattributed hit. Keep such tags out of the container; if one is ever needed, the stored grant must be replayed inline in `index.html` before the loader instead. |
+| `localStorage` refuses writes (Safari "block all cookies", private modes)   | The decision is held in memory for the session, so tracking works as chosen; the notice reappears on the next reload.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Corrupted stored value                                                      | Treated as "no decision"; the notice is shown again.                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Backend is unreachable                                                      | The router never mounts, so no pageview is recorded for the error screen, and the consent notice is not shown over it. Deliberate.                                                                                                                                                                                                                                                                                                                                                                                       |
+| Client-side redirect on load, e.g. unauthenticated `/dashboard` to `/login` | Both paths are recorded. Known inflation, inherent to client-side routing.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+---
+
+## Known gaps
+
+- **No consent-withdrawal UI.** GDPR requires withdrawal to be as easy as granting. This must be added before enabling the container for EEA/UK traffic. The current manual workaround is to clear the `analyticsConsent` localStorage key **and reload** - the in-memory session value takes precedence until the page is reloaded.
+- **The notice does not link to a privacy policy.** Terms and privacy pages are being added separately; link them from the notice once they exist.
+- **Consent does not sync across tabs.** Granting in one tab leaves another tab's notice up until it reloads.
+- **`canonical` and `og:url` in `index.html` are hardcoded to the site root**, so `/login`, `/register` and `/public` in `sitemap.xml` self-canonicalize to `/`. Submitting that sitemap to Search Console will report those URLs as duplicates. Fix the canonical handling before submitting the sitemap.
+- **Search Console ownership is not verified.** DNS TXT or a `google-site-verification` meta tag are the robust methods; the GTM method additionally requires publish rights on the container.
+- **e2e consent seeding is only partial.** `frontend/e2e/global-setup.ts` seeds `analyticsConsent=denied` into the authenticated storage state, but specs that build their own unauthenticated context (the login and registration flows) will still meet the notice once a container ID is set for the tested build.
+
+---
+
+## Testing
+
+| Suite                                                                  | Covers                                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/utils/__tests__/analytics.test.ts`                       | Guard, consent storage, buffering and flush, path sanitization. Also reads the inline scripts out of `public/index.html` and evaluates them, so the `gtag` shim, the consent defaults and the loader guard are asserted rather than described |
+| `frontend/src/components/common/__tests__/ConsentBanner.test.tsx`      | Visibility rules, both decisions, accessibility role                                                                                                                                                                                          |
+| `frontend/src/components/common/__tests__/RouteChangeTracker.test.tsx` | Initial and subsequent pageviews, dedupe, query-string exclusion, standalone suppression                                                                                                                                                      |
+| `frontend/src/store/__tests__/analyticsMiddleware.test.ts`             | Action-to-event mapping, impersonation exclusion, standalone suppression                                                                                                                                                                      |
+
+Verify end to end with GTM Preview and GA4 DebugView after setting the container ID: confirm exactly one pageview per navigation and that no query string appears in `page_location`.

--- a/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
+++ b/infrastructure/documentation/DEPLOYMENT_PROCEDURE.md
@@ -38,6 +38,16 @@ This document covers **application code deployment, release procedures, and Git 
 brew install terraform
 ```
 
+### Optional Build Configuration
+
+`infrastructure/.env.deploy` (gitignored) supplies build-time frontend values that Terraform does not own. Currently only the analytics container ID, keyed per environment. Without it the frontend is built with analytics disabled, which the build log states explicitly. See [ANALYTICS_ARCHITECTURE.md](ANALYTICS_ARCHITECTURE.md).
+
+```bash
+# infrastructure/.env.deploy
+REACT_APP_GTM_ID_SUBSCR=GTM-XXXXXXX       # production
+REACT_APP_GTM_ID_DEVELOPMENT=GTM-YYYYYYY  # development
+```
+
 ### Required AWS Permissions
 
 The deploying user needs the following AWS permissions:

--- a/infrastructure/scripts/ecr_build_push.sh
+++ b/infrastructure/scripts/ecr_build_push.sh
@@ -149,14 +149,34 @@ if ! aws ecr describe-repositories --repository-names $REPO_NAME --region $REGIO
     exit 1
 fi
 
+# infrastructure/.env.deploy (gitignored) holds build-time values Terraform does
+# not own. Keyed per environment so a development build can never be published
+# with the production analytics container. Sourced in a subshell so a stray
+# assignment in that file cannot clobber the variables used below.
+GTM_ID_VAR="REACT_APP_GTM_ID_$(echo "$ENVIRONMENT" | tr '[:lower:]-' '[:upper:]_')"
+REACT_APP_GTM_ID=$(
+    set +e
+    if [ -f "$REPO_ROOT/infrastructure/.env.deploy" ]; then
+        . "$REPO_ROOT/infrastructure/.env.deploy"
+    fi
+    printf '%s' "${!GTM_ID_VAR:-}"
+)
+
+if [ -n "$REACT_APP_GTM_ID" ] && ! [[ "$REACT_APP_GTM_ID" =~ ^GTM-[A-Z0-9]+$ ]]; then
+    echo "ERROR: malformed $GTM_ID_VAR ('$REACT_APP_GTM_ID'). Expected GTM-XXXXXXX."
+    exit 1
+fi
+
 # Build frontend with custom domain for autoscaling
 echo "Building frontend for autoscaling with ${AUTOSCALING_PROTO}://${AUTOSCALING_HOST}:${AUTOSCALING_PORT}"
+echo "Analytics ($ENVIRONMENT): ${REACT_APP_GTM_ID:-<$GTM_ID_VAR unset, analytics disabled>}"
 cd "$REPO_ROOT/frontend"
 cat > .env.production << ENV_EOF
 REACT_APP_SERVER_HOST=${AUTOSCALING_HOST}
 REACT_APP_SERVER_PORT=${AUTOSCALING_PORT}
 REACT_APP_SERVER_PROTO=${AUTOSCALING_PROTO}
 REACT_APP_EXPDB_METADATA_EDITABLE=true
+REACT_APP_GTM_ID=${REACT_APP_GTM_ID:-}
 ENV_EOF
 
 yarn install


### PR DESCRIPTION
### Content

#### Summary
- Introduces Google Tag Manager as the single tag container for the hosted frontend, with GA4 measured through it, Consent Mode v2 defaulting every signal to `denied`, a consent notice, SPA route-transition pageviews, and the four custom events the issue asks for (`sign_up`, `login`, `run_pipeline`, `view_public_data`).
- The entire subsystem is **inert unless `REACT_APP_GTM_ID` is set at build time**: with it unset, `gtm.js` is never requested, the consent notice never renders, and `trackEvent` is a no-op. This was verified by executing the built inline snippet, not just by reading it.
- **Nothing is pushed to `dataLayer` until the visitor answers the notice.** Events raised before the decision are buffered (FIFO, max 10) and flushed only on acceptance, so accepting does not lose the entry pageview and declining sends nothing at all.
- The Google-console side (creating the GA4 property and GTM container, configuring tags and triggers, Search Console verification) cannot be done from a repo change. The mandatory container configuration is committed to `infrastructure/documentation/ANALYTICS_ARCHITECTURE.md` so it is not lost in a PR thread.

#### Issue #652 checklist status

This PR does not close #652. Four of the nine tasks live in the Google console and cannot be done from a repository change; one of those has a code prerequisite in this repo as well.

| # | Task | Status |
|---|---|---|
| 1 | Create the GA4 property and GTM container, obtain `GTM-XXXXXXX` | **Not done.** Google console |
| 2 | `REACT_APP_GTM_ID` in env, guard when unset | **Done.** Guarded in four places; verified inert on the deployed build |
| 3 | Consent Mode default then the GTM snippet in `index.html`, `<head>` plus a `<body>` `<noscript>` | **Head done, `<noscript>` deliberately omitted.** The Consent Mode default, the `gtag` shim and the guarded container loader are all inline in `<head>`, ahead of `gtm.js`. The `<noscript>` iframe is not present and will not be added: this is a CRA SPA that renders nothing without JavaScript (`index.html` already ships "You need to enable JavaScript to run this app"), so a no-JS pageview would record a visitor who saw a blank page. Adding it would inject measurable but meaningless traffic |
| 4 | Consent notice on all pages, persist the choice, fire `gtag('consent', 'update', ...)` | **Done.** Decline and Accept now carry identical styling, and `/account` offers withdrawal and re-grant |
| 5 | `useLocation` route-transition `dataLayer.push`, no duplication | **Done.** `RouteChangeTracker`; the SPA owns 100% of pageviews |
| 6 | GA4 configuration tag plus triggers on the GTM side | **Not done.** Google console, blocked on task 1 |
| 7 | Custom events per page, no PII | **Done client-side.** Query strings are never sent and numeric path segments collapse to `:id`. Fully closed only once the console `page_location` override is applied, which this repo cannot enforce |
| 8 | Search Console ownership plus `sitemap.xml` submission | **Not done,** and it has a code prerequisite: `index.html` hardcodes `canonical` and `og:url` to the site root for every route, so three of the four sitemap URLs self-canonicalize to `/`. Submitting today reports them as duplicates |
| 9 | GTM Preview / GA4 DebugView firing check; lint, test and `yarn build` green | **Partial.** Lint, tests and all build configurations verified below. Preview and DebugView are impossible without a container |

Tasks 1, 6, 8 and 9 plus the enablement preconditions are carried in #807. Task 8 additionally blocks on #809.

#### Review follow-ups addressed in this PR

Four items from the review thread, all small and all landed here rather than deferred:

1. **Equal-prominence consent buttons.** Decline was a plain text button next to a `contained` Accept, which EDPB and CNIL guidance rules out. Both are now `outlined`, differing only by label, and a test asserts their class lists are identical so a restyle of either cannot silently regress it.
2. **Build-time container-ID validation.** CRA interpolates the ID straight into a JS string literal in `index.html`, so the runtime guard there is already too late for a value that breaks out of the string. `config-overrides.js` now throws on a set-but-malformed ID, closing the one path the deploy script never sees (a local `yarn build` with a hostile `.env`). Verified: `REACT_APP_GTM_ID='GTM-A"; alert(1); x="' yarn build` fails with exit code 1.
3. **Consent withdrawal.** `/account` gains an Analytics Cookies switch that both withdraws and re-grants. It takes effect on the very next event with no reload, because `trackEvent` reads the in-memory session value before `localStorage`. It renders only once a decision exists, so it and the notice can never describe different states, and that needs no shared state between the two components.
4. **The rollout conditions are now a blocking gate in the repo, not prose in a PR thread.** `ANALYTICS_ARCHITECTURE.md` gains a "Before setting a container ID" section covering GTM publish-rights lockdown and 2FA, the CSP posture decision, the privacy-policy link, and the six GTM Preview / GA4 DebugView verification cases with expected results.

Not addressed here, with reasons: **CSP** is app-wide and needs its own design pass (MUI and emotion inject inline styles at runtime, CRA has no per-response nonce mechanism, and enforcing blind would break the app). No CSP exists anywhere today, so this diff regresses nothing, and the GTM injection surface does not exist until an ID is set. It is filed as #808 rather than a checkbox here, because the gap pre-dates this work. The **privacy-policy link** is blocked on PR #770. **Cross-tab consent sync** is cosmetic. **`view_public_data` overlapping the `/public` pageview** is intentional: #652 asked for that event by name.

Copilot's single comment was fixed in eb65bc7.

#### Design Decisions

**Where the snippet lives.** The Consent Mode default and the container loader are inline in `frontend/public/index.html`, which is what the issue asks for and what makes the "do not load when unset" guard possible. Verified against the installed toolchain: `react-scripts/config/env.js` only exports `REACT_APP_*` keys actually present in `process.env`, and `react-dev-utils/InterpolateHtmlPlugin` substitutes only the keys it is given, so an unset variable leaves the literal `%REACT_APP_GTM_ID%` in the output. A runtime pattern check therefore covers unset, empty, and malformed alike. The placeholder is deliberately kept inside a quoted string literal: `InterpolateHtmlPlugin` runs *before* html-webpack-plugin's production `minifyJS`, so an unquoted surviving placeholder would fail terser and break `yarn build` in exactly the default (unset) configuration.

**The SPA owns 100% of pageviews.** The GA4 configuration tag must have its automatic `page_view` turned off; `route_change` is the only pageview signal. The alternative ("GTM counts the first pageview, we count the rest") is worse here, because `Layout` redirects with `navigate(..., { replace: true })` on nearly every load and `App` has two catch-all `<Navigate replace>` routes, so a container-load pageview would count paths the visitor never saw while the landing page went unrecorded. Owning all of them also means the stored consent decision is always re-applied before the first hit, which is why `wait_for_update` is not load-bearing.

**Consent grant sets `analytics_storage` only.** No advertising product is in use, so `ad_storage`, `ad_user_data` and `ad_personalization` stay `denied` permanently. This keeps the notice's promise narrow and avoids advertising-consent surface entirely.

**Custom events come from one Redux middleware**, keyed on exact `thunk.fulfilled.type`, so no feature component contains tracking code and every present or future dispatcher is covered. Two subtleties: `proxyLogin` (admin impersonation) shares `login`'s `user/login` action type, so the real login is identified *positively* by its `LoginDTO` shape rather than by excluding a string argument (a negative test would fail open for any future same-prefix thunk); and `runApplyFilter` is `pipeline/run/filter`, which shares a stem with `run`, so lookups are exact-equality via a `Map` rather than a prefix match or a plain-object index.

**No PII, enforced where it can be.** `page_path` and `page_location` are both sanitized: `location.search` is never sent and numeric path segments collapse to `:id`. This bounds GA4 cardinality and keeps internal identifiers out of a third party. The frontend cannot fully close this on its own - GA4's configuration tag defaults `page_location` to `document.location.href`, and two live routes carry personal data in their query strings (`/account-manager?email=...&name=...` and `/subscription/thanks?session_id=...`). The diff therefore supplies a ready-made sanitized `page_location` so the console override is a one-field change, and that override is written down as a blocking requirement in the architecture doc.

**Standalone installs are excluded.** `pyproject.toml` packages `frontend/build/` into the pip wheel, so a local build made on a machine with a container ID in its untracked `.env` would otherwise ship third-party tracking and a cookie notice into a local scientific tool. The route tracker, the event middleware and the notice all suppress themselves in standalone mode, and `.env.example` states that local builds must leave the variable unset.

**The container ID is reachable.** `ecr_build_push.sh` rewrites `frontend/.env.production` from a fixed heredoc on every build, so nothing a human puts in that file survives - without this change the feature would have been permanently unreachable in the deployed artifact. The script now takes the ID from a gitignored `infrastructure/.env.deploy`, **keyed per environment** (`REACT_APP_GTM_ID_SUBSCR` / `REACT_APP_GTM_ID_DEVELOPMENT`, derived from the Terraform `environment` output) so a development deploy cannot publish the production container and pollute the property. The file is sourced in a subshell so a stray assignment in it cannot clobber `REPO_ROOT` or the ALB values, and a malformed ID hard-fails the build rather than producing a broken inline script. No Terraform change: a GTM container ID is a Google console value, not a Terraform-managed resource.

**Deliberate deviations from the issue checklist**, both documented and both restated in the checklist table above:
- **No `<noscript>` GTM iframe** (issue task 3). This is a CRA SPA that renders nothing without JavaScript (`index.html` already ships "You need to enable JavaScript to run this app"), so a no-JS pageview would be measuring a broken page.
- **Search Console verification method left to the deployer** (issue task 8). The issue suggests the GTM method; that additionally requires publish rights on the container and documents the `<body>` snippet. DNS TXT or a `google-site-verification` meta tag are the robust methods. The HTML placement stands on its own merits regardless.

**Rejected:** injecting the container from TypeScript instead of `index.html` (loses the served-HTML verification option and gains nothing for an SPA); a certified CMP (a new third-party dependency for two buttons); a single-slot pending-event buffer (dropped the `/public` entry pageview - caught in review); a full-width bottom bar (covered the always-mounted bottom-left logs button and react-flow controls); anchoring the notice top-center (already occupied by `InactivityWarning`).

### Evidence

`yarn build` with `REACT_APP_GTM_ID` unset (the state of every current build) succeeds, and the minified inline snippet was extracted from `build/index.html` and executed. Both the unset and the substituted-ID paths behave as designed:

```
GTM ID UNSET (%REACT_APP_GTM_ID% survives minification, 1 occurrence):
  dataLayer entries: [["consent","default",{"ad_storage":"denied","ad_user_data":"denied",
    "ad_personalization":"denied","analytics_storage":"denied","wait_for_update":500}]]
  gtm.js requested: null

GTM ID SET (GTM-ABC1234):
  dataLayer entries: 2  (consent default, then {"gtm.start":...,"event":"gtm.js"})
  gtm.js src: https://www.googletagmanager.com/gtm.js?id=GTM-ABC1234
```

Terser keeps both blocks as classic (non-module) `<script>` tags, which is what makes the top-level `function gtag()` declaration a property of `window` - the contract `utils/analytics.ts` depends on. That contract is now a jest assertion rather than a manual observation; see Test Coverage.

Deploy-script environment logic, exercised in an isolated harness across 8 scenarios:

```
1. no .env.deploy         -> <REACT_APP_GTM_ID_DEVELOPMENT unset, analytics disabled>
2. environment=development -> GTM-DEV456
3. environment=subscr      -> GTM-PROD123
4. environment=staging     -> disabled (no matching key)
5. stray REPO_ROOT=/hacked and AUTOSCALING_HOST=evil in the file -> ignored, REPO_ROOT intact
6. id "gtm-lowercase"      -> ERROR: malformed ... Expected GTM-XXXXXXX (exit 1)
7. a failing command in the file -> does not abort the deploy
8. id 'GTM-A"; alert(1); x="' -> rejected (exit 1)
```

The build-time ID guard added in review, exercised across all five configurations:

```
REACT_APP_GTM_ID unset            -> build succeeds, %REACT_APP_GTM_ID% survives minification
REACT_APP_GTM_ID=""               -> build succeeds, guard rejects "" at runtime
REACT_APP_GTM_ID=gtm-bad          -> Error: Malformed REACT_APP_GTM_ID: 'gtm-bad'.  exit 1
REACT_APP_GTM_ID='GTM-A"; alert(1); x="'
                                  -> Error: Malformed REACT_APP_GTM_ID: ...          exit 1
REACT_APP_GTM_ID=GTM-ABC1234      -> build succeeds, ID present in build/index.html
```

Full frontend suite:

```
Test Suites: 63 passed, 63 total
Tests:       5 skipped, 765 passed, 770 total
```

Up from 62 / 759 by exactly the six tests added in review. Both new tests are mutation-verified: reverting Accept to `variant="contained"` and dropping the `analyticsConsent !== null` gate on the `/account` row fails exactly those two tests and no others.

`tsc --noEmit` reports 46 errors, exactly the pre-existing `develop-main` baseline, none of them in new or changed files. eslint reports 0 errors; prettier is clean across every changed file.

### References
- Issue: https://github.com/arayabrain/araya-optinist/issues/652 (milestone v1.1.10). This PR does not close it; see the checklist status above
- Follow-ups filed from the review of this PR:
  - https://github.com/arayabrain/araya-optinist/issues/807 - Enable GTM. Carries #652 tasks 1, 6, 8 and 9 plus the enablement preconditions
  - https://github.com/arayabrain/araya-optinist/issues/808 - Add CSP. A pre-existing gap on `develop-main`, raised here because GTM raises what an injection is worth
  - https://github.com/arayabrain/araya-optinist/issues/809 - Update canonical URL. Blocks #652 task 8
- New doc: `infrastructure/documentation/ANALYTICS_ARCHITECTURE.md` - the required GTM container configuration, per-environment setup, edge-case behaviour and known gaps
- Consent Mode v2: https://developers.google.com/tag-platform/security/guides/consent
- The issue's "current state" note is stale in one respect: it says `frontend/src/config/firebase.ts` sets `measurementId` without calling `getAnalytics()`. That file does not exist and the frontend has no Firebase SDK at all (Firebase is backend-only, `firebase-admin` in `studio/`). This makes the work smaller, not different: there is no second measurement path to disable and no double-counting risk.

#### Files changed

**Frontend - new**
- `frontend/src/utils/analytics.ts` - the only writer to `dataLayer`; container-ID guard, consent state (session value ahead of `localStorage`), the pending-event buffer, and path sanitization.
- `frontend/src/utils/analyticsTestUtils.ts` - shared, hermetic test setup. Placed beside the source rather than under `__tests__/` because CRA's `testMatch` treats every file in a `__tests__` directory as a suite; follows the existing `store/slice/Pipeline/PipelineTestUtils.ts` precedent.
- `frontend/src/components/common/ConsentBanner.tsx` - the notice. Bottom-right, single line, at a new `Z_INDEX.CONSENT_BANNER` below MUI's modal and snackbar layers so dialogs and toasts stay on top and clickable.
- `frontend/src/components/common/RouteChangeTracker.tsx` - pageviews. Deduplicates on the raw pathname and pushes the normalized one, so two different workspace ids are two pageviews.
- `frontend/src/store/analyticsMiddleware.ts` - maps fulfilled thunks to custom events.
- Five test files: `src/utils/__tests__/analytics.test.ts`, `src/components/common/__tests__/ConsentBanner.test.tsx`, `src/components/common/__tests__/RouteChangeTracker.test.tsx`, `src/store/__tests__/analyticsMiddleware.test.ts`, `src/pages/Account/__tests__/AnalyticsConsent.test.tsx`. The first of these also reads and evaluates the inline scripts from `public/index.html`, so that file is covered by the suite rather than by inspection. The last covers the withdrawal switch and mirrors the harness already in `Account/__tests__/DeletionPriority.test.tsx`.

**Frontend - edited**
- `frontend/config-overrides.js` - throws on a set-but-malformed `REACT_APP_GTM_ID`, so a hostile value cannot break out of the JS string literal CRA interpolates it into.
- `frontend/src/pages/Account/index.tsx` - the Analytics Cookies switch: withdraws or re-grants an existing decision, using the page's own `BoxFlex` / `TitleData` layout components.
- `frontend/public/index.html` - Consent Mode defaults, the `gtag` shim, and the guarded container loader, inline in `<head>`.
- `frontend/src/index.tsx` - `initAnalyticsConsent()` beside the existing `init*` calls, and `<ConsentBanner/>` as a sibling of `<App/>` wrapped in the existing `ErrorBoundary`. Mounted here rather than inside `App` because `App` returns `<BackendUnavailable>`/`<Loading>` before `<BrowserRouter>`, and because an optional analytics widget must not be able to white-screen the landing page.
- `frontend/src/App.tsx` - `<RouteChangeTracker/>` inside `<BrowserRouter>`, covering both route trees.
- `frontend/src/pages/PublicDataview/index.tsx` - `view_public_data` on mount.
- `frontend/src/store/store.ts` - registers the middleware.
- `frontend/src/const/Layout.ts` - `Z_INDEX.CONSENT_BANNER`.
- `frontend/src/react-app-env.d.ts` - `Window` augmentation for `dataLayer`/`gtag`.
- `frontend/.env.example`, `frontend/.env.production.example` - documented placeholder; states that local/standalone builds must leave it unset and that `.env.production` is regenerated by the deploy script.
- `frontend/e2e/global-setup.ts` - seeds `analyticsConsent=denied` into the authenticated storage state so the notice cannot front the suite once an ID is set.

**Infrastructure**
- `infrastructure/scripts/ecr_build_push.sh` - per-environment container ID from a gitignored `infrastructure/.env.deploy`, sourced in a subshell, format-validated, and logged.
- `infrastructure/documentation/ANALYTICS_ARCHITECTURE.md` - new. Includes the "Before setting a container ID" blocking gate added in review.
- `infrastructure/documentation/DEPLOYMENT_PROCEDURE.md` - Prerequisites entry for `.env.deploy`.

### Manual Testcases

All of these need `REACT_APP_GTM_ID` set, since the feature is inert otherwise.

1. **Inert by default.** Developer runs `yarn build` with no `REACT_APP_GTM_ID` and serves `build/`. Expected: no request to `googletagmanager.com` in the network panel, no consent notice, `window.dataLayer` contains only the `consent default` entry.
2. **First visit, accept.** Visitor with cleared storage loads `/public` with an ID configured. Expected: the notice appears bottom-right; on Accept it disappears and `dataLayer` gains `route_change` for `/public` *followed by* `view_public_data` (the pageview must not be missing).
3. **First visit, decline.** Same, but click Decline. Expected: notice disappears, `dataLayer` gains no application events, and navigating around adds none.
4. **Returning visitor.** Reload after accepting. Expected: no notice, and a `consent update` with `analytics_storage: granted` precedes the first `route_change`.
5. **No identifiers leak.** Admin navigates to `/account-manager` and searches for a user by email, then opens a workspace. Expected: `page_path`/`page_location` read `/account-manager` and `/workspaces/:id` - no email, no numeric id, no query string anywhere in `dataLayer`.
6. **Pageviews are not duplicated.** Navigate between two different workspaces. Expected: exactly one `route_change` per navigation, and two distinct pageviews for two different ids.
7. **Storage refused.** Safari with "block all cookies", accept the notice. Expected: events flow for the rest of the session; the notice returns on the next reload.
8. **Impersonation is not a login.** Admin proxy-logs in as a user from `/account-manager`. Expected: no `login` event.
9. **Deploy.** With `REACT_APP_GTM_ID_DEVELOPMENT=GTM-XXXXXXX` in `infrastructure/.env.deploy`, run the deploy script against the development backend. Expected: the log line reads `Analytics (development): GTM-XXXXXXX`, and the built `index.html` contains that ID. With the key removed, it reads `analytics disabled` and the built HTML keeps the literal placeholder.

Automated: `docker compose -f docker-compose.test.yml run test_studio_frontend` - 62 suites, 759 tests pass, 5 skipped.

### Unit, Integration, Contract Test Coverage

60 new tests across four suites:
- `analytics.test.ts` - guard accepts/rejects the same ids as the loader (lowercase, bare `GTM-`, query-appended, the un-interpolated placeholder); consent round-trip; unrecognised stored value reads as no decision; buffering, in-order flush, the cap, discard on denial, no replay after a denial; `params` cannot override the event name; both consent directions; storage-refused fallback; no throw when the head snippet never ran; path normalization including segments that merely contain digits.
- `analytics.test.ts`, `index.html head snippet` - reads the inline scripts straight out of `frontend/public/index.html` and evaluates them through `window.eval`, so the head snippet is asserted rather than described: the `gtag` shim really lands on `window`, all four consent signals really default to `denied`, the loader inserts `gtm.js` for a well-formed id, and inserts nothing for the un-interpolated placeholder or for any id `isGtmEnabled()` rejects. This is the drift guard for the `^GTM-[A-Z0-9]+$` pattern, which necessarily exists in both files; mutating either the pattern or the shim name in `index.html` fails 5 of the 6.
- `ConsentBanner.test.tsx` - hidden when unconfigured, when a decision exists, in standalone mode, and before the backend has confirmed the mode; both decisions persist, signal, and dismiss; buffered events released on accept and dropped on decline; uses a labelled region, not `role="alert"`.
- `RouteChangeTracker.test.tsx` - initial location recorded; one pageview per navigation; two different ids are two pageviews; query-string-only change ignored and the query string never sent; suppressed in standalone mode and when unconfigured.
- `analyticsMiddleware.test.ts` - the action always passes through unchanged; each mapping fires once; impersonation and arg-less login ignored; filter re-runs and pending/rejected variants ignored; `Object` prototype keys ignored; suppressed in standalone mode, when unconfigured, and before consent.

Not covered by jest: the deploy script's environment selection, verified by direct execution against an isolated harness - see Evidence. The third copy of the id pattern lives in that script and is deliberately outside the jest drift guard, because the frontend test image (`frontend/Dockerfile.test`) copies only `frontend/`; a test reading `infrastructure/` would pass locally and fail in CI. A drifted pattern there fails the deploy loudly rather than silently, which is the acceptable half of the trade.

### Others

#### Difficulties

Two problems were only found by building and running rather than by reading:
- The shared test-setup helper broke `yarn build` with `TS2741`. It sits in `src/utils/`, which CRA's `ForkTsChecker` type-checks (it excludes only `__tests__/`), and an explicit `jest.Mock` return type clashes with the `@jest/globals` mock it returns. Fixed by letting inference do it.
- The test for "the notice must not render before the mode is known" failed for the wrong reason: my own test helper used a destructuring default, which silently converted an explicitly passed `undefined` back to `false`. The helper now takes the whole slice state.

`expect` is deliberately left global in `ConsentBanner.test.tsx`: importing it from `@jest/globals` detaches the jest-dom matcher types, because jest-dom v6 augments a one-parameter `Matchers` while CRA's pinned jest exposes a two-parameter one. That trade costs 15 `no-undef` lint warnings, matching the existing pattern in `components/common/__tests__/ErrorBoundary.test.tsx`.

#### Second review pass

A full re-review of the diff against `develop-main` produced one substantive change and confirmed the rest. Checks that held: `proxyLogin` really does share `login`'s `user/login` type string, so the positive `LoginDTO` guard is load-bearing; `runApplyFilter` and `runByCurrentUid` are independent thunks that never dispatch `run`, so the exact-match `Map` cannot double-count; `loginApi` is the frontend's only authentication path, so no sign-in bypasses the `login` event; `App` renders `<Loading>` until `getModeStandalone` settles, so `RouteChangeTracker` never observes an undefined mode; `.env*` is gitignored, so `infrastructure/.env.deploy` cannot be committed and cannot trip the deploy script's own dirty-worktree guard; and bash indirect expansion plus `tr '[:lower:]-' '[:upper:]_'` produce `SUBSCR` and `DEVELOPMENT` correctly on the macOS toolchain a deploy actually runs from.

What changed: the head snippet in `index.html` was the only part of the subsystem with no automated coverage, and the `^GTM-[A-Z0-9]+$` pattern it duplicates was held together by a code comment. It now has six tests (see Test Coverage). The one claim in this document that a re-check falsified was its own: it said the inline scripts are "not reachable from jsdom". They are, through `window.eval`, which is also the only way to reproduce the real global-scope semantics the `gtag` shim depends on.

Not changed, deliberately: the 10-event buffer cap drops the newest events rather than the oldest, which keeps the entry pageview - the one that matters - and is asserted; `setAnalyticsConsent` still writes `localStorage` even when no container is configured, which is harmless; and the e2e seeding stays partial, because the specs that would meet the notice cannot in CI (no container ID) and a fixture for a case that cannot occur is scaffolding.

#### Code consolidated or relocated during review
- Extracted `analyticsTestUtils.ts` after the same ~20 lines of environment save/restore appeared in all four new suites. That logic is what keeps the tests hermetic against a developer's own `.env`, so having one copy rather than four matters more than the line count.
- Reused rather than reinvented: `safeLocalStorage` (already handles quota and private-mode throws), the `Z_INDEX` scale in `const/Layout.ts`, the existing `ErrorBoundary`, and the `_resetForTesting()` convention from `utils/errorReporter.ts`.
- `Window` augmentation moved to `react-app-env.d.ts`, the idiomatic home, so no file needs an import for those types.

#### What a reviewer should scrutinise
1. **The GTM container configuration is load-bearing and outside this repo.** If the GA4 tag keeps its automatic `page_view`, everything double-counts; if `page_location` is not overridden, real query strings reach Google. Both are spelled out in `ANALYTICS_ARCHITECTURE.md`.
2. **The notice's copy has not had a legal review.** It only appears once an ID is configured, so that is a separate deliberate step.
3. **Visual placement.** The bottom-right position was chosen from a survey of fixed elements (bottom-left logs button, react-flow controls, notistack toasts, the top-center inactivity warning), but it has not been eyeballed at common viewport sizes. It will sit over react-flow's attribution link, and it may overlap right-aligned table pagination on `/public`, `/workspaces` and `/account-manager` until dismissed. `Theme.ts` sets no `zIndex` overrides, so MUI's defaults hold and 1200 is genuinely below `modal` (1300) and `snackbar` (1400); it ties with `drawer`, so the notice paints over the bottom corner of the persistent right-hand FlowChart drawer until dismissed. The temporary left menu renders through a Modal at 1300 and is unaffected.

#### Known gaps (deliberately not in this diff)
- **No CSP.** There is none anywhere in the repo today, so this diff regresses nothing, and the GTM injection surface does not exist until an ID is set. Deciding the posture is now a blocking item in the architecture doc's enablement gate, and the underlying gap is tracked in #808 because it pre-dates this work and outlives the GTM decision.
- **The notice does not link to a privacy policy.** Those pages are being added in #673 / PR #770; link them once they exist.
- **Sitemap submission is deferred with a reason.** `index.html` hardcodes `<link rel="canonical">` to the site root for every route, so three of the four URLs in `sitemap.xml` self-canonicalize to `/`. Submitting it today would report them as duplicates. That is an SEO defect rather than measurement infrastructure, and the issue's claim that SEO is already in order does not hold here.
- **Consent does not sync across tabs** (`utils/crossTabSync.ts` exists and could be reused).
- **e2e consent seeding is partial** - the authenticated storage state only; specs that build their own unauthenticated context still need it.
- **Client-side redirects inflate pageviews** (an unauthenticated hit on `/dashboard` records `/dashboard` then `/login`). Inherent to client-side routing; documented.
- **Sitemap and canonical.** Tracked in #809; #652 task 8 stays blocked until it lands.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Frontend runtime (`REACT_APP_GTM_ID` unset) | Low | Verified inert by executing the built snippet: no network request, no notice, no `dataLayer` writes. This is the state of every current build, including CI and local. |
| Frontend runtime (ID set) | Medium | First activation of third-party tracking on the site. Rollback is removing the key from `.env.deploy` and rebuilding. Behaviour depends on console configuration that this repo cannot enforce. |
| Redux store | Low | One middleware appended after `getDefaultMiddleware`; it calls `next(action)` first and never mutates the action or the result. No existing test executes real middleware (all use `redux-mock-store` or call `rootReducer` directly). |
| `index.html` | Low | Additive `<head>` scripts. Both build configurations compile and the minified output was executed. |
| Deploy script | Medium | Touches the path that produces every deployed frontend. The `.env.production` heredoc gains one line; the new block cannot alter existing variables (subshell) and fails loudly on a malformed ID. Exercised across 8 scenarios but not through a real deploy. |
| Privacy / compliance | Medium | Consent is collected before any event is sent, no personal data is sent by this code, both notice buttons carry equal weight, and withdrawal is available on `/account` and takes effect immediately. Residual exposure is GA4's own `page_location` default, which must be overridden in the container, and the missing privacy-policy link. |
| `/account` page | Low | One conditional row appended to an existing page. It renders only when a container ID is compiled in, which is never in a current build, so it is unreachable today. |
| `config-overrides.js` | Low | Runs on `yarn build` and `yarn start` only. A no-op unless `REACT_APP_GTM_ID` is set; all five configurations exercised above. |
| e2e suite | Low | Cannot regress today (no ID in CI). Partial seeding is documented. |

