### PR TITLE
Fix docker crash during github action testing

### DIFF
--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -55,7 +55,7 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
 # this environment, so installing the lock replaces packages poetry itself
 # imports mid-run (distlib, via build isolation) and the install fails at random.
 RUN poetry export -f requirements.txt -o requirements.studio.txt --with dev
-RUN pip3 install -r requirements.studio.txt
+RUN pip3 install --no-cache-dir -r requirements.studio.txt
 
 # setup optinist: download caiman model files
 COPY studio/app/optinist/wrappers/caiman/run_download_model_files.sh ./

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -48,9 +48,14 @@ RUN echo 'alias ll="ls -la --color=auto"' >> /root/.bashrc && \
 # setup optinist
 COPY pyproject.toml poetry.lock ./
 RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install poetry && \
+    pip3 install poetry poetry-plugin-export && \
     poetry config virtualenvs.create false
-RUN poetry install --no-root --with dev
+
+# NOTE: Export and install with pip rather than `poetry install`. Poetry shares
+# this environment, so installing the lock replaces packages poetry itself
+# imports mid-run (distlib, via build isolation) and the install fails at random.
+RUN poetry export -f requirements.txt -o requirements.studio.txt --with dev
+RUN pip3 install -r requirements.studio.txt
 
 # setup optinist: download caiman model files
 COPY studio/app/optinist/wrappers/caiman/run_download_model_files.sh ./


### PR DESCRIPTION
### Content

#### Summary

The `e2e` job of *E2E Release Tests* started failing during `Start db and backend`, before a single
test ran, with `ModuleNotFoundError: No module named 'distlib'` while building `Dockerfile.dev`.
Cause: `poetry config virtualenvs.create false` makes poetry install the lock into its *own*
site-packages, so `poetry install` replaces packages poetry itself is using while it runs. The dev
image now uses poetry only to export the lock and pip to install it, matching what
`Dockerfile.test` already does. A second commit adds `--no-cache-dir` to that install, which drops a
measured 278MB of pip cache from the image. This is a flaky-infrastructure fix; it changes no
application code and no test.

#### Design Decisions

- **Use `poetry export` + `pip install` (chosen).** Poetry no longer installs anything, so it can
  no longer pull its own dependencies out from under itself. This is not a new pattern:
  `studio/config/docker/Dockerfile.test` has installed this way for a long time and was green in
  the same run that this failure came from, including its later `poetry run python -m pytest`.
- **Rejected: install poetry into its own venv** (`/opt/poetry`, pipx, or the official installer,
  which is what Poetry's own install docs recommend). It cannot work here: with
  `virtualenvs.create false` poetry installs into whatever environment it is running from, so the
  project's dependencies would land in `/opt/poetry` instead of the system python, breaking
  `poetry run python main.py` and `alembic upgrade head` in `docker-compose.dev.multiuser.yml`.
- **Rejected: pin `distlib==0.4.0` before `poetry install`.** It only plugs the one package that
  happens to be imported lazily. The same build also swaps `cachecontrol`, `certifi`, `cffi`,
  `charset-normalizer`, `filelock` and `fastjsonschema` under the running poetry, and the pin goes
  stale the next time the lock moves.
- **Rejected: retry `poetry install` on failure.** Hides genuine dependency breakage and pays for a
  second full install.
- **`--no-cache-dir` on the pip install.** Measured 278MB in `/root/.cache/pip` in the built dev
  image, against a 4.47GB total. A pip cache written by a layer can never be reused by a later build
  of that same layer, so it is image weight with no rebuild benefit to trade against.
- **Rejected: also deleting `requirements.studio.txt` and merging the two `RUN`s into one layer**
  (raised in review). The file is 222KB, and `docker-compose.dev.multiuser.yml` bind-mounts `.:/app`
  over it at runtime, so it is invisible in the container anyway. Merging the layers and relocating
  the file to `/tmp` would also diverge from `Dockerfile.test`, whose layout this PR deliberately
  mirrors; that trade is not worth 222KB.
- **`studio/config/docker/Dockerfile` (production) deliberately left alone.** It has the identical
  `pip3 install poetry` + `poetry install --no-root` pattern and therefore the identical latent
  race. Changing the release image build inside a CI fix is the wrong blast radius; it should be its
  own PR. Flagged under Risk Assessment.

### Evidence

#### 1. The failure

[Run 31072091261](https://github.com/arayabrain/araya-optinist/actions/runs/31072091261), job `e2e`,
step `Start db and backend`. `unit / test_backend`, `unit / test_frontend` and `premium_lock_it`
passed in the same run:

```
#18 2.414   - Installing connection-pool (0.0.3)
#18 2.784   - Downgrading distlib (0.4.3 -> 0.4.0)
#18 3.921   ModuleNotFoundError
#18 3.921   No module named 'distlib'
#18 3.921   at /usr/local/lib/python3.11/site-packages/virtualenv/seed/embed/via_app_data/pip_install/base.py:16 in <module>
#18 3.932     →  16│ from distlib.scripts import ScriptMaker, enquote_executable
#18 3.932   Cannot install connection-pool.
ERROR: process "/bin/sh -c poetry install --no-root --with dev" did not complete successfully
```

`connection-pool 0.0.3` is sdist-only, so poetry seeds a build-isolation venv for it; `virtualenv`
imports `distlib` at that point, 0.37s after another install worker began replacing distlib.

#### 2. The mechanism, reproduced deterministically

Remove distlib and ask virtualenv to seed an env exactly as poetry does during an isolated build.
The traceback matches the CI failure frame for frame:

```
$ docker run --rm python:3.11-slim bash -c 'pip3 -q install poetry; pip3 uninstall -y -q distlib; \
    python3 -c "from virtualenv import cli_run; cli_run([\"/tmp/v\"])"'
before: distlib 0.4.3 virtualenv 21.7.1
  File ".../virtualenv/seed/embed/via_app_data/pip_install/base.py", line 16, in <module>
    from distlib.scripts import ScriptMaker, enquote_executable
ModuleNotFoundError: No module named 'distlib'
```

#### 3. It is timing, not state: same versions, same runner, opposite outcomes

Every run below installed poetry 2.4.1 + distlib 0.4.3, then downgraded distlib to the locked 0.4.0
while building `connection-pool`. Timestamps are seconds into the `poetry install` layer:

| Run | Date | `connection-pool` starts | distlib swap | Gap | Result |
|-----|------|--------------------------|--------------|-----|--------|
| [29233462595](https://github.com/arayabrain/araya-optinist/actions/runs/29233462595) | Jul 13 | 1.935 | 2.228 | 0.29s | won |
| [30228343746](https://github.com/arayabrain/araya-optinist/actions/runs/30228343746) | Jul 27 | 2.255 | 2.468 | 0.21s | won |
| [30796121386](https://github.com/arayabrain/araya-optinist/actions/runs/30796121386) | Aug 3 | 2.371 | 2.619 | 0.25s | won |
| [30988793895](https://github.com/arayabrain/araya-optinist/actions/runs/30988793895) | Aug 5 | 2.294 | 2.792 | 0.50s | won |
| [31072091261](https://github.com/arayabrain/araya-optinist/actions/runs/31072091261) | Aug 6 | 2.414 | 2.784 | 0.37s | **lost** |

Aug 5 and Aug 6 additionally ran on the same runner image (`ubuntu24/20260720.247`) with identical
resolved package versions. Nothing in this repository changed between them: this branch does not
touch `pyproject.toml` or `poetry.lock`.

#### 4. Why it never happened before

The collision needs a distlib *swap* to exist at all. It didn't, for the six months before this:

| Period | Lock pins | Latest on PyPI | Swap during build? |
|--------|-----------|----------------|--------------------|
| 2025-12-11 (lock bumped to 0.4.0) to 2026-06-01 | 0.4.0 | 0.4.0 (2025-07-17) | **No** - poetry installed exactly the locked version |
| 2026-06-02 onward | 0.4.0 | 0.4.1 (06-02), 0.4.2 (06-08), 0.4.3 (06-12) | **Yes** - every build downgrades 0.4.3 -> 0.4.0 |

So the window opened when distlib 0.4.1 shipped on 2026-06-02, while `poetry.lock` still pins
`distlib 0.4.0` (via `pre-commit` -> `virtualenv` -> `distlib`, dev group). The *E2E Release Tests*
workflow's first runs are from Jul 13, so every run it has ever made carried this window and won it
four times before losing on Aug 6. `virtualenv 21.7.1` is not the trigger either: it was already
present in the Aug 3 and Aug 5 runs, both green.

Honest caveat: before 2025-12-11 the lock pinned `distlib 0.3.7`/`0.3.9` while PyPI was ahead, so
the same window existed in those eras too. No failure from it is on record and I have not audited
that far back, so "first occurrence" is a claim about this workflow's history, not about all time.

#### 5. What I could not show

I ran the original `poetry install --no-root --with dev` six times in fresh containers against this
exact lock and it won 6/6, so this PR does not come with a local reproduction of the failure or a
measured flake rate. The diagnosis rests on items 1-4: the collision is proven, the op that enables
it is dated, and the fix removes the op rather than the interleaving.

#### 6. The fix builds and the image works

```
$ docker compose -f docker-compose.dev.multiuser.yml build studio-dev-be
 => naming to docker.io/library/araya-optinist-studio-dev-be    DONE
exit 0
```

Runtime checks inside the built image, covering what `docker-compose.dev.multiuser.yml` runs:

```
$ poetry run python -c "import sys; print(sys.executable)"
/usr/local/bin/python                      <- system env, not a stray venv
$ poetry run python -c "import fastapi, alembic, sqlalchemy, snakemake, firebase_admin"
main deps OK 0.104.1
$ poetry run python -c "import black, pre_commit"
dev deps OK                                <- --with dev preserved
$ alembic --version
alembic 1.9.2
```

The export itself was validated against this lock before use: `poetry export --with dev` produces
2697 requirement lines and includes the dev group (`black==23.11.0`, `pre-commit==4.3.0`) plus
`distlib==0.4.0` and `connection-pool==0.0.3`.

### References

- Failing run: https://github.com/arayabrain/araya-optinist/actions/runs/31072091261
- Last green run of the same workflow: https://github.com/arayabrain/araya-optinist/actions/runs/30988793895
- Supersedes #803: same branch, same commits. #803 targeted `feature/system-test-automation-4` and
  could not be retargeted, because it was position 6 of GitHub stack #789 and a stack member's base
  is immutable at both the GraphQL and REST layer. The branch was rebased onto `develop-main` with
  `git rebase --onto`; `Dockerfile.dev` is byte-identical to the version reviewed on #803. Targeting
  the trunk directly so the fix can be pulled up into the stack branches rather than merged through
  five PRs.
- Existing precedent for this install pattern: `studio/config/docker/Dockerfile.test`
- distlib releases: https://pypi.org/project/distlib/#history
- Poetry installation docs (isolated install recommendation): https://python-poetry.org/docs/#installation

#### Files changed

- `studio/config/docker/Dockerfile.dev` - replace `poetry install --no-root --with dev` with
  `poetry export` + `pip3 install -r`, and add `poetry-plugin-export` (required for `export` on
  poetry 2.x), so installing the lock cannot replace packages the running poetry depends on. Second
  commit adds `--no-cache-dir` to that install, matching the `pip` upgrade on the line above it.

### Manual Testcases

1. Developer, from repo root: `docker compose -f docker-compose.dev.multiuser.yml build studio-dev-be`
   -> build completes, exit 0. **Run, passed.**
2. Developer, in the built image: `poetry run python -c "import sys; print(sys.executable)"`
   -> prints `/usr/local/bin/python`, i.e. the project env, not a poetry-private venv. **Run, passed.**
3. Developer, in the built image: `poetry run python -c "import fastapi, alembic, snakemake"` and
   `alembic --version` -> imports succeed, `alembic 1.9.2`. **Run, passed.**
4. Developer: `docker compose -f docker-compose.dev.multiuser.yml up -d db studio-dev-be`, then
   `curl -sf http://localhost:8000/docs` -> backend serves docs, which is the exact gate the CI step
   waits on. **Not run locally; delegated to CI.**
5. Developer, in the built image: `rm -rf /root/.cache/pip && pip3 install --no-cache-dir -r
   /app/requirements.studio.txt` -> pip parses all 2697 requirement lines, exit 0, and
   `/root/.cache/pip` is absent afterwards. **Run, passed.** Testcase 1's build predates the flag and
   was not repeated: the flag changes only whether that layer writes a cache, and this check exercises
   it against the real export.
6. Reviewer: re-run *E2E Release Tests* on this branch -> `Start db and backend` completes and the
   suite proceeds to `Run e2e tests`. **Required before merge.**

Automated checks:

- `docker compose -f docker-compose.dev.multiuser.yml build studio-dev-be` -- exit 0, verified locally.
- `make test_backend` -- not run for this PR; it builds `Dockerfile.test`, which this PR does not
  touch, and it was already green in run 31072091261.

### Unit, Integration, Contract Test Coverage

None added. The change is a container build step; the only meaningful check is that the image builds
and its entrypoint commands resolve, which is what Testcases 1-3 verify and what every CI run of
this workflow re-verifies. Adding a test to assert the contents of a Dockerfile layer would pin the
implementation without catching the failure mode.

### Others

#### Difficulties

The failure is nondeterministic and I could not reproduce it locally (6/6 wins), so the diagnosis
had to be built from CI log timestamps plus a separate deterministic reproduction of the collision
itself. My first reading of the evidence was also wrong in one respect worth recording: I initially
concluded the distlib downgrade only began in June 2026 in general, but the lock's distlib pin has
lagged PyPI in earlier eras too. The corrected, narrower claim is in Evidence item 4.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| `Dockerfile.dev` build | Low | Same versions installed, from the same lock, with hashes; pip replaces poetry only as the installer. Identical pattern already proven by `Dockerfile.test`. |
| Dev backend runtime (`poetry run`, `alembic`) | Low | The one real hazard of this approach was `poetry run` resolving to a private venv. Verified it resolves to `/usr/local/bin/python`, with main and dev deps importable. |
| Dev group contents | Low | `poetry export --with dev` verified to emit the dev group; `black` and `pre_commit` import in the built image. |
| E2E workflow | Low | Only unblocks a step that currently fails before any test executes. Cannot mask a test failure. |
| `--no-cache-dir` | Low | A pip flag, verified against the real 2697-line export inside the built image (Testcase 5). The full image build was not repeated after adding it. |
| `studio/config/docker/Dockerfile` (production) | Medium | Untouched, still carries the same race, so a production image build can fail this way at random. It also ships 451MB of build caches (`pypoetry` 426MB, `pip` 26MB), measured in `development-optinist-for-cloud:latest`. Needs a follow-up PR; do not treat this PR as having fixed the release path. |
| Reproducibility of diagnosis | Low | If the root cause were somehow different, the symptom still cannot occur after this change, because poetry no longer performs installs. |
