### PR TITLE
Unify legal links in the footer and reset scroll on navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import IconButton from "@mui/material/IconButton"
 import BackendUnavailable from "components/common/BackendUnavailable"
 import ErrorBoundary from "components/common/ErrorBoundary"
 import Loading from "components/common/Loading"
+import ScrollToTop from "components/common/ScrollToTop"
 import Layout from "components/Layout"
 import { RETRY_MAX_COUNT, RETRY_WAIT, RETRY_WAIT_LONG } from "const/Mode"
 import Account from "pages/Account"
@@ -120,6 +121,7 @@ const App: FC = () => {
         style={{ maxWidth: "600px" }}
       >
         <BrowserRouter>
+          <ScrollToTop />
           <Routes>
             {/* Landing page - outside Layout */}
             <Route path="/" element={<LandingPage />} />

--- a/frontend/src/components/Dataview/DataviewRecords.tsx
+++ b/frontend/src/components/Dataview/DataviewRecords.tsx
@@ -1244,9 +1244,13 @@ const DataviewRecords = ({
   )
 }
 
+// Vertical space reserved for surrounding chrome; the grid fills the rest of
+// the viewport and scrolls internally.
+export const DATAVIEW_GRID_RESERVED_HEIGHT = 280
+
 const DataviewRecordsWrapper = styled(Box)(() => ({
   width: "100%",
-  height: "calc(100vh - 280px)",
+  height: `calc(100vh - ${DATAVIEW_GRID_RESERVED_HEIGHT}px)`,
   display: "flex",
   flexDirection: "column",
 }))

--- a/frontend/src/components/Dataview/PublicDataviewWrapper.tsx
+++ b/frontend/src/components/Dataview/PublicDataviewWrapper.tsx
@@ -2,7 +2,9 @@ import { FC, ReactNode } from "react"
 
 import { Box, styled } from "@mui/material"
 
+import { DATAVIEW_GRID_RESERVED_HEIGHT } from "components/Dataview/DataviewRecords"
 import PublicLayout from "components/PublicLayout"
+import { PUBLIC_FOOTER_HEIGHT } from "components/PublicLayout/PublicFooter"
 
 const PublicDataviewWrapper: FC<{ children: ReactNode }> = ({ children }) => {
   return (
@@ -18,10 +20,21 @@ const PublicDataviewWrapper: FC<{ children: ReactNode }> = ({ children }) => {
   )
 }
 
+// Part of the base grid reserve reclaimed for the grid on the public page,
+// leaving the footer a small bottom margin within the viewport.
+const FOOTER_BOTTOM_SLACK = 50
+
 const DataviewContent = styled(Box)(() => ({
   width: "94vw",
   margin: "auto",
   marginTop: 15,
+  // The grid sizes itself to the viewport; on the public page it is followed by
+  // PublicFooter, so shrink it to keep the grid and footer within the viewport.
+  "& > div": {
+    height: `calc(100vh - ${
+      DATAVIEW_GRID_RESERVED_HEIGHT + PUBLIC_FOOTER_HEIGHT - FOOTER_BOTTOM_SLACK
+    }px)`,
+  },
 }))
 
 export default PublicDataviewWrapper

--- a/frontend/src/components/PublicLayout/PublicFooter.tsx
+++ b/frontend/src/components/PublicLayout/PublicFooter.tsx
@@ -1,26 +1,63 @@
 import { FC } from "react"
+import { Link } from "react-router-dom"
 
-import { Box, Container, Divider, Grid, Typography } from "@mui/material"
+import { Box, Divider, styled, Typography } from "@mui/material"
+
+import { FONT_SIZE, TEXT_COLOR } from "const/Style"
+
+// Fixed footer height so the public page can reserve space for the footer.
+export const PUBLIC_FOOTER_HEIGHT = 71
 
 const PublicFooter: FC = () => {
   return (
-    <>
-      <Box sx={{ paddingTop: 4, paddingBottom: 2 }}>
-        <Divider />
-      </Box>
-      <Box>
-        <Container>
-          <Grid container direction="column" alignItems="center">
-            <Grid item xs={12}>
-              <Typography>
-                {`${new Date().getFullYear()}`} Studio. All rights reserved.
-              </Typography>
-            </Grid>
-          </Grid>
-        </Container>
-      </Box>
-    </>
+    <FooterRoot>
+      <Divider />
+      <FooterContent>
+        <FooterLegal>
+          <LegalLink to="/terms">Terms of Service</LegalLink>
+          <LegalLink to="/privacy">Privacy Policy</LegalLink>
+        </FooterLegal>
+        <FooterCopyright>
+          &copy; {`${new Date().getFullYear()}`} ARAYA Inc.
+        </FooterCopyright>
+      </FooterContent>
+    </FooterRoot>
   )
 }
+
+const FooterRoot = styled(Box)({
+  height: PUBLIC_FOOTER_HEIGHT,
+  boxSizing: "border-box",
+  paddingTop: 8,
+})
+
+const FooterContent = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "0.5rem",
+  textAlign: "center",
+  marginTop: 8,
+})
+
+const FooterLegal = styled(Box)({
+  display: "flex",
+  gap: "1rem",
+})
+
+const LegalLink = styled(Link)({
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
+  textDecoration: "underline",
+  transition: "color 0.2s",
+  "&:hover": {
+    color: TEXT_COLOR.ACCENT,
+  },
+})
+
+const FooterCopyright = styled(Typography)({
+  fontSize: FONT_SIZE.SMALL,
+  color: TEXT_COLOR.SECONDARY,
+})
 
 export default PublicFooter

--- a/frontend/src/components/PublicLayout/PublicHeader.tsx
+++ b/frontend/src/components/PublicLayout/PublicHeader.tsx
@@ -38,8 +38,6 @@ const PublicHeader: FC = () => {
         </HeaderLogoLink>
       )}
       <NavSection>
-        <NavLink to="/terms">Terms of Service</NavLink>
-        <NavLink to="/privacy">Privacy Policy</NavLink>
         {user ? (
           <NavButton to="/dashboard">Dashboard</NavButton>
         ) : (

--- a/frontend/src/components/PublicLayout/index.tsx
+++ b/frontend/src/components/PublicLayout/index.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from "react"
 
 import { Box } from "@mui/material"
 
-// import PublicFooter from "components/PublicLayout/PublicFooter"
+import PublicFooter from "components/PublicLayout/PublicFooter"
 import PublicHeader from "components/PublicLayout/PublicHeader"
 
 const PublicLayout: FC<{ children: ReactNode }> = ({ children }) => {
@@ -10,7 +10,7 @@ const PublicLayout: FC<{ children: ReactNode }> = ({ children }) => {
     <Box sx={{ height: "100%", width: "100%" }}>
       <PublicHeader />
       <Box>{children}</Box>
-      {/* <PublicFooter /> */}
+      <PublicFooter />
     </Box>
   )
 }

--- a/frontend/src/components/common/ScrollToTop.tsx
+++ b/frontend/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,23 @@
+import { FC, useEffect } from "react"
+import { useLocation, useNavigationType } from "react-router-dom"
+
+// Reset the window scroll position to the top on a new navigation. React Router
+// keeps the previous scroll offset across client-side navigations, which
+// otherwise makes a new page open partway down (e.g. when navigating from the
+// bottom of a long page).
+const ScrollToTop: FC = () => {
+  const { pathname } = useLocation()
+  const navigationType = useNavigationType()
+
+  useEffect(() => {
+    // Leave back/forward (POP) to the browser's native scroll restoration;
+    // only reset to the top for new navigations (link clicks, redirects).
+    if (navigationType !== "POP") {
+      window.scrollTo(0, 0)
+    }
+  }, [pathname, navigationType])
+
+  return null
+}
+
+export default ScrollToTop

--- a/frontend/src/pages/LandingPage/components/Footer.tsx
+++ b/frontend/src/pages/LandingPage/components/Footer.tsx
@@ -69,26 +69,23 @@ export const Footer = () => {
               OIST
             </FooterLink>
           </FooterAttribution>
-          <CompanyLine>
-            <CompanyLink
-              href="https://www.araya.org/en/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <img
-                src="/static/araya_logo.png"
-                alt="ARAYA"
-                style={{ height: 20, width: "auto" }}
-              />
-              <span>Araya Inc.</span>
-            </CompanyLink>
-          </CompanyLine>
           <FooterLegal>
             <LegalLink to="/terms">Terms of Service</LegalLink>
             <LegalLink to="/privacy">Privacy Policy</LegalLink>
           </FooterLegal>
           <FooterCopyright>
-            &copy; 2025 ARAYA OptiNiSt. Built for Science.
+            <CompanyLink
+              href="https://www.araya.org/en/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>&copy; {`${new Date().getFullYear()}`}</span>
+              <img
+                src="/static/araya_logo.png"
+                alt="Araya Inc"
+                style={{ height: 20, width: "auto" }}
+              />
+            </CompanyLink>
           </FooterCopyright>
         </FooterBottom>
       </Container>
@@ -184,7 +181,7 @@ const FooterLink = styled("a")({
   },
 })
 
-const CompanyLine = styled(Box)({
+const FooterCopyright = styled(Box)({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -216,9 +213,4 @@ const LegalLink = styled(Link)({
   "&:hover": {
     color: TEXT_COLOR.ACCENT,
   },
-})
-
-const FooterCopyright = styled(Typography)({
-  fontSize: FONT_SIZE.SMALL,
-  color: TEXT_COLOR.SECONDARY,
 })

--- a/frontend/src/pages/LandingPage/components/Footer.tsx
+++ b/frontend/src/pages/LandingPage/components/Footer.tsx
@@ -53,13 +53,17 @@ export const Footer = () => {
         <FooterBottom>
           <FooterAttribution>
             ARAYA OptiNiSt is based on OptiNiSt. OptiNiSt was developed by{" "}
-            <FooterLink
-              href="https://www.araya.org/en/"
+            <LogoLink
+              href="https://www.araya.org/"
               target="_blank"
               rel="noopener noreferrer"
             >
-              ARAYA
-            </FooterLink>{" "}
+              <img
+                src="/static/araya_logo.png"
+                alt="Araya Inc"
+                style={{ height: 20, width: "auto", verticalAlign: "middle" }}
+              />
+            </LogoLink>{" "}
             and{" "}
             <FooterLink
               href="https://www.oist.jp/"
@@ -74,18 +78,7 @@ export const Footer = () => {
             <LegalLink to="/privacy">Privacy Policy</LegalLink>
           </FooterLegal>
           <FooterCopyright>
-            <CompanyLink
-              href="https://www.araya.org/en/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span>&copy; {`${new Date().getFullYear()}`}</span>
-              <img
-                src="/static/araya_logo.png"
-                alt="Araya Inc"
-                style={{ height: 20, width: "auto" }}
-              />
-            </CompanyLink>
+            &copy; {`${new Date().getFullYear()}`} ARAYA Inc.
           </FooterCopyright>
         </FooterBottom>
       </Container>
@@ -181,23 +174,23 @@ const FooterLink = styled("a")({
   },
 })
 
-const FooterCopyright = styled(Box)({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
+// Logo link: fade the image slightly on hover to signal it is a link
+const LogoLink = styled(FooterLink)({
+  display: "inline-block",
+  verticalAlign: "middle",
+  fontSize: 0,
+  textDecoration: "none",
+  "& img": {
+    transition: "opacity 0.2s",
+  },
+  "&:hover img": {
+    opacity: 0.7,
+  },
 })
 
-const CompanyLink = styled("a")({
-  display: "inline-flex",
-  alignItems: "center",
-  gap: "0.5rem",
-  color: TEXT_COLOR.SECONDARY,
+const FooterCopyright = styled(Typography)({
   fontSize: FONT_SIZE.SMALL,
-  textDecoration: "none",
-  transition: "color 0.2s",
-  "&:hover": {
-    color: TEXT_COLOR.ACCENT,
-  },
+  color: TEXT_COLOR.SECONDARY,
 })
 
 const FooterLegal = styled(Box)({

--- a/frontend/src/pages/PublicDataview/index.tsx
+++ b/frontend/src/pages/PublicDataview/index.tsx
@@ -2,12 +2,10 @@ import { Box, styled } from "@mui/material"
 
 import DataviewRecords from "components/Dataview/DataviewRecords"
 import PublicDataviewWrapper from "components/Dataview/PublicDataviewWrapper"
-import PublicHeader from "components/PublicLayout/PublicHeader"
 
 const PublicDataview = () => {
   return (
     <>
-      <PublicHeader />
       <PageWrapper>
         <Title>OptiNiSt Public Repository</Title>
         <PublicDataviewWrapper>


### PR DESCRIPTION
## Summary

A follow-up to the Terms of Service / Privacy Policy work ( #770 ) that unifies where the
legal links live, clarifies the footer copyright, and fixes two navigation/layout
glitches surfaced while testing those pages:

1. **Legal links unified into the footer.** On the public page the "Terms of
   Service" / "Privacy Policy" links move from the header to the footer, matching
   the landing page footer so both surfaces present the links the same way.
2. **Footer copyright clarified.** The landing page footer copyright is corrected
   from a product-name notice with a hardcoded year to a proper rights-holder
   line with a dynamic year.
3. **Layout & scroll fixes.** The public footer no longer produces a second,
   document-level scrollbar on top of the data grid's own scroll, and navigating
   between pages now starts at the top instead of inheriting the previous scroll
   offset.

---

## Commits

### 1. f3c9c87b2 — Clarified ambiguous footer copyright text
`frontend/src/pages/LandingPage/components/Footer.tsx`

<img width="611" height="93" alt="image" src="https://github.com/user-attachments/assets/38cafce1-7269-411a-8b38-9c0659d53228" />

- Merges the separate copyright line into the company line so the notice reads
  `© {year}`, with the rights holder (Araya Inc.) rather than the
  product name.
- Uses a dynamic `new Date().getFullYear()` instead of a hardcoded `2025`.
- Renames the `CompanyLine` container to `FooterCopyright` and removes the now
  unused `FooterCopyright` typography style.

### 2. 32ca6957d — Move Terms/Privacy from the public header to the footer

`PublicFooter.tsx`, `PublicHeader.tsx`, `PublicLayout/index.tsx`,
`PublicDataview/index.tsx`, `PublicDataviewWrapper.tsx`, `DataviewRecords.tsx`

<img width="1173" height="650" alt="image" src="https://github.com/user-attachments/assets/8c015405-0696-44ff-8ec0-c1d19fafed9d" />

- Adds the Terms/Privacy links to `PublicFooter` and removes them from
  `PublicHeader`, so the public page shows them in the footer to match the
  landing page design.
- Aligns the footer typography with the landing page footer (shared `const/Style`
  tokens) and replaces the redundant `Grid` layout with a simple flex box.
- **Double-scrollbar fix:** `PublicFooter` is given a fixed height, and the public
  data grid reserves that height so the grid + footer stay within the viewport
  instead of overflowing the document. The grid's viewport reserve is extracted
  into the exported `DATAVIEW_GRID_RESERVED_HEIGHT` constant (no behavior change
  for the private data view).

### 3. ad72cde56 — Reset scroll to top on navigation
`frontend/src/components/common/ScrollToTop.tsx` (new), `frontend/src/App.tsx`

- Adds a small `ScrollToTop` component mounted under `BrowserRouter` that scrolls
  the window to the top on a new navigation.
- Fixes pages opening partway down when navigated to from the bottom of a long
  page (e.g. clicking Terms/Privacy in the landing page footer).
- Back/forward (POP) is left to the browser's native scroll restoration; only
  link clicks and redirects (PUSH/REPLACE) reset to the top.
- Note that the links after signing in remain as implemented for #770 and have not been changed.
  - <img width="248" height="247" alt="Screenshot 2026-08-07 at 17 58 00" src="https://github.com/user-attachments/assets/c4eecdeb-cd0e-4ad2-bab3-826da69268b6" />

---

## Why

- The legal links previously lived in different places on the public header vs.
  the landing page footer; unifying them in the footer keeps the design
  consistent.
- The old copyright line attributed rights to a product name and hardcoded the
  year, which was ambiguous and would go stale.
- Adding the footer to the public layout pushed the total content just past the
  viewport, producing a redundant document-level scrollbar on top of the grid's
  own scroll.
- React Router does not reset scroll position across client-side navigations, so
  a new page inherited the previous page's scroll offset.

---

## Testing / how to verify

- Public page: Terms/Privacy links appear in the footer (not the header) and
  navigate correctly.
- Public data view: only the grid scrolls — there is no second, document-level
  scrollbar; the footer sits just below the grid within the viewport.
- Data view interactions (pagination, filters via query params) do not jump the
  scroll position.
- Landing page: scroll to the bottom, click Terms/Privacy → the target page opens
  at the top.
- Browser back/forward still restores the previous scroll position.

---

## Risk / side effects

- **Low.** `ScrollToTop` only touches window scroll and only on new navigations;
  query-param updates and inner scroll containers (Workspace, data grid) are
  unaffected, and back/forward keeps native scroll restoration.
- The public-only grid-height reservation does not change the private data view
  (`DATAVIEW_GRID_RESERVED_HEIGHT` computes the same value as before).
