### PR TITLE
Fix workflow status timezone skew and harden the e2e run assertions

### DIFF
--- a/frontend/e2e/03-workflow.spec.ts
+++ b/frontend/e2e/03-workflow.spec.ts
@@ -11,6 +11,7 @@ import {
   ensureTutorialRecords,
   reproduceTutorial,
   runTutorial,
+  RUN_TEST_TIMEOUT_MS,
   DATA_WS,
 } from "./helpers"
 
@@ -94,7 +95,7 @@ test.describe("Workflow Execution", () => {
     test(`${id} - Run ${tutorial} workflow via ${mode} @slow`, async ({
       page,
     }) => {
-      test.setTimeout(900_000)
+      test.setTimeout(RUN_TEST_TIMEOUT_MS)
       await openWorkspace(page, DATA_WS)
       await ensureTutorialRecords(page, DATA_WS)
 

--- a/frontend/e2e/04-record.spec.ts
+++ b/frontend/e2e/04-record.spec.ts
@@ -9,6 +9,7 @@ import {
   openWorkspace,
   ensureCompletedTutorialRun,
   ensureTutorialRecords,
+  RUN_TEST_TIMEOUT_MS,
   DATA_WS,
 } from "./helpers"
 
@@ -139,7 +140,7 @@ test.describe("Record Management", () => {
     // workspace at the start of every run, so the run is this test's
     // precondition. It used to skip on the resulting 404; now it runs the
     // workflow, which is what puts it in the @slow lane.
-    test.setTimeout(900_000)
+    test.setTimeout(RUN_TEST_TIMEOUT_MS)
     await ensureCompletedTutorialRun(page, DATA_WS)
 
     const nwbButton = page

--- a/frontend/e2e/05-file-handling.spec.ts
+++ b/frontend/e2e/05-file-handling.spec.ts
@@ -168,17 +168,19 @@ test.describe("File Select Dialog", () => {
   }) => {
     await page.locator('[role="dialog"] button:has-text("cancel")').click()
     await expect(page.locator('[role="dialog"]')).toBeHidden()
+    // A reload clears the cached tree (reopening the dialog alone does not
+    // refetch), but it also restores the workspace's persisted workflow, which
+    // need not carry an image node at all - so put Tutorial1 back explicitly
+    await page.reload()
+    await reproduceTutorial(page, "Tutorial1")
     // Only the merged-tree fetch drives isLoading; a broad /files glob would
-    // also hold shape/sync/upload requests open
+    // also hold shape/sync/upload requests open. Registered after the
+    // reproduce, which never fetches the tree itself.
     const treeFetch = routeGate()
     await page.route("**/files/*/merged*", async (route) => {
       await treeFetch.held
       await route.continue()
     })
-    // A reload clears the cached tree (reopening the dialog alone does not
-    // refetch) and resets the flowchart to its default image node, which
-    // carries the same select button and lists the same workspace files
-    await page.reload()
     const selectFile = page
       .locator(
         '.react-flow__node-ImageFileNode button:has([data-testid="ChecklistRtlIcon"])',

--- a/frontend/e2e/06-dataview.spec.ts
+++ b/frontend/e2e/06-dataview.spec.ts
@@ -14,6 +14,7 @@ import {
   filterWorkspace,
   openWorkspace,
   apiUrl,
+  RUN_TEST_TIMEOUT_MS,
   DATA_WS,
 } from "./helpers"
 
@@ -113,10 +114,10 @@ test.describe("Private Dataview @slow", () => {
   test.beforeEach(async ({ page }) => {
     skipWithoutCreds()
     // The first hook mints its rows with a real Tutorial1 run (the sample data
-    // ships metadata YAML only, so snakemake recomputes). runTutorial's inner
-    // wait is 840s, so a 600s budget here expired mid-run and reported the
-    // timeout against this hook rather than against the run.
-    if (!recordsMinted) test.setTimeout(900_000)
+    // ships metadata YAML only, so snakemake recomputes). A budget below
+    // runTutorial's own wait expires mid-run and reports the timeout against
+    // this hook rather than against the run.
+    if (!recordsMinted) test.setTimeout(RUN_TEST_TIMEOUT_MS)
     await gotoDashboard(page)
     dataviewId = await ensureDataviewRows(page)
     await page.goto(`/dataview/${dataviewId}`)

--- a/frontend/e2e/14-public.spec.ts
+++ b/frontend/e2e/14-public.spec.ts
@@ -11,6 +11,7 @@ import {
   gotoDashboard,
   openWorkspace,
   skipWithoutCreds,
+  RUN_TEST_TIMEOUT_MS,
   DATA_WS,
 } from "./helpers"
 
@@ -187,8 +188,8 @@ async function setPublished(page: Page, name: string, on: boolean) {
 // assertions stay on the public UI
 async function ensurePublishedRecord(page: Page, tutorialName: string) {
   if (!(await findRecord(page, tutorialName))) {
-    // Minting costs a real workflow run (see runTutorial's 840s wait)
-    test.setTimeout(900_000)
+    // Minting costs a real workflow run (see RUN_TIMEOUT_MS)
+    test.setTimeout(RUN_TEST_TIMEOUT_MS)
     await openWorkspace(page, DATA_WS)
     await ensureCompletedTutorialRun(page, DATA_WS, tutorialName)
     // The record registers slightly after "Workflow finished"

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -518,7 +518,28 @@ async function startRun(page: Page, mode: "RUN" | "RUN ALL") {
     await dialog.locator("input").fill("e2e-runall")
     await dialog.getByRole("button", { name: "Run", exact: true }).click()
   }
-  await runStarted
+  // Both /run/{ws} and /run/{ws}/{uid} answer the run's uid as a bare string
+  const response = await runStarted
+  return {
+    workspaceId: response.url().match(/\/run\/(\d+)/)?.[1] ?? "",
+    uid: String(await response.json()),
+  }
+}
+
+// experiment.yaml's own success flag, which finalization writes: "running"
+// until the pipeline settles, then "success" or "error".
+async function recordedRunStatus(
+  page: Page,
+  workspaceId: string,
+  uid: string,
+): Promise<string> {
+  const headers = await apiHeaders(page)
+  const res = await page.request.get(`${apiUrl()}/experiments/${workspaceId}`, {
+    headers,
+  })
+  if (!res.ok()) return `GET /experiments/${workspaceId} -> ${res.status()}`
+  const experiments = (await res.json()) as Record<string, { success?: string }>
+  return experiments?.[uid]?.success ?? "absent"
 }
 
 // Reproduce a tutorial and run it to completion. Loading an already-finished
@@ -526,19 +547,51 @@ async function startRun(page: Page, mode: "RUN" | "RUN ALL") {
 // before waiting for the real one. "RUN ALL" = fresh uid, full pipeline
 // compute (5-10 min, @slow); "RUN" = by-uid rerun, which snakemake treats
 // as already complete for the imported tutorials (seconds).
+// A real snakemake run. The ceiling is environment-dependent: the docker stack
+// CI uses clears a tutorial well inside the default, a deployed environment can
+// take far longer, so RUN_TIMEOUT_MS raises it without a code edit.
+export const RUN_TIMEOUT_MS = Number(process.env.RUN_TIMEOUT_MS ?? 840_000)
+// After the snackbar, how long the recorded result may take to settle
+const RECORD_TIMEOUT_MS = 300_000
+// The surrounding reproduce/start steps need headroom above the run itself
+export const RUN_TEST_TIMEOUT_MS = RUN_TIMEOUT_MS + RECORD_TIMEOUT_MS + 60_000
+
 export async function runTutorial(
   page: Page,
   tutorialName: string,
   mode: "RUN" | "RUN ALL" = "RUN ALL",
 ) {
   await reproduceTutorial(page, tutorialName)
-  await startRun(page, mode)
-  await expect(page.locator("text=Workflow finished")).toBeHidden({
-    timeout: 30_000,
+  const { workspaceId, uid } = await startRun(page, mode)
+  const finished = page.locator("text=Workflow finished")
+  const aborted = page.locator("text=Workflow aborted")
+  await expect(finished).toBeHidden({ timeout: 30_000 })
+  // Race the two terminal snackbars: waiting on success alone burns the whole
+  // ceiling on a run that already died, and reports it as a plain timeout
+  await expect(finished.or(aborted).first()).toBeVisible({
+    timeout: RUN_TIMEOUT_MS,
   })
-  await expect(page.locator("text=Workflow finished")).toBeVisible({
-    timeout: 840_000,
-  })
+  await expect(
+    aborted,
+    `${tutorialName} aborted instead of finishing`,
+  ).toHaveCount(0)
+
+  // The snackbar alone is not proof. Where the workflow PID file is not visible
+  // to the API process, unrun nodes are reported errored, no node is left
+  // pending, and the frontend calls that FINISHED seconds into the run.
+  let recorded = ""
+  await expect
+    .poll(
+      async () => (recorded = await recordedRunStatus(page, workspaceId, uid)),
+      {
+        timeout: RECORD_TIMEOUT_MS,
+        message: `${tutorialName} (${uid}) never settled in experiment.yaml`,
+      },
+    )
+    .toMatch(/^(success|error)$/)
+  expect(recorded, `${tutorialName} recorded "${recorded}", not success`).toBe(
+    "success",
+  )
 }
 
 // Mints the success record + thumbnails the dataview needs.
@@ -546,7 +599,7 @@ export async function runTutorial(
 // This is NOT a no-op: `git ls-files sample_data/tutorial/output` is 12 files,
 // all of them experiment/snakemake/workflow YAML. No node output directories, no
 // JSON, no NWB ship at all, and global setup deletes the e2e-* workspace each
-// run, so snakemake recomputes from scratch. Budget a real run (see the 840s
+// run, so snakemake recomputes from scratch. Budget a real run (see RUN_TIMEOUT_MS
 // inner wait in runTutorial), not the ~15s a rerun-by-uid would take.
 export async function ensureCompletedTutorialRun(
   page: Page,

--- a/studio/app/common/core/experiment/experiment_services.py
+++ b/studio/app/common/core/experiment/experiment_services.py
@@ -19,6 +19,7 @@ from studio.app.common.core.storage.remote_storage_controller import (
     RemoteStorageController,
     RemoteSyncLockFileUtil,
 )
+from studio.app.common.core.utils.datetime_utils import parse_datetime_for_timezone
 from studio.app.common.core.workflow.workflow_runner import WorkflowRunner
 from studio.app.common.schemas.experiment import CopyItem
 from studio.app.const import DATE_FORMAT
@@ -27,6 +28,13 @@ logger = AppLogger.get_logger()
 
 
 class ExperimentService:
+    @staticmethod
+    def _started_at(config: ExptConfig) -> datetime:
+        # ordered across experiments, so different user zones must resolve first
+        return parse_datetime_for_timezone(
+            config.started_at, DATE_FORMAT, config.timezone
+        )
+
     @classmethod
     def get_last_experiment(cls, workspace_id: str):
         last_expt_config: Optional[ExptConfig] = None
@@ -36,9 +44,7 @@ class ExperimentService:
             config = ExptConfigReader.read_from_path(path)
             if not last_expt_config:
                 last_expt_config = config
-            elif datetime.strptime(config.started_at, DATE_FORMAT) > datetime.strptime(
-                last_expt_config.started_at, DATE_FORMAT
-            ):
+            elif cls._started_at(config) > cls._started_at(last_expt_config):
                 last_expt_config = config
 
         return last_expt_config

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -146,6 +146,8 @@ class ExptConfigWriter:
                 get_datetime_for_timezone_formatted(self.timezone, DATE_FORMAT)
             )  # Update time
             .set_success(WorkflowRunStatus.RUNNING.value)
+            # rewritten with started_at above, or the pair disagrees on a rerun
+            .set_timezone(self.timezone)
             .build()
         )
 

--- a/studio/app/common/core/utils/datetime_utils.py
+++ b/studio/app/common/core/utils/datetime_utils.py
@@ -98,6 +98,34 @@ def get_datetime_for_timezone_formatted(
     return dt.strftime(format_string)
 
 
+def parse_datetime_for_timezone(
+    value: str, format_string: str, timezone_str: str = None
+) -> datetime:
+    """
+    Inverse of get_datetime_for_timezone_formatted.
+
+    The stored string carries no offset, so reading it back naively resolves it
+    against the container's TZ instead of the zone it was written in - which
+    skews the result by that offset wherever the two differ.
+
+    Args:
+        value: the formatted timestamp to parse
+        format_string: the strftime format it was written with
+        timezone_str: the IANA timezone it was written in. Falls back to UTC,
+            matching get_datetime_for_timezone.
+    """
+    tz = TZ_UTC
+    if timezone_str:
+        try:
+            tz = ZoneInfo(timezone_str)
+        except (ZoneInfoNotFoundError, KeyError) as e:
+            logger.warning(
+                f"Invalid timezone '{timezone_str}', "
+                f"falling back to {TIMEZONE_UTC}: {e}"
+            )
+    return datetime.strptime(value, format_string).replace(tzinfo=tz)
+
+
 def format_date_for_display(dt: datetime, format_string: str = "%Y-%m-%d") -> str:
     """
     Format a datetime for display, appending "(UTC)" indicator.

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -5,7 +5,6 @@ import signal
 import time
 from abc import ABCMeta, abstractmethod
 from dataclasses import asdict
-from datetime import datetime
 from glob import glob
 from typing import Dict, List
 
@@ -28,6 +27,7 @@ from studio.app.common.core.utils.datetime_utils import (
     TIMEZONE_KEY,
     datetime_from_timestamp,
     get_datetime_for_timezone_formatted,
+    parse_datetime_for_timezone,
 )
 from studio.app.common.core.utils.filepath_creater import (
     join_filepath,
@@ -538,8 +538,11 @@ class WorkflowMonitor:
             # Refer experiment_data instead of pid_data
             expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
             try:
-                expt_started_time = datetime.strptime(
-                    expt_config.started_at, DATE_FORMAT
+                # Read back in the zone it was written in: a naive parse resolves
+                # against the container's TZ, inflating elapsed_time by that
+                # offset and expiring the startup grace on the very first poll
+                expt_started_time = parse_datetime_for_timezone(
+                    expt_config.started_at, DATE_FORMAT, expt_config.timezone
                 )
             except ValueError:
                 expt_started_time = datetime_from_timestamp(0)

--- a/studio/tests/app/common/core/experiment/test_experiment_services_last.py
+++ b/studio/tests/app/common/core/experiment/test_experiment_services_last.py
@@ -1,0 +1,43 @@
+"""Tests for ExperimentService.get_last_experiment ordering."""
+
+from unittest.mock import patch
+
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_services import ExperimentService
+
+
+def _config(unique_id: str, started_at: str, timezone: str):
+    config = ExptConfigReader.create_empty_experiment_config()
+    config.unique_id = unique_id
+    config.started_at = started_at
+    config.timezone = timezone
+    return config
+
+
+def test_get_last_experiment_orders_by_absolute_time_not_wall_clock():
+    """Tokyo 10:00 is 01:00 UTC, so the UTC 09:00 run is genuinely later.
+    A naive wall-clock comparison picks the Tokyo one."""
+    tokyo = _config("tokyo_run", "2024-01-15 10:00:00", "Asia/Tokyo")
+    utc = _config("utc_run", "2024-01-15 09:00:00", "UTC")
+
+    with patch(
+        "studio.app.common.core.experiment.experiment_services.glob",
+        return_value=["/out/ws1/tokyo_run/experiment.yaml", "/out/ws1/utc_run/e.yaml"],
+    ), patch.object(ExptConfigReader, "read_from_path", side_effect=[tokyo, utc]):
+        last = ExperimentService.get_last_experiment("ws1")
+
+    assert last.unique_id == "utc_run"
+
+
+def test_get_last_experiment_missing_timezone_falls_back_to_utc():
+    """Legacy configs with no timezone still order against each other."""
+    older = _config("older", "2024-01-15 09:00:00", None)
+    newer = _config("newer", "2024-01-15 11:00:00", None)
+
+    with patch(
+        "studio.app.common.core.experiment.experiment_services.glob",
+        return_value=["/out/ws1/older/experiment.yaml", "/out/ws1/newer/e.yaml"],
+    ), patch.object(ExptConfigReader, "read_from_path", side_effect=[older, newer]):
+        last = ExperimentService.get_last_experiment("ws1")
+
+    assert last.unique_id == "newer"

--- a/studio/tests/app/common/core/experiment/test_expt_writer.py
+++ b/studio/tests/app/common/core/experiment/test_expt_writer.py
@@ -2,9 +2,15 @@ import os
 import shutil
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
+from studio.app.common.core.utils.datetime_utils import (
+    get_current_datetime,
+    parse_datetime_for_timezone,
+)
 from studio.app.common.core.workflow.workflow import Edge, Node, NodeData, RunItem
 from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.const import DATE_FORMAT
 from studio.app.dir_path import DIRPATH
 
 workspace_id = "default2"
@@ -73,6 +79,32 @@ def test_add_run_info():
     ).add_run_info()
 
     assert expt_config.success == "running"
+
+
+def test_add_run_info_rewrites_the_recorded_timezone():
+    """A rerun rewrites started_at in the new run's zone, so the recorded
+    timezone must follow it: a legacy config with no timezone would otherwise
+    have its local-time started_at read back as UTC."""
+    existing = ExptConfigReader.create_empty_experiment_config()
+    existing.timezone = None
+    existing.started_at = "2020/01/01 00:00:00"
+
+    writer = ExptConfigWriter(
+        workspace_id="",
+        unique_id="",
+        name="",
+        timezone="Asia/Tokyo",
+    )
+    writer.builder.set_config(existing)
+    expt_config = writer.add_run_info()
+
+    assert expt_config.timezone == "Asia/Tokyo"
+
+    started = parse_datetime_for_timezone(
+        expt_config.started_at, DATE_FORMAT, expt_config.timezone
+    )
+    elapsed = get_current_datetime().timestamp() - started.timestamp()
+    assert abs(elapsed) < 60, f"started_at read back skewed by {elapsed} sec"
 
 
 dirpath = f"{DIRPATH.OUTPUT_DIR}/{workspace_id}/{unique_id}"

--- a/studio/tests/app/common/core/utils/test_datetime_utils.py
+++ b/studio/tests/app/common/core/utils/test_datetime_utils.py
@@ -22,6 +22,7 @@ from studio.app.common.core.utils.datetime_utils import (
     get_datetime_for_timezone,
     get_datetime_for_timezone_formatted,
     is_datetime_aware,
+    parse_datetime_for_timezone,
 )
 
 
@@ -264,3 +265,43 @@ class TestIsDatetimeAware:
 
         ny_dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=ZoneInfo("America/New_York"))
         assert is_datetime_aware(ny_dt) is True
+
+
+class TestParseDatetimeForTimezone:
+    """Tests for parse_datetime_for_timezone (inverse of the formatted writer)."""
+
+    FORMAT = "%Y-%m-%d %H:%M:%S"
+
+    def test_parse_is_aware_and_utc_by_default(self):
+        """No timezone means UTC, matching get_datetime_for_timezone."""
+        parsed = parse_datetime_for_timezone("2024-01-15 10:30:45", self.FORMAT)
+        assert is_datetime_aware(parsed)
+        assert parsed.utcoffset().total_seconds() == 0
+
+    def test_parse_honours_the_recorded_timezone(self):
+        """A Tokyo string resolves to Tokyo, not to the host's zone."""
+        parsed = parse_datetime_for_timezone(
+            "2024-01-15 10:30:45", self.FORMAT, "Asia/Tokyo"
+        )
+        assert parsed.utcoffset().total_seconds() == 9 * 3600
+
+    def test_invalid_timezone_falls_back_to_utc(self):
+        parsed = parse_datetime_for_timezone(
+            "2024-01-15 10:30:45", self.FORMAT, "Not/AZone"
+        )
+        assert parsed.utcoffset().total_seconds() == 0
+
+    def test_roundtrip_elapsed_is_not_skewed_by_the_host_zone(self):
+        """The regression: a UTC-written stamp read back must not gain the host's
+        offset, which expired the workflow startup grace on the first poll."""
+        written = get_datetime_for_timezone_formatted(None, self.FORMAT)
+        parsed = parse_datetime_for_timezone(written, self.FORMAT)
+        elapsed = get_current_timestamp() - parsed.timestamp()
+        assert abs(elapsed) < 60, f"elapsed skewed by {elapsed} sec"
+
+    def test_roundtrip_elapsed_for_a_non_utc_writer(self):
+        """Same guarantee when the stamp was written in the user's own zone."""
+        written = get_datetime_for_timezone_formatted("Asia/Tokyo", self.FORMAT)
+        parsed = parse_datetime_for_timezone(written, self.FORMAT, "Asia/Tokyo")
+        elapsed = get_current_timestamp() - parsed.timestamp()
+        assert abs(elapsed) < 60, f"elapsed skewed by {elapsed} sec"


### PR DESCRIPTION
# Pull Request: Fix workflow status timezone skew and harden the e2e run assertions

**Current Branch:** fix/e2e-tests
**Target Branch:** develop-main

----------
### Content

#### Summary
- **Production bug:** on any deployment whose container `TZ` differs from the timezone an experiment's `started_at` was written in, a running workflow is reported as **errored within seconds of starting**. On deployed dev this made the UI announce "Workflow finished" 16 seconds into a run that was 12% complete.
- The cause is a naive `datetime.strptime(...).timestamp()` in `WorkflowMonitor.search_process`. The stored timestamp carries no offset, so it resolved against the container's `TZ` instead of the zone it was written in, inflating `elapsed_time` by exactly that offset (`32411.0` sec = 9h + the run's real 11 sec). That blew past the 7200s startup grace on the very first poll, so `search_process` reported no snakemake process, `observe()` flagged the whole workflow errored, and every not-yet-run node was returned as `error` rather than `pending`.
- The frontend then did what it is designed to do: `PipelineSlice` marks a run `FINISHED` when no node is pending and `completeStatus != PROCESSING`. With every node reported terminal, that fires immediately.
- **This silently corrupted e2e:** WF-04 passed in 38.6s while the pipeline was still computing, and kept running for 77+ seconds after the test process exited. Every `@slow` test that mints a run (REC-07, DV-12..20, PUB-05/06) inherited the same false signal.
- `runTutorial` no longer trusts the snackbar. It races both terminal snackbars and then asserts the run's own recorded `success` flag in `experiment.yaml`, which only finalization writes.
- Also fixes FILE-06, which raced the flowchart restore after a reload.

#### Design Decisions
- **The fix lives in `datetime_utils` beside the writer it inverts.** `get_datetime_for_timezone_formatted` writes the string; `parse_datetime_for_timezone` reads it back in the same zone, with the same UTC fallback. Keeping the pair together is what stops the two drifting apart again. It is a pure function, so the regression is unit-testable without a workflow.
- **The timeout was never the problem, and was deliberately not raised.** The 14-minute failures that started this looked like a ceiling that was too low. Measured properly, a full Tutorial1 run is about 2 minutes on deployed dev and 3.8 minutes locally, both far inside the existing 840s. Raising it would have hidden the real bug behind a longer wait.
- **`runTutorial` races `Workflow finished` against `Workflow aborted`.** Waiting on success alone burns the entire ceiling on a run that already died and then reports a bare timeout. Racing both makes a dead run fail in seconds with a message naming the tutorial.
- **The recorded-status assertion is the load-bearing one.** A snackbar is a UI signal derived from a poll that this very bug could forge. `experiment.yaml`'s `success` field is written at finalization, so it cannot be faked mid-run. This is what turns a false green into a named failure.
- **`RUN_TIMEOUT_MS` and `RUN_TEST_TIMEOUT_MS` replace four hand-synced literals.** The inner wait (840s) and four `test.setTimeout(900_000)` calls had to be kept in step by hand, and `06-dataview` already carries a comment describing someone getting that wrong. The test timeout now derives from the run timeout. `RUN_TIMEOUT_MS` is env-overridable, which is how the real run duration was measured without editing code.
- **FILE-06 no longer assumes a reload restores an image node.** A reload restores the workspace's *persisted* workflow, which need not carry one. The node appeared briefly, `toBeVisible` passed, the restore replaced it with Tutorial4's hdf5/matlab nodes, and the click target detached. It now reproduces Tutorial1 explicitly after the reload, and registers the held route afterwards (the reproduce never fetches the tree).

### Evidence
**Root cause, reproduced under the deployed container's timezone (`TZ=Asia/Tokyo`):**
```
naive parse elapsed: 32401 sec  -> grace(7200) expired: True
fixed parse elapsed: 1 sec      -> grace(7200) expired: False
```
`32401` matches the `elapsed_time='32411.0'` seen in the deployed logs; the 10 sec delta is the run's real age.

**Before the fix, deployed dev:**
| Time | Event |
| --- | --- |
| 17:23:55 | `WORKFLOW START` (tutorial1) |
| 17:24:05 | `run_result(): Remote data is temporary locked` -> HTTP 423 |
| 17:24:11 | **test reported PASS (38.6s)** |
| 17:24:28 | `suite2p_file_convert` output written, 38% |
| 17:25:28 | `eta` output written, 75%, still running |

**After the fix, deployed dev:**
- WF-04 (Tutorial1, RUN): **passed, 2.9m**
- WF-05 (Tutorial2, RUN ALL): **passed, 3.4m**
- WF-06 (Tutorial3, RUN ALL): **passed, 2.5m**
- REC-07 (NWB download): **passed, 3.7m** -- the strongest of the four, since it downloads a real NWB artifact rather than asserting on a status field. That file only exists if the pipeline genuinely finished, so it could not have passed under the old behaviour, which moved on at 38%.
- Logs for those runs: `steps (100%) done`, and `No workflow process found at all` absent entirely (it appeared on every run beforehand)

**No regression on the lane CI actually uses:** WF-04 against the local docker stack passes in 3.8m. Local runs `TZ=UTC` with the PID file visible to the API process, so neither precondition for the bug exists there, which is also why this was never caught: `e2e.yml` states the job runs the local docker stack and "does NOT test the deployed AWS environment".

**Backend tests:** 38 tests in `test_datetime_utils.py` pass under both `TZ=UTC` and `TZ=Asia/Tokyo`; flake8 clean. The 5 pre-existing failures in `studio/tests/app/common/core/workflow/` were baselined at HEAD with these changes reverted and are identical (the known `studio_data` fixture teardown issue).

**FILE-06:** 18/18 with `--repeat-each 3 --retries 0` against the environment it previously flaked on (FILE-06 itself 9.1s / 10.0s / 9.2s).

### References
- PR #810 (previous PR in this series; this branch stacks on its merge)
- `search_process` grace: `PROCESS_SNAKEMAKE_WAIT_TIMEOUT = 7200`
- Frontend rule that consumes the node statuses: `PipelineSlice`, `pollRunResult.fulfilled`

#### Files changed

Backend:
- `studio/app/common/core/utils/datetime_utils.py` -- new `parse_datetime_for_timezone`, the inverse of `get_datetime_for_timezone_formatted`: parses with the recorded IANA zone, falls back to UTC on absent or invalid, returns an aware datetime
- `studio/app/common/core/workflow/workflow_result.py` -- `search_process` now parses `started_at` with the experiment's own `timezone` instead of naively; drops the now-unused `datetime` import
- `studio/tests/app/common/core/utils/test_datetime_utils.py` -- 5 tests: UTC default, a recorded Tokyo zone, invalid-zone fallback, and two round-trip tests asserting elapsed time is not skewed by the host zone

Frontend e2e:
- `frontend/e2e/helpers.ts` -- `startRun` returns the run's `workspaceId`/`uid`; new `recordedRunStatus` reads that run's `success` from `GET /experiments/{ws}`; `runTutorial` races both terminal snackbars then asserts the recorded result; adds `RUN_TIMEOUT_MS` / `RUN_TEST_TIMEOUT_MS`
- `frontend/e2e/05-file-handling.spec.ts` -- FILE-06 reproduces Tutorial1 after the reload so the image node is deterministic, and registers the held route after it
- `frontend/e2e/03-workflow.spec.ts`, `04-record.spec.ts`, `06-dataview.spec.ts`, `14-public.spec.ts` -- `test.setTimeout(900_000)` -> `RUN_TEST_TIMEOUT_MS`, plus comment updates where the old 840s literal was cited

### Manual Testcases
- Backend unit: `docker compose -f docker-compose.dev.multiuser.yml exec -T studio-dev-be sh -c 'cd /app && poetry run pytest studio/tests/app/common/core/utils/test_datetime_utils.py -q'` -- 38 passed.
- Same command with `-e TZ=Asia/Tokyo` -- 38 passed, proving the fix under the deployed container's zone.
- Local e2e (docker stack, `BASE_URL=http://localhost:3003`): `RUN_SLOW=1 npx playwright test e2e/03-workflow.spec.ts --grep "WF-04" --retries 0` -- 1 passed (3.8m).
- Deployed e2e (`BASE_URL`/`API_URL` at the dev ALB): the same command -- 1 passed (2.9m). Before this branch the same test passed in 38.6s against an incomplete run, then failed at 40.9s with `recorded "error"` once the assertion was added.
- Deployed e2e, `--grep "WF-05|WF-06|REC-07" --retries 0` -- WF-05 and WF-06 passed; REC-07 was cut short by the environment shutdown described in Difficulties.
- Deployed e2e, `--grep "REC-07" --retries 0` re-run the next morning -- 1 passed (3.7m). REC-07 mints its own run via `ensureCompletedTutorialRun`, so it needs no preceding WF test.
- FILE-06: `npx playwright test e2e/05-file-handling.spec.ts --grep-invert @slow --repeat-each 3 --retries 0` -- 18 passed.

### Unit, Integration, Contract Test Coverage
- `parse_datetime_for_timezone` is covered by 5 new unit tests, two of which are round-trips that fail if the host-zone skew returns.
- No existing test covered `search_process`'s elapsed-time arithmetic, which is why a 9-hour error shipped unnoticed; the new tests close that specific gap at the helper level.
- The e2e side gains a real assertion where it previously had none: a run is only green when its own recorded result says `success`.

### Others

#### Difficulties (if any)
- **The first diagnosis was wrong and is worth recording.** The symptom was two 14-minute WF-04 timeouts, which read as a ceiling that was too low. Measuring instead of assuming showed the opposite: runs are 2 to 4 minutes, and the 14-minute failures were a pre-redeploy state. Had the timeout simply been raised, the false-pass bug would have remained and looked like a fix.
- **A ~30-test cascade mid-investigation was a concurrent redeploy**, not a regression: the ECS rollout started at 14:20:46 and everything after that failed in ~6 seconds. Only failures before that timestamp were treated as signal.
- **REC-07 first failed for an environmental reason worth recording.** It reported a locator timeout, but the screenshot was a `503 Service Temporarily Unavailable`, which is the ALB error page rather than an app failure: `development-dev-schedule-stop` (`cron(0 13 ? * MON-FRI *)` = 22:00 JST) stopped the ECS task at 22:00:42 mid-test, and the 180s retry loop expired at 22:03:27. WF-05 and WF-06 had already passed before the shutdown. Re-run the next morning it passed in 3.7m. The lesson: a scaled-to-zero environment surfaces in Playwright as a locator timeout on what looks like a broken page, so check `describe-services` for `running=0 desired=0` before diagnosing the app. A deployed `@slow` run must finish before 22:00 JST.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| `parse_datetime_for_timezone` | Low | New pure function, no existing caller changed; 5 unit tests including host-zone round-trips |
| `search_process` timezone parse | Medium | One line, but it gates the workflow startup grace for every run. Wrong in the safe direction now: the grace can only get *longer*, never expire early. Verified on deployed (3 real runs) and locally (`TZ=UTC`, unchanged behaviour) |
| `runTutorial` recorded-status assertion | Medium | Every `@slow` test that mints a run routes through it, so a backend that misrecords a good run turns these red. That is the intent: it converts silent false greens into named failures. Verified green on both local and deployed |
| `RUN_TIMEOUT_MS` constants | Low | Defaults resolve to the previous 840s / 900s values, so behaviour is unchanged unless the env var is set |
| FILE-06 | Low | One test, additive reproduce step; 3/3 repeats with retries disabled |
