### PR TITLE
Pin hdmf below 4 in the conda envs that write NWB

### DIFF
--- a/docs/specifications/add_algorithm.md
+++ b/docs/specifications/add_algorithm.md
@@ -141,6 +141,7 @@ dependencies:
 - Note:
   - Currently, Optinist packages supports NumPy versions below 2. Please ensure that your Conda environment is configured with an appropriate version of NumPy.
   - If you plan to use NumPy 2.x or higher, ensure all other packages in your environment are compatible with it.
+  - These envs are solved fresh at run time rather than baked into the image, so your node can get a different package set than the one you developed against, including transitive packages the yaml never lists. Pin your direct dependencies as tightly as the function allows.
 
 ### Check your custom node inputs and outputs
 

--- a/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
+++ b/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
@@ -10,5 +10,6 @@ dependencies:
   - pandas>=1.5.0
   - scikit-image>=0.19.0
   - pynwb<3
+  - hdmf<4
   - tensorflow>=2.12,<2.16
   - caiman>=1.11.3,<=1.11.4

--- a/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
+++ b/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
@@ -8,6 +8,7 @@ dependencies:
       - scikit-learn==1.1.*
       - statsmodels==0.13.*
       - pynwb<3
+      - hdmf<4
       - numexpr
       - numba
       - dpca


### PR DESCRIPTION
### Content

#### Summary
- The Weekly Regression e2e lane fails on `develop-main` at `WF-05 - Run Tutorial2 workflow via RUN ALL`. Tutorial2's first node, `caiman_mc`, dies writing its NWB file with `TypeError: Can't instantiate abstract class NWBFile with abstract method external_resources`; the other three node errors are cascade only.
- Root cause: `caiman.yaml` requests `pynwb<3` but places no bound on `hdmf`. conda-forge `pynwb 2.8.3` declares only `hdmf>=3.14.5` with no ceiling, and the wrapper envs are not baked into the image, so this env re-solves from the live index on every run and is free to cross a major version. `hdmf 5.1.0` turned `HERDManager` into an ABC with an abstract `external_resources` that pynwb 2's `NWBFile` never declares.
- Adds `hdmf<4` to `caiman.yaml` and to `optinist.yaml`, the two envs that write NWB with an unbounded hdmf.
- `hdmf<4` lands the writers on hdmf 3.14.6, byte-identical to what the app image reads these files back with (`pyproject.toml`: `hdmf = "3.*"`).

#### Design Decisions

- **`hdmf<4` rather than `hdmf<5.1`.** hdmf 4.x is not itself broken with pynwb 2.x (verified: pynwb 2.8.3 + hdmf 4.1.0 instantiates an `NWBFile` fine). But no pynwb 2.x release declares an hdmf ceiling at all, so any bound is ours to choose, and `nwb_creater.py` is shared: the app image writes and reads these same files with hdmf 3.14.6. Holding the writers to the reader's major is the same pattern `microscope.yaml` (`hdmf==3.*`) already uses. A `<5.1` ceiling would instead bless the hdmf 4.x/5.0.x window that nothing in this repo exercises.

- **`optinist.yaml` changed too, and to the same ceiling.** That env is python 3.9, and hdmf 5.0.0 raised its requires-python to `>=3.10`, so it was already capped at 4.3.1 and is not part of the WF-05 failure. It is included because the exact mechanism that broke caiman was an interpreter bump silently uncapping hdmf (see the blame note below), and because leaving it at 4.3.1 while pulling caiman back to 3.14.6 would make the two writers diverge from each other and from the reader. This is a deliberate policy alignment, not part of the minimal fix - it is separable if a reviewer prefers to drop it. Its resolution was validated rather than assumed: the exact pip set on python 3.9 with `hdmf<4` resolves to hdmf 3.14.6 + pynwb 2.8.3 and writes an `NWBFile` successfully.

- **No regression test for the pin.** An earlier revision of this branch carried `studio/tests/app/test_conda_env_pins.py`, a checker that parsed every wrapper conda yaml and proved that any section requesting pynwb 2.x also carried a specifier admitting nothing at or above hdmf 4. It was dropped before review. The check encoded three specific facts - that the ceiling is 4, that the trigger is pynwb 2.x, and how conda and pip specifier syntax is spelled - none of which survive the upgrades this repo will actually make. A pynwb 3 migration, a python bump in `optinist.yaml`, or a deliberate move to hdmf 4 each turn it red while the tree is correct, and the only available response is to edit or delete the test. A guard whose expected failure mode is "delete the guard" is worse than no guard: it costs a red lane and teaches contributors to ignore it. The durable version of this check is not a specifier parser but a dry-run solve of each conda yaml in CI, which catches unbounded drift in `pandas`, `scikit-image` and `cython` too - see Follow-ups.

- **Rejected: migrating to pynwb 3/4 instead of pinning.** pynwb 3.0 declares `hdmf>=3.14.5,<5` and pynwb 4.1 declares `hdmf>=6.1.0,<7`, so upstream added the ceiling pynwb 2.x lacks. But `pyproject.toml`, `caiman.yaml`, `optinist.yaml` and `microscope.yaml` all read and write the same files and would have to move together, plus an audit of `nwb_creater.py` against pynwb 3's removed APIs and a revalidation of every tutorial's NWB output. It also would not address the defect that broke CI, which is an env with no ceiling.

#### Blame

`d07a43804` "Caiman yaml upgrade" (2026-04-09) bumped `caiman.yaml` from `python=3.9` to `python=3.11`. hdmf 5+ requires python >= 3.10, so before that commit the env was hard-capped below the breaking major by its own interpreter, and the missing `hdmf` bound was harmless. That commit's intent was a legitimate caiman/tensorflow upgrade; this change preserves it by adding the ceiling rather than reverting the interpreter. `optinist.yaml`'s `pynwb<3` came from `5d16b2b4e` (2026-03-24), which loosened an exact `pynwb==2.2.0` that had broken CI - that intent is preserved too, since the pynwb range is left open and only an hdmf ceiling is added.

### Evidence

Root cause reproduced directly, in `python:3.11-slim`:

```
hdmf 6.2.0 pynwb 2.8.3
FAILED: TypeError Can't instantiate abstract class NWBFile with abstract method external_resources
```

Which hdmf release actually introduced it, by introspecting `hdmf.container.HERDManager`:

```
hdmf 4.3.1 | bases: ['object'] | abstractmethods: []
hdmf 5.0.0 | bases: ['object'] | abstractmethods: []
hdmf 5.0.1 | bases: ['object'] | abstractmethods: []
hdmf 5.1.0 | bases: ['ABC']    | abstractmethods: ['external_resources']
hdmf 6.2.0 | bases: ['ABC']    | abstractmethods: ['external_resources']
```

The solve, run with the `conda` frontend that `snakemake_executor.py` configures (`conda_frontend="conda"`), for linux-64, channels `conda-forge` + `defaults`:

```
current caiman.yaml spec set   -> hdmf 6.2.0, pynwb 2.8.3
with `hdmf<4` added            -> hdmf 3.14.6, pynwb 2.8.3, caiman 1.11.4
```

Full package-list diff of those two solves - the pin moves nothing else:

```
unpinned pkgs: 453   pinned pkgs: 453
DIFFERENCES (unpinned -> pinned):
  hdmf: 6.2.0 -> 3.14.6
```

`optinist.yaml`'s pip set on python 3.9 with `hdmf<4`:

```
optinist py3.9 with hdmf<4 ->  hdmf 3.14.6 pynwb 2.8.3
NWBFile OK
```

Actual installed versions in the built envs on the dev instance, which is how the exposure audit below was established rather than inferred:

| env | python | pynwb | hdmf |
|---|---|---|---|
| caiman | 3.11 | 2.8.3 | **6.1.0** |
| optinist | 3.9 | 2.8.3 | 4.3.1 |
| microscope | 3.9 | 2.6.0 | 3.14.6 |
| suite2p / lccd | 3.9 | none | none |
| app image | - | 2.8.3 | 3.14.6 |

Backend suite on this branch:

```
1632 passed, 2 skipped, 2 deselected, 1128 warnings in 131.50s
```

### References

- Issue: https://github.com/arayabrain/araya-optinist/issues/817
- Failing run: https://github.com/arayabrain/araya-optinist/actions/runs/32676365616 (2026-08-24)
- Last green runs: 31981674833 (2026-08-17), 32089054683 (2026-08-18)

#### Files changed

Backend / environments
- `studio/app/optinist/wrappers/caiman/conda/caiman.yaml` -- add `hdmf<4`. This is the fix: it is the env WF-05 fails in.
- `studio/app/optinist/wrappers/optinist/conda/optinist.yaml` -- add `hdmf<4`. Not part of the WF-05 failure; aligns the second NWB writer with the reader and closes the same latent hole.

Docs
- `docs/specifications/add_algorithm.md` -- one bullet in the custom-conda-env section, stating the general hazard this defect exposed: wrapper envs solve fresh at run time, so a node can get a package set it was never developed against. Deliberately version-free - naming hdmf 4 / pynwb 2.x here would go stale on the pynwb 3 migration and misinstruct silently, which is the same reason the specifier test was dropped. It stops short of telling contributors to ceiling every dependency: hdmf was never listed in `caiman.yaml` (it came in transitively via pynwb), so that policy would not have prevented this defect and is not what fixes the class - see Follow-ups.

### Manual Testcases

1. Reviewer confirms the solve, which is the assertion the pin actually rests on:
   `CONDA_OVERRIDE_GLIBC=2.17 conda create --dry-run --platform linux-64 -c conda-forge -c defaults 'python=3.11' 'setuptools<81' cython 'numpy<2' 'pandas>=1.5.0' 'scikit-image>=0.19.0' 'pynwb<3' 'hdmf<4' 'tensorflow>=2.12,<2.16' 'caiman>=1.11.3,<=1.11.4'` -- resolves hdmf 3.14.6, pynwb 2.8.3, caiman 1.11.4.
2. Reviewer repeats that command with `'hdmf<4'` removed -- resolves hdmf 6.2.0, the broken pairing, confirming the pin is what moves it.
3. Reviewer pre-builds the caiman env from the edited yaml, opens Tutorial2 in the UI and runs RUN ALL -- the `caiman_mc` node completes and writes its NWB file instead of raising `TypeError: Can't instantiate abstract class NWBFile`.
4. Full lane: `docker compose -f docker-compose.test.yml run test_studio_backend poetry run pytest -s studio/tests/app/ -m "not heavier_processing"` -- all 1632 tests pass, 2 skipped, 2 deselected.

Final confirmation is the Weekly Regression lane itself. It has `workflow_dispatch`, so `gh workflow run e2e.yml --ref fix/pin-hdmf-caiman-conda-env-817` runs WF-05 against this branch (~30 min). That was deliberately **not** dispatched from the unattended run - it is a remote-affecting action, and the branch is not pushed.

### Unit, Integration, Contract Test Coverage

None added, deliberately - see the "No regression test for the pin" design decision. The change is two dependency-specifier lines in conda env files; no production code path is touched, and the property that matters is a solver outcome against a live package index, which a unit test cannot observe. The existing backend suite is run unchanged as a regression check, and the real verification is the dry-run solve in Manual Testcases 1-2 plus the Weekly Regression lane.

### Others

#### Consolidation and placement review

No changes needed. No production code changed, and the two yaml edits follow the pin style already used by `microscope.yaml` (`hdmf==3.*`) rather than introducing a new convention. The doc bullet is added to the existing custom-conda-env note in `add_algorithm.md` rather than to a new page.

#### Difficulties

The trigger date is not fully explained, and the PR does not claim it is. hdmf 5.1.0 has been on conda-forge since 2026-03-24 and `caiman.yaml` has been python 3.11 since 2026-04-09, yet WF-05 was green on 2026-08-17 and 2026-08-18 and red on 2026-08-24. Probing ceilings against the current index shows hdmf 5.x is unreachable for this spec set for unrelated reasons (`hdmf<6` resolves 4.2.0) while `hdmf<6.2` resolves 6.1.0, so "hdmf 6.2.0 landed on 2026-08-19" is not by itself a sufficient explanation either. What *is* established is that the current spec resolves to a broken pairing, that the pairing provably cannot write an NWB file, and that the pin removes the entire failure class deterministically. The remaining question is which upstream index change flipped it, not whether the fix is correct.

The issue text says the installed hdmf version is unrecoverable from the run's logs. That is correct as written - the dev instance holds hdmf 6.1.0 in an env directory whose name matches the traceback, but the snakemake env address is a hash of the env path plus the yaml bytes, so that proves spec identity, not that it is the version the runner installed.

#### Follow-ups (not in this PR)

- **The defect class is wider than hdmf, and wider than the specs the yamls list.** `pandas>=1.5.0`, `scikit-image>=0.19.0` and a bare `cython` in `caiman.yaml` have no ceiling either and will drift the same way. More importantly hdmf itself was never listed: it entered as pynwb's transitive dependency, one of 453 packages the caiman solve resolves from a 10-line spec. So hand-written ceilings cannot close this class - they only bound the packages someone already thought to name. The mechanism that does close it is a lockfile: snakemake 9.10.1 (installed here) already looks for `<env>.<platform>.pin.txt` beside each yaml (`snakemake/deployment/conda.py`, `pin_file`), so `caiman/conda/caiman.linux-64.pin.txt` would freeze the whole solve with no code change. Pre-creating the envs at image build is the alternative. Either is larger than this issue. A PR job that dry-run-solves each yaml is the cheaper interim, and is also the durable replacement for the specifier test dropped from this branch: it verifies what the pin is actually for, and it does not go stale when the pins legitimately move.
- **The e2e "Dump backend logs on failure" step captured only the final minute** of container output, so the node traceback had to be recovered from the Playwright trace.
- **Four of the seven wrapper envs declare no pynwb** (`suite2p`, `lccd`, `custom`, `dummy`) yet every algo node runs `runner.py`, which imports `pynwb` at module scope. Confirmed on the dev instance that those built envs contain neither pynwb nor hdmf, and those nodes pass in green runs. Where they obtain pynwb is a pre-existing open question, unaffected by this change and out of scope here.

#### Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| `caiman.yaml` solve | Low | Verified by dry-run with the same conda frontend CI uses. 453 packages resolve identically before and after; hdmf is the only difference. |
| `optinist.yaml` solve | Low | Verified by a real python 3.9 install of the exact pip set: hdmf 3.14.6, pynwb 2.8.3, `NWBFile` writes. Moves the env down from hdmf 4.3.1 to the pairing the app image already ships. |
| Deployment / env rebuild | **Medium** | The snakemake env address is a content hash of the yaml, so both edits orphan the existing env directories rather than replacing them. `.snakemake/conda` is a persistent bind mount, so the stale multi-GB caiman env is left behind on every dev machine and deployed instance and is not garbage collected. Until the new env is built, `verify_conda_env_exists` returns False, `algolist` reports `conda_env_exists=false`, and the UI renders `CondaNoticeButton` instead of the plain add button for the CaImAn and optinist nodes. The first caiman run after deploy otherwise pays a full ~450-package solve inside the user's workflow. **Pre-build both envs after deploy** (the `setup_conda_caiman` / `setup_conda_optinist` maintenance nodes exist for exactly this) before re-running the e2e lane, and reclaim the orphaned directories. |
| WF-05 | Low-Medium | The causal chain is verified end to end, but WF-05 itself was not run - it needs the full e2e lane. Dispatch Weekly Regression on this branch to confirm, after the env pre-build above so the node does not race the workflow timeout. |
| No automated guard on the pin | Low-Medium | Nothing in CI fails if `hdmf<4` is deleted or widened; the next unbounded solve would surface as a red e2e lane, the same way this defect did. Accepted because the specifier test that would have caught it does not survive the upgrades this repo intends to make. The dry-run-solve CI job in Follow-ups is the durable cover. |
